### PR TITLE
Fix RPC error in module conversion

### DIFF
--- a/addons/tbwa_spectra_integration/data/tbwa_cron.xml
+++ b/addons/tbwa_spectra_integration/data/tbwa_cron.xml
@@ -15,7 +15,7 @@
             <field name="code">model.cron_auto_export()</field>
             <field name="interval_number">1</field>
             <field name="interval_type">months</field>
-            <field name="numbercall">-1</field>
+            <field name="max_calls">-1</field>
             <field name="active" eval="True"/>
             <field name="priority">5</field>
             <field name="user_id" ref="base.user_admin"/>
@@ -31,7 +31,7 @@
             <field name="code">model.cron_send_liquidation_reminders()</field>
             <field name="interval_number">1</field>
             <field name="interval_type">days</field>
-            <field name="numbercall">-1</field>
+            <field name="max_calls">-1</field>
             <field name="active" eval="True"/>
             <field name="priority">10</field>
             <field name="user_id" ref="base.user_admin"/>
@@ -47,7 +47,7 @@
             <field name="code">model.cron_monitor_approval_sla()</field>
             <field name="interval_number">1</field>
             <field name="interval_type">hours</field>
-            <field name="numbercall">-1</field>
+            <field name="max_calls">-1</field>
             <field name="active" eval="True"/>
             <field name="priority">15</field>
             <field name="user_id" ref="base.user_admin"/>
@@ -63,7 +63,7 @@
             <field name="code">model.cron_cleanup_old_exports()</field>
             <field name="interval_number">1</field>
             <field name="interval_type">weeks</field>
-            <field name="numbercall">-1</field>
+            <field name="max_calls">-1</field>
             <field name="active" eval="True"/>
             <field name="priority">20</field>
             <field name="user_id" ref="base.user_admin"/>


### PR DESCRIPTION
…ra_integration

Odoo 18 renamed the ir.cron field 'numbercall' to 'max_calls'. Updated all 4 cron job definitions in tbwa_spectra_integration module to use the new field name.

Resolves RPC_ERROR: ValueError: Invalid field 'numbercall' on model 'ir.cron'

Changed in:
- ir_cron_spectra_monthly_export
- ir_cron_liquidation_reminders
- ir_cron_approval_sla_monitor
- ir_cron_export_cleanup