### PR TITLE
Add CI constraints for gevent compatibility

### DIFF
--- a/.github/workflows/odoo-parity-tests.yml
+++ b/.github/workflows/odoo-parity-tests.yml
@@ -60,10 +60,21 @@ jobs:
             zlib1g-dev
 
       - name: Install Python dependencies
+        env:
+          PIP_CONSTRAINT: scripts/ci/constraints-gevent.txt
         run: |
           pip install --upgrade pip
-          pip install -r requirements.txt || echo "requirements.txt not found, installing odoo dependencies"
-          pip install psycopg2-binary wheel
+
+          # Apply CI-only constraints to avoid gevent/Cython build issues
+          pip install -c "$PIP_CONSTRAINT" "Cython<3" "greenlet<3" "gevent==22.10.2"
+
+          if [ -f requirements.txt ]; then
+            pip install -c "$PIP_CONSTRAINT" -r requirements.txt
+          else
+            echo "requirements.txt not found, installing odoo dependencies"
+          fi
+
+          pip install -c "$PIP_CONSTRAINT" psycopg2-binary wheel
 
       - name: Install Odoo 18 CE from source
         run: |

--- a/scripts/ci/constraints-gevent.txt
+++ b/scripts/ci/constraints-gevent.txt
@@ -1,0 +1,4 @@
+# CI-only constraints to keep gevent compatible with prebuilt Cython wheels
+Cython<3
+greenlet<3
+gevent==22.10.2

--- a/scripts/ci/install_odoo_18.sh
+++ b/scripts/ci/install_odoo_18.sh
@@ -3,6 +3,21 @@ set -euo pipefail
 
 # Directory where Odoo source will live on CI
 ODOO_SRC_DIR="${ODOO_SRC_DIR:-$HOME/odoo-source-18}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_CONSTRAINTS="$SCRIPT_DIR/constraints-gevent.txt"
+
+# Honor an explicit PIP_CONSTRAINT if provided; otherwise, use the CI constraints file when available
+PIP_CONSTRAINT_FILE="${PIP_CONSTRAINT:-}"
+if [[ -z "$PIP_CONSTRAINT_FILE" && -f "$DEFAULT_CONSTRAINTS" ]]; then
+  PIP_CONSTRAINT_FILE="$DEFAULT_CONSTRAINTS"
+fi
+
+if [[ -n "$PIP_CONSTRAINT_FILE" ]]; then
+  echo "Using pip constraints from: $PIP_CONSTRAINT_FILE"
+  PIP_CONSTRAINT_ARG=( -c "$PIP_CONSTRAINT_FILE" )
+else
+  PIP_CONSTRAINT_ARG=()
+fi
 
 echo "🔧 Installing Odoo 18 CE into: $ODOO_SRC_DIR"
 
@@ -11,9 +26,9 @@ if [ ! -d "$ODOO_SRC_DIR" ]; then
 fi
 
 pip install --upgrade pip
-pip install -r "$ODOO_SRC_DIR/requirements.txt"
+pip install "${PIP_CONSTRAINT_ARG[@]}" -r "$ODOO_SRC_DIR/requirements.txt"
 # For safety – often needed by tests
-pip install psycopg2-binary
+pip install "${PIP_CONSTRAINT_ARG[@]}" psycopg2-binary
 
 # Export ODOO_BIN path for downstream steps
 ODOO_BIN="$ODOO_SRC_DIR/odoo-bin"
@@ -30,4 +45,7 @@ echo "✅ Odoo installed. Binary: $ODOO_BIN"
   echo "ODOO_SRC_DIR=$ODOO_SRC_DIR"
   echo "ODOO_BIN=$ODOO_BIN"
   echo "PATH=$ODOO_SRC_DIR:\$PATH"
+  if [[ -n "$PIP_CONSTRAINT_FILE" ]]; then
+    echo "PIP_CONSTRAINT=$PIP_CONSTRAINT_FILE"
+  fi
 } >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- add CI-only constraints file to pin gevent, greenlet, and Cython versions
- apply constraints during workflow dependency installation and Odoo 18 setup

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239c85cbe48322be8ec8881c4ce7a6)