### PR TITLE
Add unified deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,99 @@
+name: Deploy Odoo CE
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  ci:
+    name: Lint and quality checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install lint tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit pylint-odoo
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+
+      - name: Run pylint-odoo on custom addons
+        run: pylint-odoo addons
+
+  build_image:
+    name: Build and push GHCR image
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: jgtolentino
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Build image
+        run: |
+          IMAGE=ghcr.io/jgtolentino/odoo-ce:latest
+          docker build -t "$IMAGE" .
+
+      - name: Push image
+        run: |
+          IMAGE=ghcr.io/jgtolentino/odoo-ce:latest
+          docker push "$IMAGE"
+
+  deploy_vps:
+    name: Deploy to DigitalOcean VPS
+    needs: build_image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to VPS
+        uses: appleboy/ssh-action@v1
+        with:
+          host: 159.223.75.148
+          username: ubuntu
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -e
+            cd ~/odoo-prod
+            git pull origin main
+            docker compose -f docker-compose.prod.yml pull odoo
+            docker compose -f docker-compose.prod.yml up -d
+            docker compose -f docker-compose.prod.yml exec odoo \
+              odoo-bin -c /etc/odoo.conf \
+              -d odoo \
+              -u ipai_ppm_advanced,ipai_internal_shop,ipai_finance_ppm,auth_oidc \
+              --stop-after-init
+
+  deploy_doks:
+    name: Deploy to DOKS
+    needs: build_image
+    runs-on: ubuntu-latest
+    if: ${{ false }}
+    steps:
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Update Odoo deployment image
+        env:
+          KUBECONFIG: ${{ secrets.DOKS_KUBECONFIG }}
+        run: |
+          kubectl set image deployment/odoo odoo=ghcr.io/jgtolentino/odoo-ce:latest
+          kubectl rollout status deployment/odoo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ docker compose exec db psql -U odoo -d odoo_ce_prod -f /docker-entrypoint-initdb
 
 - **Configuration Updates**
   - `deploy/odoo.conf` - Added worker tuning parameters
-  - `deploy/docker-compose.yml` - Added PostgreSQL connection limits
+  - `docker-compose.prod.yml` - Added PostgreSQL connection limits
 
 - **Documentation & Procedures**
   - `docs/N8N_CREDENTIALS_BOOTSTRAP.md` - n8n credential management

--- a/COMPREHENSIVE_DEPLOYMENT_SUMMARY.md
+++ b/COMPREHENSIVE_DEPLOYMENT_SUMMARY.md
@@ -14,13 +14,13 @@ This document summarizes the complete production readiness bundle with three ver
 **Key Features**:
 - Database & worker tuning (100 connections, 4 HTTP + 2 cron workers)
 - Installation safety with pre-install snapshots
-- Configuration updates for odoo.conf and docker-compose.yml
+- Configuration updates for odoo.conf and docker-compose.prod.yml
 - Documentation for n8n credentials, Mattermost alerts, and app icons
 - Regression test scaffolding for core modules
 
 **Files**:
 - `deploy/odoo.conf` - Production-optimized configuration
-- `deploy/docker-compose.yml` - Worker scaling and resource limits
+- `docker-compose.prod.yml` - Worker scaling and resource limits
 - `scripts/pre_install_snapshot.sh` - Safe module installation
 - `scripts/install_ipai_finance_ppm.sh` - Installation wrapper
 - `tests/regression/` - Test scaffolding for core modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Custom Odoo CE image for InsightPulse
+# Base image
+FROM odoo:18.0
+
+# Install required system dependencies for custom modules
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libpq-dev \
+        git \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy custom addons baked into the image; owner set to odoo for runtime safety
+COPY --chown=odoo:odoo ./addons /mnt/extra-addons/
+
+# Install Python dependencies if a requirements file exists
+RUN if [ -f /mnt/extra-addons/requirements.txt ]; then \
+      pip install --no-cache-dir -r /mnt/extra-addons/requirements.txt; \
+    fi
+
+# Provide default configuration inside the image (override with bind mount in compose)
+COPY --chown=odoo:odoo ./deploy/odoo.conf /etc/odoo/odoo.conf
+
+# Default environment placeholders (override at runtime via compose/ENV)
+ENV HOST=db \
+    PORT=5432 \
+    USER=odoo \
+    PASSWORD=odoo \
+    DB=odoo
+
+# Run as non-root for security
+USER odoo

--- a/agents/capabilities/CAPABILITY_MATRIX.yaml
+++ b/agents/capabilities/CAPABILITY_MATRIX.yaml
@@ -227,7 +227,7 @@ capabilities:
     preconditions:
       - digitalocean_account: "doctl configured"
       - dns_configured: "Domain DNS points to droplet IP"
-      - docker_compose_ready: "deploy/docker-compose.yml exists"
+      - docker_compose_ready: "docker-compose.prod.yml exists"
 
     skills_required:
       - deploy_to_digitalocean

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,7 +29,7 @@ services:
           memory: 512M
 
   odoo:
-    image: odoo:18.0
+    image: ghcr.io/jgtolentino/odoo-ce:latest
     container_name: odoo-ce
     restart: unless-stopped
     depends_on:
@@ -43,11 +43,11 @@ services:
       ODOO_RC: /etc/odoo/odoo.conf
     volumes:
       # Main config
-      - ./odoo.conf:/etc/odoo/odoo.conf:ro
+      - ./deploy/odoo.conf:/etc/odoo/odoo.conf:ro
 
       # Custom CE/OCA addons only – NO Enterprise mounts
-      - ../addons:/mnt/extra-addons
-      - ../oca:/mnt/oca-addons
+      - ./addons:/mnt/extra-addons
+      - ./oca:/mnt/oca-addons
 
       # Filestore
       - odoo-filestore:/var/lib/odoo

--- a/docs/DOKS_DEPLOYMENT_SUCCESS_CRITERIA.md
+++ b/docs/DOKS_DEPLOYMENT_SUCCESS_CRITERIA.md
@@ -1,0 +1,32 @@
+# DOKS Deployment Success Criteria Specification
+
+This specification defines the measurable signals that confirm the DigitalOcean Kubernetes (DOKS) deployment of Odoo CE is production-ready for the Finance team. Each criterion is paired with a verification command so the automation pipeline can gate progression based on objective outcomes.
+
+## 1. Infrastructure Provisioning (`doctl` CLI)
+
+| Action / Component | Success Metric | Verification Command (`doctl`) |
+| --- | --- | --- |
+| **Cluster Creation** | Command exits with code `0` and the cluster `status` becomes `running`. | `doctl kubernetes cluster create ...` |
+| **Cluster Health** | All node pools are `active` and `ready`; control plane responds to API calls. | `doctl kubernetes cluster list` |
+| **Image Registry Link** | GHCR registry credentials allow successful image pulls by cluster service accounts. | Confirmed via successful pod image pulls (see Odoo pod logs). |
+
+## 2. Core Components Deployment (`kubectl` & Manifests)
+
+| Component | Manifest Type | Success Metric (State) | Verification Command (`kubectl`) |
+| --- | --- | --- | --- |
+| **PostgreSQL** | StatefulSet | Pods show `Running` and `Ready` (e.g., `1/1`); PVCs show `Bound`. | `kubectl get pods -l app=postgres`<br>`kubectl get pvc` |
+| **Odoo / Keycloak** | Deployment | All replicas are `Ready` and `Available`; liveness probes succeed. | `kubectl get deployments`<br>`kubectl describe deployment odoo` |
+| **Odoo Config** | ConfigMap | Required files (for example, `odoo.conf`) mount at `/etc/odoo` in Odoo pods. | `kubectl describe pod odoo-xxx`<br>`kubectl exec odoo-xxx -- cat /etc/odoo/odoo.conf` |
+
+## 3. External Access & Functional Parity (Ingress & Application)
+
+| Action / Endpoint | Success Metric | Verification Tool |
+| --- | --- | --- |
+| **Ingress Controller** | Ingress service receives a public IP address. | `kubectl get ingress odoo-ingress` |
+| **SSL/HTTPS Access** | `https://erp.insightpulseai.net/` returns HTTP status `200` over HTTPS. | `curl -s -o /dev/null -w "%{http_code}" https://erp.insightpulseai.net/` |
+| **Odoo Functional Check** | Odoo logs show a healthy database connection during startup/initialization. | Review Odoo pod startup logs. |
+| **Keycloak Functional Check** | Admin console login screen responds via `https://auth.insightpulseai.net/admin`. | `curl -s -o /dev/null -w "%{http_code}" https://auth.insightpulseai.net/admin` |
+
+## Completion Rule
+
+The deployment is considered successful when all checks in Section 3 pass in succession after the core components are healthy. Automation should fail fast on any unmet criterion to prevent partial rollouts.

--- a/docs/FINAL_DEPLOYMENT_RUNBOOK.md
+++ b/docs/FINAL_DEPLOYMENT_RUNBOOK.md
@@ -1,0 +1,59 @@
+# Final Deployment Runbook: Switching to Image-Based CD
+
+This runbook documents the server-side steps to replace the legacy file-sync deployment with the new image-based continuous delivery pipeline for Odoo CE on the DigitalOcean VPS (`159.223.75.148`). Execute the steps sequentially on the droplet to pull the latest artifacts, start containers with the custom image, and apply database migrations.
+
+## Prerequisites
+- Latest changes (including `docker-compose.prod.yml` and the `Dockerfile`) are merged into `main` and published to the image registry.
+- The droplet has a local clone of the repository at `~/odoo-prod/`.
+- You have SSH access as `ubuntu` and permission to run `docker compose`.
+- `docker-compose.prod.yml` references the production image `ghcr.io/jgtolentino/odoo-ce:latest`.
+
+## Step 1: (If Needed) Build and Publish the Production Image
+If CI has not already built and pushed the release image, build it from the root-level `Dockerfile` and publish to GHCR:
+```bash
+# Build the custom Odoo image that bakes in all addons
+docker build -t ghcr.io/jgtolentino/odoo-ce:latest .
+
+# Push to GHCR for consumption by docker-compose.prod.yml
+docker push ghcr.io/jgtolentino/odoo-ce:latest
+```
+
+## Step 2: Log In and Sync Documentation
+```bash
+# 1. SSH into the Droplet
+ssh ubuntu@159.223.75.148
+
+# 2. Navigate to the project root
+cd ~/odoo-prod
+
+# 3. Pull the latest repository changes (gets the new compose file)
+git pull origin main
+```
+
+## Step 3: Activate the New Image-Based Pipeline
+```bash
+# Pull the newly built production image (ghcr.io/jgtolentino/odoo-ce:latest)
+docker compose -f docker-compose.prod.yml pull odoo
+
+# Restart Odoo with the freshly pulled image
+docker compose -f docker-compose.prod.yml up -d
+```
+
+## Step 4: Apply Final Database Migrations
+```bash
+# Export environment variables for module updates and database selection
+export ODOO_MODULES="ipai_finance_ppm,ipai_equipment,ipai_payment_payout"
+export DB_NAME="odoo"
+
+# Run schema updates inside the refreshed Odoo container
+# (adjust DB_NAME/ODOO_MODULES if your environment differs)
+docker compose -f docker-compose.prod.yml exec odoo odoo-bin -c /etc/odoo.conf \
+    -d ${DB_NAME} -u ${ODOO_MODULES} --stop-after-init
+```
+
+## Final Verification
+1. **Image Tag**: `docker ps` should show the Odoo container running `ghcr.io/jgtolentino/odoo-ce:latest` (or a `main` commit SHA tag). Use `docker inspect $(docker compose -f docker-compose.prod.yml ps -q odoo) --format '{{.Config.Image}}'` if you need to confirm the exact reference.
+2. **Functional Check**: Log into Odoo and confirm WBS Auto-Numbering still operates correctly after the image swap.
+3. **Ingress/HTTPS**: If routed through Ingress, ensure the public endpoints return HTTP 200 over HTTPS.
+
+Following these steps retires the file-sync workflow and fully activates the image-based CD pipeline.

--- a/docs/MVP_GO_LIVE_CHECKLIST.md
+++ b/docs/MVP_GO_LIVE_CHECKLIST.md
@@ -1,0 +1,38 @@
+# Strategic Finance & Portfolio Command Center: MVP Go-Live Checklist (v1.0)
+
+The minimum viable product is validated by running the core workflows that prove the platform can securely control spend and manage the financial close. The system is operational only when all four pillars below are functioning in production.
+
+## Pillars & Required Validations
+
+| # | Pillar / Component | Required Validation | Owner |
+| --- | --- | --- | --- |
+| 1 | Identity & Access | Users log into Odoo (`erp.insightpulseai.net`) via Keycloak SSO. | CKVC (Khalil) |
+| 2 | Spend Control | Internal procurement flow creates a `purchase.request` (not `sale.order`) when an employee submits a cart request on the Website. | BOM (Beng) |
+| 3 | Core PPM Logic | Finance dashboard shows the Month-End Close project with calculated RAG status; WBS codes (1.1, 1.2) auto-number correctly on create/re-sequence. | RIM (Rey) |
+| 4 | Deployment | A merge to `main` triggers GitHub Actions to build the custom Docker image and automatically update the Odoo server (no manual SSH). | DevOps |
+
+## Feature Bundle Included in This MVP
+
+- WBS Auto-Numbering (Work Breakdown Structure) — `ipai_ppm_advanced`
+- Budget Control Interface (Procure-to-Pay) — `ipai_internal_shop`
+- Email/Mobile Alerts (Communications Management) — `ipai_finance_ppm` (Alerts)
+- External Auth — `auth_oidc` (Keycloak)
+- Image Deployment — `deploy.yml` (image-based CD)
+
+## Production Image Activation (Next Action)
+
+The latest production image (`ghcr.io/jgtolentino/odoo-ce:latest`) contains all merged features. Run these commands on the DigitalOcean VPS (`159.223.75.148`) to pull and start it:
+
+```bash
+# From ~/odoo-prod with docker-compose.prod.yml pointing to ghcr.io/jgtolentino/odoo-ce:latest
+docker compose -f docker-compose.prod.yml pull odoo
+
+docker compose -f docker-compose.prod.yml up -d
+```
+
+## Branch Discipline for Release
+
+- Do **not** rename or mark the technical feature branch (`codex/implement-ipai_ppm_advanced-module-in-odoo`) as `main`.
+- Merge PR #25 (Runbook docs) into the aggregation branch (for example, `feature/add-expense-equipment-prd`).
+- Merge the stable aggregation branch into `main` to trigger the production CD pipeline.
+- Only the clean, stable `main` branch should deploy to the live server.

--- a/docs/PROD_READINESS_GAPS.md
+++ b/docs/PROD_READINESS_GAPS.md
@@ -73,7 +73,7 @@
 
 ### v1.0 - Production Readiness Bundle ✅
 - ✅ `deploy/odoo.conf` - Production configuration
-- ✅ `deploy/docker-compose.yml` - Worker scaling
+- ✅ `docker-compose.prod.yml` - Worker scaling
 - ✅ `scripts/pre_install_snapshot.sh` - Safe installation
 - ✅ `scripts/install_ipai_finance_ppm.sh` - Installation wrapper
 - ✅ `tests/regression/` - Test scaffolding

--- a/plan.md
+++ b/plan.md
@@ -34,7 +34,7 @@ Aligned PRD: specs/002-odoo-expense-equipment-mvp.prd.md
 
 - Provision target runtime:
   - Docker Compose or K8s (DigitalOcean/DOKS acceptable).
-- Add `deploy/docker-compose.yml`:
+- Add `docker-compose.prod.yml` at repo root:
   - Odoo CE 18 container.
   - PostgreSQL container.
   - Volume mounts for `addons/` and `oca/`.

--- a/scripts/backup_odoo.sh
+++ b/scripts/backup_odoo.sh
@@ -45,7 +45,7 @@ log "Backing up configuration files..."
 tar czf "$BACKUP_DIR/odoo-config-$TIMESTAMP.tar.gz" \
     -C "$INSTALL_DIR" \
     deploy/odoo.conf \
-    deploy/docker-compose.yml \
+    docker-compose.prod.yml \
     deploy/nginx/ \
     addons/ \
     2>/dev/null || true

--- a/tasks.md
+++ b/tasks.md
@@ -19,7 +19,7 @@ Status: Draft checklist aligned with plan.md
 
 ## Phase 1 – CE/OCA Base Stack
 
-- [ ] Create `deploy/docker-compose.yml` with:
+- [ ] Create root-level `docker-compose.prod.yml` with:
   - [ ] Odoo CE 18 service.
   - [ ] PostgreSQL service.
   - [ ] Volumes for `addons/` and `oca/`.


### PR DESCRIPTION
## Summary
- add a single main-branch workflow that lints custom addons, builds the GHCR image, and deploys to the VPS
- include optional DOKS rollout step gated off for now

## Testing
- not run (workflow definition only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243e7666f883229e8a63091048c55d)