### PR TITLE
Fix website template rendering error

### DIFF
--- a/addons/ipai_portal_fix/__init__.py
+++ b/addons/ipai_portal_fix/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/addons/ipai_portal_fix/__manifest__.py
+++ b/addons/ipai_portal_fix/__manifest__.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'IPAI Portal Fix',
+    'version': '18.0.1.0.0',
+    'category': 'Technical',
+    'summary': 'Fixes KeyError: website in portal.frontend_layout template',
+    'description': """
+IPAI Portal Fix
+===============
+
+Fixes the KeyError: 'website' error in portal.frontend_layout template.
+
+This error occurs when the portal templates try to access the 'website'
+variable in the QWeb context, but it's not present. This can happen when:
+
+1. The website module is not installed
+2. A route doesn't have website=True set
+3. The context is cleared or corrupted
+
+This module fixes the issue by:
+1. Injecting a default 'website' context variable when missing
+2. Adding defensive checks in template overrides
+    """,
+    'author': 'InsightPulseAI',
+    'website': 'https://insightpulseai.net',
+    'license': 'AGPL-3',
+    'depends': [
+        'portal',
+    ],
+    'data': [
+        'views/portal_templates.xml',
+    ],
+    'installable': True,
+    'application': False,
+    'auto_install': True,  # Auto-install when portal is installed
+}

--- a/addons/ipai_portal_fix/models/__init__.py
+++ b/addons/ipai_portal_fix/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import ir_http
+from . import ir_qweb

--- a/addons/ipai_portal_fix/models/ir_http.py
+++ b/addons/ipai_portal_fix/models/ir_http.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""
+IR HTTP Extension for Portal Fix
+
+This module extends the ir.http model to inject a default 'website' context
+variable when rendering QWeb templates. This prevents KeyError: 'website'
+errors in portal.frontend_layout and other templates that expect this variable.
+"""
+
+from odoo import models
+from odoo.http import request
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @classmethod
+    def _get_default_website_context(cls):
+        """
+        Get a safe default website context value.
+
+        Returns the current website record if available, or an empty
+        recordset as a safe fallback that won't break template rendering.
+        """
+        if not request:
+            return None
+
+        try:
+            # Check if website module is installed and accessible
+            if 'website.website' in request.env.registry:
+                # Try to get the current website from the request
+                if hasattr(request, 'website') and request.website:
+                    return request.website
+                # Otherwise get the default website
+                Website = request.env['website.website'].sudo()
+                website = Website.get_current_website()
+                if website:
+                    return website
+                # Fallback to first website or empty recordset
+                return Website.search([], limit=1) or Website
+        except Exception:
+            pass
+
+        return None
+
+    @classmethod
+    def _get_website_context_fallback(cls):
+        """
+        Create a minimal mock website object for templates that expect one.
+
+        This returns a simple object with common website attributes set to
+        safe default values, preventing KeyError while allowing templates
+        to render.
+        """
+        class WebsiteFallback:
+            """Minimal mock website for template context fallback."""
+            id = False
+            name = ''
+            domain = ''
+            company_id = False
+            default_lang_id = False
+            language_ids = []
+
+            def __bool__(self):
+                return False
+
+            def __iter__(self):
+                return iter([])
+
+            def __len__(self):
+                return 0
+
+            @property
+            def sudo(self):
+                return lambda: self
+
+            def exists(self):
+                return False
+
+        return WebsiteFallback()

--- a/addons/ipai_portal_fix/models/ir_qweb.py
+++ b/addons/ipai_portal_fix/models/ir_qweb.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""
+IR QWeb Extension for Portal Fix
+
+This module extends the ir.qweb model to inject a default 'website' context
+variable when rendering QWeb templates. This prevents KeyError: 'website'
+errors in portal.frontend_layout and other templates that expect this variable.
+"""
+
+from odoo import models
+from odoo.http import request
+
+
+class IrQweb(models.AbstractModel):
+    _inherit = 'ir.qweb'
+
+    def _prepare_frontend_context(self, values):
+        """
+        Prepare the frontend context with a safe website fallback.
+
+        Ensures the 'website' key exists in the rendering context to prevent
+        KeyError exceptions in templates that expect this variable.
+        """
+        if values is None:
+            values = {}
+
+        # Only inject if 'website' key is missing
+        if 'website' not in values:
+            website = self._get_safe_website()
+            if website is not None:
+                values['website'] = website
+
+        # Also ensure main_object has a safe fallback
+        if 'main_object' not in values:
+            values['main_object'] = self.env['ir.ui.view']  # Empty recordset
+
+        # Ensure edit_in_backend has a default
+        if 'edit_in_backend' not in values:
+            values['edit_in_backend'] = False
+
+        return values
+
+    def _get_safe_website(self):
+        """
+        Get a safe website record for the context.
+
+        Returns:
+            - The current website if available
+            - The first website found
+            - An empty website recordset as fallback
+            - None if website module is not installed
+        """
+        try:
+            # Check if website module is installed
+            if 'website.website' not in self.env.registry:
+                return None
+
+            Website = self.env['website.website'].sudo()
+
+            # Try to get website from request
+            if request and hasattr(request, 'website') and request.website:
+                return request.website
+
+            # Try get_current_website method
+            if hasattr(Website, 'get_current_website'):
+                website = Website.get_current_website()
+                if website:
+                    return website
+
+            # Return first website or empty recordset
+            return Website.search([], limit=1) or Website
+
+        except Exception:
+            # If anything fails, return None (website module might not be ready)
+            return None
+
+    def _render(self, template, values=None, **options):
+        """
+        Override _render to inject website context before rendering.
+
+        This ensures that templates like portal.frontend_layout always have
+        access to the 'website' variable, preventing KeyError exceptions.
+        """
+        # Prepare context with website fallback
+        values = self._prepare_frontend_context(values or {})
+
+        return super()._render(template, values, **options)

--- a/addons/ipai_portal_fix/views/portal_templates.xml
+++ b/addons/ipai_portal_fix/views/portal_templates.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <!--
+        Portal Frontend Layout Fix
+
+        This template inherits from portal.frontend_layout and adds defensive
+        checks to prevent KeyError: 'website' errors when the website context
+        is missing.
+
+        The fix works by:
+        1. Setting a safe default for 'website' if not present
+        2. Wrapping website-dependent code in conditional checks
+    -->
+
+    <!-- Inject safe website default at the beginning of frontend_layout -->
+    <template id="portal_frontend_layout_fix"
+              inherit_id="portal.frontend_layout"
+              name="Portal Frontend Layout - Website Fix"
+              priority="1">
+
+        <!-- Add a safe website variable at the start of the template -->
+        <xpath expr="//t[@t-call='web.frontend_layout']" position="before">
+            <!--
+                Set a safe default for website variable if not present.
+                This prevents KeyError when templates try to access website.
+            -->
+            <t t-if="website is not defined or not website">
+                <t t-set="website" t-value="request.env['website.website'].sudo().search([], limit=1) if 'website.website' in request.env.registry else False"/>
+            </t>
+
+            <!-- Set safe default for main_object if not defined -->
+            <t t-if="main_object is not defined">
+                <t t-set="main_object" t-value="request.env['ir.ui.view']"/>
+            </t>
+
+            <!-- Set safe default for edit_in_backend if not defined -->
+            <t t-if="edit_in_backend is not defined">
+                <t t-set="edit_in_backend" t-value="False"/>
+            </t>
+
+            <!-- Set safe default for html_data if not defined -->
+            <t t-if="html_data is not defined">
+                <t t-set="html_data" t-value="{}"/>
+            </t>
+        </xpath>
+
+    </template>
+
+    <!--
+        Web Frontend Layout Fix
+
+        Similar fix for the base web.frontend_layout template which may also
+        try to access website-related variables.
+    -->
+    <template id="web_frontend_layout_fix"
+              inherit_id="web.frontend_layout"
+              name="Web Frontend Layout - Website Fix"
+              priority="1">
+
+        <xpath expr="//html" position="before">
+            <!-- Ensure website variable exists -->
+            <t t-if="website is not defined">
+                <t t-set="website" t-value="request.env['website.website'].sudo().search([], limit=1) if 'website.website' in request.env.registry else False"/>
+            </t>
+        </xpath>
+
+    </template>
+
+</odoo>


### PR DESCRIPTION
…tal templates

This module fixes the HTTP 500 error caused by KeyError: 'website' in the portal.frontend_layout QWeb template. The error occurs when templates try to access the 'website' variable but it's not present in the rendering context.

The fix includes:
- ir_qweb.py: Injects safe default website context before template rendering
- ir_http.py: Provides helper methods to get safe website fallback
- portal_templates.xml: Adds defensive checks in template inheritance

Root cause: Portal templates inherit from website layouts and expect a 'website' variable that may not be present when the website module isn't fully initialized or routes don't have website=True set.