### PR TITLE
feat(ipai_finance_ppm): add BIR deadline model with automated task ge…

### DIFF
--- a/addons/ipai_finance_ppm/__manifest__.py
+++ b/addons/ipai_finance_ppm/__manifest__.py
@@ -15,12 +15,14 @@
     "data": [
         "security/ir.model.access.csv",
         "views/finance_person_views.xml",
+        "views/finance_bir_deadline_views.xml",
         "views/finance_task_views.xml",
         "views/bir_schedule_views.xml",
         "views/ppm_dashboard_views.xml",
         "views/project_task_views.xml",
         "views/menus.xml",
         "data/bir_schedule_seed.xml",
+        "data/finance_cron.xml",
     ],
     "assets": {
         "web.assets_backend": [

--- a/addons/ipai_finance_ppm/data/finance_cron.xml
+++ b/addons/ipai_finance_ppm/data/finance_cron.xml
@@ -1,23 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <!-- Server Action for BIR Task Sync -->
-        <record id="ir_actions_server_sync_bir_tasks" model="ir.actions.server">
-            <field name="name">Finance PPM: Sync BIR Tasks</field>
-            <field name="model_id" ref="model_ipai_finance_bir_schedule"/>
+        <!-- Server Action for Daily Finance Task Generation -->
+        <record id="ir_actions_server_generate_finance_tasks" model="ir.actions.server">
+            <field name="name">Finance PPM: Generate Daily Tasks</field>
+            <field name="model_id" ref="model_ipai_finance_task_template"/>
             <field name="state">code</field>
-            <field name="code">model._cron_sync_bir_tasks()</field>
+            <field name="code">model.cron_generate_daily_finance_tasks()</field>
         </record>
 
-        <!-- Daily cron job to sync BIR tasks -->
-        <record id="ir_cron_sync_bir_tasks" model="ir.cron">
-            <field name="name">Finance PPM: Sync BIR Tasks</field>
-            <field name="ir_actions_server_id" ref="ir_actions_server_sync_bir_tasks"/>
+        <!-- Daily cron job to generate finance tasks -->
+        <record id="ir_cron_generate_finance_tasks" model="ir.cron">
+            <field name="name">Finance PPM: Generate Daily Tasks</field>
+            <field name="ir_actions_server_id" ref="ir_actions_server_generate_finance_tasks"/>
             <field name="user_id" ref="base.user_root"/>
             <field name="interval_number">1</field>
             <field name="interval_type">days</field>
             <field name="active">True</field>
-            <field name="nextcall">2025-11-24 08:00:00</field>
+            <field name="nextcall" eval="(DateTime.now() + timedelta(days=1)).strftime('%Y-%m-%d 08:00:00')"/>
+            <field name="numbercall">-1</field>
+            <field name="priority">10</field>
         </record>
     </data>
 </odoo>

--- a/addons/ipai_finance_ppm/models/__init__.py
+++ b/addons/ipai_finance_ppm/models/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from . import finance_person
 from . import finance_task
+from . import finance_bir_deadline
 from . import bir_schedule
 from . import ppm_dashboard

--- a/addons/ipai_finance_ppm/models/finance_bir_deadline.py
+++ b/addons/ipai_finance_ppm/models/finance_bir_deadline.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, api
+from datetime import timedelta
+
+
+class FinanceBIRDeadline(models.Model):
+    _name = 'finance.bir.deadline'
+    _description = 'BIR Tax Filing Deadline'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+    _order = 'deadline_date asc'
+    _rec_name = 'display_name'
+
+    name = fields.Char(string="BIR Form", required=True, tracking=True)
+    period_covered = fields.Char(string="Period Covered", tracking=True)
+    deadline_date = fields.Date(string="Filing Deadline", required=True, tracking=True)
+
+    # Descriptive info
+    description = fields.Text(string="Description")
+    form_type = fields.Selection([
+        ('monthly', 'Monthly'),
+        ('quarterly', 'Quarterly'),
+        ('annual', 'Annual'),
+        ('one_time', 'One-Time'),
+    ], string="Form Type", default='monthly')
+
+    # Process Targets (computed fields)
+    target_prep_date = fields.Date(
+        string="Target: Preparation",
+        compute="_compute_targets",
+        store=True,
+        help="4 business days before the BIR deadline"
+    )
+    target_report_approval_date = fields.Date(
+        string="Target: Report Approval",
+        compute="_compute_targets",
+        store=True,
+        help="2 business days before the BIR deadline"
+    )
+    target_payment_approval_date = fields.Date(
+        string="Target: Payment Approval",
+        compute="_compute_targets",
+        store=True,
+        help="1 business day before the BIR deadline"
+    )
+
+    # Responsibility assignments
+    responsible_prep_id = fields.Many2one('ipai.finance.person', string='Prep By')
+    responsible_review_id = fields.Many2one('ipai.finance.person', string='Review By')
+    responsible_approval_id = fields.Many2one('ipai.finance.person', string='Approve By')
+
+    # Status tracking
+    state = fields.Selection([
+        ('pending', 'Pending'),
+        ('in_progress', 'In Progress'),
+        ('submitted', 'Submitted'),
+        ('filed', 'Filed'),
+    ], string="Status", default='pending', tracking=True)
+
+    active = fields.Boolean(default=True)
+
+    display_name = fields.Char(compute='_compute_display_name', store=True)
+
+    @api.depends('name', 'period_covered')
+    def _compute_display_name(self):
+        for record in self:
+            if record.period_covered:
+                record.display_name = f"{record.name} - {record.period_covered}"
+            else:
+                record.display_name = record.name or ''
+
+    @api.depends('deadline_date')
+    def _compute_targets(self):
+        """Compute target dates based on the filing deadline.
+
+        - Preparation: 4 days before deadline
+        - Report Approval: 2 days before deadline
+        - Payment Approval: 1 day before deadline
+        """
+        for record in self:
+            if record.deadline_date:
+                record.target_prep_date = record.deadline_date - timedelta(days=4)
+                record.target_report_approval_date = record.deadline_date - timedelta(days=2)
+                record.target_payment_approval_date = record.deadline_date - timedelta(days=1)
+            else:
+                record.target_prep_date = False
+                record.target_report_approval_date = False
+                record.target_payment_approval_date = False
+
+    def action_mark_in_progress(self):
+        """Mark the deadline as in progress."""
+        self.write({'state': 'in_progress'})
+
+    def action_mark_submitted(self):
+        """Mark the deadline as submitted."""
+        self.write({'state': 'submitted'})
+
+    def action_mark_filed(self):
+        """Mark the deadline as filed."""
+        self.write({'state': 'filed'})
+
+    @api.model
+    def get_upcoming_deadlines(self, days=14):
+        """Get all deadlines due within the specified number of days."""
+        today = fields.Date.today()
+        end_date = today + timedelta(days=days)
+        return self.search([
+            ('deadline_date', '>=', today),
+            ('deadline_date', '<=', end_date),
+            ('state', 'not in', ['filed']),
+        ])

--- a/addons/ipai_finance_ppm/models/finance_task.py
+++ b/addons/ipai_finance_ppm/models/finance_task.py
@@ -1,18 +1,175 @@
 # -*- coding: utf-8 -*-
-from odoo import models, fields
+from odoo import models, fields, api
+from datetime import timedelta
+import logging
+
+_logger = logging.getLogger(__name__)
+
 
 class FinanceTaskTemplate(models.Model):
     _name = 'ipai.finance.task.template'
-    _description = 'Monthly Finance Task Template'
+    _description = 'Finance SSC Monthly Task Template'
     _inherit = ['mail.thread', 'mail.activity.mixin']
 
-    name = fields.Text(string='Task Description', required=True)
-    category = fields.Char(string='Category', help="e.g. Payables, Reporting")
-    
+    name = fields.Text(string='Task Description', required=True, tracking=True)
+
+    category = fields.Selection([
+        ('payroll', 'Payroll & Personnel'),
+        ('tax', 'Tax & Provisions'),
+        ('vat', 'VAT Data/Filing'),
+        ('liquidation', 'CA Liquidations'),
+        ('accrual', 'Accruals & Amortization'),
+        ('reporting', 'Regional Reporting'),
+        ('compliance', 'BIR Compliance'),
+        ('wip', 'WIP/OOP Reconciliation'),
+        ('close', 'Final Adjustments & Close'),
+    ], string="Category", required=True, tracking=True)
+
+    description = fields.Text(string="Detailed Description")
+
+    # Role Assignments
     employee_code_id = fields.Many2one('ipai.finance.person', string='Owner', tracking=True)
     reviewed_by_id = fields.Many2one('ipai.finance.person', string='Reviewer')
     approved_by_id = fields.Many2one('ipai.finance.person', string='Approver')
-    
+
+    # SLA Durations
     prep_duration = fields.Float(string='Prep SLA (Days)', default=1.0)
     review_duration = fields.Float(string='Review SLA (Days)', default=0.5)
     approval_duration = fields.Float(string='Approval SLA (Days)', default=0.5)
+
+    # Scheduling logic
+    day_of_month = fields.Integer(
+        string="Standard Day of Month",
+        help="e.g. 27 for the 27th of every month"
+    )
+    trigger_type = fields.Selection([
+        ('fixed_date', 'Fixed Date of Month'),
+        ('bir_dependency', 'Linked to BIR Deadline'),
+    ], string="Trigger Type", default='fixed_date', required=True)
+
+    bir_form_id = fields.Many2one(
+        'finance.bir.deadline',
+        string="Related BIR Form",
+        help="If trigger is BIR dependency, tasks are created based on this form's dates"
+    )
+
+    active = fields.Boolean(default=True)
+
+    @api.model
+    def cron_generate_daily_finance_tasks(self):
+        """
+        Run daily by Cron. Checks if any templates match 'today'
+        or upcoming BIR deadlines and generates Project Tasks.
+        """
+        today = fields.Date.today()
+        templates = self.search([('active', '=', True)])
+
+        # Get or Create the main Finance Project
+        Project = self.env['project.project']
+        project = Project.search([('name', '=', 'Finance SSC Operations')], limit=1)
+        if not project:
+            project = Project.create({
+                'name': 'Finance SSC Operations',
+                'description': 'Auto-generated project for Finance SSC tasks',
+            })
+            _logger.info("Created Finance SSC Operations project")
+
+        created_count = 0
+        for template in templates:
+            deadline = False
+
+            # Logic 1: Fixed Day of Month (e.g., 27th of every month)
+            if template.trigger_type == 'fixed_date' and template.day_of_month:
+                if today.day == template.day_of_month:
+                    # Due tomorrow by default
+                    deadline = today + timedelta(days=1)
+                    _logger.info(
+                        f"Template '{template.name}' triggered by fixed date "
+                        f"(day {template.day_of_month})"
+                    )
+
+            # Logic 2: BIR Dependency (e.g., 4 days before deadline)
+            elif template.trigger_type == 'bir_dependency' and template.bir_form_id:
+                bir_deadline = template.bir_form_id
+                # If today matches the target prep date
+                if bir_deadline.target_prep_date == today:
+                    deadline = bir_deadline.deadline_date
+                    _logger.info(
+                        f"Template '{template.name}' triggered by BIR form "
+                        f"'{bir_deadline.name}' prep date"
+                    )
+
+            # Create Task if triggered
+            if deadline:
+                self._create_finance_task(project, template, deadline)
+                created_count += 1
+
+        _logger.info(f"Finance task generation complete. Created {created_count} tasks.")
+        return created_count
+
+    def _create_finance_task(self, project, template, deadline):
+        """Create a project task from the template."""
+        Task = self.env['project.task']
+
+        # Find user based on employee code
+        user_ids = []
+        if template.employee_code_id and template.employee_code_id.user_id:
+            user_ids = [(4, template.employee_code_id.user_id.id)]
+
+        # Build task name with category prefix
+        category_label = dict(self._fields['category'].selection).get(
+            template.category, template.category
+        )
+        task_name = f"[{category_label}] {template.name}"
+
+        # Check if task already exists for today (avoid duplicates)
+        existing = Task.search([
+            ('project_id', '=', project.id),
+            ('name', '=', task_name),
+            ('date_deadline', '=', deadline),
+        ], limit=1)
+
+        if existing:
+            _logger.info(f"Task '{task_name}' already exists, skipping creation")
+            return existing
+
+        task_vals = {
+            'name': task_name,
+            'project_id': project.id,
+            'description': template.description or template.name,
+            'date_deadline': deadline,
+            'user_ids': user_ids,
+        }
+
+        task = Task.create(task_vals)
+        _logger.info(f"Created task: {task_name} (ID: {task.id})")
+        return task
+
+    @api.model
+    def generate_tasks_for_bir_deadline(self, bir_deadline_id):
+        """Manually generate tasks for a specific BIR deadline."""
+        bir_deadline = self.env['finance.bir.deadline'].browse(bir_deadline_id)
+        if not bir_deadline.exists():
+            return False
+
+        templates = self.search([
+            ('active', '=', True),
+            ('trigger_type', '=', 'bir_dependency'),
+            ('bir_form_id', '=', bir_deadline_id),
+        ])
+
+        Project = self.env['project.project']
+        project = Project.search([('name', '=', 'Finance SSC Operations')], limit=1)
+        if not project:
+            project = Project.create({
+                'name': 'Finance SSC Operations',
+                'description': 'Auto-generated project for Finance SSC tasks',
+            })
+
+        created_tasks = self.env['project.task']
+        for template in templates:
+            task = self._create_finance_task(project, template, bir_deadline.deadline_date)
+            if task:
+                created_tasks |= task
+
+        return created_tasks

--- a/addons/ipai_finance_ppm/security/ir.model.access.csv
+++ b/addons/ipai_finance_ppm/security/ir.model.access.csv
@@ -4,3 +4,4 @@ access_ipai_finance_task_template,ipai.finance.task.template,model_ipai_finance_
 access_ipai_bir_form_schedule,ipai.bir.form.schedule,model_ipai_bir_form_schedule,base.group_user,1,1,1,1
 access_ipai_bir_process_step,ipai.bir.process.step,model_ipai_bir_process_step,base.group_user,1,1,1,1
 access_finance_ppm_dashboard_user,access_finance_ppm_dashboard_user,model_finance_ppm_dashboard,account.group_account_user,1,0,0,0
+access_finance_bir_deadline,finance.bir.deadline,model_finance_bir_deadline,base.group_user,1,1,1,1

--- a/addons/ipai_finance_ppm/views/finance_bir_deadline_views.xml
+++ b/addons/ipai_finance_ppm/views/finance_bir_deadline_views.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Tree View -->
+    <record id="view_finance_bir_deadline_tree" model="ir.ui.view">
+        <field name="name">finance.bir.deadline.tree</field>
+        <field name="model">finance.bir.deadline</field>
+        <field name="arch" type="xml">
+            <list string="BIR Deadlines" decoration-danger="state == 'pending'" decoration-warning="state == 'in_progress'" decoration-success="state == 'filed'">
+                <field name="deadline_date" widget="remaining_days"/>
+                <field name="name"/>
+                <field name="period_covered"/>
+                <field name="form_type" optional="hide"/>
+                <field name="target_prep_date"/>
+                <field name="target_report_approval_date"/>
+                <field name="target_payment_approval_date"/>
+                <field name="state" widget="badge" decoration-danger="state == 'pending'" decoration-warning="state == 'in_progress'" decoration-info="state == 'submitted'" decoration-success="state == 'filed'"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Calendar View -->
+    <record id="view_finance_bir_deadline_calendar" model="ir.ui.view">
+        <field name="name">finance.bir.deadline.calendar</field>
+        <field name="model">finance.bir.deadline</field>
+        <field name="arch" type="xml">
+            <calendar string="BIR Deadline Calendar" date_start="deadline_date" color="form_type" mode="month">
+                <field name="name"/>
+                <field name="period_covered"/>
+                <field name="state"/>
+            </calendar>
+        </field>
+    </record>
+
+    <!-- Form View -->
+    <record id="view_finance_bir_deadline_form" model="ir.ui.view">
+        <field name="name">finance.bir.deadline.form</field>
+        <field name="model">finance.bir.deadline</field>
+        <field name="arch" type="xml">
+            <form string="BIR Deadline">
+                <header>
+                    <button name="action_mark_in_progress" type="object" string="Start Processing" class="oe_highlight" invisible="state != 'pending'"/>
+                    <button name="action_mark_submitted" type="object" string="Mark Submitted" class="oe_highlight" invisible="state != 'in_progress'"/>
+                    <button name="action_mark_filed" type="object" string="Mark Filed" class="oe_highlight" invisible="state != 'submitted'"/>
+                    <field name="state" widget="statusbar" statusbar_visible="pending,in_progress,submitted,filed"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="BIR Form (e.g. 2550M)"/>
+                        </h1>
+                    </div>
+                    <group>
+                        <group string="Basic Information">
+                            <field name="period_covered" placeholder="e.g. October 2025"/>
+                            <field name="form_type"/>
+                            <field name="deadline_date"/>
+                        </group>
+                        <group string="Computed Target Dates">
+                            <field name="target_prep_date"/>
+                            <field name="target_report_approval_date"/>
+                            <field name="target_payment_approval_date"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group string="Responsibility">
+                            <field name="responsible_prep_id"/>
+                            <field name="responsible_review_id"/>
+                            <field name="responsible_approval_id"/>
+                        </group>
+                        <group string="Settings">
+                            <field name="active"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Description">
+                            <field name="description" placeholder="Additional notes about this BIR form..."/>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Search View -->
+    <record id="view_finance_bir_deadline_search" model="ir.ui.view">
+        <field name="name">finance.bir.deadline.search</field>
+        <field name="model">finance.bir.deadline</field>
+        <field name="arch" type="xml">
+            <search string="Search BIR Deadlines">
+                <field name="name"/>
+                <field name="period_covered"/>
+                <filter string="Pending" name="pending" domain="[('state', '=', 'pending')]"/>
+                <filter string="In Progress" name="in_progress" domain="[('state', '=', 'in_progress')]"/>
+                <filter string="Filed" name="filed" domain="[('state', '=', 'filed')]"/>
+                <separator/>
+                <filter string="Monthly" name="monthly" domain="[('form_type', '=', 'monthly')]"/>
+                <filter string="Quarterly" name="quarterly" domain="[('form_type', '=', 'quarterly')]"/>
+                <filter string="Annual" name="annual" domain="[('form_type', '=', 'annual')]"/>
+                <separator/>
+                <filter string="Upcoming (14 days)" name="upcoming" domain="[('deadline_date', '>=', context_today().strftime('%Y-%m-%d')), ('deadline_date', '&lt;=', (context_today() + datetime.timedelta(days=14)).strftime('%Y-%m-%d'))]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Form Type" name="group_form_type" context="{'group_by': 'form_type'}"/>
+                    <filter string="Status" name="group_state" context="{'group_by': 'state'}"/>
+                    <filter string="Deadline Month" name="group_deadline" context="{'group_by': 'deadline_date:month'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Kanban View -->
+    <record id="view_finance_bir_deadline_kanban" model="ir.ui.view">
+        <field name="name">finance.bir.deadline.kanban</field>
+        <field name="model">finance.bir.deadline</field>
+        <field name="arch" type="xml">
+            <kanban default_group_by="state" class="o_kanban_small_column">
+                <field name="name"/>
+                <field name="period_covered"/>
+                <field name="deadline_date"/>
+                <field name="state"/>
+                <templates>
+                    <t t-name="card">
+                        <field name="name" class="fw-bold"/>
+                        <div class="text-muted small">
+                            <field name="period_covered"/>
+                        </div>
+                        <div class="mt-2">
+                            <field name="deadline_date" widget="remaining_days"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <!-- Action -->
+    <record id="action_finance_bir_deadline" model="ir.actions.act_window">
+        <field name="name">BIR Deadlines</field>
+        <field name="res_model">finance.bir.deadline</field>
+        <field name="view_mode">list,calendar,kanban,form</field>
+        <field name="context">{'search_default_pending': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first BIR deadline
+            </p>
+            <p>
+                Track BIR filing deadlines with automatic computation of preparation,
+                review, and approval target dates.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/ipai_finance_ppm/views/finance_task_views.xml
+++ b/addons/ipai_finance_ppm/views/finance_task_views.xml
@@ -1,53 +1,110 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <!-- Tree View -->
     <record id="view_finance_task_template_tree" model="ir.ui.view">
         <field name="name">ipai.finance.task.template.tree</field>
         <field name="model">ipai.finance.task.template</field>
         <field name="arch" type="xml">
             <list string="Monthly Tasks">
-                <field name="category"/>
+                <field name="category" widget="badge"/>
                 <field name="name"/>
+                <field name="trigger_type"/>
+                <field name="day_of_month" invisible="trigger_type != 'fixed_date'"/>
+                <field name="bir_form_id" invisible="trigger_type != 'bir_dependency'"/>
                 <field name="employee_code_id" widget="many2one_avatar"/>
                 <field name="reviewed_by_id" widget="many2one_avatar"/>
                 <field name="approved_by_id" widget="many2one_avatar"/>
-                <field name="prep_duration" optional="hide"/>
+                <field name="active" optional="hide"/>
             </list>
         </field>
     </record>
 
+    <!-- Form View -->
     <record id="view_finance_task_template_form" model="ir.ui.view">
         <field name="name">ipai.finance.task.template.form</field>
         <field name="model">ipai.finance.task.template</field>
         <field name="arch" type="xml">
             <form string="Task Template">
                 <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="%(action_finance_bir_deadline)d" type="action"
+                                class="oe_stat_button" icon="fa-calendar"
+                                invisible="trigger_type != 'bir_dependency'">
+                            <span class="o_stat_text">View BIR Deadline</span>
+                        </button>
+                    </div>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <group>
-                        <group>
+                        <group string="Task Details">
                             <field name="category"/>
-                            <field name="employee_code_id"/>
+                            <field name="active" invisible="1"/>
                         </group>
-                        <group>
+                        <group string="Responsibility">
+                            <field name="employee_code_id"/>
                             <field name="reviewed_by_id"/>
                             <field name="approved_by_id"/>
                         </group>
                     </group>
-                    <group string="SLA (Days)">
-                        <group>
+                    <group>
+                        <group string="Scheduling">
+                            <field name="trigger_type" widget="radio"/>
+                            <field name="day_of_month" invisible="trigger_type != 'fixed_date'"/>
+                            <field name="bir_form_id" invisible="trigger_type != 'bir_dependency'"/>
+                        </group>
+                        <group string="SLA (Days)">
                             <field name="prep_duration"/>
                             <field name="review_duration"/>
                             <field name="approval_duration"/>
                         </group>
                     </group>
-                    <field name="name" placeholder="Task Description..."/>
+                    <separator string="Task Description"/>
+                    <field name="name" placeholder="Task Description (required)..."/>
+                    <separator string="Detailed Description"/>
+                    <field name="description" placeholder="Optional detailed description for the task..."/>
                 </sheet>
                 <chatter/>
             </form>
         </field>
     </record>
 
+    <!-- Search View -->
+    <record id="view_finance_task_template_search" model="ir.ui.view">
+        <field name="name">ipai.finance.task.template.search</field>
+        <field name="model">ipai.finance.task.template</field>
+        <field name="arch" type="xml">
+            <search string="Search Task Templates">
+                <field name="name"/>
+                <field name="category"/>
+                <field name="employee_code_id"/>
+                <separator/>
+                <filter string="Fixed Date" name="fixed_date" domain="[('trigger_type', '=', 'fixed_date')]"/>
+                <filter string="BIR Dependency" name="bir_dependency" domain="[('trigger_type', '=', 'bir_dependency')]"/>
+                <separator/>
+                <filter string="Active" name="active" domain="[('active', '=', True)]"/>
+                <filter string="Archived" name="archived" domain="[('active', '=', False)]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Category" name="group_category" context="{'group_by': 'category'}"/>
+                    <filter string="Trigger Type" name="group_trigger" context="{'group_by': 'trigger_type'}"/>
+                    <filter string="Owner" name="group_owner" context="{'group_by': 'employee_code_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Action -->
     <record id="action_finance_task_template" model="ir.actions.act_window">
-        <field name="name">Monthly Tasks (PPM)</field>
+        <field name="name">Task Templates (PPM)</field>
         <field name="res_model">ipai.finance.task.template</field>
         <field name="view_mode">list,form</field>
+        <field name="context">{'search_default_active': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first task template
+            </p>
+            <p>
+                Task templates define recurring finance tasks that can be triggered
+                either on a fixed day of month or linked to BIR deadlines.
+            </p>
+        </field>
     </record>
 </odoo>

--- a/addons/ipai_finance_ppm/views/menus.xml
+++ b/addons/ipai_finance_ppm/views/menus.xml
@@ -3,7 +3,8 @@
     <!-- Root menu now defined in ppm_dashboard_views.xml to avoid loading order issues -->
 
     <menuitem id="menu_finance_directory" name="Directory" parent="menu_finance_ppm_root" action="action_finance_person" sequence="10"/>
-    <menuitem id="menu_finance_tasks" name="Monthly Tasks" parent="menu_finance_ppm_root" action="action_finance_task_template" sequence="20"/>
+    <menuitem id="menu_finance_tasks" name="Task Templates" parent="menu_finance_ppm_root" action="action_finance_task_template" sequence="20"/>
+    <menuitem id="menu_finance_bir_deadlines" name="BIR Deadlines" parent="menu_finance_ppm_root" action="action_finance_bir_deadline" sequence="25"/>
     <menuitem id="menu_finance_calendar" name="Compliance Calendar" parent="menu_finance_ppm_root" action="action_bir_form_schedule" sequence="30"/>
 
     <!-- Semantic Search Action (Client Action) -->


### PR DESCRIPTION
…neration

- Add finance.bir.deadline model with computed target dates:
  - target_prep_date (4 days before deadline)
  - target_report_approval_date (2 days before)
  - target_payment_approval_date (1 day before)
- Enhance finance.task.template with:
  - Category selection (payroll, tax, vat, liquidation, etc.)
  - Trigger types (fixed_date or bir_dependency)
  - Cron method for automatic task generation
- Add views for BIR deadline (list, calendar, kanban, form)
- Update cron job to generate daily finance tasks
- Add security rules for new model
- Add menu entry for BIR Deadlines