### PR TITLE
Create Odoo 18 industry pack data model

### DIFF
--- a/addons/ipai_accounting_firm_pack/__init__.py
+++ b/addons/ipai_accounting_firm_pack/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/addons/ipai_accounting_firm_pack/__manifest__.py
+++ b/addons/ipai_accounting_firm_pack/__manifest__.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "IPAI Accounting Firm Pack",
+    "summary": "Accounting Firm industry pack for engagements, compliance, and workpapers.",
+    "version": "18.0.1.0.0",
+    "category": "Accounting/Services",
+    "author": "InsightPulseAI",
+    "website": "https://insightpulseai.net",
+    "license": "AGPL-3",
+    "depends": [
+        "base",
+        "mail",
+        "account",
+        "project",
+        "hr_timesheet",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/engagement_views.xml",
+        "views/compliance_views.xml",
+        "views/workpaper_views.xml",
+        "views/menus.xml",
+        "data/engagement_data.xml",
+    ],
+    "installable": True,
+    "application": True,
+    "auto_install": False,
+}

--- a/addons/ipai_accounting_firm_pack/data/engagement_data.xml
+++ b/addons/ipai_accounting_firm_pack/data/engagement_data.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <!-- This file can be used to seed sample engagement types or templates -->
+    <!-- For now, we leave it minimal to avoid data dependencies -->
+</odoo>

--- a/addons/ipai_accounting_firm_pack/models/__init__.py
+++ b/addons/ipai_accounting_firm_pack/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from . import (
+    engagement,
+    compliance,
+    workpaper,
+)

--- a/addons/ipai_accounting_firm_pack/models/compliance.py
+++ b/addons/ipai_accounting_firm_pack/models/compliance.py
@@ -1,0 +1,242 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models, _
+
+
+class ComplianceTask(models.Model):
+    """Compliance task for tracking deadlines and requirements."""
+    _name = "ipai.compliance.task"
+    _description = "IPAI Compliance Task"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "due_date, priority desc"
+
+    name = fields.Char(string="Task Name", required=True, tracking=True)
+
+    engagement_id = fields.Many2one(
+        "ipai.engagement",
+        string="Engagement",
+        required=True,
+        tracking=True,
+        ondelete="cascade",
+    )
+
+    partner_id = fields.Many2one(
+        "res.partner",
+        string="Client",
+        related="engagement_id.partner_id",
+        store=True,
+    )
+
+    task_type = fields.Selection([
+        ("tax_filing", "Tax Filing"),
+        ("annual_report", "Annual Report"),
+        ("quarterly_report", "Quarterly Report"),
+        ("monthly_close", "Monthly Close"),
+        ("audit_procedure", "Audit Procedure"),
+        ("client_request", "Client Request"),
+        ("internal", "Internal Task"),
+        ("regulatory", "Regulatory Requirement"),
+        ("other", "Other"),
+    ], string="Task Type", required=True, tracking=True)
+
+    due_date = fields.Date(string="Due Date", required=True, tracking=True)
+    completion_date = fields.Date(string="Completion Date")
+
+    priority = fields.Selection([
+        ("0", "Low"),
+        ("1", "Normal"),
+        ("2", "High"),
+        ("3", "Urgent"),
+    ], string="Priority", default="1", tracking=True)
+
+    state = fields.Selection([
+        ("todo", "To Do"),
+        ("in_progress", "In Progress"),
+        ("blocked", "Blocked"),
+        ("done", "Done"),
+        ("cancelled", "Cancelled"),
+    ], string="Status", default="todo", tracking=True)
+
+    assigned_id = fields.Many2one(
+        "res.users",
+        string="Assigned To",
+        tracking=True,
+    )
+
+    reviewer_id = fields.Many2one(
+        "res.users",
+        string="Reviewer",
+    )
+
+    description = fields.Text(string="Description")
+    notes = fields.Text(string="Notes")
+
+    # Color for kanban
+    color = fields.Integer(string="Color Index")
+
+    # Days until due (for filtering)
+    days_until_due = fields.Integer(
+        string="Days Until Due",
+        compute="_compute_days_until_due",
+        store=True,
+    )
+
+    is_overdue = fields.Boolean(
+        string="Overdue",
+        compute="_compute_days_until_due",
+        store=True,
+    )
+
+    @api.depends("due_date", "state")
+    def _compute_days_until_due(self):
+        today = fields.Date.today()
+        for task in self:
+            if task.due_date:
+                delta = (task.due_date - today).days
+                task.days_until_due = delta
+                task.is_overdue = delta < 0 and task.state not in ("done", "cancelled")
+            else:
+                task.days_until_due = 0
+                task.is_overdue = False
+
+    def action_start(self):
+        self.write({"state": "in_progress"})
+
+    def action_block(self):
+        self.write({"state": "blocked"})
+
+    def action_done(self):
+        self.write({
+            "state": "done",
+            "completion_date": fields.Date.today(),
+        })
+
+    def action_cancel(self):
+        self.write({"state": "cancelled"})
+
+    def action_reset(self):
+        self.write({"state": "todo", "completion_date": False})
+
+
+class DocumentRequest(models.Model):
+    """Document request for client document collection."""
+    _name = "ipai.document.request"
+    _description = "IPAI Document Request"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "client_upload_deadline, create_date desc"
+
+    name = fields.Char(
+        string="Request Reference",
+        default=lambda self: _("New"),
+        readonly=True,
+        copy=False,
+    )
+
+    engagement_id = fields.Many2one(
+        "ipai.engagement",
+        string="Engagement",
+        required=True,
+        tracking=True,
+        ondelete="cascade",
+    )
+
+    partner_id = fields.Many2one(
+        "res.partner",
+        string="Client",
+        related="engagement_id.partner_id",
+        store=True,
+    )
+
+    state = fields.Selection([
+        ("draft", "Draft"),
+        ("sent", "Sent to Client"),
+        ("partial", "Partially Received"),
+        ("received", "Fully Received"),
+        ("cancelled", "Cancelled"),
+    ], string="Status", default="draft", tracking=True)
+
+    request_list = fields.Text(
+        string="Document Request List (JSON)",
+        help="JSON array of requested documents with status",
+        default='[]',
+    )
+
+    request_description = fields.Html(
+        string="Request Description",
+        help="Human-readable description of requested documents",
+    )
+
+    client_upload_deadline = fields.Date(
+        string="Client Upload Deadline",
+        required=True,
+        tracking=True,
+    )
+
+    sent_date = fields.Date(string="Sent Date")
+    received_date = fields.Date(string="Received Date")
+
+    # Link to DMS if available (placeholder for OCA DMS integration)
+    dms_directory_id = fields.Integer(
+        string="DMS Directory ID",
+        help="Reference to DMS directory for uploads",
+    )
+
+    notes = fields.Text(string="Notes")
+
+    # Attachment count
+    attachment_count = fields.Integer(
+        string="Attachments",
+        compute="_compute_attachment_count",
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get("name", _("New")) == _("New"):
+                vals["name"] = self.env["ir.sequence"].next_by_code(
+                    "ipai.document.request"
+                ) or _("New")
+        return super().create(vals_list)
+
+    def _compute_attachment_count(self):
+        Attachment = self.env["ir.attachment"]
+        for request in self:
+            request.attachment_count = Attachment.search_count([
+                ("res_model", "=", self._name),
+                ("res_id", "=", request.id),
+            ])
+
+    def action_send(self):
+        self.write({
+            "state": "sent",
+            "sent_date": fields.Date.today(),
+        })
+
+    def action_mark_partial(self):
+        self.write({"state": "partial"})
+
+    def action_mark_received(self):
+        self.write({
+            "state": "received",
+            "received_date": fields.Date.today(),
+        })
+
+    def action_cancel(self):
+        self.write({"state": "cancelled"})
+
+    def action_view_attachments(self):
+        """View attachments for this request."""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Attachments"),
+            "res_model": "ir.attachment",
+            "view_mode": "kanban,list,form",
+            "domain": [
+                ("res_model", "=", self._name),
+                ("res_id", "=", self.id),
+            ],
+            "context": {
+                "default_res_model": self._name,
+                "default_res_id": self.id,
+            },
+        }

--- a/addons/ipai_accounting_firm_pack/models/engagement.py
+++ b/addons/ipai_accounting_firm_pack/models/engagement.py
@@ -1,0 +1,291 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class Engagement(models.Model):
+    """Client engagement for accounting services."""
+    _name = "ipai.engagement"
+    _description = "IPAI Accounting Engagement"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "fiscal_year desc, partner_id"
+
+    name = fields.Char(
+        string="Engagement Reference",
+        default=lambda self: _("New"),
+        readonly=True,
+        copy=False,
+    )
+
+    partner_id = fields.Many2one(
+        "res.partner",
+        string="Client",
+        required=True,
+        tracking=True,
+        domain="[('is_company', '=', True)]",
+    )
+
+    engagement_type = fields.Selection([
+        ("bookkeeping", "Bookkeeping"),
+        ("tax_prep", "Tax Preparation"),
+        ("tax_planning", "Tax Planning"),
+        ("audit", "Audit"),
+        ("review", "Review"),
+        ("compilation", "Compilation"),
+        ("advisory", "Advisory/Consulting"),
+        ("payroll", "Payroll Services"),
+        ("forensic", "Forensic Accounting"),
+    ], string="Engagement Type", required=True, tracking=True)
+
+    fiscal_year = fields.Char(
+        string="Fiscal Year",
+        required=True,
+        tracking=True,
+        help="e.g., 2024, FY2024, CY2024",
+    )
+
+    fiscal_year_start = fields.Date(string="Fiscal Year Start")
+    fiscal_year_end = fields.Date(string="Fiscal Year End")
+
+    state = fields.Selection([
+        ("draft", "Draft"),
+        ("planning", "Planning"),
+        ("fieldwork", "Fieldwork"),
+        ("review", "Review"),
+        ("reporting", "Reporting"),
+        ("completed", "Completed"),
+        ("cancelled", "Cancelled"),
+    ], string="Status", default="draft", tracking=True)
+
+    billing_mode = fields.Selection([
+        ("fixed", "Fixed Fee"),
+        ("hourly", "Hourly"),
+        ("retainer", "Retainer"),
+        ("value", "Value-Based"),
+    ], string="Billing Mode", default="hourly", tracking=True)
+
+    estimated_fee = fields.Monetary(
+        string="Estimated Fee",
+        currency_field="currency_id",
+        tracking=True,
+    )
+
+    actual_fee = fields.Monetary(
+        string="Actual Fee",
+        currency_field="currency_id",
+        compute="_compute_actual_fee",
+        store=True,
+    )
+
+    currency_id = fields.Many2one(
+        "res.currency",
+        string="Currency",
+        default=lambda self: self.env.company.currency_id,
+    )
+
+    project_id = fields.Many2one(
+        "project.project",
+        string="Delivery Project",
+        tracking=True,
+    )
+
+    manager_id = fields.Many2one(
+        "res.users",
+        string="Engagement Manager",
+        tracking=True,
+    )
+
+    partner_in_charge_id = fields.Many2one(
+        "res.users",
+        string="Partner in Charge",
+        tracking=True,
+    )
+
+    # Related records
+    period_ids = fields.One2many(
+        "ipai.engagement.period",
+        "engagement_id",
+        string="Periods",
+    )
+
+    compliance_task_ids = fields.One2many(
+        "ipai.compliance.task",
+        "engagement_id",
+        string="Compliance Tasks",
+    )
+
+    document_request_ids = fields.One2many(
+        "ipai.document.request",
+        "engagement_id",
+        string="Document Requests",
+    )
+
+    workpaper_ids = fields.One2many(
+        "ipai.workpaper",
+        "engagement_id",
+        string="Workpapers",
+    )
+
+    description = fields.Html(string="Description")
+    notes = fields.Text(string="Internal Notes")
+
+    # Computed fields
+    period_count = fields.Integer(compute="_compute_counts", store=True)
+    compliance_count = fields.Integer(compute="_compute_counts", store=True)
+    document_request_count = fields.Integer(compute="_compute_counts", store=True)
+    workpaper_count = fields.Integer(compute="_compute_counts", store=True)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get("name", _("New")) == _("New"):
+                vals["name"] = self.env["ir.sequence"].next_by_code(
+                    "ipai.engagement"
+                ) or _("New")
+        return super().create(vals_list)
+
+    @api.depends("period_ids", "compliance_task_ids", "document_request_ids", "workpaper_ids")
+    def _compute_counts(self):
+        for engagement in self:
+            engagement.period_count = len(engagement.period_ids)
+            engagement.compliance_count = len(engagement.compliance_task_ids)
+            engagement.document_request_count = len(engagement.document_request_ids)
+            engagement.workpaper_count = len(engagement.workpaper_ids)
+
+    @api.depends("workpaper_ids.billable_hours")
+    def _compute_actual_fee(self):
+        for engagement in self:
+            # This is a simplified calculation - can be extended
+            # to pull from timesheets or invoices
+            engagement.actual_fee = sum(
+                engagement.workpaper_ids.mapped("billable_hours")
+            ) * 150  # Default rate
+
+    @api.constrains("fiscal_year_start", "fiscal_year_end")
+    def _check_fiscal_dates(self):
+        for engagement in self:
+            if engagement.fiscal_year_start and engagement.fiscal_year_end:
+                if engagement.fiscal_year_end < engagement.fiscal_year_start:
+                    raise ValidationError(
+                        _("Fiscal year end must be after fiscal year start.")
+                    )
+
+    def action_start_planning(self):
+        self.write({"state": "planning"})
+
+    def action_start_fieldwork(self):
+        self.write({"state": "fieldwork"})
+
+    def action_start_review(self):
+        self.write({"state": "review"})
+
+    def action_start_reporting(self):
+        self.write({"state": "reporting"})
+
+    def action_complete(self):
+        self.write({"state": "completed"})
+
+    def action_cancel(self):
+        self.write({"state": "cancelled"})
+
+    def action_view_workpapers(self):
+        """Open workpapers for this engagement."""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Workpapers"),
+            "res_model": "ipai.workpaper",
+            "view_mode": "list,form",
+            "domain": [("engagement_id", "=", self.id)],
+            "context": {"default_engagement_id": self.id},
+        }
+
+    def action_view_compliance(self):
+        """Open compliance tasks for this engagement."""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Compliance Tasks"),
+            "res_model": "ipai.compliance.task",
+            "view_mode": "list,form,kanban",
+            "domain": [("engagement_id", "=", self.id)],
+            "context": {"default_engagement_id": self.id},
+        }
+
+    def action_view_document_requests(self):
+        """Open document requests for this engagement."""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Document Requests"),
+            "res_model": "ipai.document.request",
+            "view_mode": "list,form",
+            "domain": [("engagement_id", "=", self.id)],
+            "context": {"default_engagement_id": self.id},
+        }
+
+
+class EngagementPeriod(models.Model):
+    """Engagement periods for tracking work across time."""
+    _name = "ipai.engagement.period"
+    _description = "IPAI Engagement Period"
+    _order = "period_start"
+
+    engagement_id = fields.Many2one(
+        "ipai.engagement",
+        string="Engagement",
+        required=True,
+        ondelete="cascade",
+    )
+
+    name = fields.Char(
+        string="Period Name",
+        compute="_compute_name",
+        store=True,
+    )
+
+    period_start = fields.Date(string="Period Start", required=True)
+    period_end = fields.Date(string="Period End", required=True)
+
+    close_status = fields.Selection([
+        ("open", "Open"),
+        ("in_progress", "In Progress"),
+        ("pending_review", "Pending Review"),
+        ("closed", "Closed"),
+    ], string="Close Status", default="open")
+
+    reviewer_id = fields.Many2one(
+        "res.users",
+        string="Reviewer",
+    )
+
+    review_date = fields.Date(string="Review Date")
+    close_date = fields.Date(string="Close Date")
+
+    notes = fields.Text(string="Notes")
+
+    @api.depends("period_start", "period_end")
+    def _compute_name(self):
+        for period in self:
+            if period.period_start and period.period_end:
+                period.name = f"{period.period_start.strftime('%b %Y')} - {period.period_end.strftime('%b %Y')}"
+            else:
+                period.name = "New Period"
+
+    @api.constrains("period_start", "period_end")
+    def _check_dates(self):
+        for period in self:
+            if period.period_end < period.period_start:
+                raise ValidationError(_("Period end must be after period start."))
+
+    def action_start_work(self):
+        self.write({"close_status": "in_progress"})
+
+    def action_submit_review(self):
+        self.write({"close_status": "pending_review"})
+
+    def action_close(self):
+        self.write({
+            "close_status": "closed",
+            "close_date": fields.Date.today(),
+        })

--- a/addons/ipai_accounting_firm_pack/models/workpaper.py
+++ b/addons/ipai_accounting_firm_pack/models/workpaper.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models, _
+
+
+class Workpaper(models.Model):
+    """Workpaper for accounting engagement documentation."""
+    _name = "ipai.workpaper"
+    _description = "IPAI Workpaper"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "engagement_id, sequence, name"
+
+    name = fields.Char(string="Workpaper Name", required=True, tracking=True)
+    reference = fields.Char(string="Reference Code", tracking=True)
+    sequence = fields.Integer(string="Sequence", default=10)
+
+    engagement_id = fields.Many2one(
+        "ipai.engagement",
+        string="Engagement",
+        required=True,
+        tracking=True,
+        ondelete="cascade",
+    )
+
+    partner_id = fields.Many2one(
+        "res.partner",
+        string="Client",
+        related="engagement_id.partner_id",
+        store=True,
+    )
+
+    workpaper_type = fields.Selection([
+        ("trial_balance", "Trial Balance"),
+        ("lead_schedule", "Lead Schedule"),
+        ("supporting_schedule", "Supporting Schedule"),
+        ("reconciliation", "Reconciliation"),
+        ("analytical_review", "Analytical Review"),
+        ("testing", "Testing Documentation"),
+        ("memo", "Memo"),
+        ("correspondence", "Correspondence"),
+        ("checklist", "Checklist"),
+        ("other", "Other"),
+    ], string="Workpaper Type", required=True, tracking=True)
+
+    account_area = fields.Selection([
+        ("cash", "Cash & Bank"),
+        ("receivables", "Accounts Receivable"),
+        ("inventory", "Inventory"),
+        ("fixed_assets", "Fixed Assets"),
+        ("payables", "Accounts Payable"),
+        ("accruals", "Accruals"),
+        ("debt", "Debt"),
+        ("equity", "Equity"),
+        ("revenue", "Revenue"),
+        ("expenses", "Expenses"),
+        ("payroll", "Payroll"),
+        ("tax", "Tax"),
+        ("general", "General"),
+    ], string="Account Area", default="general")
+
+    signoff_state = fields.Selection([
+        ("draft", "Draft"),
+        ("prepared", "Prepared"),
+        ("reviewed", "Reviewed"),
+        ("approved", "Approved"),
+    ], string="Signoff Status", default="draft", tracking=True)
+
+    prepared_by_id = fields.Many2one(
+        "res.users",
+        string="Prepared By",
+        tracking=True,
+    )
+
+    prepared_date = fields.Date(string="Prepared Date")
+
+    reviewed_by_id = fields.Many2one(
+        "res.users",
+        string="Reviewed By",
+        tracking=True,
+    )
+
+    review_date = fields.Date(string="Review Date")
+
+    approved_by_id = fields.Many2one(
+        "res.users",
+        string="Approved By",
+        tracking=True,
+    )
+
+    approval_date = fields.Date(string="Approval Date")
+
+    # File storage
+    file = fields.Binary(string="Workpaper File", attachment=True)
+    file_name = fields.Char(string="File Name")
+
+    # Link to DMS if available
+    dms_file_id = fields.Integer(
+        string="DMS File ID",
+        help="Reference to DMS file",
+    )
+
+    # Time tracking
+    billable_hours = fields.Float(
+        string="Billable Hours",
+        tracking=True,
+    )
+
+    description = fields.Html(string="Description/Scope")
+    conclusion = fields.Text(string="Conclusion")
+    notes = fields.Text(string="Internal Notes")
+
+    # Review notes
+    review_notes = fields.Text(string="Review Notes")
+
+    def action_mark_prepared(self):
+        self.write({
+            "signoff_state": "prepared",
+            "prepared_by_id": self.env.user.id,
+            "prepared_date": fields.Date.today(),
+        })
+
+    def action_mark_reviewed(self):
+        self.write({
+            "signoff_state": "reviewed",
+            "reviewed_by_id": self.env.user.id,
+            "review_date": fields.Date.today(),
+        })
+
+    def action_approve(self):
+        self.write({
+            "signoff_state": "approved",
+            "approved_by_id": self.env.user.id,
+            "approval_date": fields.Date.today(),
+        })
+
+    def action_reset_draft(self):
+        self.write({
+            "signoff_state": "draft",
+            "prepared_by_id": False,
+            "prepared_date": False,
+            "reviewed_by_id": False,
+            "review_date": False,
+            "approved_by_id": False,
+            "approval_date": False,
+        })
+
+    _sql_constraints = [
+        ("engagement_reference_uniq", "unique(engagement_id, reference)",
+         "Workpaper reference must be unique within an engagement!"),
+    ]

--- a/addons/ipai_accounting_firm_pack/security/ir.model.access.csv
+++ b/addons/ipai_accounting_firm_pack/security/ir.model.access.csv
@@ -1,0 +1,11 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_ipai_engagement_user,ipai.engagement.user,model_ipai_engagement,account.group_account_user,1,1,1,0
+access_ipai_engagement_manager,ipai.engagement.manager,model_ipai_engagement,account.group_account_manager,1,1,1,1
+access_ipai_engagement_period_user,ipai.engagement.period.user,model_ipai_engagement_period,account.group_account_user,1,1,1,0
+access_ipai_engagement_period_manager,ipai.engagement.period.manager,model_ipai_engagement_period,account.group_account_manager,1,1,1,1
+access_ipai_compliance_task_user,ipai.compliance.task.user,model_ipai_compliance_task,account.group_account_user,1,1,1,0
+access_ipai_compliance_task_manager,ipai.compliance.task.manager,model_ipai_compliance_task,account.group_account_manager,1,1,1,1
+access_ipai_document_request_user,ipai.document.request.user,model_ipai_document_request,account.group_account_user,1,1,1,0
+access_ipai_document_request_manager,ipai.document.request.manager,model_ipai_document_request,account.group_account_manager,1,1,1,1
+access_ipai_workpaper_user,ipai.workpaper.user,model_ipai_workpaper,account.group_account_user,1,1,1,0
+access_ipai_workpaper_manager,ipai.workpaper.manager,model_ipai_workpaper,account.group_account_manager,1,1,1,1

--- a/addons/ipai_accounting_firm_pack/views/compliance_views.xml
+++ b/addons/ipai_accounting_firm_pack/views/compliance_views.xml
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Compliance Task Tree View -->
+    <record id="view_compliance_task_tree" model="ir.ui.view">
+        <field name="name">ipai.compliance.task.tree</field>
+        <field name="model">ipai.compliance.task</field>
+        <field name="arch" type="xml">
+            <list string="Compliance Tasks" decoration-danger="is_overdue" decoration-muted="state in ('done', 'cancelled')">
+                <field name="name"/>
+                <field name="engagement_id"/>
+                <field name="partner_id"/>
+                <field name="task_type" widget="badge"/>
+                <field name="due_date"/>
+                <field name="days_until_due"/>
+                <field name="assigned_id" widget="many2one_avatar_user"/>
+                <field name="priority" widget="priority"/>
+                <field name="state" widget="badge" decoration-info="state == 'todo'" decoration-primary="state == 'in_progress'" decoration-warning="state == 'blocked'" decoration-success="state == 'done'" decoration-danger="state == 'cancelled'"/>
+                <field name="is_overdue" column_invisible="True"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Compliance Task Form View -->
+    <record id="view_compliance_task_form" model="ir.ui.view">
+        <field name="name">ipai.compliance.task.form</field>
+        <field name="model">ipai.compliance.task</field>
+        <field name="arch" type="xml">
+            <form string="Compliance Task">
+                <header>
+                    <button name="action_start" string="Start" type="object" class="oe_highlight" invisible="state != 'todo'"/>
+                    <button name="action_done" string="Done" type="object" class="oe_highlight" invisible="state not in ('todo', 'in_progress')"/>
+                    <button name="action_block" string="Block" type="object" invisible="state != 'in_progress'"/>
+                    <button name="action_cancel" string="Cancel" type="object" invisible="state in ('done', 'cancelled')"/>
+                    <button name="action_reset" string="Reset" type="object" invisible="state == 'todo'"/>
+                    <field name="state" widget="statusbar" statusbar_visible="todo,in_progress,done"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" placeholder="Task Name..."/></h1>
+                    </div>
+                    <group>
+                        <group string="Engagement">
+                            <field name="engagement_id"/>
+                            <field name="partner_id"/>
+                            <field name="task_type"/>
+                        </group>
+                        <group string="Schedule">
+                            <field name="due_date"/>
+                            <field name="completion_date" invisible="state != 'done'"/>
+                            <field name="priority" widget="priority"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group string="Assignment">
+                            <field name="assigned_id"/>
+                            <field name="reviewer_id"/>
+                        </group>
+                        <group string="Status Info">
+                            <field name="days_until_due"/>
+                            <field name="is_overdue"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Description" name="description">
+                            <field name="description"/>
+                        </page>
+                        <page string="Notes" name="notes">
+                            <field name="notes"/>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Compliance Task Kanban View -->
+    <record id="view_compliance_task_kanban" model="ir.ui.view">
+        <field name="name">ipai.compliance.task.kanban</field>
+        <field name="model">ipai.compliance.task</field>
+        <field name="arch" type="xml">
+            <kanban default_group_by="state" class="o_kanban_small_column">
+                <field name="name"/>
+                <field name="engagement_id"/>
+                <field name="task_type"/>
+                <field name="due_date"/>
+                <field name="state"/>
+                <field name="priority"/>
+                <field name="assigned_id"/>
+                <field name="is_overdue"/>
+                <field name="color"/>
+                <templates>
+                    <t t-name="card" class="flex-row">
+                        <aside>
+                            <field name="priority" widget="priority"/>
+                        </aside>
+                        <main>
+                            <field class="fw-bold" name="name"/>
+                            <field name="engagement_id"/>
+                            <div class="mt-2">
+                                <span class="badge bg-secondary"><field name="task_type"/></span>
+                            </div>
+                            <div class="mt-2 text-muted">
+                                Due: <field name="due_date"/>
+                            </div>
+                        </main>
+                        <footer>
+                            <field name="assigned_id" widget="many2one_avatar_user"/>
+                        </footer>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <!-- Compliance Task Search View -->
+    <record id="view_compliance_task_search" model="ir.ui.view">
+        <field name="name">ipai.compliance.task.search</field>
+        <field name="model">ipai.compliance.task</field>
+        <field name="arch" type="xml">
+            <search string="Search Tasks">
+                <field name="name"/>
+                <field name="engagement_id"/>
+                <field name="partner_id"/>
+                <field name="assigned_id"/>
+                <separator/>
+                <filter string="Overdue" name="filter_overdue" domain="[('is_overdue', '=', True)]"/>
+                <filter string="Due This Week" name="filter_this_week" domain="[('due_date', '&gt;=', (context_today() - datetime.timedelta(days=context_today().weekday())).strftime('%Y-%m-%d')), ('due_date', '&lt;=', (context_today() + datetime.timedelta(days=6-context_today().weekday())).strftime('%Y-%m-%d'))]"/>
+                <filter string="My Tasks" name="filter_mine" domain="[('assigned_id', '=', uid)]"/>
+                <separator/>
+                <filter string="To Do" name="filter_todo" domain="[('state', '=', 'todo')]"/>
+                <filter string="In Progress" name="filter_progress" domain="[('state', '=', 'in_progress')]"/>
+                <filter string="Done" name="filter_done" domain="[('state', '=', 'done')]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Engagement" name="group_engagement" context="{'group_by': 'engagement_id'}"/>
+                    <filter string="Client" name="group_client" context="{'group_by': 'partner_id'}"/>
+                    <filter string="Type" name="group_type" context="{'group_by': 'task_type'}"/>
+                    <filter string="State" name="group_state" context="{'group_by': 'state'}"/>
+                    <filter string="Assigned To" name="group_assigned" context="{'group_by': 'assigned_id'}"/>
+                    <filter string="Due Date" name="group_due" context="{'group_by': 'due_date:month'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Compliance Task Action -->
+    <record id="action_compliance_task" model="ir.actions.act_window">
+        <field name="name">Compliance Tasks</field>
+        <field name="res_model">ipai.compliance.task</field>
+        <field name="view_mode">kanban,list,form</field>
+        <field name="context">{'search_default_filter_todo': 1, 'search_default_filter_progress': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first compliance task
+            </p>
+            <p>
+                Track tax filings, regulatory deadlines, and other
+                compliance requirements for engagements.
+            </p>
+        </field>
+    </record>
+
+    <!-- Document Request Tree View -->
+    <record id="view_document_request_tree" model="ir.ui.view">
+        <field name="name">ipai.document.request.tree</field>
+        <field name="model">ipai.document.request</field>
+        <field name="arch" type="xml">
+            <list string="Document Requests" decoration-success="state == 'received'" decoration-warning="state == 'partial'">
+                <field name="name"/>
+                <field name="engagement_id"/>
+                <field name="partner_id"/>
+                <field name="client_upload_deadline"/>
+                <field name="sent_date"/>
+                <field name="received_date"/>
+                <field name="attachment_count"/>
+                <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state in ('sent', 'partial')" decoration-success="state == 'received'" decoration-danger="state == 'cancelled'"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Document Request Form View -->
+    <record id="view_document_request_form" model="ir.ui.view">
+        <field name="name">ipai.document.request.form</field>
+        <field name="model">ipai.document.request</field>
+        <field name="arch" type="xml">
+            <form string="Document Request">
+                <header>
+                    <button name="action_send" string="Send to Client" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                    <button name="action_mark_partial" string="Mark Partial" type="object" invisible="state != 'sent'"/>
+                    <button name="action_mark_received" string="Mark Received" type="object" class="oe_highlight" invisible="state not in ('sent', 'partial')"/>
+                    <button name="action_cancel" string="Cancel" type="object" invisible="state in ('received', 'cancelled')"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,sent,received"/>
+                </header>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button class="oe_stat_button" type="object" name="action_view_attachments" icon="fa-paperclip">
+                            <field name="attachment_count" widget="statinfo" string="Attachments"/>
+                        </button>
+                    </div>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" readonly="1"/></h1>
+                    </div>
+                    <group>
+                        <group string="Engagement">
+                            <field name="engagement_id"/>
+                            <field name="partner_id"/>
+                        </group>
+                        <group string="Dates">
+                            <field name="client_upload_deadline"/>
+                            <field name="sent_date" invisible="state == 'draft'"/>
+                            <field name="received_date" invisible="state != 'received'"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Request Description" name="description">
+                            <field name="request_description"/>
+                        </page>
+                        <page string="Request List (JSON)" name="json">
+                            <field name="request_list" widget="ace" options="{'mode': 'json'}"/>
+                        </page>
+                        <page string="Notes" name="notes">
+                            <field name="notes"/>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Document Request Action -->
+    <record id="action_document_request" model="ir.actions.act_window">
+        <field name="name">Document Requests</field>
+        <field name="res_model">ipai.document.request</field>
+        <field name="view_mode">list,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first document request
+            </p>
+            <p>
+                Request documents from clients and track receipt status.
+            </p>
+        </field>
+    </record>
+
+    <!-- Sequence for Document Request -->
+    <record id="sequence_document_request" model="ir.sequence">
+        <field name="name">Document Request</field>
+        <field name="code">ipai.document.request</field>
+        <field name="prefix">DOC-</field>
+        <field name="padding">5</field>
+    </record>
+</odoo>

--- a/addons/ipai_accounting_firm_pack/views/engagement_views.xml
+++ b/addons/ipai_accounting_firm_pack/views/engagement_views.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Engagement Tree View -->
+    <record id="view_engagement_tree" model="ir.ui.view">
+        <field name="name">ipai.engagement.tree</field>
+        <field name="model">ipai.engagement</field>
+        <field name="arch" type="xml">
+            <list string="Engagements" decoration-muted="state == 'cancelled'" decoration-success="state == 'completed'">
+                <field name="name"/>
+                <field name="partner_id"/>
+                <field name="engagement_type" widget="badge"/>
+                <field name="fiscal_year"/>
+                <field name="manager_id" widget="many2one_avatar_user"/>
+                <field name="billing_mode"/>
+                <field name="estimated_fee" widget="monetary"/>
+                <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state in ('planning', 'fieldwork')" decoration-primary="state in ('review', 'reporting')" decoration-success="state == 'completed'" decoration-danger="state == 'cancelled'"/>
+                <field name="currency_id" column_invisible="True"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Engagement Form View -->
+    <record id="view_engagement_form" model="ir.ui.view">
+        <field name="name">ipai.engagement.form</field>
+        <field name="model">ipai.engagement</field>
+        <field name="arch" type="xml">
+            <form string="Engagement">
+                <header>
+                    <button name="action_start_planning" string="Start Planning" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                    <button name="action_start_fieldwork" string="Start Fieldwork" type="object" class="oe_highlight" invisible="state != 'planning'"/>
+                    <button name="action_start_review" string="Start Review" type="object" class="oe_highlight" invisible="state != 'fieldwork'"/>
+                    <button name="action_start_reporting" string="Start Reporting" type="object" class="oe_highlight" invisible="state != 'review'"/>
+                    <button name="action_complete" string="Complete" type="object" class="oe_highlight" invisible="state != 'reporting'"/>
+                    <button name="action_cancel" string="Cancel" type="object" invisible="state in ('completed', 'cancelled')"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,planning,fieldwork,review,reporting,completed"/>
+                </header>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button class="oe_stat_button" type="object" name="action_view_workpapers" icon="fa-file-text-o">
+                            <field name="workpaper_count" widget="statinfo" string="Workpapers"/>
+                        </button>
+                        <button class="oe_stat_button" type="object" name="action_view_compliance" icon="fa-check-square-o">
+                            <field name="compliance_count" widget="statinfo" string="Tasks"/>
+                        </button>
+                        <button class="oe_stat_button" type="object" name="action_view_document_requests" icon="fa-folder-open-o">
+                            <field name="document_request_count" widget="statinfo" string="Doc Requests"/>
+                        </button>
+                    </div>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" readonly="1"/></h1>
+                    </div>
+                    <group>
+                        <group string="Client &amp; Engagement">
+                            <field name="partner_id"/>
+                            <field name="engagement_type"/>
+                            <field name="project_id"/>
+                        </group>
+                        <group string="Fiscal Year">
+                            <field name="fiscal_year"/>
+                            <field name="fiscal_year_start"/>
+                            <field name="fiscal_year_end"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group string="Team">
+                            <field name="manager_id"/>
+                            <field name="partner_in_charge_id"/>
+                        </group>
+                        <group string="Billing">
+                            <field name="currency_id" invisible="1"/>
+                            <field name="billing_mode"/>
+                            <field name="estimated_fee"/>
+                            <field name="actual_fee"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Description" name="description">
+                            <field name="description"/>
+                        </page>
+                        <page string="Periods" name="periods">
+                            <field name="period_ids">
+                                <list editable="bottom">
+                                    <field name="period_start"/>
+                                    <field name="period_end"/>
+                                    <field name="close_status" widget="badge"/>
+                                    <field name="reviewer_id"/>
+                                    <field name="review_date"/>
+                                    <field name="close_date"/>
+                                </list>
+                            </field>
+                        </page>
+                        <page string="Notes" name="notes">
+                            <field name="notes"/>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Engagement Kanban View -->
+    <record id="view_engagement_kanban" model="ir.ui.view">
+        <field name="name">ipai.engagement.kanban</field>
+        <field name="model">ipai.engagement</field>
+        <field name="arch" type="xml">
+            <kanban default_group_by="state" class="o_kanban_small_column">
+                <field name="name"/>
+                <field name="partner_id"/>
+                <field name="engagement_type"/>
+                <field name="fiscal_year"/>
+                <field name="state"/>
+                <field name="manager_id"/>
+                <templates>
+                    <t t-name="card">
+                        <div class="oe_kanban_content">
+                            <strong><field name="name"/></strong>
+                            <div><field name="partner_id"/></div>
+                            <div class="mt-2">
+                                <span class="badge bg-secondary"><field name="engagement_type"/></span>
+                                <span class="badge bg-info"><field name="fiscal_year"/></span>
+                            </div>
+                            <div class="mt-2">
+                                <field name="manager_id" widget="many2one_avatar_user"/>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <!-- Engagement Search View -->
+    <record id="view_engagement_search" model="ir.ui.view">
+        <field name="name">ipai.engagement.search</field>
+        <field name="model">ipai.engagement</field>
+        <field name="arch" type="xml">
+            <search string="Search Engagements">
+                <field name="name"/>
+                <field name="partner_id"/>
+                <field name="fiscal_year"/>
+                <field name="manager_id"/>
+                <separator/>
+                <filter string="Active" name="filter_active" domain="[('state', 'not in', ('completed', 'cancelled'))]"/>
+                <filter string="Completed" name="filter_completed" domain="[('state', '=', 'completed')]"/>
+                <separator/>
+                <filter string="Tax" name="filter_tax" domain="[('engagement_type', 'in', ('tax_prep', 'tax_planning'))]"/>
+                <filter string="Audit" name="filter_audit" domain="[('engagement_type', '=', 'audit')]"/>
+                <filter string="Bookkeeping" name="filter_bookkeeping" domain="[('engagement_type', '=', 'bookkeeping')]"/>
+                <separator/>
+                <filter string="My Engagements" name="filter_mine" domain="[('manager_id', '=', uid)]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Client" name="group_client" context="{'group_by': 'partner_id'}"/>
+                    <filter string="Type" name="group_type" context="{'group_by': 'engagement_type'}"/>
+                    <filter string="Fiscal Year" name="group_year" context="{'group_by': 'fiscal_year'}"/>
+                    <filter string="State" name="group_state" context="{'group_by': 'state'}"/>
+                    <filter string="Manager" name="group_manager" context="{'group_by': 'manager_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Engagement Action -->
+    <record id="action_engagement" model="ir.actions.act_window">
+        <field name="name">Engagements</field>
+        <field name="res_model">ipai.engagement</field>
+        <field name="view_mode">kanban,list,form</field>
+        <field name="context">{'search_default_filter_active': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first client engagement
+            </p>
+            <p>
+                Engagements track accounting services like tax preparation,
+                audits, and bookkeeping for clients.
+            </p>
+        </field>
+    </record>
+
+    <!-- Sequence for Engagement -->
+    <record id="sequence_engagement" model="ir.sequence">
+        <field name="name">Engagement</field>
+        <field name="code">ipai.engagement</field>
+        <field name="prefix">ENG-</field>
+        <field name="padding">5</field>
+    </record>
+</odoo>

--- a/addons/ipai_accounting_firm_pack/views/menus.xml
+++ b/addons/ipai_accounting_firm_pack/views/menus.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Root Menu -->
+    <menuitem id="menu_accounting_firm_root"
+              name="Accounting Firm"
+              web_icon="ipai_accounting_firm_pack,static/description/icon.png"
+              sequence="60"/>
+
+    <!-- Engagements Submenu -->
+    <menuitem id="menu_engagements"
+              name="Engagements"
+              parent="menu_accounting_firm_root"
+              action="action_engagement"
+              sequence="10"/>
+
+    <!-- Compliance Menu -->
+    <menuitem id="menu_compliance"
+              name="Compliance"
+              parent="menu_accounting_firm_root"
+              sequence="20"/>
+
+    <menuitem id="menu_compliance_tasks"
+              name="Compliance Tasks"
+              parent="menu_compliance"
+              action="action_compliance_task"
+              sequence="10"/>
+
+    <menuitem id="menu_document_requests"
+              name="Document Requests"
+              parent="menu_compliance"
+              action="action_document_request"
+              sequence="20"/>
+
+    <!-- Workpapers Submenu -->
+    <menuitem id="menu_workpapers"
+              name="Workpapers"
+              parent="menu_accounting_firm_root"
+              action="action_workpaper"
+              sequence="30"/>
+</odoo>

--- a/addons/ipai_accounting_firm_pack/views/workpaper_views.xml
+++ b/addons/ipai_accounting_firm_pack/views/workpaper_views.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Workpaper Tree View -->
+    <record id="view_workpaper_tree" model="ir.ui.view">
+        <field name="name">ipai.workpaper.tree</field>
+        <field name="model">ipai.workpaper</field>
+        <field name="arch" type="xml">
+            <list string="Workpapers">
+                <field name="sequence" widget="handle"/>
+                <field name="reference"/>
+                <field name="name"/>
+                <field name="engagement_id"/>
+                <field name="partner_id"/>
+                <field name="workpaper_type" widget="badge"/>
+                <field name="account_area"/>
+                <field name="prepared_by_id" widget="many2one_avatar_user"/>
+                <field name="reviewed_by_id" widget="many2one_avatar_user"/>
+                <field name="signoff_state" widget="badge" decoration-info="signoff_state == 'draft'" decoration-warning="signoff_state == 'prepared'" decoration-primary="signoff_state == 'reviewed'" decoration-success="signoff_state == 'approved'"/>
+                <field name="billable_hours" sum="Total Hours"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Workpaper Form View -->
+    <record id="view_workpaper_form" model="ir.ui.view">
+        <field name="name">ipai.workpaper.form</field>
+        <field name="model">ipai.workpaper</field>
+        <field name="arch" type="xml">
+            <form string="Workpaper">
+                <header>
+                    <button name="action_mark_prepared" string="Mark Prepared" type="object" class="oe_highlight" invisible="signoff_state != 'draft'"/>
+                    <button name="action_mark_reviewed" string="Mark Reviewed" type="object" class="oe_highlight" invisible="signoff_state != 'prepared'"/>
+                    <button name="action_approve" string="Approve" type="object" class="oe_highlight" invisible="signoff_state != 'reviewed'"/>
+                    <button name="action_reset_draft" string="Reset to Draft" type="object" invisible="signoff_state == 'draft'"/>
+                    <field name="signoff_state" widget="statusbar" statusbar_visible="draft,prepared,reviewed,approved"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" placeholder="Workpaper Name..."/></h1>
+                    </div>
+                    <group>
+                        <group string="Classification">
+                            <field name="reference"/>
+                            <field name="engagement_id"/>
+                            <field name="partner_id"/>
+                            <field name="sequence"/>
+                        </group>
+                        <group string="Type">
+                            <field name="workpaper_type"/>
+                            <field name="account_area"/>
+                            <field name="billable_hours"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group string="Prepared">
+                            <field name="prepared_by_id"/>
+                            <field name="prepared_date"/>
+                        </group>
+                        <group string="Reviewed">
+                            <field name="reviewed_by_id"/>
+                            <field name="review_date"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group string="Approved">
+                            <field name="approved_by_id"/>
+                            <field name="approval_date"/>
+                        </group>
+                        <group string="File">
+                            <field name="file" filename="file_name"/>
+                            <field name="file_name" invisible="1"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Description/Scope" name="description">
+                            <field name="description"/>
+                        </page>
+                        <page string="Conclusion" name="conclusion">
+                            <field name="conclusion"/>
+                        </page>
+                        <page string="Review Notes" name="review_notes">
+                            <field name="review_notes"/>
+                        </page>
+                        <page string="Internal Notes" name="notes">
+                            <field name="notes"/>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Workpaper Search View -->
+    <record id="view_workpaper_search" model="ir.ui.view">
+        <field name="name">ipai.workpaper.search</field>
+        <field name="model">ipai.workpaper</field>
+        <field name="arch" type="xml">
+            <search string="Search Workpapers">
+                <field name="name"/>
+                <field name="reference"/>
+                <field name="engagement_id"/>
+                <field name="partner_id"/>
+                <separator/>
+                <filter string="Draft" name="filter_draft" domain="[('signoff_state', '=', 'draft')]"/>
+                <filter string="Prepared" name="filter_prepared" domain="[('signoff_state', '=', 'prepared')]"/>
+                <filter string="Reviewed" name="filter_reviewed" domain="[('signoff_state', '=', 'reviewed')]"/>
+                <filter string="Approved" name="filter_approved" domain="[('signoff_state', '=', 'approved')]"/>
+                <separator/>
+                <filter string="Needs Review" name="filter_needs_review" domain="[('signoff_state', '=', 'prepared')]"/>
+                <filter string="Needs Approval" name="filter_needs_approval" domain="[('signoff_state', '=', 'reviewed')]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Engagement" name="group_engagement" context="{'group_by': 'engagement_id'}"/>
+                    <filter string="Client" name="group_client" context="{'group_by': 'partner_id'}"/>
+                    <filter string="Type" name="group_type" context="{'group_by': 'workpaper_type'}"/>
+                    <filter string="Account Area" name="group_area" context="{'group_by': 'account_area'}"/>
+                    <filter string="Signoff State" name="group_state" context="{'group_by': 'signoff_state'}"/>
+                    <filter string="Prepared By" name="group_prepared" context="{'group_by': 'prepared_by_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Workpaper Action -->
+    <record id="action_workpaper" model="ir.actions.act_window">
+        <field name="name">Workpapers</field>
+        <field name="res_model">ipai.workpaper</field>
+        <field name="view_mode">list,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first workpaper
+            </p>
+            <p>
+                Workpapers document accounting procedures, analysis,
+                and conclusions with formal signoff workflow.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/ipai_marketing_agency_pack/__init__.py
+++ b/addons/ipai_marketing_agency_pack/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/addons/ipai_marketing_agency_pack/__manifest__.py
+++ b/addons/ipai_marketing_agency_pack/__manifest__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "IPAI Marketing Agency Pack",
+    "summary": "Marketing Agency industry pack for campaigns, creative production, and retainers.",
+    "version": "18.0.1.0.0",
+    "category": "Services/Marketing",
+    "author": "InsightPulseAI",
+    "website": "https://insightpulseai.net",
+    "license": "AGPL-3",
+    "depends": [
+        "base",
+        "mail",
+        "crm",
+        "sale_management",
+        "project",
+        "hr_timesheet",
+        "calendar",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/client_brand_views.xml",
+        "views/campaign_views.xml",
+        "views/creative_views.xml",
+        "views/media_views.xml",
+        "views/menus.xml",
+        "data/campaign_data.xml",
+    ],
+    "installable": True,
+    "application": True,
+    "auto_install": False,
+}

--- a/addons/ipai_marketing_agency_pack/data/campaign_data.xml
+++ b/addons/ipai_marketing_agency_pack/data/campaign_data.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <!-- This file can be used to seed sample data if needed -->
+    <!-- For now, we leave it minimal to avoid data dependencies -->
+</odoo>

--- a/addons/ipai_marketing_agency_pack/models/__init__.py
+++ b/addons/ipai_marketing_agency_pack/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from . import (
+    client_brand,
+    campaign,
+    creative,
+    media,
+)

--- a/addons/ipai_marketing_agency_pack/models/campaign.py
+++ b/addons/ipai_marketing_agency_pack/models/campaign.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+import json
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class Campaign(models.Model):
+    """Marketing campaign management."""
+    _name = "ipai.campaign"
+    _description = "IPAI Marketing Campaign"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "start_date desc, name"
+
+    name = fields.Char(string="Campaign Name", required=True, tracking=True)
+    code = fields.Char(string="Campaign Code", tracking=True)
+    active = fields.Boolean(default=True)
+
+    brand_id = fields.Many2one(
+        "ipai.client.brand",
+        string="Brand",
+        required=True,
+        tracking=True,
+    )
+
+    partner_id = fields.Many2one(
+        "res.partner",
+        string="Client",
+        related="brand_id.partner_id",
+        store=True,
+    )
+
+    project_id = fields.Many2one(
+        "project.project",
+        string="Delivery Project",
+        tracking=True,
+    )
+
+    objective = fields.Selection([
+        ("awareness", "Brand Awareness"),
+        ("consideration", "Consideration"),
+        ("conversion", "Conversion"),
+        ("retention", "Retention/Loyalty"),
+        ("engagement", "Engagement"),
+        ("launch", "Product Launch"),
+    ], string="Objective", required=True, tracking=True)
+
+    state = fields.Selection([
+        ("draft", "Draft"),
+        ("planning", "Planning"),
+        ("briefing", "Briefing"),
+        ("production", "Production"),
+        ("live", "Live"),
+        ("completed", "Completed"),
+        ("cancelled", "Cancelled"),
+    ], string="Status", default="draft", tracking=True)
+
+    start_date = fields.Date(string="Start Date", required=True, tracking=True)
+    end_date = fields.Date(string="End Date", required=True, tracking=True)
+
+    budget = fields.Monetary(
+        string="Budget",
+        currency_field="currency_id",
+        tracking=True,
+    )
+
+    spent = fields.Monetary(
+        string="Spent",
+        currency_field="currency_id",
+        compute="_compute_financials",
+        store=True,
+    )
+
+    remaining_budget = fields.Monetary(
+        string="Remaining",
+        currency_field="currency_id",
+        compute="_compute_financials",
+        store=True,
+    )
+
+    currency_id = fields.Many2one(
+        "res.currency",
+        string="Currency",
+        default=lambda self: self.env.company.currency_id,
+    )
+
+    kpi_targets = fields.Text(
+        string="KPI Targets (JSON)",
+        help="JSON structure for key performance indicator targets",
+        default='{"reach": 0, "impressions": 0, "clicks": 0, "leads": 0, "conversions": 0}',
+    )
+
+    description = fields.Html(string="Campaign Description")
+
+    # Related records
+    brief_ids = fields.One2many(
+        "ipai.creative.brief",
+        "campaign_id",
+        string="Creative Briefs",
+    )
+
+    asset_ids = fields.One2many(
+        "ipai.asset",
+        "campaign_id",
+        string="Assets",
+    )
+
+    calendar_item_ids = fields.One2many(
+        "ipai.content.calendar.item",
+        "campaign_id",
+        string="Content Calendar",
+    )
+
+    snapshot_ids = fields.One2many(
+        "ipai.performance.snapshot",
+        "campaign_id",
+        string="Performance Snapshots",
+    )
+
+    # Computed counts
+    brief_count = fields.Integer(compute="_compute_counts", store=True)
+    asset_count = fields.Integer(compute="_compute_counts", store=True)
+    calendar_count = fields.Integer(compute="_compute_counts", store=True)
+
+    @api.depends("brief_ids", "asset_ids", "calendar_item_ids")
+    def _compute_counts(self):
+        for campaign in self:
+            campaign.brief_count = len(campaign.brief_ids)
+            campaign.asset_count = len(campaign.asset_ids)
+            campaign.calendar_count = len(campaign.calendar_item_ids)
+
+    @api.depends("budget", "snapshot_ids.spend")
+    def _compute_financials(self):
+        for campaign in self:
+            campaign.spent = sum(campaign.snapshot_ids.mapped("spend"))
+            campaign.remaining_budget = (campaign.budget or 0) - campaign.spent
+
+    @api.constrains("start_date", "end_date")
+    def _check_dates(self):
+        for campaign in self:
+            if campaign.end_date and campaign.start_date:
+                if campaign.end_date < campaign.start_date:
+                    raise ValidationError(_("End date must be after start date."))
+
+    def action_start_planning(self):
+        self.write({"state": "planning"})
+
+    def action_start_briefing(self):
+        self.write({"state": "briefing"})
+
+    def action_start_production(self):
+        self.write({"state": "production"})
+
+    def action_go_live(self):
+        self.write({"state": "live"})
+
+    def action_complete(self):
+        self.write({"state": "completed"})
+
+    def action_cancel(self):
+        self.write({"state": "cancelled"})
+
+    def action_view_briefs(self):
+        """Open creative briefs for this campaign."""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Creative Briefs"),
+            "res_model": "ipai.creative.brief",
+            "view_mode": "list,form",
+            "domain": [("campaign_id", "=", self.id)],
+            "context": {"default_campaign_id": self.id},
+        }
+
+    def action_view_assets(self):
+        """Open assets for this campaign."""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Assets"),
+            "res_model": "ipai.asset",
+            "view_mode": "kanban,list,form",
+            "domain": [("campaign_id", "=", self.id)],
+            "context": {"default_campaign_id": self.id, "default_brand_id": self.brand_id.id},
+        }
+
+    def action_view_calendar(self):
+        """Open content calendar for this campaign."""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Content Calendar"),
+            "res_model": "ipai.content.calendar.item",
+            "view_mode": "calendar,list,form",
+            "domain": [("campaign_id", "=", self.id)],
+            "context": {"default_campaign_id": self.id},
+        }
+
+    def get_kpi_targets_dict(self):
+        """Return KPI targets as Python dict."""
+        self.ensure_one()
+        try:
+            return json.loads(self.kpi_targets or "{}")
+        except json.JSONDecodeError:
+            return {}

--- a/addons/ipai_marketing_agency_pack/models/client_brand.py
+++ b/addons/ipai_marketing_agency_pack/models/client_brand.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models, _
+
+
+class ClientBrand(models.Model):
+    """Client brand for marketing agency operations."""
+    _name = "ipai.client.brand"
+    _description = "IPAI Client Brand"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "partner_id, name"
+
+    name = fields.Char(string="Brand Name", required=True, tracking=True)
+    code = fields.Char(string="Brand Code", tracking=True)
+    active = fields.Boolean(default=True)
+
+    partner_id = fields.Many2one(
+        "res.partner",
+        string="Client",
+        required=True,
+        tracking=True,
+        domain="[('is_company', '=', True)]",
+    )
+
+    brand_guidelines_url = fields.Char(
+        string="Brand Guidelines URL",
+        help="Link to brand guidelines document or folder",
+    )
+
+    logo = fields.Binary(string="Brand Logo", attachment=True)
+    logo_filename = fields.Char(string="Logo Filename")
+
+    tone_tags = fields.Char(
+        string="Tone Tags",
+        help="Comma-separated tone descriptors (e.g., professional, playful, bold)",
+    )
+
+    primary_color = fields.Char(string="Primary Color (Hex)")
+    secondary_color = fields.Char(string="Secondary Color (Hex)")
+
+    description = fields.Html(string="Brand Description")
+
+    target_audience = fields.Text(
+        string="Target Audience",
+        help="Description of primary target audience segments",
+    )
+
+    brand_voice = fields.Text(
+        string="Brand Voice",
+        help="Guidelines for brand voice and messaging",
+    )
+
+    # Related records
+    campaign_ids = fields.One2many(
+        "ipai.campaign",
+        "brand_id",
+        string="Campaigns",
+    )
+
+    asset_ids = fields.One2many(
+        "ipai.asset",
+        "brand_id",
+        string="Assets",
+    )
+
+    # Computed fields
+    campaign_count = fields.Integer(
+        string="Campaigns",
+        compute="_compute_counts",
+        store=True,
+    )
+    asset_count = fields.Integer(
+        string="Assets",
+        compute="_compute_counts",
+        store=True,
+    )
+
+    @api.depends("campaign_ids", "asset_ids")
+    def _compute_counts(self):
+        for brand in self:
+            brand.campaign_count = len(brand.campaign_ids)
+            brand.asset_count = len(brand.asset_ids)
+
+    def action_view_campaigns(self):
+        """Open campaigns for this brand."""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Campaigns"),
+            "res_model": "ipai.campaign",
+            "view_mode": "list,form,kanban",
+            "domain": [("brand_id", "=", self.id)],
+            "context": {"default_brand_id": self.id},
+        }
+
+    def action_view_assets(self):
+        """Open assets for this brand."""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Assets"),
+            "res_model": "ipai.asset",
+            "view_mode": "list,form,kanban",
+            "domain": [("brand_id", "=", self.id)],
+            "context": {"default_brand_id": self.id},
+        }
+
+    _sql_constraints = [
+        ("partner_code_uniq", "unique(partner_id, code)", "Brand code must be unique per client!"),
+    ]

--- a/addons/ipai_marketing_agency_pack/models/creative.py
+++ b/addons/ipai_marketing_agency_pack/models/creative.py
@@ -1,0 +1,262 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models, _
+
+
+class CreativeBrief(models.Model):
+    """Creative brief for campaign production."""
+    _name = "ipai.creative.brief"
+    _description = "IPAI Creative Brief"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "create_date desc"
+
+    name = fields.Char(
+        string="Brief Title",
+        required=True,
+        tracking=True,
+        default=lambda self: _("New Brief"),
+    )
+
+    campaign_id = fields.Many2one(
+        "ipai.campaign",
+        string="Campaign",
+        required=True,
+        tracking=True,
+    )
+
+    brand_id = fields.Many2one(
+        "ipai.client.brand",
+        string="Brand",
+        related="campaign_id.brand_id",
+        store=True,
+    )
+
+    state = fields.Selection([
+        ("draft", "Draft"),
+        ("review", "In Review"),
+        ("approved", "Approved"),
+        ("revision", "Needs Revision"),
+        ("rejected", "Rejected"),
+    ], string="Status", default="draft", tracking=True)
+
+    # Brief content
+    audience = fields.Text(
+        string="Target Audience",
+        help="Who is this creative targeting?",
+    )
+
+    single_minded_proposition = fields.Text(
+        string="Single-Minded Proposition",
+        help="The one key message or takeaway",
+    )
+
+    mandatories = fields.Text(
+        string="Mandatories (JSON)",
+        help="JSON list of mandatory elements to include",
+        default='[]',
+    )
+
+    channels = fields.Text(
+        string="Channels (JSON)",
+        help="JSON list of channels for distribution",
+        default='["social", "web"]',
+    )
+
+    tone = fields.Char(
+        string="Tone",
+        help="Desired tone for the creative",
+    )
+
+    key_messages = fields.Text(
+        string="Key Messages",
+        help="Primary messages to communicate",
+    )
+
+    call_to_action = fields.Char(string="Call to Action")
+
+    deliverables_description = fields.Html(string="Deliverables Description")
+
+    deadline = fields.Date(string="Creative Deadline", tracking=True)
+
+    # Related assets
+    asset_ids = fields.One2many(
+        "ipai.asset",
+        "brief_id",
+        string="Assets",
+    )
+
+    asset_count = fields.Integer(compute="_compute_asset_count", store=True)
+
+    @api.depends("asset_ids")
+    def _compute_asset_count(self):
+        for brief in self:
+            brief.asset_count = len(brief.asset_ids)
+
+    def action_submit_review(self):
+        self.write({"state": "review"})
+
+    def action_approve(self):
+        self.write({"state": "approved"})
+
+    def action_request_revision(self):
+        self.write({"state": "revision"})
+
+    def action_reject(self):
+        self.write({"state": "rejected"})
+
+    def action_reset_draft(self):
+        self.write({"state": "draft"})
+
+
+class Asset(models.Model):
+    """Creative asset for campaigns."""
+    _name = "ipai.asset"
+    _description = "IPAI Creative Asset"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "create_date desc"
+
+    name = fields.Char(string="Asset Name", required=True, tracking=True)
+    code = fields.Char(string="Asset Code")
+
+    campaign_id = fields.Many2one(
+        "ipai.campaign",
+        string="Campaign",
+        tracking=True,
+    )
+
+    brand_id = fields.Many2one(
+        "ipai.client.brand",
+        string="Brand",
+        required=True,
+        tracking=True,
+    )
+
+    brief_id = fields.Many2one(
+        "ipai.creative.brief",
+        string="Creative Brief",
+    )
+
+    asset_type = fields.Selection([
+        ("video", "Video"),
+        ("image", "Image/Static"),
+        ("copy", "Copy/Text"),
+        ("deck", "Presentation/Deck"),
+        ("audio", "Audio"),
+        ("animation", "Animation/GIF"),
+        ("document", "Document"),
+        ("other", "Other"),
+    ], string="Asset Type", required=True, default="image", tracking=True)
+
+    version = fields.Integer(string="Version", default=1, tracking=True)
+
+    state = fields.Selection([
+        ("draft", "Draft"),
+        ("internal_review", "Internal Review"),
+        ("client_review", "Client Review"),
+        ("approved", "Approved"),
+        ("revision", "Revision Needed"),
+        ("rejected", "Rejected"),
+        ("published", "Published"),
+    ], string="Status", default="draft", tracking=True)
+
+    # File storage
+    file = fields.Binary(string="File", attachment=True)
+    file_name = fields.Char(string="File Name")
+    file_size = fields.Integer(string="File Size (KB)")
+    file_url = fields.Char(string="File URL", help="External URL if hosted elsewhere")
+
+    # Specifications
+    format = fields.Char(string="Format", help="e.g., 1080x1080, 16:9, etc.")
+    duration = fields.Float(string="Duration (seconds)", help="For video/audio")
+    file_type = fields.Char(string="File Type", help="e.g., MP4, PNG, DOCX")
+
+    description = fields.Text(string="Description")
+    notes = fields.Text(string="Internal Notes")
+
+    # Approval workflow
+    approval_cycle_ids = fields.One2many(
+        "ipai.approval.cycle",
+        "asset_id",
+        string="Approval History",
+    )
+
+    def action_submit_internal(self):
+        self.write({"state": "internal_review"})
+
+    def action_submit_client(self):
+        self.write({"state": "client_review"})
+
+    def action_approve(self):
+        self.write({"state": "approved"})
+
+    def action_request_revision(self):
+        self.write({"state": "revision"})
+        # Increment version when revision is requested
+        self.write({"version": self.version + 1})
+
+    def action_reject(self):
+        self.write({"state": "rejected"})
+
+    def action_publish(self):
+        self.write({"state": "published"})
+
+    def action_reset_draft(self):
+        self.write({"state": "draft"})
+
+
+class ApprovalCycle(models.Model):
+    """Approval workflow for assets."""
+    _name = "ipai.approval.cycle"
+    _description = "IPAI Asset Approval Cycle"
+    _order = "create_date desc"
+
+    asset_id = fields.Many2one(
+        "ipai.asset",
+        string="Asset",
+        required=True,
+        ondelete="cascade",
+    )
+
+    stage = fields.Selection([
+        ("internal", "Internal Review"),
+        ("client", "Client Review"),
+        ("legal", "Legal Review"),
+        ("final", "Final Approval"),
+    ], string="Review Stage", required=True)
+
+    approver_id = fields.Many2one(
+        "res.partner",
+        string="Approver",
+        required=True,
+    )
+
+    user_id = fields.Many2one(
+        "res.users",
+        string="Reviewed By",
+        help="User who recorded this decision",
+        default=lambda self: self.env.user,
+    )
+
+    due_date = fields.Date(string="Due Date")
+    decision_date = fields.Datetime(string="Decision Date")
+
+    decision = fields.Selection([
+        ("pending", "Pending"),
+        ("approved", "Approved"),
+        ("revision", "Revision Needed"),
+        ("rejected", "Rejected"),
+    ], string="Decision", default="pending", required=True)
+
+    comments = fields.Text(string="Comments")
+    revision_notes = fields.Text(string="Revision Notes")
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get("decision") and vals["decision"] != "pending":
+                vals["decision_date"] = fields.Datetime.now()
+        return super().create(vals_list)
+
+    def write(self, vals):
+        if "decision" in vals and vals["decision"] != "pending":
+            vals["decision_date"] = fields.Datetime.now()
+        return super().write(vals)

--- a/addons/ipai_marketing_agency_pack/models/media.py
+++ b/addons/ipai_marketing_agency_pack/models/media.py
@@ -1,0 +1,247 @@
+# -*- coding: utf-8 -*-
+import json
+from odoo import api, fields, models, _
+
+
+class ContentCalendarItem(models.Model):
+    """Content calendar for campaign scheduling."""
+    _name = "ipai.content.calendar.item"
+    _description = "IPAI Content Calendar Item"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "scheduled_datetime"
+
+    name = fields.Char(string="Post Title", required=True, tracking=True)
+
+    campaign_id = fields.Many2one(
+        "ipai.campaign",
+        string="Campaign",
+        required=True,
+        tracking=True,
+    )
+
+    brand_id = fields.Many2one(
+        "ipai.client.brand",
+        string="Brand",
+        related="campaign_id.brand_id",
+        store=True,
+    )
+
+    asset_id = fields.Many2one(
+        "ipai.asset",
+        string="Asset",
+    )
+
+    channel = fields.Selection([
+        ("facebook", "Facebook"),
+        ("instagram", "Instagram"),
+        ("twitter", "Twitter/X"),
+        ("linkedin", "LinkedIn"),
+        ("tiktok", "TikTok"),
+        ("youtube", "YouTube"),
+        ("pinterest", "Pinterest"),
+        ("website", "Website/Blog"),
+        ("email", "Email"),
+        ("other", "Other"),
+    ], string="Channel", required=True, tracking=True)
+
+    post_type = fields.Selection([
+        ("organic", "Organic"),
+        ("paid", "Paid/Sponsored"),
+        ("story", "Story"),
+        ("reel", "Reel/Short"),
+        ("live", "Live"),
+        ("carousel", "Carousel"),
+        ("article", "Article/Blog"),
+    ], string="Post Type", default="organic")
+
+    state = fields.Selection([
+        ("draft", "Draft"),
+        ("scheduled", "Scheduled"),
+        ("published", "Published"),
+        ("cancelled", "Cancelled"),
+    ], string="Status", default="draft", tracking=True)
+
+    scheduled_datetime = fields.Datetime(
+        string="Scheduled Date/Time",
+        required=True,
+        tracking=True,
+    )
+
+    published_datetime = fields.Datetime(string="Published Date/Time")
+
+    copy = fields.Text(string="Post Copy")
+    hashtags = fields.Char(string="Hashtags")
+    link_url = fields.Char(string="Link URL")
+
+    notes = fields.Text(string="Notes")
+
+    # For calendar view
+    start = fields.Datetime(
+        string="Start",
+        compute="_compute_calendar_fields",
+        store=True,
+    )
+
+    @api.depends("scheduled_datetime")
+    def _compute_calendar_fields(self):
+        for item in self:
+            item.start = item.scheduled_datetime
+
+    def action_schedule(self):
+        self.write({"state": "scheduled"})
+
+    def action_publish(self):
+        self.write({
+            "state": "published",
+            "published_datetime": fields.Datetime.now(),
+        })
+
+    def action_cancel(self):
+        self.write({"state": "cancelled"})
+
+    def action_reset_draft(self):
+        self.write({"state": "draft"})
+
+
+class PerformanceSnapshot(models.Model):
+    """Performance metrics snapshot for campaigns."""
+    _name = "ipai.performance.snapshot"
+    _description = "IPAI Campaign Performance Snapshot"
+    _order = "date desc, campaign_id"
+
+    campaign_id = fields.Many2one(
+        "ipai.campaign",
+        string="Campaign",
+        required=True,
+        ondelete="cascade",
+    )
+
+    brand_id = fields.Many2one(
+        "ipai.client.brand",
+        string="Brand",
+        related="campaign_id.brand_id",
+        store=True,
+    )
+
+    date = fields.Date(
+        string="Snapshot Date",
+        required=True,
+        default=fields.Date.today,
+    )
+
+    channel = fields.Selection([
+        ("all", "All Channels"),
+        ("facebook", "Facebook"),
+        ("instagram", "Instagram"),
+        ("twitter", "Twitter/X"),
+        ("linkedin", "LinkedIn"),
+        ("tiktok", "TikTok"),
+        ("youtube", "YouTube"),
+        ("google", "Google Ads"),
+        ("other", "Other"),
+    ], string="Channel", default="all")
+
+    # Core metrics
+    reach = fields.Integer(string="Reach")
+    impressions = fields.Integer(string="Impressions")
+    clicks = fields.Integer(string="Clicks")
+    engagement = fields.Integer(string="Engagements")
+
+    # Calculated rates
+    ctr = fields.Float(
+        string="CTR (%)",
+        compute="_compute_rates",
+        store=True,
+        digits=(16, 2),
+    )
+    engagement_rate = fields.Float(
+        string="Engagement Rate (%)",
+        compute="_compute_rates",
+        store=True,
+        digits=(16, 2),
+    )
+
+    # Conversion metrics
+    leads = fields.Integer(string="Leads")
+    conversions = fields.Integer(string="Conversions")
+
+    # Cost metrics
+    spend = fields.Monetary(
+        string="Spend",
+        currency_field="currency_id",
+    )
+
+    cpc = fields.Monetary(
+        string="CPC",
+        currency_field="currency_id",
+        compute="_compute_costs",
+        store=True,
+    )
+
+    cpm = fields.Monetary(
+        string="CPM",
+        currency_field="currency_id",
+        compute="_compute_costs",
+        store=True,
+    )
+
+    cpl = fields.Monetary(
+        string="CPL",
+        currency_field="currency_id",
+        compute="_compute_costs",
+        store=True,
+    )
+
+    currency_id = fields.Many2one(
+        "res.currency",
+        string="Currency",
+        default=lambda self: self.env.company.currency_id,
+    )
+
+    # Extended metrics (JSON for flexibility)
+    metrics_json = fields.Text(
+        string="Additional Metrics (JSON)",
+        help="JSON object for additional platform-specific metrics",
+        default="{}",
+    )
+
+    notes = fields.Text(string="Notes")
+
+    @api.depends("clicks", "impressions", "engagement", "reach")
+    def _compute_rates(self):
+        for snapshot in self:
+            snapshot.ctr = (
+                (snapshot.clicks / snapshot.impressions * 100)
+                if snapshot.impressions else 0
+            )
+            snapshot.engagement_rate = (
+                (snapshot.engagement / snapshot.reach * 100)
+                if snapshot.reach else 0
+            )
+
+    @api.depends("spend", "clicks", "impressions", "leads")
+    def _compute_costs(self):
+        for snapshot in self:
+            snapshot.cpc = (
+                snapshot.spend / snapshot.clicks if snapshot.clicks else 0
+            )
+            snapshot.cpm = (
+                snapshot.spend / snapshot.impressions * 1000
+                if snapshot.impressions else 0
+            )
+            snapshot.cpl = (
+                snapshot.spend / snapshot.leads if snapshot.leads else 0
+            )
+
+    def get_metrics_dict(self):
+        """Return extended metrics as Python dict."""
+        self.ensure_one()
+        try:
+            return json.loads(self.metrics_json or "{}")
+        except json.JSONDecodeError:
+            return {}
+
+    _sql_constraints = [
+        ("campaign_date_channel_uniq", "unique(campaign_id, date, channel)",
+         "Only one snapshot per campaign/date/channel combination!"),
+    ]

--- a/addons/ipai_marketing_agency_pack/security/ir.model.access.csv
+++ b/addons/ipai_marketing_agency_pack/security/ir.model.access.csv
@@ -1,0 +1,15 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_ipai_client_brand_user,ipai.client.brand.user,model_ipai_client_brand,base.group_user,1,0,0,0
+access_ipai_client_brand_manager,ipai.client.brand.manager,model_ipai_client_brand,sales_team.group_sale_manager,1,1,1,1
+access_ipai_campaign_user,ipai.campaign.user,model_ipai_campaign,base.group_user,1,1,1,0
+access_ipai_campaign_manager,ipai.campaign.manager,model_ipai_campaign,sales_team.group_sale_manager,1,1,1,1
+access_ipai_creative_brief_user,ipai.creative.brief.user,model_ipai_creative_brief,base.group_user,1,1,1,0
+access_ipai_creative_brief_manager,ipai.creative.brief.manager,model_ipai_creative_brief,sales_team.group_sale_manager,1,1,1,1
+access_ipai_asset_user,ipai.asset.user,model_ipai_asset,base.group_user,1,1,1,0
+access_ipai_asset_manager,ipai.asset.manager,model_ipai_asset,sales_team.group_sale_manager,1,1,1,1
+access_ipai_approval_cycle_user,ipai.approval.cycle.user,model_ipai_approval_cycle,base.group_user,1,1,1,0
+access_ipai_approval_cycle_manager,ipai.approval.cycle.manager,model_ipai_approval_cycle,sales_team.group_sale_manager,1,1,1,1
+access_ipai_content_calendar_item_user,ipai.content.calendar.item.user,model_ipai_content_calendar_item,base.group_user,1,1,1,0
+access_ipai_content_calendar_item_manager,ipai.content.calendar.item.manager,model_ipai_content_calendar_item,sales_team.group_sale_manager,1,1,1,1
+access_ipai_performance_snapshot_user,ipai.performance.snapshot.user,model_ipai_performance_snapshot,base.group_user,1,1,1,0
+access_ipai_performance_snapshot_manager,ipai.performance.snapshot.manager,model_ipai_performance_snapshot,sales_team.group_sale_manager,1,1,1,1

--- a/addons/ipai_marketing_agency_pack/views/campaign_views.xml
+++ b/addons/ipai_marketing_agency_pack/views/campaign_views.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Campaign Tree View -->
+    <record id="view_campaign_tree" model="ir.ui.view">
+        <field name="name">ipai.campaign.tree</field>
+        <field name="model">ipai.campaign</field>
+        <field name="arch" type="xml">
+            <list string="Campaigns" decoration-muted="state == 'cancelled'" decoration-success="state == 'completed'">
+                <field name="code"/>
+                <field name="name"/>
+                <field name="brand_id"/>
+                <field name="partner_id"/>
+                <field name="objective" widget="badge"/>
+                <field name="start_date"/>
+                <field name="end_date"/>
+                <field name="budget" widget="monetary"/>
+                <field name="spent" widget="monetary"/>
+                <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state in ('planning', 'briefing')" decoration-primary="state == 'production'" decoration-success="state in ('live', 'completed')" decoration-danger="state == 'cancelled'"/>
+                <field name="currency_id" column_invisible="True"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Campaign Form View -->
+    <record id="view_campaign_form" model="ir.ui.view">
+        <field name="name">ipai.campaign.form</field>
+        <field name="model">ipai.campaign</field>
+        <field name="arch" type="xml">
+            <form string="Campaign">
+                <header>
+                    <button name="action_start_planning" string="Start Planning" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                    <button name="action_start_briefing" string="Start Briefing" type="object" class="oe_highlight" invisible="state != 'planning'"/>
+                    <button name="action_start_production" string="Start Production" type="object" class="oe_highlight" invisible="state != 'briefing'"/>
+                    <button name="action_go_live" string="Go Live" type="object" class="oe_highlight" invisible="state != 'production'"/>
+                    <button name="action_complete" string="Complete" type="object" invisible="state != 'live'"/>
+                    <button name="action_cancel" string="Cancel" type="object" invisible="state in ('completed', 'cancelled')"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,planning,briefing,production,live,completed"/>
+                </header>
+                <sheet>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                    <div class="oe_button_box" name="button_box">
+                        <button class="oe_stat_button" type="object" name="action_view_briefs" icon="fa-file-text-o">
+                            <field name="brief_count" widget="statinfo" string="Briefs"/>
+                        </button>
+                        <button class="oe_stat_button" type="object" name="action_view_assets" icon="fa-image">
+                            <field name="asset_count" widget="statinfo" string="Assets"/>
+                        </button>
+                        <button class="oe_stat_button" type="object" name="action_view_calendar" icon="fa-calendar">
+                            <field name="calendar_count" widget="statinfo" string="Posts"/>
+                        </button>
+                    </div>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" placeholder="Campaign Name..."/></h1>
+                    </div>
+                    <group>
+                        <group string="Campaign Details">
+                            <field name="code"/>
+                            <field name="brand_id"/>
+                            <field name="partner_id"/>
+                            <field name="objective"/>
+                            <field name="project_id"/>
+                            <field name="active" invisible="1"/>
+                        </group>
+                        <group string="Timeline">
+                            <field name="start_date"/>
+                            <field name="end_date"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group string="Budget">
+                            <field name="currency_id" invisible="1"/>
+                            <field name="budget"/>
+                            <field name="spent"/>
+                            <field name="remaining_budget"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Description" name="description">
+                            <field name="description"/>
+                        </page>
+                        <page string="KPI Targets" name="kpis">
+                            <field name="kpi_targets" widget="ace" options="{'mode': 'json'}"/>
+                        </page>
+                        <page string="Performance" name="performance">
+                            <field name="snapshot_ids">
+                                <list editable="bottom">
+                                    <field name="date"/>
+                                    <field name="channel" widget="badge"/>
+                                    <field name="reach"/>
+                                    <field name="impressions"/>
+                                    <field name="clicks"/>
+                                    <field name="engagement"/>
+                                    <field name="ctr"/>
+                                    <field name="spend"/>
+                                    <field name="cpc"/>
+                                </list>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Campaign Kanban View -->
+    <record id="view_campaign_kanban" model="ir.ui.view">
+        <field name="name">ipai.campaign.kanban</field>
+        <field name="model">ipai.campaign</field>
+        <field name="arch" type="xml">
+            <kanban default_group_by="state" class="o_kanban_small_column">
+                <field name="name"/>
+                <field name="brand_id"/>
+                <field name="objective"/>
+                <field name="state"/>
+                <field name="start_date"/>
+                <field name="end_date"/>
+                <field name="budget"/>
+                <field name="currency_id"/>
+                <progressbar field="state" colors='{"draft": "secondary", "planning": "info", "briefing": "info", "production": "warning", "live": "success", "completed": "success", "cancelled": "danger"}'/>
+                <templates>
+                    <t t-name="card">
+                        <div class="oe_kanban_content">
+                            <strong class="o_kanban_record_title"><field name="name"/></strong>
+                            <div class="text-muted"><field name="brand_id"/></div>
+                            <div class="mt-2">
+                                <span class="badge bg-info"><field name="objective"/></span>
+                            </div>
+                            <div class="mt-2">
+                                <field name="start_date"/> - <field name="end_date"/>
+                            </div>
+                            <div class="mt-2">
+                                <strong>Budget:</strong> <field name="budget" widget="monetary"/>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <!-- Campaign Search View -->
+    <record id="view_campaign_search" model="ir.ui.view">
+        <field name="name">ipai.campaign.search</field>
+        <field name="model">ipai.campaign</field>
+        <field name="arch" type="xml">
+            <search string="Search Campaigns">
+                <field name="name"/>
+                <field name="code"/>
+                <field name="brand_id"/>
+                <field name="partner_id"/>
+                <separator/>
+                <filter string="Active" name="filter_active" domain="[('state', 'not in', ('completed', 'cancelled'))]"/>
+                <filter string="Live" name="filter_live" domain="[('state', '=', 'live')]"/>
+                <filter string="Completed" name="filter_completed" domain="[('state', '=', 'completed')]"/>
+                <separator/>
+                <filter string="Awareness" name="filter_awareness" domain="[('objective', '=', 'awareness')]"/>
+                <filter string="Conversion" name="filter_conversion" domain="[('objective', '=', 'conversion')]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Brand" name="group_brand" context="{'group_by': 'brand_id'}"/>
+                    <filter string="Client" name="group_client" context="{'group_by': 'partner_id'}"/>
+                    <filter string="State" name="group_state" context="{'group_by': 'state'}"/>
+                    <filter string="Objective" name="group_objective" context="{'group_by': 'objective'}"/>
+                    <filter string="Start Date" name="group_start" context="{'group_by': 'start_date:month'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Campaign Action -->
+    <record id="action_campaign" model="ir.actions.act_window">
+        <field name="name">Campaigns</field>
+        <field name="res_model">ipai.campaign</field>
+        <field name="view_mode">kanban,list,form</field>
+        <field name="context">{'search_default_filter_active': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first campaign
+            </p>
+            <p>
+                Campaigns organize creative production, content calendars,
+                and performance tracking for marketing initiatives.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/ipai_marketing_agency_pack/views/client_brand_views.xml
+++ b/addons/ipai_marketing_agency_pack/views/client_brand_views.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Client Brand Tree View -->
+    <record id="view_client_brand_tree" model="ir.ui.view">
+        <field name="name">ipai.client.brand.tree</field>
+        <field name="model">ipai.client.brand</field>
+        <field name="arch" type="xml">
+            <list string="Client Brands">
+                <field name="partner_id"/>
+                <field name="code"/>
+                <field name="name"/>
+                <field name="campaign_count"/>
+                <field name="asset_count"/>
+                <field name="active" optional="hide"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Client Brand Form View -->
+    <record id="view_client_brand_form" model="ir.ui.view">
+        <field name="name">ipai.client.brand.form</field>
+        <field name="model">ipai.client.brand</field>
+        <field name="arch" type="xml">
+            <form string="Client Brand">
+                <sheet>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                    <field name="logo" widget="image" class="oe_avatar"/>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" placeholder="Brand Name..."/></h1>
+                    </div>
+                    <div class="oe_button_box" name="button_box">
+                        <button class="oe_stat_button" type="object" name="action_view_campaigns" icon="fa-bullhorn">
+                            <field name="campaign_count" widget="statinfo" string="Campaigns"/>
+                        </button>
+                        <button class="oe_stat_button" type="object" name="action_view_assets" icon="fa-image">
+                            <field name="asset_count" widget="statinfo" string="Assets"/>
+                        </button>
+                    </div>
+                    <group>
+                        <group string="Client Information">
+                            <field name="partner_id"/>
+                            <field name="code"/>
+                            <field name="active" invisible="1"/>
+                        </group>
+                        <group string="Brand Colors">
+                            <field name="primary_color" widget="color"/>
+                            <field name="secondary_color" widget="color"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group string="Brand Guidelines">
+                            <field name="brand_guidelines_url" widget="url"/>
+                            <field name="tone_tags"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Description" name="description">
+                            <field name="description"/>
+                        </page>
+                        <page string="Target Audience" name="audience">
+                            <field name="target_audience"/>
+                        </page>
+                        <page string="Brand Voice" name="voice">
+                            <field name="brand_voice"/>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Client Brand Kanban View -->
+    <record id="view_client_brand_kanban" model="ir.ui.view">
+        <field name="name">ipai.client.brand.kanban</field>
+        <field name="model">ipai.client.brand</field>
+        <field name="arch" type="xml">
+            <kanban class="o_kanban_mobile">
+                <field name="name"/>
+                <field name="partner_id"/>
+                <field name="logo"/>
+                <field name="campaign_count"/>
+                <templates>
+                    <t t-name="card">
+                        <div class="d-flex">
+                            <field name="logo" widget="image" class="o_kanban_image me-3"/>
+                            <div class="flex-grow-1">
+                                <strong><field name="name"/></strong>
+                                <div class="text-muted"><field name="partner_id"/></div>
+                                <div class="mt-2">
+                                    <span class="badge bg-primary"><field name="campaign_count"/> Campaigns</span>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <!-- Client Brand Search View -->
+    <record id="view_client_brand_search" model="ir.ui.view">
+        <field name="name">ipai.client.brand.search</field>
+        <field name="model">ipai.client.brand</field>
+        <field name="arch" type="xml">
+            <search string="Search Brands">
+                <field name="name"/>
+                <field name="code"/>
+                <field name="partner_id"/>
+                <separator/>
+                <filter string="Active" name="filter_active" domain="[('active', '=', True)]"/>
+                <filter string="Archived" name="filter_archived" domain="[('active', '=', False)]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Client" name="group_client" context="{'group_by': 'partner_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Client Brand Action -->
+    <record id="action_client_brand" model="ir.actions.act_window">
+        <field name="name">Client Brands</field>
+        <field name="res_model">ipai.client.brand</field>
+        <field name="view_mode">kanban,list,form</field>
+        <field name="context">{'search_default_filter_active': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first client brand
+            </p>
+            <p>
+                Client brands store brand guidelines, tone, colors,
+                and serve as the foundation for campaigns and assets.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/ipai_marketing_agency_pack/views/creative_views.xml
+++ b/addons/ipai_marketing_agency_pack/views/creative_views.xml
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Creative Brief Tree View -->
+    <record id="view_creative_brief_tree" model="ir.ui.view">
+        <field name="name">ipai.creative.brief.tree</field>
+        <field name="model">ipai.creative.brief</field>
+        <field name="arch" type="xml">
+            <list string="Creative Briefs" decoration-muted="state == 'rejected'">
+                <field name="name"/>
+                <field name="campaign_id"/>
+                <field name="brand_id"/>
+                <field name="deadline"/>
+                <field name="asset_count"/>
+                <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state in ('review', 'revision')" decoration-success="state == 'approved'" decoration-danger="state == 'rejected'"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Creative Brief Form View -->
+    <record id="view_creative_brief_form" model="ir.ui.view">
+        <field name="name">ipai.creative.brief.form</field>
+        <field name="model">ipai.creative.brief</field>
+        <field name="arch" type="xml">
+            <form string="Creative Brief">
+                <header>
+                    <button name="action_submit_review" string="Submit for Review" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                    <button name="action_approve" string="Approve" type="object" class="oe_highlight" invisible="state != 'review'"/>
+                    <button name="action_request_revision" string="Request Revision" type="object" invisible="state != 'review'"/>
+                    <button name="action_reject" string="Reject" type="object" invisible="state != 'review'"/>
+                    <button name="action_reset_draft" string="Reset to Draft" type="object" invisible="state in ('draft', 'approved')"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,review,approved"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" placeholder="Brief Title..."/></h1>
+                    </div>
+                    <group>
+                        <group string="Campaign">
+                            <field name="campaign_id"/>
+                            <field name="brand_id"/>
+                            <field name="deadline"/>
+                        </group>
+                        <group string="Statistics">
+                            <field name="asset_count"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Brief Content" name="content">
+                            <group>
+                                <group string="Target">
+                                    <field name="audience" placeholder="Who is this creative targeting?"/>
+                                </group>
+                                <group string="Message">
+                                    <field name="single_minded_proposition" placeholder="The one key takeaway..."/>
+                                    <field name="tone"/>
+                                    <field name="call_to_action"/>
+                                </group>
+                            </group>
+                            <separator string="Key Messages"/>
+                            <field name="key_messages"/>
+                        </page>
+                        <page string="Requirements" name="requirements">
+                            <group>
+                                <field name="mandatories" widget="ace" options="{'mode': 'json'}"/>
+                            </group>
+                            <group>
+                                <field name="channels" widget="ace" options="{'mode': 'json'}"/>
+                            </group>
+                        </page>
+                        <page string="Deliverables" name="deliverables">
+                            <field name="deliverables_description"/>
+                        </page>
+                        <page string="Assets" name="assets">
+                            <field name="asset_ids">
+                                <list>
+                                    <field name="name"/>
+                                    <field name="asset_type" widget="badge"/>
+                                    <field name="version"/>
+                                    <field name="state" widget="badge"/>
+                                </list>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Creative Brief Action -->
+    <record id="action_creative_brief" model="ir.actions.act_window">
+        <field name="name">Creative Briefs</field>
+        <field name="res_model">ipai.creative.brief</field>
+        <field name="view_mode">list,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first creative brief
+            </p>
+            <p>
+                Creative briefs define the direction and requirements
+                for campaign assets and deliverables.
+            </p>
+        </field>
+    </record>
+
+    <!-- Asset Tree View -->
+    <record id="view_asset_tree" model="ir.ui.view">
+        <field name="name">ipai.asset.tree</field>
+        <field name="model">ipai.asset</field>
+        <field name="arch" type="xml">
+            <list string="Assets" decoration-muted="state == 'rejected'">
+                <field name="code"/>
+                <field name="name"/>
+                <field name="brand_id"/>
+                <field name="campaign_id"/>
+                <field name="asset_type" widget="badge"/>
+                <field name="version"/>
+                <field name="format"/>
+                <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state in ('internal_review', 'client_review', 'revision')" decoration-success="state in ('approved', 'published')" decoration-danger="state == 'rejected'"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Asset Form View -->
+    <record id="view_asset_form" model="ir.ui.view">
+        <field name="name">ipai.asset.form</field>
+        <field name="model">ipai.asset</field>
+        <field name="arch" type="xml">
+            <form string="Asset">
+                <header>
+                    <button name="action_submit_internal" string="Submit Internal Review" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                    <button name="action_submit_client" string="Submit to Client" type="object" class="oe_highlight" invisible="state != 'internal_review'"/>
+                    <button name="action_approve" string="Approve" type="object" class="oe_highlight" invisible="state != 'client_review'"/>
+                    <button name="action_request_revision" string="Request Revision" type="object" invisible="state not in ('internal_review', 'client_review')"/>
+                    <button name="action_reject" string="Reject" type="object" invisible="state not in ('internal_review', 'client_review')"/>
+                    <button name="action_publish" string="Publish" type="object" class="oe_highlight" invisible="state != 'approved'"/>
+                    <button name="action_reset_draft" string="Reset to Draft" type="object" invisible="state in ('draft', 'published')"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,internal_review,client_review,approved,published"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" placeholder="Asset Name..."/></h1>
+                    </div>
+                    <group>
+                        <group string="Classification">
+                            <field name="code"/>
+                            <field name="brand_id"/>
+                            <field name="campaign_id"/>
+                            <field name="brief_id"/>
+                        </group>
+                        <group string="Type &amp; Version">
+                            <field name="asset_type"/>
+                            <field name="version"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group string="File">
+                            <field name="file" filename="file_name"/>
+                            <field name="file_name" invisible="1"/>
+                            <field name="file_url" widget="url"/>
+                        </group>
+                        <group string="Specifications">
+                            <field name="format"/>
+                            <field name="file_type"/>
+                            <field name="duration" invisible="asset_type not in ('video', 'audio', 'animation')"/>
+                            <field name="file_size"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Description" name="description">
+                            <field name="description"/>
+                        </page>
+                        <page string="Internal Notes" name="notes">
+                            <field name="notes"/>
+                        </page>
+                        <page string="Approval History" name="approvals">
+                            <field name="approval_cycle_ids">
+                                <list editable="bottom">
+                                    <field name="stage"/>
+                                    <field name="approver_id"/>
+                                    <field name="due_date"/>
+                                    <field name="decision" widget="badge"/>
+                                    <field name="decision_date"/>
+                                    <field name="comments"/>
+                                </list>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Asset Kanban View -->
+    <record id="view_asset_kanban" model="ir.ui.view">
+        <field name="name">ipai.asset.kanban</field>
+        <field name="model">ipai.asset</field>
+        <field name="arch" type="xml">
+            <kanban default_group_by="state" class="o_kanban_small_column">
+                <field name="name"/>
+                <field name="brand_id"/>
+                <field name="asset_type"/>
+                <field name="state"/>
+                <field name="version"/>
+                <templates>
+                    <t t-name="card">
+                        <div class="oe_kanban_content">
+                            <strong><field name="name"/></strong>
+                            <div class="text-muted"><field name="brand_id"/></div>
+                            <div class="mt-2">
+                                <span class="badge bg-secondary"><field name="asset_type"/></span>
+                                <span class="badge bg-info">v<field name="version"/></span>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <!-- Asset Search View -->
+    <record id="view_asset_search" model="ir.ui.view">
+        <field name="name">ipai.asset.search</field>
+        <field name="model">ipai.asset</field>
+        <field name="arch" type="xml">
+            <search string="Search Assets">
+                <field name="name"/>
+                <field name="code"/>
+                <field name="brand_id"/>
+                <field name="campaign_id"/>
+                <separator/>
+                <filter string="Video" name="filter_video" domain="[('asset_type', '=', 'video')]"/>
+                <filter string="Image" name="filter_image" domain="[('asset_type', '=', 'image')]"/>
+                <filter string="Copy" name="filter_copy" domain="[('asset_type', '=', 'copy')]"/>
+                <separator/>
+                <filter string="In Review" name="filter_review" domain="[('state', 'in', ('internal_review', 'client_review'))]"/>
+                <filter string="Approved" name="filter_approved" domain="[('state', '=', 'approved')]"/>
+                <filter string="Published" name="filter_published" domain="[('state', '=', 'published')]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Brand" name="group_brand" context="{'group_by': 'brand_id'}"/>
+                    <filter string="Campaign" name="group_campaign" context="{'group_by': 'campaign_id'}"/>
+                    <filter string="Type" name="group_type" context="{'group_by': 'asset_type'}"/>
+                    <filter string="State" name="group_state" context="{'group_by': 'state'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Asset Action -->
+    <record id="action_asset" model="ir.actions.act_window">
+        <field name="name">Assets</field>
+        <field name="res_model">ipai.asset</field>
+        <field name="view_mode">kanban,list,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first asset
+            </p>
+            <p>
+                Assets are creative deliverables like images, videos,
+                and copy that go through approval workflows.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/ipai_marketing_agency_pack/views/media_views.xml
+++ b/addons/ipai_marketing_agency_pack/views/media_views.xml
@@ -1,0 +1,249 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Content Calendar Item Tree View -->
+    <record id="view_content_calendar_item_tree" model="ir.ui.view">
+        <field name="name">ipai.content.calendar.item.tree</field>
+        <field name="model">ipai.content.calendar.item</field>
+        <field name="arch" type="xml">
+            <list string="Content Calendar" decoration-muted="state == 'cancelled'" decoration-success="state == 'published'">
+                <field name="scheduled_datetime"/>
+                <field name="name"/>
+                <field name="campaign_id"/>
+                <field name="brand_id"/>
+                <field name="channel" widget="badge"/>
+                <field name="post_type"/>
+                <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state == 'scheduled'" decoration-success="state == 'published'" decoration-danger="state == 'cancelled'"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Content Calendar Item Form View -->
+    <record id="view_content_calendar_item_form" model="ir.ui.view">
+        <field name="name">ipai.content.calendar.item.form</field>
+        <field name="model">ipai.content.calendar.item</field>
+        <field name="arch" type="xml">
+            <form string="Content Calendar Item">
+                <header>
+                    <button name="action_schedule" string="Schedule" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                    <button name="action_publish" string="Mark Published" type="object" class="oe_highlight" invisible="state != 'scheduled'"/>
+                    <button name="action_cancel" string="Cancel" type="object" invisible="state in ('published', 'cancelled')"/>
+                    <button name="action_reset_draft" string="Reset to Draft" type="object" invisible="state == 'draft'"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,scheduled,published"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" placeholder="Post Title..."/></h1>
+                    </div>
+                    <group>
+                        <group string="Campaign">
+                            <field name="campaign_id"/>
+                            <field name="brand_id"/>
+                            <field name="asset_id" domain="[('campaign_id', '=', campaign_id)]"/>
+                        </group>
+                        <group string="Channel &amp; Type">
+                            <field name="channel"/>
+                            <field name="post_type"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group string="Schedule">
+                            <field name="scheduled_datetime"/>
+                            <field name="published_datetime" invisible="state != 'published'"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Post Content" name="content">
+                            <group>
+                                <field name="copy" placeholder="Post copy/caption..."/>
+                            </group>
+                            <group>
+                                <field name="hashtags" placeholder="#hashtag1 #hashtag2"/>
+                                <field name="link_url" widget="url"/>
+                            </group>
+                        </page>
+                        <page string="Notes" name="notes">
+                            <field name="notes"/>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Content Calendar Calendar View -->
+    <record id="view_content_calendar_item_calendar" model="ir.ui.view">
+        <field name="name">ipai.content.calendar.item.calendar</field>
+        <field name="model">ipai.content.calendar.item</field>
+        <field name="arch" type="xml">
+            <calendar string="Content Calendar" date_start="start" color="channel" mode="month" quick_create="0">
+                <field name="name"/>
+                <field name="channel"/>
+                <field name="brand_id"/>
+                <field name="state"/>
+            </calendar>
+        </field>
+    </record>
+
+    <!-- Content Calendar Search View -->
+    <record id="view_content_calendar_item_search" model="ir.ui.view">
+        <field name="name">ipai.content.calendar.item.search</field>
+        <field name="model">ipai.content.calendar.item</field>
+        <field name="arch" type="xml">
+            <search string="Search Content Calendar">
+                <field name="name"/>
+                <field name="campaign_id"/>
+                <field name="brand_id"/>
+                <separator/>
+                <filter string="Scheduled" name="filter_scheduled" domain="[('state', '=', 'scheduled')]"/>
+                <filter string="Published" name="filter_published" domain="[('state', '=', 'published')]"/>
+                <separator/>
+                <filter string="Facebook" name="filter_facebook" domain="[('channel', '=', 'facebook')]"/>
+                <filter string="Instagram" name="filter_instagram" domain="[('channel', '=', 'instagram')]"/>
+                <filter string="LinkedIn" name="filter_linkedin" domain="[('channel', '=', 'linkedin')]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Campaign" name="group_campaign" context="{'group_by': 'campaign_id'}"/>
+                    <filter string="Brand" name="group_brand" context="{'group_by': 'brand_id'}"/>
+                    <filter string="Channel" name="group_channel" context="{'group_by': 'channel'}"/>
+                    <filter string="State" name="group_state" context="{'group_by': 'state'}"/>
+                    <filter string="Scheduled Date" name="group_date" context="{'group_by': 'scheduled_datetime:day'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Content Calendar Action -->
+    <record id="action_content_calendar_item" model="ir.actions.act_window">
+        <field name="name">Content Calendar</field>
+        <field name="res_model">ipai.content.calendar.item</field>
+        <field name="view_mode">calendar,list,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Schedule your first content post
+            </p>
+            <p>
+                Plan and schedule content across channels with the content calendar.
+            </p>
+        </field>
+    </record>
+
+    <!-- Performance Snapshot Tree View -->
+    <record id="view_performance_snapshot_tree" model="ir.ui.view">
+        <field name="name">ipai.performance.snapshot.tree</field>
+        <field name="model">ipai.performance.snapshot</field>
+        <field name="arch" type="xml">
+            <list string="Performance Snapshots">
+                <field name="date"/>
+                <field name="campaign_id"/>
+                <field name="brand_id"/>
+                <field name="channel" widget="badge"/>
+                <field name="reach"/>
+                <field name="impressions"/>
+                <field name="clicks"/>
+                <field name="ctr" widget="percentage"/>
+                <field name="spend" widget="monetary"/>
+                <field name="cpc" widget="monetary"/>
+                <field name="leads"/>
+                <field name="conversions"/>
+                <field name="currency_id" column_invisible="True"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Performance Snapshot Form View -->
+    <record id="view_performance_snapshot_form" model="ir.ui.view">
+        <field name="name">ipai.performance.snapshot.form</field>
+        <field name="model">ipai.performance.snapshot</field>
+        <field name="arch" type="xml">
+            <form string="Performance Snapshot">
+                <sheet>
+                    <group>
+                        <group string="Campaign">
+                            <field name="campaign_id"/>
+                            <field name="brand_id"/>
+                            <field name="date"/>
+                            <field name="channel"/>
+                        </group>
+                        <group string="Currency">
+                            <field name="currency_id"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Core Metrics" name="metrics">
+                            <group>
+                                <group string="Reach &amp; Engagement">
+                                    <field name="reach"/>
+                                    <field name="impressions"/>
+                                    <field name="engagement"/>
+                                    <field name="engagement_rate" widget="percentage"/>
+                                </group>
+                                <group string="Clicks &amp; CTR">
+                                    <field name="clicks"/>
+                                    <field name="ctr" widget="percentage"/>
+                                </group>
+                            </group>
+                            <group>
+                                <group string="Conversions">
+                                    <field name="leads"/>
+                                    <field name="conversions"/>
+                                </group>
+                                <group string="Costs">
+                                    <field name="spend"/>
+                                    <field name="cpc"/>
+                                    <field name="cpm"/>
+                                    <field name="cpl"/>
+                                </group>
+                            </group>
+                        </page>
+                        <page string="Additional Metrics" name="additional">
+                            <field name="metrics_json" widget="ace" options="{'mode': 'json'}"/>
+                        </page>
+                        <page string="Notes" name="notes">
+                            <field name="notes"/>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Performance Snapshot Search View -->
+    <record id="view_performance_snapshot_search" model="ir.ui.view">
+        <field name="name">ipai.performance.snapshot.search</field>
+        <field name="model">ipai.performance.snapshot</field>
+        <field name="arch" type="xml">
+            <search string="Search Performance">
+                <field name="campaign_id"/>
+                <field name="brand_id"/>
+                <separator/>
+                <filter string="All Channels" name="filter_all" domain="[('channel', '=', 'all')]"/>
+                <filter string="Facebook" name="filter_facebook" domain="[('channel', '=', 'facebook')]"/>
+                <filter string="Instagram" name="filter_instagram" domain="[('channel', '=', 'instagram')]"/>
+                <filter string="Google" name="filter_google" domain="[('channel', '=', 'google')]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Campaign" name="group_campaign" context="{'group_by': 'campaign_id'}"/>
+                    <filter string="Brand" name="group_brand" context="{'group_by': 'brand_id'}"/>
+                    <filter string="Channel" name="group_channel" context="{'group_by': 'channel'}"/>
+                    <filter string="Date" name="group_date" context="{'group_by': 'date:month'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Performance Snapshot Action -->
+    <record id="action_performance_snapshot" model="ir.actions.act_window">
+        <field name="name">Performance Metrics</field>
+        <field name="res_model">ipai.performance.snapshot</field>
+        <field name="view_mode">list,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Add your first performance snapshot
+            </p>
+            <p>
+                Track campaign performance metrics like reach, impressions,
+                clicks, and conversions over time.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/ipai_marketing_agency_pack/views/menus.xml
+++ b/addons/ipai_marketing_agency_pack/views/menus.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Root Menu -->
+    <menuitem id="menu_marketing_agency_root"
+              name="Marketing Agency"
+              web_icon="ipai_marketing_agency_pack,static/description/icon.png"
+              sequence="55"/>
+
+    <!-- Client Brands Submenu -->
+    <menuitem id="menu_client_brands"
+              name="Client Brands"
+              parent="menu_marketing_agency_root"
+              action="action_client_brand"
+              sequence="10"/>
+
+    <!-- Campaigns Submenu -->
+    <menuitem id="menu_campaigns"
+              name="Campaigns"
+              parent="menu_marketing_agency_root"
+              action="action_campaign"
+              sequence="20"/>
+
+    <!-- Creative Production Menu -->
+    <menuitem id="menu_creative_production"
+              name="Creative Production"
+              parent="menu_marketing_agency_root"
+              sequence="30"/>
+
+    <menuitem id="menu_creative_briefs"
+              name="Creative Briefs"
+              parent="menu_creative_production"
+              action="action_creative_brief"
+              sequence="10"/>
+
+    <menuitem id="menu_assets"
+              name="Assets"
+              parent="menu_creative_production"
+              action="action_asset"
+              sequence="20"/>
+
+    <!-- Media & Content Menu -->
+    <menuitem id="menu_media_content"
+              name="Media &amp; Content"
+              parent="menu_marketing_agency_root"
+              sequence="40"/>
+
+    <menuitem id="menu_content_calendar"
+              name="Content Calendar"
+              parent="menu_media_content"
+              action="action_content_calendar_item"
+              sequence="10"/>
+
+    <menuitem id="menu_performance"
+              name="Performance Metrics"
+              parent="menu_media_content"
+              action="action_performance_snapshot"
+              sequence="20"/>
+</odoo>

--- a/addons/ipai_partner_pack/__init__.py
+++ b/addons/ipai_partner_pack/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/addons/ipai_partner_pack/__manifest__.py
+++ b/addons/ipai_partner_pack/__manifest__.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "IPAI Partner Pack",
+    "summary": "Odoo Partner industry pack for implementation services and success packs.",
+    "version": "18.0.1.0.0",
+    "category": "Services/Partner",
+    "author": "InsightPulseAI",
+    "website": "https://insightpulseai.net",
+    "license": "AGPL-3",
+    "depends": [
+        "base",
+        "mail",
+        "crm",
+        "sale_management",
+        "project",
+        "hr_timesheet",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/service_pack_views.xml",
+        "views/quote_calculator_views.xml",
+        "views/implementation_views.xml",
+        "views/menus.xml",
+        "data/service_pack_data.xml",
+    ],
+    "installable": True,
+    "application": True,
+    "auto_install": False,
+}

--- a/addons/ipai_partner_pack/data/service_pack_data.xml
+++ b/addons/ipai_partner_pack/data/service_pack_data.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <!-- Default Quote Calculator Configuration -->
+    <record id="quote_calculator_config_default" model="ipai.quote.calculator.config">
+        <field name="name">Standard Implementation Pricing</field>
+        <field name="code">IMPL-STD</field>
+        <field name="sequence">10</field>
+        <field name="base_hourly_rate">150.00</field>
+        <field name="pricing_rules">{
+    "discount_thresholds": {
+        "100": 0.05,
+        "200": 0.10,
+        "500": 0.15
+    }
+}</field>
+        <field name="user_count_bands">[
+    {"min": 1, "max": 10, "multiplier": 1.0},
+    {"min": 11, "max": 50, "multiplier": 1.2},
+    {"min": 51, "max": 100, "multiplier": 1.4},
+    {"min": 101, "max": 500, "multiplier": 1.6},
+    {"min": 501, "max": 99999, "multiplier": 1.8}
+]</field>
+        <field name="app_bundle_rules">{
+    "core": ["crm", "sales", "purchase", "inventory"],
+    "finance": ["accounting", "invoicing", "expenses"],
+    "hr": ["employees", "recruitment", "appraisals", "time_off"],
+    "manufacturing": ["mrp", "quality", "maintenance"],
+    "bundle_discount": 0.10
+}</field>
+        <field name="description">Standard pricing configuration for Odoo implementation services.</field>
+    </record>
+
+    <!-- Sample Service Packs -->
+    <record id="service_pack_starter" model="ipai.service.pack">
+        <field name="name">Odoo Starter Pack</field>
+        <field name="code">PACK-STARTER</field>
+        <field name="tier">starter</field>
+        <field name="default_hours">80</field>
+        <field name="ratio_impl_to_pm">5.0</field>
+        <field name="sequence">10</field>
+        <field name="description">&lt;p&gt;Entry-level implementation package suitable for small businesses with basic requirements.&lt;/p&gt;
+&lt;ul&gt;
+    &lt;li&gt;Up to 3 core apps&lt;/li&gt;
+    &lt;li&gt;Basic configuration&lt;/li&gt;
+    &lt;li&gt;Standard training&lt;/li&gt;
+    &lt;li&gt;1 month hypercare&lt;/li&gt;
+&lt;/ul&gt;</field>
+    </record>
+
+    <record id="service_pack_professional" model="ipai.service.pack">
+        <field name="name">Odoo Professional Pack</field>
+        <field name="code">PACK-PRO</field>
+        <field name="tier">professional</field>
+        <field name="default_hours">200</field>
+        <field name="ratio_impl_to_pm">4.0</field>
+        <field name="sequence">20</field>
+        <field name="description">&lt;p&gt;Comprehensive implementation package for medium-sized businesses with integration needs.&lt;/p&gt;
+&lt;ul&gt;
+    &lt;li&gt;Up to 7 core apps&lt;/li&gt;
+    &lt;li&gt;Advanced configuration&lt;/li&gt;
+    &lt;li&gt;Data migration support&lt;/li&gt;
+    &lt;li&gt;Custom training program&lt;/li&gt;
+    &lt;li&gt;3 months hypercare&lt;/li&gt;
+&lt;/ul&gt;</field>
+    </record>
+
+    <record id="service_pack_enterprise" model="ipai.service.pack">
+        <field name="name">Odoo Enterprise Pack</field>
+        <field name="code">PACK-ENT</field>
+        <field name="tier">enterprise</field>
+        <field name="default_hours">500</field>
+        <field name="ratio_impl_to_pm">3.0</field>
+        <field name="sequence">30</field>
+        <field name="description">&lt;p&gt;Full-scale enterprise implementation with dedicated resources and comprehensive support.&lt;/p&gt;
+&lt;ul&gt;
+    &lt;li&gt;Unlimited apps&lt;/li&gt;
+    &lt;li&gt;Custom development&lt;/li&gt;
+    &lt;li&gt;Complex integrations&lt;/li&gt;
+    &lt;li&gt;Full data migration&lt;/li&gt;
+    &lt;li&gt;Role-based training&lt;/li&gt;
+    &lt;li&gt;6 months hypercare&lt;/li&gt;
+&lt;/ul&gt;</field>
+    </record>
+
+    <!-- Sample Implementation Template -->
+    <record id="implementation_template_standard" model="ipai.implementation.template">
+        <field name="name">Standard Implementation</field>
+        <field name="code">IMPL-STD</field>
+        <field name="sequence">10</field>
+        <field name="description">&lt;p&gt;Standard implementation methodology for Odoo deployments.&lt;/p&gt;</field>
+    </record>
+
+    <!-- Standard Implementation Phases -->
+    <record id="phase_kickoff" model="ipai.implementation.phase">
+        <field name="template_id" ref="implementation_template_standard"/>
+        <field name="name">Project Kickoff</field>
+        <field name="sequence">10</field>
+        <field name="milestone_type">kickoff</field>
+        <field name="duration_days">2</field>
+        <field name="gate_criteria">Project charter signed, stakeholders identified, communication plan approved</field>
+    </record>
+
+    <record id="phase_discovery" model="ipai.implementation.phase">
+        <field name="template_id" ref="implementation_template_standard"/>
+        <field name="name">Discovery &amp; Requirements</field>
+        <field name="sequence">20</field>
+        <field name="milestone_type">discovery</field>
+        <field name="duration_days">10</field>
+        <field name="gate_criteria">Business requirements document approved, gap analysis complete</field>
+    </record>
+
+    <record id="phase_config" model="ipai.implementation.phase">
+        <field name="template_id" ref="implementation_template_standard"/>
+        <field name="name">Configuration &amp; Setup</field>
+        <field name="sequence">30</field>
+        <field name="milestone_type">config</field>
+        <field name="duration_days">15</field>
+        <field name="gate_criteria">System configured per specifications, unit testing complete</field>
+    </record>
+
+    <record id="phase_migration" model="ipai.implementation.phase">
+        <field name="template_id" ref="implementation_template_standard"/>
+        <field name="name">Data Migration</field>
+        <field name="sequence">40</field>
+        <field name="milestone_type">migration</field>
+        <field name="duration_days">10</field>
+        <field name="gate_criteria">Data migrated and validated, reconciliation complete</field>
+    </record>
+
+    <record id="phase_uat" model="ipai.implementation.phase">
+        <field name="template_id" ref="implementation_template_standard"/>
+        <field name="name">User Acceptance Testing</field>
+        <field name="sequence">50</field>
+        <field name="milestone_type">uat</field>
+        <field name="duration_days">10</field>
+        <field name="gate_criteria">All UAT scenarios passed, sign-off obtained</field>
+    </record>
+
+    <record id="phase_golive" model="ipai.implementation.phase">
+        <field name="template_id" ref="implementation_template_standard"/>
+        <field name="name">Go-Live</field>
+        <field name="sequence">60</field>
+        <field name="milestone_type">golive</field>
+        <field name="duration_days">5</field>
+        <field name="gate_criteria">Production cutover complete, users operational</field>
+    </record>
+
+    <record id="phase_hypercare" model="ipai.implementation.phase">
+        <field name="template_id" ref="implementation_template_standard"/>
+        <field name="name">Hypercare Support</field>
+        <field name="sequence">70</field>
+        <field name="milestone_type">hypercare</field>
+        <field name="duration_days">20</field>
+        <field name="gate_criteria">Issue resolution rate above 95%, user adoption metrics met</field>
+    </record>
+
+    <!-- Standard Implementation Deliverables -->
+    <record id="deliverable_charter" model="ipai.implementation.deliverable">
+        <field name="template_id" ref="implementation_template_standard"/>
+        <field name="phase_id" ref="phase_kickoff"/>
+        <field name="name">Project Charter</field>
+        <field name="sequence">10</field>
+        <field name="deliverable_type">document</field>
+        <field name="owner_role">pm</field>
+        <field name="is_mandatory">True</field>
+        <field name="description">Formal project charter defining scope, objectives, and stakeholders.</field>
+    </record>
+
+    <record id="deliverable_brd" model="ipai.implementation.deliverable">
+        <field name="template_id" ref="implementation_template_standard"/>
+        <field name="phase_id" ref="phase_discovery"/>
+        <field name="name">Business Requirements Document</field>
+        <field name="sequence">20</field>
+        <field name="deliverable_type">document</field>
+        <field name="owner_role">consultant</field>
+        <field name="is_mandatory">True</field>
+        <field name="description">Comprehensive documentation of business requirements and processes.</field>
+    </record>
+
+    <record id="deliverable_gap" model="ipai.implementation.deliverable">
+        <field name="template_id" ref="implementation_template_standard"/>
+        <field name="phase_id" ref="phase_discovery"/>
+        <field name="name">Gap Analysis Report</field>
+        <field name="sequence">30</field>
+        <field name="deliverable_type">document</field>
+        <field name="owner_role">consultant</field>
+        <field name="is_mandatory">True</field>
+        <field name="description">Analysis of gaps between requirements and standard Odoo functionality.</field>
+    </record>
+
+    <record id="deliverable_training" model="ipai.implementation.deliverable">
+        <field name="template_id" ref="implementation_template_standard"/>
+        <field name="phase_id" ref="phase_uat"/>
+        <field name="name">Training Materials</field>
+        <field name="sequence">40</field>
+        <field name="deliverable_type">training</field>
+        <field name="owner_role">consultant</field>
+        <field name="is_mandatory">True</field>
+        <field name="description">User training documentation and materials.</field>
+    </record>
+
+    <record id="deliverable_signoff" model="ipai.implementation.deliverable">
+        <field name="template_id" ref="implementation_template_standard"/>
+        <field name="phase_id" ref="phase_golive"/>
+        <field name="name">Go-Live Sign-Off</field>
+        <field name="sequence">50</field>
+        <field name="deliverable_type">signoff</field>
+        <field name="owner_role">customer</field>
+        <field name="is_mandatory">True</field>
+        <field name="description">Formal customer sign-off authorizing go-live.</field>
+    </record>
+</odoo>

--- a/addons/ipai_partner_pack/models/__init__.py
+++ b/addons/ipai_partner_pack/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from . import (
+    service_pack,
+    quote_calculator,
+    implementation,
+)

--- a/addons/ipai_partner_pack/models/implementation.py
+++ b/addons/ipai_partner_pack/models/implementation.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models, _
+
+
+class ImplementationTemplate(models.Model):
+    """Implementation project templates for service delivery."""
+    _name = "ipai.implementation.template"
+    _description = "IPAI Implementation Template"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "sequence, name"
+
+    name = fields.Char(string="Template Name", required=True, tracking=True)
+    code = fields.Char(string="Template Code", tracking=True)
+    sequence = fields.Integer(string="Sequence", default=10)
+    active = fields.Boolean(default=True)
+
+    description = fields.Html(string="Description")
+
+    phase_ids = fields.One2many(
+        "ipai.implementation.phase",
+        "template_id",
+        string="Phases",
+    )
+
+    deliverable_ids = fields.One2many(
+        "ipai.implementation.deliverable",
+        "template_id",
+        string="Deliverables",
+    )
+
+    # Statistics
+    total_phases = fields.Integer(
+        string="Total Phases",
+        compute="_compute_totals",
+        store=True,
+    )
+    total_deliverables = fields.Integer(
+        string="Total Deliverables",
+        compute="_compute_totals",
+        store=True,
+    )
+    estimated_duration = fields.Float(
+        string="Estimated Duration (Days)",
+        compute="_compute_totals",
+        store=True,
+    )
+
+    @api.depends("phase_ids", "deliverable_ids", "phase_ids.duration_days")
+    def _compute_totals(self):
+        for template in self:
+            template.total_phases = len(template.phase_ids)
+            template.total_deliverables = len(template.deliverable_ids)
+            template.estimated_duration = sum(template.phase_ids.mapped("duration_days"))
+
+    def action_create_project(self, partner_id=None, sale_order_id=None):
+        """Create a project from this template."""
+        self.ensure_one()
+        project_vals = {
+            "name": f"{self.name} - Implementation",
+            "description": self.description,
+            "partner_id": partner_id,
+            "sale_order_id": sale_order_id,
+        }
+
+        project = self.env["project.project"].create(project_vals)
+
+        # Create tasks from phases
+        for phase in self.phase_ids.sorted("sequence"):
+            task_vals = {
+                "name": phase.name,
+                "project_id": project.id,
+                "description": phase.description,
+            }
+            self.env["project.task"].create(task_vals)
+
+        return project
+
+    _sql_constraints = [
+        ("code_uniq", "unique(code)", "Template code must be unique!"),
+    ]
+
+
+class ImplementationPhase(models.Model):
+    """Implementation phases within a template."""
+    _name = "ipai.implementation.phase"
+    _description = "IPAI Implementation Phase"
+    _order = "sequence, id"
+
+    template_id = fields.Many2one(
+        "ipai.implementation.template",
+        string="Template",
+        required=True,
+        ondelete="cascade",
+    )
+
+    name = fields.Char(string="Phase Name", required=True)
+    sequence = fields.Integer(string="Sequence", default=10)
+    description = fields.Html(string="Description")
+
+    duration_days = fields.Float(string="Duration (Days)", default=5.0)
+
+    milestone_type = fields.Selection([
+        ("kickoff", "Kickoff"),
+        ("discovery", "Discovery Complete"),
+        ("config", "Configuration Complete"),
+        ("migration", "Data Migration Complete"),
+        ("uat", "UAT Signoff"),
+        ("golive", "Go-Live"),
+        ("hypercare", "Hypercare Complete"),
+        ("closure", "Project Closure"),
+    ], string="Milestone Type")
+
+    gate_criteria = fields.Text(
+        string="Gate Criteria",
+        help="Criteria that must be met to complete this phase",
+    )
+
+
+class ImplementationDeliverable(models.Model):
+    """Deliverables associated with implementation templates."""
+    _name = "ipai.implementation.deliverable"
+    _description = "IPAI Implementation Deliverable"
+    _order = "sequence, id"
+
+    template_id = fields.Many2one(
+        "ipai.implementation.template",
+        string="Template",
+        required=True,
+        ondelete="cascade",
+    )
+
+    phase_id = fields.Many2one(
+        "ipai.implementation.phase",
+        string="Phase",
+        domain="[('template_id', '=', template_id)]",
+    )
+
+    name = fields.Char(string="Deliverable Name", required=True)
+    sequence = fields.Integer(string="Sequence", default=10)
+    description = fields.Text(string="Description")
+
+    deliverable_type = fields.Selection([
+        ("document", "Document"),
+        ("configuration", "Configuration"),
+        ("training", "Training Material"),
+        ("signoff", "Signoff/Approval"),
+        ("artifact", "Technical Artifact"),
+    ], string="Type", required=True, default="document")
+
+    is_mandatory = fields.Boolean(string="Mandatory", default=True)
+
+    owner_role = fields.Selection([
+        ("pm", "Project Manager"),
+        ("consultant", "Consultant"),
+        ("developer", "Developer"),
+        ("customer", "Customer"),
+    ], string="Owner Role", default="consultant")
+
+
+class RiskRegisterItem(models.Model):
+    """Risk register for tracking implementation risks."""
+    _name = "ipai.risk.register.item"
+    _description = "IPAI Risk Register Item"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "priority desc, create_date desc"
+
+    name = fields.Char(string="Risk Title", required=True, tracking=True)
+
+    project_id = fields.Many2one(
+        "project.project",
+        string="Project",
+        tracking=True,
+    )
+
+    sale_order_id = fields.Many2one(
+        "sale.order",
+        string="Sale Order",
+    )
+
+    description = fields.Text(string="Risk Description", tracking=True)
+
+    risk_category = fields.Selection([
+        ("scope", "Scope"),
+        ("schedule", "Schedule"),
+        ("resource", "Resource"),
+        ("technical", "Technical"),
+        ("budget", "Budget"),
+        ("change", "Change Management"),
+        ("integration", "Integration"),
+        ("data", "Data Quality"),
+    ], string="Category", required=True, tracking=True)
+
+    probability = fields.Selection([
+        ("1", "Very Low (1)"),
+        ("2", "Low (2)"),
+        ("3", "Medium (3)"),
+        ("4", "High (4)"),
+        ("5", "Very High (5)"),
+    ], string="Probability", required=True, default="3", tracking=True)
+
+    impact = fields.Selection([
+        ("1", "Very Low (1)"),
+        ("2", "Low (2)"),
+        ("3", "Medium (3)"),
+        ("4", "High (4)"),
+        ("5", "Very High (5)"),
+    ], string="Impact", required=True, default="3", tracking=True)
+
+    priority = fields.Integer(
+        string="Risk Score",
+        compute="_compute_priority",
+        store=True,
+    )
+
+    state = fields.Selection([
+        ("identified", "Identified"),
+        ("analyzing", "Analyzing"),
+        ("mitigating", "Mitigating"),
+        ("monitoring", "Monitoring"),
+        ("closed", "Closed"),
+    ], string="Status", default="identified", tracking=True)
+
+    mitigation_plan = fields.Text(string="Mitigation Plan")
+    contingency_plan = fields.Text(string="Contingency Plan")
+
+    owner_id = fields.Many2one(
+        "res.users",
+        string="Risk Owner",
+        default=lambda self: self.env.user,
+        tracking=True,
+    )
+
+    identified_date = fields.Date(
+        string="Identified Date",
+        default=fields.Date.today,
+    )
+
+    review_date = fields.Date(string="Next Review Date")
+
+    @api.depends("probability", "impact")
+    def _compute_priority(self):
+        for risk in self:
+            prob = int(risk.probability or "1")
+            imp = int(risk.impact or "1")
+            risk.priority = prob * imp
+
+    def action_analyze(self):
+        self.write({"state": "analyzing"})
+
+    def action_mitigate(self):
+        self.write({"state": "mitigating"})
+
+    def action_monitor(self):
+        self.write({"state": "monitoring"})
+
+    def action_close(self):
+        self.write({"state": "closed"})

--- a/addons/ipai_partner_pack/models/quote_calculator.py
+++ b/addons/ipai_partner_pack/models/quote_calculator.py
@@ -1,0 +1,345 @@
+# -*- coding: utf-8 -*-
+import json
+import logging
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class QuoteCalculatorConfig(models.Model):
+    """Quote calculator configuration for pricing rules."""
+    _name = "ipai.quote.calculator.config"
+    _description = "IPAI Quote Calculator Configuration"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "sequence, name"
+
+    name = fields.Char(string="Configuration Name", required=True, tracking=True)
+    code = fields.Char(string="Config Code", tracking=True)
+    sequence = fields.Integer(string="Sequence", default=10)
+    active = fields.Boolean(default=True)
+
+    pricing_rules = fields.Text(
+        string="Pricing Rules (JSON)",
+        help="JSON structure for pricing rules and conditions",
+        default="{}",
+    )
+
+    user_count_bands = fields.Text(
+        string="User Count Bands (JSON)",
+        help="JSON structure for user count pricing bands",
+        default='[{"min": 1, "max": 10, "multiplier": 1.0}, {"min": 11, "max": 50, "multiplier": 1.5}]',
+    )
+
+    app_bundle_rules = fields.Text(
+        string="App Bundle Rules (JSON)",
+        help="JSON structure for app bundle pricing",
+        default="{}",
+    )
+
+    base_hourly_rate = fields.Float(
+        string="Base Hourly Rate",
+        default=150.0,
+        tracking=True,
+    )
+
+    currency_id = fields.Many2one(
+        "res.currency",
+        string="Currency",
+        default=lambda self: self.env.company.currency_id,
+    )
+
+    description = fields.Text(string="Description")
+
+    def get_pricing_rules_dict(self):
+        """Return pricing rules as Python dict."""
+        self.ensure_one()
+        try:
+            return json.loads(self.pricing_rules or "{}")
+        except json.JSONDecodeError:
+            _logger.warning("Invalid JSON in pricing_rules for config %s", self.name)
+            return {}
+
+    def get_user_count_bands_list(self):
+        """Return user count bands as Python list."""
+        self.ensure_one()
+        try:
+            return json.loads(self.user_count_bands or "[]")
+        except json.JSONDecodeError:
+            _logger.warning("Invalid JSON in user_count_bands for config %s", self.name)
+            return []
+
+
+class QuoteCalculatorRun(models.Model):
+    """Quote calculator execution/run record."""
+    _name = "ipai.quote.calculator.run"
+    _description = "IPAI Quote Calculator Run"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "create_date desc"
+
+    name = fields.Char(
+        string="Run Reference",
+        default=lambda self: _("New"),
+        readonly=True,
+        copy=False,
+    )
+
+    state = fields.Selection([
+        ("draft", "Draft"),
+        ("calculated", "Calculated"),
+        ("quoted", "Quote Created"),
+        ("cancelled", "Cancelled"),
+    ], string="Status", default="draft", tracking=True)
+
+    config_id = fields.Many2one(
+        "ipai.quote.calculator.config",
+        string="Calculator Config",
+        required=True,
+        tracking=True,
+    )
+
+    lead_id = fields.Many2one(
+        "crm.lead",
+        string="Lead/Opportunity",
+        tracking=True,
+    )
+
+    partner_id = fields.Many2one(
+        "res.partner",
+        string="Customer",
+        tracking=True,
+    )
+
+    # Input parameters
+    inputs_json = fields.Text(
+        string="Calculator Inputs (JSON)",
+        help="JSON structure of all calculator inputs",
+        default="{}",
+    )
+
+    user_count = fields.Integer(
+        string="User Count",
+        help="Number of users for implementation",
+    )
+
+    app_count = fields.Integer(
+        string="App Count",
+        help="Number of Odoo apps to implement",
+    )
+
+    complexity = fields.Selection([
+        ("low", "Low"),
+        ("medium", "Medium"),
+        ("high", "High"),
+        ("very_high", "Very High"),
+    ], string="Complexity", default="medium")
+
+    # Output / results
+    recommended_pack_id = fields.Many2one(
+        "ipai.service.pack",
+        string="Recommended Pack",
+        tracking=True,
+    )
+
+    computed_lines = fields.Text(
+        string="Computed Lines (JSON)",
+        help="JSON structure of computed quote lines",
+        default="[]",
+    )
+
+    estimated_hours = fields.Float(
+        string="Estimated Hours",
+        compute="_compute_totals",
+        store=True,
+    )
+
+    estimated_amount = fields.Monetary(
+        string="Estimated Amount",
+        compute="_compute_totals",
+        store=True,
+        currency_field="currency_id",
+    )
+
+    currency_id = fields.Many2one(
+        "res.currency",
+        string="Currency",
+        related="config_id.currency_id",
+        store=True,
+    )
+
+    # Link to generated quote
+    sale_order_id = fields.Many2one(
+        "sale.order",
+        string="Generated Quote",
+        readonly=True,
+        copy=False,
+    )
+
+    notes = fields.Text(string="Notes")
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get("name", _("New")) == _("New"):
+                vals["name"] = self.env["ir.sequence"].next_by_code(
+                    "ipai.quote.calculator.run"
+                ) or _("New")
+        return super().create(vals_list)
+
+    @api.depends("computed_lines", "config_id.base_hourly_rate")
+    def _compute_totals(self):
+        for run in self:
+            total_hours = 0.0
+            try:
+                lines = json.loads(run.computed_lines or "[]")
+                for line in lines:
+                    total_hours += line.get("hours", 0)
+            except json.JSONDecodeError:
+                pass
+            run.estimated_hours = total_hours
+            run.estimated_amount = total_hours * (run.config_id.base_hourly_rate or 0)
+
+    def action_calculate(self):
+        """Run the quote calculation based on inputs."""
+        self.ensure_one()
+        if not self.config_id:
+            raise UserError(_("Please select a calculator configuration."))
+
+        # Get complexity multiplier
+        complexity_map = {
+            "low": 0.8,
+            "medium": 1.0,
+            "high": 1.3,
+            "very_high": 1.6,
+        }
+        complexity_mult = complexity_map.get(self.complexity, 1.0)
+
+        # Get user count multiplier from bands
+        user_mult = 1.0
+        bands = self.config_id.get_user_count_bands_list()
+        for band in bands:
+            if band.get("min", 0) <= self.user_count <= band.get("max", 9999):
+                user_mult = band.get("multiplier", 1.0)
+                break
+
+        # Base hours calculation
+        base_hours = (self.app_count or 1) * 40  # 40 hours per app baseline
+
+        # Apply multipliers
+        total_hours = base_hours * complexity_mult * user_mult
+
+        # Build computed lines
+        lines = [
+            {
+                "description": "Requirements & Analysis",
+                "hours": total_hours * 0.15,
+                "phase": "discovery",
+            },
+            {
+                "description": "Configuration & Setup",
+                "hours": total_hours * 0.35,
+                "phase": "implementation",
+            },
+            {
+                "description": "Data Migration",
+                "hours": total_hours * 0.20,
+                "phase": "implementation",
+            },
+            {
+                "description": "Testing & UAT",
+                "hours": total_hours * 0.15,
+                "phase": "testing",
+            },
+            {
+                "description": "Training & Go-Live Support",
+                "hours": total_hours * 0.15,
+                "phase": "deployment",
+            },
+        ]
+
+        self.write({
+            "computed_lines": json.dumps(lines),
+            "state": "calculated",
+        })
+
+        # Find recommended pack
+        packs = self.env["ipai.service.pack"].search([
+            ("active", "=", True),
+            ("default_hours", ">=", total_hours * 0.8),
+            ("default_hours", "<=", total_hours * 1.2),
+        ], limit=1, order="default_hours asc")
+        if packs:
+            self.recommended_pack_id = packs[0].id
+
+        return True
+
+    def action_create_quote(self):
+        """Create a sale order from the calculator run."""
+        self.ensure_one()
+        if self.state != "calculated":
+            raise UserError(_("Please run the calculation first."))
+
+        if not self.partner_id and not self.lead_id:
+            raise UserError(_("Please set a customer or lead."))
+
+        partner = self.partner_id or self.lead_id.partner_id
+        if not partner:
+            raise UserError(_("No customer found. Please set a customer."))
+
+        # Create sale order
+        so_vals = {
+            "partner_id": partner.id,
+            "opportunity_id": self.lead_id.id if self.lead_id else False,
+            "origin": self.name,
+        }
+
+        # Find or create implementation service product
+        product = self.env["product.product"].search([
+            ("default_code", "=", "IMPL-SERVICE"),
+        ], limit=1)
+        if not product:
+            product = self.env["product.product"].create({
+                "name": "Implementation Services",
+                "default_code": "IMPL-SERVICE",
+                "type": "service",
+                "list_price": self.config_id.base_hourly_rate or 150.0,
+            })
+
+        # Create order lines from computed lines
+        order_lines = []
+        try:
+            lines = json.loads(self.computed_lines or "[]")
+            for line in lines:
+                order_lines.append((0, 0, {
+                    "product_id": product.id,
+                    "name": line.get("description", "Implementation Service"),
+                    "product_uom_qty": line.get("hours", 0),
+                    "price_unit": self.config_id.base_hourly_rate or 150.0,
+                }))
+        except json.JSONDecodeError:
+            pass
+
+        if order_lines:
+            so_vals["order_line"] = order_lines
+
+        sale_order = self.env["sale.order"].create(so_vals)
+        self.write({
+            "sale_order_id": sale_order.id,
+            "state": "quoted",
+        })
+
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "sale.order",
+            "res_id": sale_order.id,
+            "view_mode": "form",
+            "target": "current",
+        }
+
+    def action_cancel(self):
+        """Cancel the calculator run."""
+        self.write({"state": "cancelled"})
+
+    def action_reset_draft(self):
+        """Reset to draft state."""
+        self.write({"state": "draft"})

--- a/addons/ipai_partner_pack/models/service_pack.py
+++ b/addons/ipai_partner_pack/models/service_pack.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class ServicePack(models.Model):
+    """Service packaging for Odoo Partner implementations."""
+    _name = "ipai.service.pack"
+    _description = "IPAI Service Pack"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "sequence, name"
+
+    name = fields.Char(string="Pack Name", required=True, tracking=True)
+    code = fields.Char(string="Pack Code", tracking=True)
+    sequence = fields.Integer(string="Sequence", default=10)
+    active = fields.Boolean(default=True)
+
+    tier = fields.Selection([
+        ("starter", "Starter"),
+        ("professional", "Professional"),
+        ("enterprise", "Enterprise"),
+        ("custom", "Custom"),
+    ], string="Tier", required=True, default="professional", tracking=True)
+
+    default_hours = fields.Float(
+        string="Default Hours",
+        help="Estimated hours for this service pack",
+        tracking=True,
+    )
+
+    ratio_impl_to_pm = fields.Float(
+        string="Implementation to PM Ratio",
+        default=4.0,
+        help="Ratio of implementation hours to PM hours (e.g., 4:1)",
+    )
+
+    included_deliverables = fields.Text(
+        string="Included Deliverables (JSON)",
+        help="JSON structure defining included deliverables",
+    )
+
+    default_team_template_id = fields.Many2one(
+        "ipai.implementation.template",
+        string="Default Implementation Template",
+    )
+
+    description = fields.Html(string="Description")
+    notes = fields.Text(string="Internal Notes")
+
+    line_ids = fields.One2many(
+        "ipai.service.pack.line",
+        "service_pack_id",
+        string="Pack Lines",
+    )
+
+    # Computed fields
+    total_lines = fields.Integer(
+        string="Total Lines",
+        compute="_compute_totals",
+        store=True,
+    )
+    total_quantity = fields.Float(
+        string="Total Quantity",
+        compute="_compute_totals",
+        store=True,
+    )
+
+    @api.depends("line_ids", "line_ids.qty")
+    def _compute_totals(self):
+        for pack in self:
+            pack.total_lines = len(pack.line_ids)
+            pack.total_quantity = sum(pack.line_ids.mapped("qty"))
+
+    _sql_constraints = [
+        ("code_uniq", "unique(code)", "Pack code must be unique!"),
+    ]
+
+
+class ServicePackLine(models.Model):
+    """Service pack line items."""
+    _name = "ipai.service.pack.line"
+    _description = "IPAI Service Pack Line"
+    _order = "sequence, id"
+
+    service_pack_id = fields.Many2one(
+        "ipai.service.pack",
+        string="Service Pack",
+        required=True,
+        ondelete="cascade",
+    )
+
+    sequence = fields.Integer(string="Sequence", default=10)
+
+    product_id = fields.Many2one(
+        "product.product",
+        string="Service/Product",
+        required=True,
+        domain="[('type', '=', 'service')]",
+    )
+
+    name = fields.Char(string="Description")
+    qty = fields.Float(string="Quantity", default=1.0, required=True)
+
+    uom_id = fields.Many2one(
+        "uom.uom",
+        string="Unit of Measure",
+        related="product_id.uom_id",
+        readonly=True,
+    )
+
+    is_optional = fields.Boolean(
+        string="Optional",
+        help="Mark as optional add-on for the service pack",
+    )
+
+    role_mix = fields.Text(
+        string="Role Mix (JSON)",
+        help="JSON structure for team composition (e.g., consultant, PM, developer hours)",
+    )
+
+    @api.onchange("product_id")
+    def _onchange_product_id(self):
+        if self.product_id:
+            self.name = self.product_id.name

--- a/addons/ipai_partner_pack/security/ir.model.access.csv
+++ b/addons/ipai_partner_pack/security/ir.model.access.csv
@@ -1,0 +1,17 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_ipai_service_pack_user,ipai.service.pack.user,model_ipai_service_pack,base.group_user,1,0,0,0
+access_ipai_service_pack_manager,ipai.service.pack.manager,model_ipai_service_pack,sales_team.group_sale_manager,1,1,1,1
+access_ipai_service_pack_line_user,ipai.service.pack.line.user,model_ipai_service_pack_line,base.group_user,1,0,0,0
+access_ipai_service_pack_line_manager,ipai.service.pack.line.manager,model_ipai_service_pack_line,sales_team.group_sale_manager,1,1,1,1
+access_ipai_quote_calculator_config_user,ipai.quote.calculator.config.user,model_ipai_quote_calculator_config,base.group_user,1,0,0,0
+access_ipai_quote_calculator_config_manager,ipai.quote.calculator.config.manager,model_ipai_quote_calculator_config,sales_team.group_sale_manager,1,1,1,1
+access_ipai_quote_calculator_run_user,ipai.quote.calculator.run.user,model_ipai_quote_calculator_run,base.group_user,1,1,1,0
+access_ipai_quote_calculator_run_manager,ipai.quote.calculator.run.manager,model_ipai_quote_calculator_run,sales_team.group_sale_manager,1,1,1,1
+access_ipai_implementation_template_user,ipai.implementation.template.user,model_ipai_implementation_template,base.group_user,1,0,0,0
+access_ipai_implementation_template_manager,ipai.implementation.template.manager,model_ipai_implementation_template,sales_team.group_sale_manager,1,1,1,1
+access_ipai_implementation_phase_user,ipai.implementation.phase.user,model_ipai_implementation_phase,base.group_user,1,0,0,0
+access_ipai_implementation_phase_manager,ipai.implementation.phase.manager,model_ipai_implementation_phase,sales_team.group_sale_manager,1,1,1,1
+access_ipai_implementation_deliverable_user,ipai.implementation.deliverable.user,model_ipai_implementation_deliverable,base.group_user,1,0,0,0
+access_ipai_implementation_deliverable_manager,ipai.implementation.deliverable.manager,model_ipai_implementation_deliverable,sales_team.group_sale_manager,1,1,1,1
+access_ipai_risk_register_item_user,ipai.risk.register.item.user,model_ipai_risk_register_item,base.group_user,1,1,1,0
+access_ipai_risk_register_item_manager,ipai.risk.register.item.manager,model_ipai_risk_register_item,sales_team.group_sale_manager,1,1,1,1

--- a/addons/ipai_partner_pack/views/implementation_views.xml
+++ b/addons/ipai_partner_pack/views/implementation_views.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Implementation Template Tree View -->
+    <record id="view_implementation_template_tree" model="ir.ui.view">
+        <field name="name">ipai.implementation.template.tree</field>
+        <field name="model">ipai.implementation.template</field>
+        <field name="arch" type="xml">
+            <list string="Implementation Templates">
+                <field name="sequence" widget="handle"/>
+                <field name="code"/>
+                <field name="name"/>
+                <field name="total_phases"/>
+                <field name="total_deliverables"/>
+                <field name="estimated_duration"/>
+                <field name="active" optional="hide"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Implementation Template Form View -->
+    <record id="view_implementation_template_form" model="ir.ui.view">
+        <field name="name">ipai.implementation.template.form</field>
+        <field name="model">ipai.implementation.template</field>
+        <field name="arch" type="xml">
+            <form string="Implementation Template">
+                <sheet>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" placeholder="Template Name..."/></h1>
+                    </div>
+                    <group>
+                        <group string="Configuration">
+                            <field name="code"/>
+                            <field name="sequence"/>
+                            <field name="active" invisible="1"/>
+                        </group>
+                        <group string="Statistics">
+                            <field name="total_phases"/>
+                            <field name="total_deliverables"/>
+                            <field name="estimated_duration"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Phases" name="phases">
+                            <field name="phase_ids">
+                                <list editable="bottom">
+                                    <field name="sequence" widget="handle"/>
+                                    <field name="name"/>
+                                    <field name="milestone_type" widget="badge"/>
+                                    <field name="duration_days"/>
+                                    <field name="gate_criteria"/>
+                                </list>
+                            </field>
+                        </page>
+                        <page string="Deliverables" name="deliverables">
+                            <field name="deliverable_ids">
+                                <list editable="bottom">
+                                    <field name="sequence" widget="handle"/>
+                                    <field name="name"/>
+                                    <field name="phase_id"/>
+                                    <field name="deliverable_type" widget="badge"/>
+                                    <field name="owner_role"/>
+                                    <field name="is_mandatory"/>
+                                </list>
+                            </field>
+                        </page>
+                        <page string="Description" name="description">
+                            <field name="description"/>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Implementation Template Action -->
+    <record id="action_implementation_template" model="ir.actions.act_window">
+        <field name="name">Implementation Templates</field>
+        <field name="res_model">ipai.implementation.template</field>
+        <field name="view_mode">list,form</field>
+        <field name="context">{'search_default_filter_active': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first implementation template
+            </p>
+            <p>
+                Implementation templates define standard project phases,
+                milestones, and deliverables for repeatable implementations.
+            </p>
+        </field>
+    </record>
+
+    <!-- Risk Register Tree View -->
+    <record id="view_risk_register_item_tree" model="ir.ui.view">
+        <field name="name">ipai.risk.register.item.tree</field>
+        <field name="model">ipai.risk.register.item</field>
+        <field name="arch" type="xml">
+            <list string="Risk Register" decoration-danger="priority >= 16" decoration-warning="priority >= 9 and priority &lt; 16" decoration-info="priority &lt; 9">
+                <field name="name"/>
+                <field name="project_id"/>
+                <field name="risk_category" widget="badge"/>
+                <field name="probability"/>
+                <field name="impact"/>
+                <field name="priority" string="Score"/>
+                <field name="state" widget="badge" decoration-info="state == 'identified'" decoration-warning="state in ('analyzing', 'mitigating')" decoration-success="state in ('monitoring', 'closed')"/>
+                <field name="owner_id" widget="many2one_avatar_user"/>
+                <field name="review_date"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Risk Register Form View -->
+    <record id="view_risk_register_item_form" model="ir.ui.view">
+        <field name="name">ipai.risk.register.item.form</field>
+        <field name="model">ipai.risk.register.item</field>
+        <field name="arch" type="xml">
+            <form string="Risk Register Item">
+                <header>
+                    <button name="action_analyze" string="Analyze" type="object" invisible="state != 'identified'"/>
+                    <button name="action_mitigate" string="Mitigate" type="object" invisible="state != 'analyzing'"/>
+                    <button name="action_monitor" string="Monitor" type="object" invisible="state != 'mitigating'"/>
+                    <button name="action_close" string="Close" type="object" invisible="state not in ('monitoring', 'mitigating')"/>
+                    <field name="state" widget="statusbar" statusbar_visible="identified,analyzing,mitigating,monitoring,closed"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" placeholder="Risk Title..."/></h1>
+                    </div>
+                    <group>
+                        <group string="Context">
+                            <field name="project_id"/>
+                            <field name="sale_order_id"/>
+                            <field name="risk_category"/>
+                        </group>
+                        <group string="Assessment">
+                            <field name="probability"/>
+                            <field name="impact"/>
+                            <field name="priority" string="Risk Score"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group string="Ownership">
+                            <field name="owner_id"/>
+                            <field name="identified_date"/>
+                            <field name="review_date"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Description" name="description">
+                            <field name="description" placeholder="Describe the risk in detail..."/>
+                        </page>
+                        <page string="Mitigation Plan" name="mitigation">
+                            <field name="mitigation_plan" placeholder="Actions to reduce probability or impact..."/>
+                        </page>
+                        <page string="Contingency Plan" name="contingency">
+                            <field name="contingency_plan" placeholder="Actions if the risk materializes..."/>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Risk Register Search View -->
+    <record id="view_risk_register_item_search" model="ir.ui.view">
+        <field name="name">ipai.risk.register.item.search</field>
+        <field name="model">ipai.risk.register.item</field>
+        <field name="arch" type="xml">
+            <search string="Search Risks">
+                <field name="name"/>
+                <field name="project_id"/>
+                <field name="owner_id"/>
+                <separator/>
+                <filter string="High Risk (16+)" name="filter_high" domain="[('priority', '>=', 16)]"/>
+                <filter string="Medium Risk (9-15)" name="filter_medium" domain="[('priority', '>=', 9), ('priority', '&lt;', 16)]"/>
+                <filter string="Low Risk (&lt;9)" name="filter_low" domain="[('priority', '&lt;', 9)]"/>
+                <separator/>
+                <filter string="Open" name="filter_open" domain="[('state', '!=', 'closed')]"/>
+                <filter string="Closed" name="filter_closed" domain="[('state', '=', 'closed')]"/>
+                <separator/>
+                <filter string="My Risks" name="filter_mine" domain="[('owner_id', '=', uid)]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Project" name="group_project" context="{'group_by': 'project_id'}"/>
+                    <filter string="Category" name="group_category" context="{'group_by': 'risk_category'}"/>
+                    <filter string="State" name="group_state" context="{'group_by': 'state'}"/>
+                    <filter string="Owner" name="group_owner" context="{'group_by': 'owner_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Risk Register Action -->
+    <record id="action_risk_register_item" model="ir.actions.act_window">
+        <field name="name">Risk Register</field>
+        <field name="res_model">ipai.risk.register.item</field>
+        <field name="view_mode">list,form</field>
+        <field name="context">{'search_default_filter_open': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Log a new risk
+            </p>
+            <p>
+                Track implementation risks with probability, impact assessment,
+                and mitigation plans.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/ipai_partner_pack/views/menus.xml
+++ b/addons/ipai_partner_pack/views/menus.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Root Menu -->
+    <menuitem id="menu_partner_pack_root"
+              name="Partner Pack"
+              web_icon="ipai_partner_pack,static/description/icon.png"
+              sequence="50"/>
+
+    <!-- Service Packs Submenu -->
+    <menuitem id="menu_service_packs"
+              name="Service Packs"
+              parent="menu_partner_pack_root"
+              action="action_service_pack"
+              sequence="10"/>
+
+    <!-- Quote Calculator Submenu -->
+    <menuitem id="menu_quote_calculator"
+              name="Quote Calculator"
+              parent="menu_partner_pack_root"
+              action="action_quote_calculator_run"
+              sequence="20"/>
+
+    <!-- Implementation Templates Submenu -->
+    <menuitem id="menu_implementation_templates"
+              name="Implementation Templates"
+              parent="menu_partner_pack_root"
+              action="action_implementation_template"
+              sequence="30"/>
+
+    <!-- Risk Register Submenu -->
+    <menuitem id="menu_risk_register"
+              name="Risk Register"
+              parent="menu_partner_pack_root"
+              action="action_risk_register_item"
+              sequence="40"/>
+
+    <!-- Configuration Menu -->
+    <menuitem id="menu_partner_pack_config"
+              name="Configuration"
+              parent="menu_partner_pack_root"
+              sequence="100"/>
+
+    <menuitem id="menu_calculator_config"
+              name="Calculator Configurations"
+              parent="menu_partner_pack_config"
+              action="action_quote_calculator_config"
+              sequence="10"/>
+</odoo>

--- a/addons/ipai_partner_pack/views/quote_calculator_views.xml
+++ b/addons/ipai_partner_pack/views/quote_calculator_views.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Quote Calculator Config Tree View -->
+    <record id="view_quote_calculator_config_tree" model="ir.ui.view">
+        <field name="name">ipai.quote.calculator.config.tree</field>
+        <field name="model">ipai.quote.calculator.config</field>
+        <field name="arch" type="xml">
+            <list string="Calculator Configurations">
+                <field name="sequence" widget="handle"/>
+                <field name="code"/>
+                <field name="name"/>
+                <field name="base_hourly_rate"/>
+                <field name="currency_id"/>
+                <field name="active" optional="hide"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Quote Calculator Config Form View -->
+    <record id="view_quote_calculator_config_form" model="ir.ui.view">
+        <field name="name">ipai.quote.calculator.config.form</field>
+        <field name="model">ipai.quote.calculator.config</field>
+        <field name="arch" type="xml">
+            <form string="Calculator Configuration">
+                <sheet>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" placeholder="Configuration Name..."/></h1>
+                    </div>
+                    <group>
+                        <group string="Basic Settings">
+                            <field name="code"/>
+                            <field name="sequence"/>
+                            <field name="active" invisible="1"/>
+                        </group>
+                        <group string="Pricing">
+                            <field name="base_hourly_rate"/>
+                            <field name="currency_id"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Pricing Rules" name="pricing">
+                            <field name="pricing_rules" widget="ace" options="{'mode': 'json'}"/>
+                        </page>
+                        <page string="User Count Bands" name="user_bands">
+                            <field name="user_count_bands" widget="ace" options="{'mode': 'json'}"/>
+                        </page>
+                        <page string="App Bundle Rules" name="app_bundles">
+                            <field name="app_bundle_rules" widget="ace" options="{'mode': 'json'}"/>
+                        </page>
+                        <page string="Description" name="description">
+                            <field name="description"/>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Quote Calculator Config Action -->
+    <record id="action_quote_calculator_config" model="ir.actions.act_window">
+        <field name="name">Calculator Configurations</field>
+        <field name="res_model">ipai.quote.calculator.config</field>
+        <field name="view_mode">list,form</field>
+        <field name="context">{'search_default_filter_active': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first calculator configuration
+            </p>
+            <p>
+                Calculator configurations define pricing rules, user bands,
+                and app bundle discounts for quote generation.
+            </p>
+        </field>
+    </record>
+
+    <!-- Quote Calculator Run Tree View -->
+    <record id="view_quote_calculator_run_tree" model="ir.ui.view">
+        <field name="name">ipai.quote.calculator.run.tree</field>
+        <field name="model">ipai.quote.calculator.run</field>
+        <field name="arch" type="xml">
+            <list string="Quote Calculator Runs" decoration-muted="state == 'cancelled'" decoration-success="state == 'quoted'">
+                <field name="name"/>
+                <field name="lead_id"/>
+                <field name="partner_id"/>
+                <field name="user_count"/>
+                <field name="app_count"/>
+                <field name="complexity" widget="badge"/>
+                <field name="estimated_hours"/>
+                <field name="estimated_amount" widget="monetary"/>
+                <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-success="state == 'quoted'" decoration-warning="state == 'calculated'" decoration-danger="state == 'cancelled'"/>
+                <field name="currency_id" column_invisible="True"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Quote Calculator Run Form View -->
+    <record id="view_quote_calculator_run_form" model="ir.ui.view">
+        <field name="name">ipai.quote.calculator.run.form</field>
+        <field name="model">ipai.quote.calculator.run</field>
+        <field name="arch" type="xml">
+            <form string="Quote Calculator Run">
+                <header>
+                    <button name="action_calculate" string="Calculate" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                    <button name="action_create_quote" string="Create Quote" type="object" class="oe_highlight" invisible="state != 'calculated'"/>
+                    <button name="action_cancel" string="Cancel" type="object" invisible="state in ('cancelled', 'quoted')"/>
+                    <button name="action_reset_draft" string="Reset to Draft" type="object" invisible="state != 'cancelled'"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,calculated,quoted"/>
+                </header>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button class="oe_stat_button" type="object" name="action_create_quote" icon="fa-file-text-o" invisible="not sale_order_id">
+                            <field name="sale_order_id" widget="statinfo" string="Quote"/>
+                        </button>
+                    </div>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" readonly="1"/></h1>
+                    </div>
+                    <group>
+                        <group string="Configuration">
+                            <field name="config_id"/>
+                            <field name="currency_id" invisible="1"/>
+                        </group>
+                        <group string="Customer">
+                            <field name="lead_id"/>
+                            <field name="partner_id"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group string="Calculator Inputs">
+                            <field name="user_count"/>
+                            <field name="app_count"/>
+                            <field name="complexity" widget="radio"/>
+                        </group>
+                        <group string="Results">
+                            <field name="recommended_pack_id"/>
+                            <field name="estimated_hours"/>
+                            <field name="estimated_amount" widget="monetary"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Computed Lines" name="computed">
+                            <field name="computed_lines" widget="ace" options="{'mode': 'json'}" readonly="1"/>
+                        </page>
+                        <page string="Raw Inputs" name="inputs">
+                            <field name="inputs_json" widget="ace" options="{'mode': 'json'}"/>
+                        </page>
+                        <page string="Notes" name="notes">
+                            <field name="notes"/>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Quote Calculator Run Search View -->
+    <record id="view_quote_calculator_run_search" model="ir.ui.view">
+        <field name="name">ipai.quote.calculator.run.search</field>
+        <field name="model">ipai.quote.calculator.run</field>
+        <field name="arch" type="xml">
+            <search string="Search Calculator Runs">
+                <field name="name"/>
+                <field name="lead_id"/>
+                <field name="partner_id"/>
+                <separator/>
+                <filter string="Draft" name="filter_draft" domain="[('state', '=', 'draft')]"/>
+                <filter string="Calculated" name="filter_calculated" domain="[('state', '=', 'calculated')]"/>
+                <filter string="Quoted" name="filter_quoted" domain="[('state', '=', 'quoted')]"/>
+                <separator/>
+                <group expand="0" string="Group By">
+                    <filter string="State" name="group_state" context="{'group_by': 'state'}"/>
+                    <filter string="Complexity" name="group_complexity" context="{'group_by': 'complexity'}"/>
+                    <filter string="Customer" name="group_partner" context="{'group_by': 'partner_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Quote Calculator Run Action -->
+    <record id="action_quote_calculator_run" model="ir.actions.act_window">
+        <field name="name">Quote Calculator</field>
+        <field name="res_model">ipai.quote.calculator.run</field>
+        <field name="view_mode">list,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Run a new quote calculation
+            </p>
+            <p>
+                Use the quote calculator to estimate implementation scope
+                and generate sales quotations automatically.
+            </p>
+        </field>
+    </record>
+
+    <!-- Sequence for Quote Calculator Run -->
+    <record id="sequence_quote_calculator_run" model="ir.sequence">
+        <field name="name">Quote Calculator Run</field>
+        <field name="code">ipai.quote.calculator.run</field>
+        <field name="prefix">QC-</field>
+        <field name="padding">5</field>
+    </record>
+</odoo>

--- a/addons/ipai_partner_pack/views/service_pack_views.xml
+++ b/addons/ipai_partner_pack/views/service_pack_views.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Service Pack Tree View -->
+    <record id="view_service_pack_tree" model="ir.ui.view">
+        <field name="name">ipai.service.pack.tree</field>
+        <field name="model">ipai.service.pack</field>
+        <field name="arch" type="xml">
+            <list string="Service Packs">
+                <field name="sequence" widget="handle"/>
+                <field name="code"/>
+                <field name="name"/>
+                <field name="tier" widget="badge" decoration-info="tier == 'starter'" decoration-success="tier == 'professional'" decoration-warning="tier == 'enterprise'" decoration-danger="tier == 'custom'"/>
+                <field name="default_hours"/>
+                <field name="total_lines"/>
+                <field name="active" optional="hide"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Service Pack Form View -->
+    <record id="view_service_pack_form" model="ir.ui.view">
+        <field name="name">ipai.service.pack.form</field>
+        <field name="model">ipai.service.pack</field>
+        <field name="arch" type="xml">
+            <form string="Service Pack">
+                <sheet>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" placeholder="Pack Name..."/></h1>
+                    </div>
+                    <group>
+                        <group string="Configuration">
+                            <field name="code"/>
+                            <field name="tier"/>
+                            <field name="sequence"/>
+                            <field name="active" invisible="1"/>
+                        </group>
+                        <group string="Estimates">
+                            <field name="default_hours"/>
+                            <field name="ratio_impl_to_pm"/>
+                            <field name="default_team_template_id"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Pack Lines" name="lines">
+                            <field name="line_ids">
+                                <list editable="bottom">
+                                    <field name="sequence" widget="handle"/>
+                                    <field name="product_id"/>
+                                    <field name="name"/>
+                                    <field name="qty"/>
+                                    <field name="uom_id"/>
+                                    <field name="is_optional"/>
+                                </list>
+                            </field>
+                        </page>
+                        <page string="Description" name="description">
+                            <field name="description"/>
+                        </page>
+                        <page string="Technical" name="technical">
+                            <group>
+                                <field name="included_deliverables" widget="ace" options="{'mode': 'json'}"/>
+                            </group>
+                        </page>
+                        <page string="Notes" name="notes">
+                            <field name="notes"/>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Service Pack Search View -->
+    <record id="view_service_pack_search" model="ir.ui.view">
+        <field name="name">ipai.service.pack.search</field>
+        <field name="model">ipai.service.pack</field>
+        <field name="arch" type="xml">
+            <search string="Search Service Packs">
+                <field name="name"/>
+                <field name="code"/>
+                <separator/>
+                <filter string="Starter" name="filter_starter" domain="[('tier', '=', 'starter')]"/>
+                <filter string="Professional" name="filter_professional" domain="[('tier', '=', 'professional')]"/>
+                <filter string="Enterprise" name="filter_enterprise" domain="[('tier', '=', 'enterprise')]"/>
+                <filter string="Custom" name="filter_custom" domain="[('tier', '=', 'custom')]"/>
+                <separator/>
+                <filter string="Active" name="filter_active" domain="[('active', '=', True)]"/>
+                <filter string="Archived" name="filter_archived" domain="[('active', '=', False)]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Tier" name="group_tier" context="{'group_by': 'tier'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Service Pack Action -->
+    <record id="action_service_pack" model="ir.actions.act_window">
+        <field name="name">Service Packs</field>
+        <field name="res_model">ipai.service.pack</field>
+        <field name="view_mode">list,form</field>
+        <field name="context">{'search_default_filter_active': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first service pack
+            </p>
+            <p>
+                Service packs define standard implementation offerings with
+                predefined scope, hours, and deliverables.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/docs/INDUSTRY_PACKS_OCA_DEPENDENCIES.md
+++ b/docs/INDUSTRY_PACKS_OCA_DEPENDENCIES.md
@@ -1,0 +1,210 @@
+# Odoo Industry Packs - OCA Dependencies Guide
+
+This document describes the OCA (Odoo Community Association) modules required to achieve enterprise-level parity for the three industry pack modules implemented in this repository.
+
+## Overview
+
+The three industry packs implement CE/OCA-based alternatives to Odoo Enterprise industry solutions:
+
+1. **ipai_partner_pack** - Odoo Partner implementation services
+2. **ipai_marketing_agency_pack** - Marketing Agency operations
+3. **ipai_accounting_firm_pack** - Accounting Firm engagements
+
+## Core OCA Dependencies
+
+### 1. OCA DMS (Document Management System)
+
+**Repository:** https://github.com/OCA/dms
+
+**Replaces:** Odoo Enterprise Documents app
+
+**Key modules:**
+- `dms` - Core document management
+- `dms_field` - Document fields for other models
+- `dms_attachment_link` - Link attachments to DMS
+
+**Usage in Industry Packs:**
+- Document storage for creative assets (Marketing Agency)
+- Workpaper file management (Accounting Firm)
+- Implementation deliverables (Partner Pack)
+
+**Installation:**
+```bash
+git clone https://github.com/OCA/dms.git -b 18.0 oca-addons/dms
+pip install -r oca-addons/dms/requirements.txt
+```
+
+### 2. OCA Contract (Subscription Management)
+
+**Repository:** https://github.com/OCA/contract
+
+**Replaces:** Odoo Enterprise Subscriptions app
+
+**Key modules:**
+- `contract` - Recurring contracts/subscriptions
+- `contract_sale` - Create contracts from sales orders
+- `contract_variable_quantity` - Variable billing
+
+**Usage in Industry Packs:**
+- Retainer agreements (Marketing Agency)
+- Recurring engagement billing (Accounting Firm)
+- Support/maintenance contracts (Partner Pack)
+
+**Installation:**
+```bash
+git clone https://github.com/OCA/contract.git -b 18.0 oca-addons/contract
+```
+
+### 3. OCA Timesheet
+
+**Repository:** https://github.com/OCA/timesheet
+
+**Replaces:** Enhanced timesheet features from Enterprise
+
+**Key modules:**
+- `hr_timesheet_sheet` - Timesheet approval workflow
+- `hr_timesheet_task_required` - Require task on timesheets
+- `sale_timesheet_line_exclude` - Exclude timesheet lines from invoicing
+
+**Usage in Industry Packs:**
+- Implementation time tracking (Partner Pack)
+- Campaign effort tracking (Marketing Agency)
+- Engagement hour billing (Accounting Firm)
+
+**Installation:**
+```bash
+git clone https://github.com/OCA/timesheet.git -b 18.0 oca-addons/timesheet
+```
+
+### 4. OCA Social
+
+**Repository:** https://github.com/OCA/social
+
+**Replaces:** Odoo Enterprise Social Marketing (partial)
+
+**Key modules:**
+- `mail_activity_board` - Activity dashboard
+- `mail_tracking` - Email tracking
+- `mass_mailing_custom_unsubscribe` - Unsubscribe management
+
+**Usage in Industry Packs:**
+- Campaign activity tracking (Marketing Agency)
+- Client communication tracking (All packs)
+
+**Installation:**
+```bash
+git clone https://github.com/OCA/social.git -b 18.0 oca-addons/social
+```
+
+## Enterprise Feature Gap Analysis
+
+### Features with Full OCA Parity
+
+| Enterprise Feature | OCA Alternative | Status |
+|-------------------|-----------------|--------|
+| Documents | OCA DMS | Full parity |
+| Subscriptions | OCA Contract | Full parity |
+| Timesheet grid | OCA Timesheet | Near parity |
+| Email tracking | OCA Social | Full parity |
+
+### Features with Partial OCA Parity
+
+| Enterprise Feature | OCA Alternative | Gap |
+|-------------------|-----------------|-----|
+| Planning | No direct OCA equivalent | Custom development needed |
+| e-Sign | No direct OCA equivalent | Third-party integration |
+| Social Marketing | OCA Social (partial) | Limited scheduling features |
+| Helpdesk | Various community modules | Feature subset |
+
+### Recommended Custom Development
+
+For features without OCA equivalents:
+
+1. **Planning/Resource Scheduling**
+   - Use `project.task` with custom date/resource fields
+   - Consider `resource_booking` community modules
+   - Build custom Gantt/calendar views
+
+2. **E-Signature**
+   - Integrate with DocuSign, HelloSign, or Adobe Sign APIs
+   - Build simple approval workflow using `mail.activity`
+
+3. **Social Media Scheduling**
+   - Build custom `ipai.content.calendar` (included in Marketing Agency Pack)
+   - Integrate with Buffer, Hootsuite, or platform-native APIs
+
+## Installation Guide
+
+### 1. Add OCA Repositories
+
+Create or update your `oca-addons` directory:
+
+```bash
+cd /path/to/odoo-ce
+
+# Create OCA addons directory
+mkdir -p oca-addons
+
+# Clone required OCA repos
+git clone https://github.com/OCA/dms.git -b 18.0 oca-addons/dms
+git clone https://github.com/OCA/contract.git -b 18.0 oca-addons/contract
+git clone https://github.com/OCA/timesheet.git -b 18.0 oca-addons/timesheet
+git clone https://github.com/OCA/social.git -b 18.0 oca-addons/social
+```
+
+### 2. Update Odoo Configuration
+
+Add OCA paths to your `odoo.conf`:
+
+```ini
+[options]
+addons_path = /path/to/odoo/addons,/path/to/odoo-ce/addons,/path/to/odoo-ce/oca-addons/dms,/path/to/odoo-ce/oca-addons/contract,/path/to/odoo-ce/oca-addons/timesheet,/path/to/odoo-ce/oca-addons/social
+```
+
+### 3. Install Python Dependencies
+
+```bash
+pip install -r oca-addons/dms/requirements.txt
+# Repeat for other OCA modules with requirements.txt
+```
+
+### 4. Install Modules
+
+Via Odoo UI or command line:
+
+```bash
+./odoo-bin -d your_database -i dms,contract,hr_timesheet_sheet --stop-after-init
+```
+
+## Module Dependencies Matrix
+
+| Industry Pack | Required OCA | Optional OCA |
+|--------------|--------------|--------------|
+| ipai_partner_pack | contract | dms, hr_timesheet_sheet |
+| ipai_marketing_agency_pack | dms | contract, mail_tracking |
+| ipai_accounting_firm_pack | dms, hr_timesheet_sheet | contract |
+
+## Version Compatibility
+
+All modules in this repository are designed for **Odoo 18.0**.
+
+When selecting OCA modules, ensure you checkout the `18.0` branch:
+
+```bash
+git checkout 18.0
+```
+
+## References
+
+- [OCA GitHub Organization](https://github.com/OCA)
+- [OCA Apps Store](https://odoo-community.org/)
+- [Odoo CE Documentation](https://www.odoo.com/documentation/18.0/)
+
+## Contributing
+
+To extend these industry packs with additional OCA integrations:
+
+1. Identify the OCA module that provides the needed functionality
+2. Add it as a dependency in `__manifest__.py`
+3. Extend models using `_inherit` pattern
+4. Follow OCA coding standards (AGPL-3 license, proper versioning)


### PR DESCRIPTION
Implement complete data model for CE/OCA-based industry packs that provide enterprise-level functionality using community alternatives:

- ipai_partner_pack: Odoo Partner implementation services with service packs, quote calculator, implementation templates, and risk register

- ipai_marketing_agency_pack: Marketing agency operations with client brands, campaigns, creative briefs, assets, approval workflows, content calendar, and performance tracking

- ipai_accounting_firm_pack: Accounting firm engagements with compliance tasks, document requests, workpapers, and signoff workflows

All modules follow OCA coding standards with AGPL-3 license, proper security ACLs, and comprehensive views (list, form, kanban, search, calendar where applicable).

Also includes documentation for OCA dependencies (DMS, Contract, Timesheet, Social) that provide enterprise feature parity.