### PR TITLE
fix(addons): remove missing web_icon references causing Apps internal…

### DIFF
--- a/addons/ipai_accounting_firm_pack/views/menus.xml
+++ b/addons/ipai_accounting_firm_pack/views/menus.xml
@@ -3,7 +3,6 @@
     <!-- Root Menu -->
     <menuitem id="menu_accounting_firm_root"
               name="Accounting Firm"
-              web_icon="ipai_accounting_firm_pack,static/description/icon.png"
               sequence="60"/>
 
     <!-- Engagements Submenu -->

--- a/addons/ipai_marketing_agency_pack/views/menus.xml
+++ b/addons/ipai_marketing_agency_pack/views/menus.xml
@@ -3,7 +3,6 @@
     <!-- Root Menu -->
     <menuitem id="menu_marketing_agency_root"
               name="Marketing Agency"
-              web_icon="ipai_marketing_agency_pack,static/description/icon.png"
               sequence="55"/>
 
     <!-- Client Brands Submenu -->

--- a/addons/ipai_partner_pack/views/menus.xml
+++ b/addons/ipai_partner_pack/views/menus.xml
@@ -3,7 +3,6 @@
     <!-- Root Menu -->
     <menuitem id="menu_partner_pack_root"
               name="Partner Pack"
-              web_icon="ipai_partner_pack,static/description/icon.png"
               sequence="50"/>
 
     <!-- Service Packs Submenu -->


### PR DESCRIPTION
… error

The industry pack modules referenced icon files at static/description/icon.png but these files did not exist, causing an internal server error when loading the Apps page in Odoo 18.