### PR TITLE
Add missing tree and gantt views to registry

### DIFF
--- a/addons/ipai_clarity_ppm_parity/models/project_milestone.py
+++ b/addons/ipai_clarity_ppm_parity/models/project_milestone.py
@@ -312,7 +312,7 @@ class ProjectMilestone(models.Model):
             "type": "ir.actions.act_window",
             "name": f"Tasks for {self.name}",
             "res_model": "project.task",
-            "view_mode": "tree,form",
+            "view_mode": "list,form",
             "domain": [("milestone_id", "=", self.id)],
             "context": {
                 "default_milestone_id": self.id,

--- a/addons/ipai_clarity_ppm_parity/models/project_phase.py
+++ b/addons/ipai_clarity_ppm_parity/models/project_phase.py
@@ -246,7 +246,7 @@ class ProjectPhase(models.Model):
             "type": "ir.actions.act_window",
             "name": f"Tasks in {self.name}",
             "res_model": "project.task",
-            "view_mode": "tree,form,gantt",
+            "view_mode": "list,form",
             "domain": [("parent_id", "=", self.id), ("is_phase", "=", False)],
             "context": {
                 "default_parent_id": self.id,

--- a/addons/ipai_clarity_ppm_parity/models/project_project.py
+++ b/addons/ipai_clarity_ppm_parity/models/project_project.py
@@ -191,7 +191,7 @@ class ProjectProject(models.Model):
             "type": "ir.actions.act_window",
             "name": "Phases",
             "res_model": "project.task",
-            "view_mode": "tree,form,gantt",
+            "view_mode": "list,form",
             "domain": [("project_id", "=", self.id), ("is_phase", "=", True)],
             "context": {"default_project_id": self.id, "default_is_phase": True},
         }
@@ -203,7 +203,7 @@ class ProjectProject(models.Model):
             "type": "ir.actions.act_window",
             "name": "Milestones",
             "res_model": "project.milestone",
-            "view_mode": "tree,form,gantt",
+            "view_mode": "list,form",
             "domain": [("project_id", "=", self.id)],
             "context": {"default_project_id": self.id},
         }

--- a/addons/ipai_clarity_ppm_parity/models/project_task.py
+++ b/addons/ipai_clarity_ppm_parity/models/project_task.py
@@ -216,7 +216,7 @@ class ProjectTask(models.Model):
             "type": "ir.actions.act_window",
             "name": "Task Dependencies",
             "res_model": "project.task.dependency",
-            "view_mode": "tree,form,graph",
+            "view_mode": "list,form,graph",
             "domain": ["|", ("task_id", "=", self.id), ("depend_on_id", "=", self.id)],
         }
 

--- a/addons/ipai_equipment/models/equipment.py
+++ b/addons/ipai_equipment/models/equipment.py
@@ -96,7 +96,7 @@ class IpaiEquipmentAsset(models.Model):
             "type": "ir.actions.act_window",
             "name": "Bookings",
             "res_model": "ipai.equipment.booking",
-            "view_mode": "tree,form",
+            "view_mode": "list,form",
             "domain": [("asset_id", "=", self.id)],
             "context": {"default_asset_id": self.id},
         }
@@ -107,7 +107,7 @@ class IpaiEquipmentAsset(models.Model):
             "type": "ir.actions.act_window",
             "name": "Incidents",
             "res_model": "ipai.equipment.incident",
-            "view_mode": "tree,form",
+            "view_mode": "list,form",
             "domain": [("asset_id", "=", self.id)],
             "context": {"default_asset_id": self.id},
         }


### PR DESCRIPTION
…tives

Replace view_mode definitions that cause "View types not defined" errors in Odoo Community Edition:
- tree,form,gantt -> list,form (gantt is Enterprise-only)
- tree,form -> list,form (tree is deprecated in Odoo 18)
- tree,form,graph -> list,form,graph

Affected modules:
- ipai_clarity_ppm_parity: project_project.py, project_phase.py, project_task.py, project_milestone.py
- ipai_equipment: equipment.py