### PR TITLE
Verify Odoo cron fix and documentation deployment

### DIFF
--- a/addons/ipai_workos_core/views/page_views.xml
+++ b/addons/ipai_workos_core/views/page_views.xml
@@ -143,7 +143,7 @@
     <record id="action_workos_page" model="ir.actions.act_window">
         <field name="name">Pages</field>
         <field name="res_model">ipai.workos.page</field>
-        <field name="view_mode">kanban,tree,form</field>
+        <field name="view_mode">kanban,list,form</field>
         <field name="search_view_id" ref="page_search_view"/>
         <field name="context">{'search_default_group_by_space': 1}</field>
         <field name="help" type="html">

--- a/addons/ipai_workos_core/views/space_views.xml
+++ b/addons/ipai_workos_core/views/space_views.xml
@@ -101,7 +101,7 @@
     <record id="action_workos_space" model="ir.actions.act_window">
         <field name="name">Spaces</field>
         <field name="res_model">ipai.workos.space</field>
-        <field name="view_mode">kanban,tree,form</field>
+        <field name="view_mode">kanban,list,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a space to organize your pages

--- a/addons/ipai_workos_core/views/workspace_views.xml
+++ b/addons/ipai_workos_core/views/workspace_views.xml
@@ -107,7 +107,7 @@
     <record id="action_workos_workspace" model="ir.actions.act_window">
         <field name="name">Workspaces</field>
         <field name="res_model">ipai.workos.workspace</field>
-        <field name="view_mode">kanban,tree,form</field>
+        <field name="view_mode">kanban,list,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create your first workspace

--- a/addons/ipai_workos_templates/views/template_views.xml
+++ b/addons/ipai_workos_templates/views/template_views.xml
@@ -88,7 +88,7 @@
     <record id="action_workos_template" model="ir.actions.act_window">
         <field name="name">Templates</field>
         <field name="res_model">ipai.workos.template</field>
-        <field name="view_mode">kanban,tree,form</field>
+        <field name="view_mode">kanban,list,form</field>
         <field name="context">{'search_default_published': 1}</field>
     </record>
 


### PR DESCRIPTION
Odoo 18 requires 'list' instead of 'tree' in ir.actions.act_window view_mode field. This fixes the UI error:
"View types not defined tree found in act_window action"