### PR TITLE
Improve test coverage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,43 @@ services:
     restart: unless-stopped
 
   # ===== CORE EDITION (Port 8069) =====
-  # Init service (one-time module installation)
+  # Init service - CE Core Modules (one-time installation of all CE modules)
+  odoo-core-ce-init:
+    image: odoo:18.0
+    container_name: odoo-core-ce-init
+    depends_on:
+      - postgres
+    environment:
+      - HOST=postgres
+      - USER=odoo
+      - PASSWORD=odoo
+      - DB_NAME=odoo_core
+    volumes:
+      - ./addons:/mnt/extra-addons
+      - odoo-core-web-data:/var/lib/odoo
+    # Install all CE core modules in dependency order
+    command: >
+      odoo -d odoo_core -i
+      base,web,base_setup,base_import,bus,mail,digest,iap,web_tour,web_editor,portal,resource,calendar,
+      contacts,sales_team,crm,sale,sale_management,sale_crm,
+      analytic,account,account_payment,
+      purchase,purchase_requisition,
+      stock,stock_account,stock_landed_costs,stock_picking_batch,
+      sale_stock,sale_purchase,purchase_stock,
+      mrp,maintenance,
+      project,project_todo,hr_timesheet,sale_timesheet,
+      hr,hr_contract,hr_holidays,hr_attendance,hr_expense,hr_recruitment,hr_skills,
+      website,website_sale,website_crm,website_blog,website_forum,website_slides,website_event,
+      mass_mailing,im_livechat,
+      point_of_sale,
+      survey,lunch,fleet,repair
+      --stop-after-init
+    networks:
+      - odoo-network
+    restart: "no"
+    profiles: ["ce-init"]
+
+  # Init service - IPAI custom modules (after CE modules are installed)
   odoo-core-init:
     image: odoo:18.0
     container_name: odoo-core-init

--- a/scripts/odoo/install-ce-apps.sh
+++ b/scripts/odoo/install-ce-apps.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-# Install all 38 CE-native Odoo apps in dependency order
-# Usage: ./scripts/odoo/install-ce-apps.sh [--dry-run]
+# Install all Odoo CE core modules in dependency order
+# Usage: ./scripts/odoo/install-ce-apps.sh [--dry-run] [--docker CONTAINER_NAME]
+#
+# Examples:
+#   ./scripts/odoo/install-ce-apps.sh --dry-run
+#   ./scripts/odoo/install-ce-apps.sh --docker odoo-core
+#   ODOO_DB=odoo_marketing ./scripts/odoo/install-ce-apps.sh
 
 set -e
 
@@ -12,17 +17,38 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
+CYAN='\033[0;36m'
 NC='\033[0m'
 
 DRY_RUN=false
-if [[ "$1" == "--dry-run" ]]; then
-    DRY_RUN=true
-    echo -e "${YELLOW}DRY RUN MODE - No changes will be made${NC}"
-fi
+DOCKER_MODE=false
+DOCKER_CONTAINER=""
 
-echo -e "${BLUE}╔════════════════════════════════════════════════════════════╗${NC}"
-echo -e "${BLUE}║       Odoo CE 18.0 - Install All CE-Native Apps            ║${NC}"
-echo -e "${BLUE}╚════════════════════════════════════════════════════════════╝${NC}"
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            echo -e "${YELLOW}DRY RUN MODE - No changes will be made${NC}"
+            shift
+            ;;
+        --docker)
+            DOCKER_MODE=true
+            DOCKER_CONTAINER="${2:-odoo-core}"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--dry-run] [--docker CONTAINER_NAME]"
+            exit 1
+            ;;
+    esac
+done
+
+echo -e "${BLUE}╔═══════════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║       Odoo CE 18.0 - Install All CE Core Modules                  ║${NC}"
+echo -e "${BLUE}║       Complete canonical set by functional area                   ║${NC}"
+echo -e "${BLUE}╚═══════════════════════════════════════════════════════════════════╝${NC}"
 echo ""
 
 # Odoo connection settings (from environment or defaults)
@@ -32,89 +58,213 @@ ODOO_DB="${ODOO_DB:-odoo}"
 ODOO_USER="${ODOO_USER:-admin}"
 ODOO_PASSWORD="${ODOO_PASSWORD:-admin}"
 
-# CE-native apps in dependency order
-# Group 1: Base dependencies
-GROUP1=(
-    "contacts"
-    "account"
+if [[ "$DOCKER_MODE" == "true" ]]; then
+    echo -e "${CYAN}Docker Mode: Using container '${DOCKER_CONTAINER}'${NC}"
+    echo -e "${CYAN}Database: ${ODOO_DB}${NC}"
+else
+    echo -e "${CYAN}Host: ${ODOO_HOST}:${ODOO_PORT}${NC}"
+    echo -e "${CYAN}Database: ${ODOO_DB}${NC}"
+fi
+echo ""
+
+# ============================================================================
+# CE Core Modules - Organized by Functional Area with Dependencies
+# ============================================================================
+
+# Group 0: Base / System (Already installed with Odoo, but included for completeness)
+GROUP0_NAME="Base / System"
+GROUP0=(
+    "base"
+    "web"
+    "base_setup"
+    "base_import"
+    "bus"
+    "mail"
+    "digest"
+    "iap"
+    "web_tour"
+    "web_editor"
+    "web_unsplash"
+    "portal"
+    "resource"
+    "calendar"
 )
 
-# Group 2: Core transactional
-GROUP2=(
-    "sale_management"
+# Group 1: Contacts / CRM / Sales
+GROUP1_NAME="Contacts / CRM / Sales"
+GROUP1=(
+    "contacts"
+    "sales_team"
     "crm"
+    "sale"
+    "sale_management"
+    "sale_crm"
+)
+
+# Group 2: Accounting / Invoicing / Payments
+GROUP2_NAME="Accounting / Invoicing / Payments"
+GROUP2=(
+    "analytic"
+    "account"
+    "account_payment"
+    "account_check_printing"
+    "account_bank_statement_import"
+    "account_bank_statement_import_csv"
+    "account_bank_statement_import_ofx"
+    "account_bank_statement_import_qif"
+    "account_batch_payment"
+    "account_asset"
+    "account_budget"
+    "account_tax_python"
+)
+
+# Group 3: Purchase
+GROUP3_NAME="Purchase"
+GROUP3=(
     "purchase"
+    "purchase_requisition"
+)
+
+# Group 4: Inventory / Warehouse
+GROUP4_NAME="Inventory / Warehouse"
+GROUP4=(
     "stock"
+    "stock_account"
+    "stock_landed_costs"
+    "stock_picking_batch"
+)
+
+# Group 5: Cross-module dependencies (require stock + purchase/sale)
+GROUP5_NAME="Cross-Module Integrations"
+GROUP5=(
+    "sale_stock"
+    "sale_purchase"
+    "purchase_stock"
+)
+
+# Group 6: Manufacturing
+GROUP6_NAME="Manufacturing"
+GROUP6=(
     "mrp"
     "maintenance"
 )
 
-# Group 3: HR modules
-GROUP3=(
+# Group 7: Project / Services / Timesheet
+GROUP7_NAME="Project / Services"
+GROUP7=(
+    "project"
+    "project_todo"
+    "hr_timesheet"
+    "sale_timesheet"
+)
+
+# Group 8: HR
+GROUP8_NAME="Human Resources"
+GROUP8=(
     "hr"
     "hr_contract"
-    "hr_skills"
-    "hr_recruitment"
     "hr_holidays"
     "hr_attendance"
     "hr_expense"
-    "fleet"
+    "hr_recruitment"
+    "hr_skills"
 )
 
-# Group 4: Website & Marketing
-GROUP4=(
+# Group 9: Website / eCommerce
+GROUP9_NAME="Website / eCommerce"
+GROUP9=(
     "website"
     "website_sale"
-    "website_event"
+    "website_crm"
+    "website_blog"
+    "website_forum"
     "website_slides"
-    "im_livechat"
+    "website_event"
+)
+
+# Group 10: Marketing
+GROUP10_NAME="Marketing"
+GROUP10=(
     "mass_mailing"
     "mass_mailing_sms"
     "marketing_card"
+    "im_livechat"
 )
 
-# Group 5: Project & Productivity
-GROUP5=(
-    "project"
-    "project_todo"
-    "survey"
-    "lunch"
-)
-
-# Group 6: POS & Services
-GROUP6=(
+# Group 11: POS
+GROUP11_NAME="Point of Sale"
+GROUP11=(
     "point_of_sale"
     "pos_restaurant"
-    "repair"
 )
 
-# Group 7: Admin & Compliance
-GROUP7=(
+# Group 12: Utilities / Misc
+GROUP12_NAME="Utilities / Misc"
+GROUP12=(
+    "survey"
+    "lunch"
+    "fleet"
+    "repair"
     "data_recycle"
 )
 
-# Already installed (skip)
-ALREADY_INSTALLED=(
-    "mail"
-    "calendar"
-)
+# Track success/failure
+SUCCESS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+FAILED_MODULES=()
 
 install_module() {
     local module=$1
-    echo -n "  Installing $module... "
+    printf "  %-40s " "$module"
 
     if [[ "$DRY_RUN" == "true" ]]; then
         echo -e "${YELLOW}[DRY RUN]${NC}"
+        ((SUCCESS_COUNT++))
         return 0
     fi
 
-    # Use Odoo CLI or XML-RPC to install
-    # Option 1: Odoo CLI (if running in same container)
-    if command -v odoo &> /dev/null; then
-        odoo -d "$ODOO_DB" -i "$module" --stop-after-init 2>/dev/null && \
-            echo -e "${GREEN}✓${NC}" || echo -e "${RED}✗${NC}"
+    if [[ "$DOCKER_MODE" == "true" ]]; then
+        # Docker mode: exec into container
+        result=$(docker exec "$DOCKER_CONTAINER" \
+            odoo -d "$ODOO_DB" -i "$module" --stop-after-init 2>&1) || true
+
+        if echo "$result" | grep -q "odoo.modules.loading: Module .* loaded"; then
+            echo -e "${GREEN}✓${NC}"
+            ((SUCCESS_COUNT++))
+            return 0
+        elif echo "$result" | grep -q "already"; then
+            echo -e "${CYAN}[already installed]${NC}"
+            ((SKIP_COUNT++))
+            return 0
+        else
+            echo -e "${RED}✗${NC}"
+            ((FAIL_COUNT++))
+            FAILED_MODULES+=("$module")
+            return 1
+        fi
+    elif command -v odoo &> /dev/null; then
+        # Local odoo binary
+        if odoo -d "$ODOO_DB" -i "$module" --stop-after-init 2>/dev/null; then
+            echo -e "${GREEN}✓${NC}"
+            ((SUCCESS_COUNT++))
+        else
+            echo -e "${RED}✗${NC}"
+            ((FAIL_COUNT++))
+            FAILED_MODULES+=("$module")
+        fi
+    elif command -v odoo-bin &> /dev/null; then
+        # Local odoo-bin
+        if odoo-bin -d "$ODOO_DB" -i "$module" --stop-after-init 2>/dev/null; then
+            echo -e "${GREEN}✓${NC}"
+            ((SUCCESS_COUNT++))
+        else
+            echo -e "${RED}✗${NC}"
+            ((FAIL_COUNT++))
+            FAILED_MODULES+=("$module")
+        fi
     else
-        # Option 2: HTTP API call
+        # Fallback: HTTP API call
         response=$(curl -s -X POST "http://${ODOO_HOST}:${ODOO_PORT}/web/dataset/call_kw" \
             -H "Content-Type: application/json" \
             -d "{
@@ -131,8 +281,11 @@ install_module() {
 
         if echo "$response" | grep -q '"error"'; then
             echo -e "${RED}✗${NC}"
+            ((FAIL_COUNT++))
+            FAILED_MODULES+=("$module")
         else
             echo -e "${GREEN}✓${NC}"
+            ((SUCCESS_COUNT++))
         fi
     fi
 }
@@ -142,34 +295,63 @@ install_group() {
     shift
     local modules=("$@")
 
-    echo -e "${YELLOW}▸ $group_name${NC}"
+    echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${YELLOW}▸ $group_name (${#modules[@]} modules)${NC}"
+    echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
     for module in "${modules[@]}"; do
-        install_module "$module"
+        install_module "$module" || true  # Continue on failure
     done
     echo ""
 }
 
-# Main installation
-echo -e "${YELLOW}▸ Checking already installed modules...${NC}"
-for module in "${ALREADY_INSTALLED[@]}"; do
-    echo -e "  ${GREEN}✓${NC} $module (already installed)"
-done
+# Calculate total modules
+TOTAL_MODULES=$((${#GROUP0[@]} + ${#GROUP1[@]} + ${#GROUP2[@]} + ${#GROUP3[@]} + \
+    ${#GROUP4[@]} + ${#GROUP5[@]} + ${#GROUP6[@]} + ${#GROUP7[@]} + ${#GROUP8[@]} + \
+    ${#GROUP9[@]} + ${#GROUP10[@]} + ${#GROUP11[@]} + ${#GROUP12[@]}))
+
+echo -e "${CYAN}Total CE core modules to install: ${TOTAL_MODULES}${NC}"
 echo ""
 
-install_group "Group 1: Base Dependencies" "${GROUP1[@]}"
-install_group "Group 2: Core Transactional" "${GROUP2[@]}"
-install_group "Group 3: HR Modules" "${GROUP3[@]}"
-install_group "Group 4: Website & Marketing" "${GROUP4[@]}"
-install_group "Group 5: Project & Productivity" "${GROUP5[@]}"
-install_group "Group 6: POS & Services" "${GROUP6[@]}"
-install_group "Group 7: Admin & Compliance" "${GROUP7[@]}"
+# Install in dependency order
+install_group "$GROUP0_NAME" "${GROUP0[@]}"
+install_group "$GROUP1_NAME" "${GROUP1[@]}"
+install_group "$GROUP2_NAME" "${GROUP2[@]}"
+install_group "$GROUP3_NAME" "${GROUP3[@]}"
+install_group "$GROUP4_NAME" "${GROUP4[@]}"
+install_group "$GROUP5_NAME" "${GROUP5[@]}"
+install_group "$GROUP6_NAME" "${GROUP6[@]}"
+install_group "$GROUP7_NAME" "${GROUP7[@]}"
+install_group "$GROUP8_NAME" "${GROUP8[@]}"
+install_group "$GROUP9_NAME" "${GROUP9[@]}"
+install_group "$GROUP10_NAME" "${GROUP10[@]}"
+install_group "$GROUP11_NAME" "${GROUP11[@]}"
+install_group "$GROUP12_NAME" "${GROUP12[@]}"
 
-# Count total
-TOTAL=$((${#GROUP1[@]} + ${#GROUP2[@]} + ${#GROUP3[@]} + ${#GROUP4[@]} + ${#GROUP5[@]} + ${#GROUP6[@]} + ${#GROUP7[@]} + ${#ALREADY_INSTALLED[@]}))
-
-echo -e "${GREEN}═══════════════════════════════════════════════════════════${NC}"
-echo -e "${GREEN}  Installation complete!${NC}"
-echo -e "${GREEN}  Total modules: $TOTAL${NC}"
-echo -e "${GREEN}═══════════════════════════════════════════════════════════${NC}"
+# Summary
+echo -e "${BLUE}═══════════════════════════════════════════════════════════════════${NC}"
+echo -e "${BLUE}                         INSTALLATION SUMMARY                       ${NC}"
+echo -e "${BLUE}═══════════════════════════════════════════════════════════════════${NC}"
 echo ""
-echo "  Run verification: ./scripts/odoo/verify-ce-apps.sh"
+echo -e "  ${GREEN}✓ Successful:${NC}  $SUCCESS_COUNT"
+echo -e "  ${CYAN}⊘ Skipped:${NC}     $SKIP_COUNT"
+echo -e "  ${RED}✗ Failed:${NC}      $FAIL_COUNT"
+echo -e "  ─────────────────────"
+echo -e "  Total:         $TOTAL_MODULES"
+echo ""
+
+if [[ ${#FAILED_MODULES[@]} -gt 0 ]]; then
+    echo -e "${RED}Failed modules:${NC}"
+    for mod in "${FAILED_MODULES[@]}"; do
+        echo -e "  - $mod"
+    done
+    echo ""
+    echo -e "${YELLOW}Note: Some modules may not be available in Odoo 18 CE.${NC}"
+    echo -e "${YELLOW}Run with --dry-run first to see the full list.${NC}"
+fi
+
+echo ""
+echo -e "  ${CYAN}Next steps:${NC}"
+echo -e "  - Verify installation: ./scripts/odoo/verify-ce-apps.sh"
+echo -e "  - Restart Odoo if needed: docker restart ${DOCKER_CONTAINER:-odoo-core}"
+echo ""


### PR DESCRIPTION
- Update install-ce-apps.sh with complete canonical CE module set
- Organize modules into 13 functional groups by dependency order
- Add Docker mode (--docker CONTAINER) for container-based installation
- Add ce-init profile to docker-compose.yml for bulk CE module install
- Track success/failure/skip counts with detailed summary

Groups: Base/System, CRM/Sales, Accounting, Purchase, Inventory, Manufacturing, Project/Services, HR, Website, Marketing, POS, Utilities

Usage: ./scripts/odoo/install-ce-apps.sh --docker odoo-core
       docker compose --profile ce-init up odoo-core-ce-init