### PR TITLE
docs(data-model): add canonical DBML/ERD/ORM maps + drift check

### DIFF
--- a/.github/workflows/ci-odoo-ce.yml
+++ b/.github/workflows/ci-odoo-ce.yml
@@ -71,6 +71,18 @@ jobs:
           chmod +x scripts/report_ci_telemetry.sh
           scripts/report_ci_telemetry.sh "${{ job.status }}"
 
+  data-model-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate canonical data model artifacts
+        run: python scripts/generate_odoo_dbml.py
+
+      - name: Fail if data-model artifacts drift
+        run: git diff --exit-code docs/data-model/
+
   repo-structure:
     runs-on: ubuntu-latest
     steps:

--- a/SITEMAP.md
+++ b/SITEMAP.md
@@ -204,6 +204,13 @@
 | [RAG Architecture Implementation Plan](docs/RAG_ARCHITECTURE_IMPLEMENTATION_PLAN.md) | docs |
 | [InsightPulseAI Documentation](docs/README.md) | docs |
 | [MCP Stack – Odoo + n8n + Mattermost + Superset + DO Agents](docs/README_MCP_STACK.md) | docs |
+| [Odoo Data Model Artifacts](docs/data-model/README.md) | docs/data-model |
+| [Odoo Canonical DBML Schema](docs/data-model/ODOO_CANONICAL_SCHEMA.dbml) | docs/data-model |
+| [Odoo ERD (Mermaid)](docs/data-model/ODOO_ERD.mmd) | docs/data-model |
+| [Odoo ERD (PlantUML)](docs/data-model/ODOO_ERD.puml) | docs/data-model |
+| [Odoo ORM Map](docs/data-model/ODOO_ORM_MAP.md) | docs/data-model |
+| [Odoo Module Deltas](docs/data-model/ODOO_MODULE_DELTAS.md) | docs/data-model |
+| [Odoo Model Index](docs/data-model/ODOO_MODEL_INDEX.json) | docs/data-model |
 | [Repo Tree Contract (Authoritative)](docs/REPO_TREE.contract.md) | docs |
 | [Repo Tree (generated)](docs/REPO_TREE.generated.md) | docs |
 | [SaaS Parity Readiness - Odoo CE Stack](docs/SAAS_PARITY_READINESS.md) | docs |

--- a/TREE.md
+++ b/TREE.md
@@ -1176,6 +1176,14 @@
 │   │   ├── DB_RLS_POLICY_TEMPLATES.md
 │   │   ├── DB_TABLE_CLASSIFICATION_DRAFT.md
 │   │   └── DB_TARGET_ARCHITECTURE.md
+│   ├── data-model
+│   │   ├── ODOO_CANONICAL_SCHEMA.dbml
+│   │   ├── ODOO_ERD.mmd
+│   │   ├── ODOO_ERD.puml
+│   │   ├── ODOO_MODEL_INDEX.json
+│   │   ├── ODOO_MODULE_DELTAS.md
+│   │   ├── ODOO_ORM_MAP.md
+│   │   └── README.md
 │   ├── deployment
 │   │   ├── CLAUDE_CODE_CLI_PROMPT.md
 │   │   ├── DEPLOYMENT_EXECUTION_GUIDE.md

--- a/docs/data-model/ODOO_CANONICAL_SCHEMA.dbml
+++ b/docs/data-model/ODOO_CANONICAL_SCHEMA.dbml
@@ -1,0 +1,3759 @@
+Table a1_check {
+  active boolean
+  check_type varchar
+  close_gate_template_id int
+  code varchar
+  company_id int
+  create_date datetime
+  create_uid int
+  description varchar
+  fail_action text
+  id int [pk]
+  name varchar
+  pass_criteria text
+  sequence int
+  severity varchar
+  write_date datetime
+  write_uid int
+  Note: 'code_uniq: unique(code, company_id) (Check code must be unique per company.)'
+}
+
+Table a1_check_result {
+  check_id int
+  create_date datetime
+  create_uid int
+  evidence varchar
+  executed_by int
+  executed_date datetime
+  id int [pk]
+  result varchar
+  result_notes text
+  task_id int
+  write_date datetime
+  write_uid int
+}
+
+Table a1_check_result_attachment_ids_rel {
+  a1_check_result_id int
+  ir_attachment_id int
+}
+
+Table a1_export_run {
+  company_id int
+  create_date datetime
+  create_uid int
+  created_count int
+  error_count int
+  id int [pk]
+  log text
+  run_type varchar
+  seed_hash varchar
+  seed_json text
+  status varchar
+  unchanged_count int
+  updated_count int
+  webhook_url varchar
+  write_date datetime
+  write_uid int
+}
+
+Table a1_role {
+  active boolean
+  code varchar
+  company_id int
+  create_date datetime
+  create_uid int
+  default_user_id int
+  description text
+  fallback_user_id int
+  id int [pk]
+  name varchar
+  sequence int
+  write_date datetime
+  write_uid int
+  Note: 'code_uniq: unique(code, company_id) (Role code must be unique per company.)'
+}
+
+Table a1_role_group_ids_rel {
+  a1_role_id int
+  res_groups_id int
+}
+
+Table a1_task {
+  approval_deadline date
+  approval_done_by int
+  approval_done_date datetime
+  approver_id int
+  approver_role varchar
+  checklist_progress float
+  close_task_id int
+  company_id int
+  create_date datetime
+  create_uid int
+  external_key varchar
+  id int [pk]
+  name varchar
+  notes varchar
+  owner_id int
+  owner_role varchar
+  prep_deadline date
+  prep_done_by int
+  prep_done_date datetime
+  review_deadline date
+  review_done_by int
+  review_done_date datetime
+  reviewer_id int
+  reviewer_role varchar
+  sequence int
+  state varchar
+  tasklist_id int
+  template_id int
+  workstream_id int
+  write_date datetime
+  write_uid int
+}
+
+Table a1_task_checklist {
+  code varchar
+  create_date datetime
+  create_uid int
+  done_by int
+  done_date datetime
+  id int [pk]
+  is_done boolean
+  is_required boolean
+  item_type varchar
+  name varchar
+  sequence int
+  task_id int
+  template_item_id int
+  value_attachment_id int
+  value_text text
+  write_date datetime
+  write_uid int
+}
+
+Table a1_tasklist {
+  close_cycle_id int
+  company_id int
+  create_date datetime
+  create_uid int
+  id int [pk]
+  name varchar
+  notes varchar
+  period_end date
+  period_label varchar
+  period_start date
+  progress float
+  state varchar
+  task_count int
+  task_done_count int
+  webhook_url varchar
+  write_date datetime
+  write_uid int
+  Note: 'period_uniq: unique(period_start, period_end, company_id) (A tasklist for this period already exists.)'
+}
+
+Table a1_template {
+  active boolean
+  approval_days float
+  approver_role varchar
+  close_template_id int
+  code varchar
+  company_id int
+  create_date datetime
+  create_uid int
+  description varchar
+  id int [pk]
+  name varchar
+  owner_role varchar
+  phase_code varchar
+  prep_days float
+  review_days float
+  reviewer_role varchar
+  sequence int
+  total_days float
+  workstream_id int
+  write_date datetime
+  write_uid int
+  Note: 'code_uniq: unique(code, company_id) (Template code must be unique per company.)'
+}
+
+Table a1_template_check_rel {
+  check_id int
+  template_id int
+}
+
+Table a1_template_checklist {
+  code varchar
+  create_date datetime
+  create_uid int
+  id int [pk]
+  instructions text
+  is_required boolean
+  item_type varchar
+  name varchar
+  sequence int
+  template_id int
+  write_date datetime
+  write_uid int
+}
+
+Table a1_template_step {
+  assignee_role varchar
+  code varchar
+  create_date datetime
+  create_uid int
+  deadline_offset_days int
+  effort_days float
+  id int [pk]
+  name varchar
+  sequence int
+  template_id int
+  write_date datetime
+  write_uid int
+}
+
+Table a1_workstream {
+  active boolean
+  close_category_id int
+  code varchar
+  company_id int
+  create_date datetime
+  create_uid int
+  description varchar
+  id int [pk]
+  name varchar
+  owner_role_id int
+  owner_user_id int
+  phase_code varchar
+  sequence int
+  template_count int
+  write_date datetime
+  write_uid int
+  Note: 'code_uniq: unique(code, company_id) (Workstream code must be unique per company.)'
+}
+
+Table account_account {
+  id int [pk]
+  Note: 'stub for core model'
+}
+
+Table account_move {
+  bir_2307_date date
+  bir_2307_generated boolean
+  create_date datetime
+  create_uid int
+  ewt_amount decimal
+  id int [pk]
+  write_date datetime
+  write_uid int
+}
+
+Table advisor_category {
+  active boolean
+  code varchar
+  color int
+  create_date datetime
+  create_uid int
+  description text
+  high_count int
+  icon varchar
+  id int [pk]
+  latest_score int
+  name varchar
+  open_count int
+  recommendation_count int
+  sequence int
+  write_date datetime
+  write_uid int
+  Note: 'code_unique: UNIQUE(code) (Category code must be unique!)'
+}
+
+Table advisor_playbook {
+  active boolean
+  automation_kind varchar
+  automation_params text
+  automation_ref varchar
+  code varchar
+  create_date datetime
+  create_uid int
+  description text
+  id int [pk]
+  name varchar
+  recommendation_count int
+  steps_md text
+  write_date datetime
+  write_uid int
+}
+
+Table advisor_playbook_category_ids_rel {
+  advisor_category_id int
+  advisor_playbook_id int
+}
+
+Table advisor_recommendation {
+  category_code varchar
+  category_id int
+  confidence float
+  create_date datetime
+  create_uid int
+  currency_id int
+  date_due date
+  date_resolved date
+  description text
+  estimated_savings decimal
+  evidence text
+  external_link varchar
+  id int [pk]
+  impact_score int
+  name varchar
+  owner_id int
+  playbook_id int
+  remediation_steps text
+  resource_ref varchar
+  resource_type varchar
+  severity varchar
+  severity_order int
+  snooze_until date
+  source varchar
+  status varchar
+  write_date datetime
+  write_uid int
+}
+
+Table advisor_recommendation_tag_ids_rel {
+  advisor_recommendation_id int
+  advisor_tag_id int
+}
+
+Table advisor_score {
+  as_of datetime
+  category_code varchar
+  category_id int
+  create_date datetime
+  create_uid int
+  critical_count int
+  high_count int
+  id int [pk]
+  inputs_json text
+  open_count int
+  resolved_count int
+  score int
+  write_date datetime
+  write_uid int
+}
+
+Table advisor_tag {
+  color int
+  create_date datetime
+  create_uid int
+  id int [pk]
+  name varchar
+  write_date datetime
+  write_uid int
+  Note: 'name_unique: UNIQUE(name) (Tag name must be unique!)'
+}
+
+Table base_automation {
+  id int [pk]
+  Note: 'stub for core model'
+}
+
+Table bir_alphalist {
+  company_id int
+  create_date datetime
+  create_uid int
+  currency_id int
+  fiscal_year int
+  form_type varchar
+  id int [pk]
+  name varchar
+  state varchar
+  total_gross decimal
+  total_wht decimal
+  write_date datetime
+  write_uid int
+}
+
+Table bir_alphalist_line {
+  alphalist_id int
+  create_date datetime
+  create_uid int
+  currency_id int
+  gross_income decimal
+  id int [pk]
+  income_type varchar
+  partner_id int
+  tin varchar
+  wht_amount decimal
+  write_date datetime
+  write_uid int
+}
+
+Table bir_filing_deadline {
+  company_id int
+  create_date datetime
+  create_uid int
+  deadline_date date
+  form_type varchar
+  id int [pk]
+  name varchar
+  period_month int
+  period_year int
+  reminder_date date
+  return_id int
+  state varchar
+  write_date datetime
+  write_uid int
+}
+
+Table bir_return {
+  bir_reference varchar
+  company_id int
+  create_date datetime
+  create_uid int
+  currency_id int
+  exempt_sales decimal
+  filed_by int
+  filed_date datetime
+  form_type varchar
+  id int [pk]
+  input_vat decimal
+  interest decimal
+  name varchar
+  notes text
+  output_vat decimal
+  payment_date date
+  payment_reference varchar
+  penalty decimal
+  period_end date
+  period_start date
+  state varchar
+  task_id int
+  tax_base decimal
+  tax_credits decimal
+  tax_due decimal
+  tax_payable decimal
+  total_due decimal
+  total_payments decimal
+  total_wht decimal
+  vatable_sales decimal
+  write_date datetime
+  write_uid int
+  zero_rated_sales decimal
+}
+
+Table bir_return_line {
+  amount decimal
+  create_date datetime
+  create_uid int
+  currency_id int
+  description varchar
+  id int [pk]
+  move_id int
+  partner_id int
+  return_id int
+  sequence int
+  tax_amount decimal
+  tin varchar
+  write_date datetime
+  write_uid int
+}
+
+Table bir_tax_return {
+  bir_reference varchar
+  company_id int
+  create_date datetime
+  create_uid int
+  currency_id int
+  days_until_due int
+  due_date date
+  filed_by int
+  filed_date datetime
+  form_type varchar
+  frequency varchar
+  id int [pk]
+  interest decimal
+  is_overdue boolean
+  name varchar
+  notes text
+  payment_date date
+  payment_reference varchar
+  penalty decimal
+  period_end date
+  period_start date
+  state varchar
+  tax_base decimal
+  tax_category varchar
+  tax_credits decimal
+  tax_due decimal
+  tax_payable decimal
+  total_amount_due decimal
+  write_date datetime
+  write_uid int
+}
+
+Table bir_tax_return_line {
+  create_date datetime
+  create_uid int
+  currency_id int
+  description varchar
+  id int [pk]
+  move_id int
+  partner_id int
+  return_id int
+  sequence int
+  tax_amount decimal
+  tax_base decimal
+  tax_rate float
+  tin varchar
+  write_date datetime
+  write_uid int
+}
+
+Table bir_vat_line {
+  amount_untaxed decimal
+  create_date datetime
+  create_uid int
+  currency_id int
+  id int [pk]
+  invoice_date date
+  invoice_id int
+  line_type varchar
+  partner_id int
+  return_id int
+  tin varchar
+  vat_amount decimal
+  vat_category varchar
+  write_date datetime
+  write_uid int
+}
+
+Table bir_vat_return {
+  create_date datetime
+  create_uid int
+  excess_input_vat decimal
+  excess_input_vat_previous decimal
+  exempt_sales decimal
+  id int [pk]
+  importations decimal
+  net_vat_payable decimal
+  output_vat decimal
+  purchase_of_services decimal
+  total_input_vat decimal
+  total_sales decimal
+  vatable_purchases decimal
+  vatable_sales decimal
+  write_date datetime
+  write_uid int
+  zero_rated_sales decimal
+}
+
+Table bir_withholding_line {
+  create_date datetime
+  create_uid int
+  currency_id int
+  gross_income decimal
+  id int [pk]
+  income_type varchar
+  move_id int
+  partner_id int
+  payslip_id int
+  return_id int
+  tin varchar
+  wht_amount decimal
+  wht_rate float
+  write_date datetime
+  write_uid int
+}
+
+Table bir_withholding_return {
+  compensation_tax_withheld decimal
+  create_date datetime
+  create_uid int
+  employee_count int
+  expanded_wht_amount decimal
+  final_wht_amount decimal
+  id int [pk]
+  taxable_compensation decimal
+  total_compensation decimal
+  total_payments decimal
+  withholding_type varchar
+  write_date datetime
+  write_uid int
+}
+
+Table close_approval_gate {
+  actual_value float
+  approval_notes text
+  approved_by int
+  approved_date datetime
+  approver_id int
+  approver_role varchar
+  approver_user_id int
+  block_on_exceptions boolean
+  block_reason text
+  blocking_reason text
+  company_id int
+  create_date datetime
+  create_uid int
+  cycle_id int
+  gate_level int
+  gate_type varchar
+  id int [pk]
+  min_completion_pct float
+  name varchar
+  notes varchar
+  required_approvals int
+  required_task_states varchar
+  sequence int
+  state varchar
+  template_id int
+  threshold_value float
+  write_date datetime
+  write_uid int
+}
+
+Table close_approval_gate_blocking_exceptions_rel {
+  close_approval_gate_id int
+  close_exception_id int
+}
+
+Table close_approval_gate_blocking_tasks_rel {
+  close_approval_gate_id int
+  close_task_id int
+}
+
+Table close_approval_gate_template {
+  a1_check_id int
+  active boolean
+  code varchar
+  company_id int
+  create_date datetime
+  create_uid int
+  description varchar
+  gate_type varchar
+  id int [pk]
+  name varchar
+  pass_criteria text
+  sequence int
+  write_date datetime
+  write_uid int
+}
+
+Table close_cycle {
+  a1_tasklist_id int
+  close_actual_date date
+  close_start_date date
+  close_target_date date
+  closing_period_id int
+  company_id int
+  create_date datetime
+  create_uid int
+  cycle_time_days int
+  exception_count int
+  gates_ready boolean
+  id int [pk]
+  name varchar
+  notes varchar
+  open_exception_count int
+  period_end date
+  period_label varchar
+  period_start date
+  period_type varchar
+  progress float
+  state varchar
+  task_completion_pct float
+  task_count int
+  task_done_count int
+  webhook_url varchar
+  write_date datetime
+  write_uid int
+  Note: 'period_uniq: unique(period_start, period_end, company_id) (A cycle for this period already exists.)'
+}
+
+Table close_exception {
+  amount decimal
+  assigned_to int
+  company_id int
+  create_date datetime
+  create_uid int
+  currency_id int
+  cycle_id int
+  description text
+  detected_by int
+  detected_date datetime
+  escalated_date datetime
+  escalated_to int
+  escalation_count int
+  escalation_deadline datetime
+  escalation_level int
+  exception_type varchar
+  id int [pk]
+  last_escalated datetime
+  name varchar
+  related_account_id int
+  related_move_id int
+  related_partner_id int
+  reported_by int
+  resolution varchar
+  resolution_action text
+  resolved_by int
+  resolved_date datetime
+  root_cause text
+  severity varchar
+  state varchar
+  task_id int
+  variance_pct float
+  write_date datetime
+  write_uid int
+}
+
+Table close_task {
+  a1_task_id int
+  approval_deadline date
+  approval_done_by int
+  approval_done_date datetime
+  approve_done_date datetime
+  approve_due_date date
+  approve_notes text
+  approve_user_id int
+  approver_id int
+  category_id int
+  checklist_done_pct float
+  checklist_progress float
+  company_id int
+  create_date datetime
+  create_uid int
+  cycle_id int
+  days_overdue int
+  description text
+  external_key varchar
+  gl_entry_count int
+  has_exceptions boolean
+  has_open_exceptions boolean
+  id int [pk]
+  is_overdue boolean
+  name varchar
+  notes varchar
+  prep_deadline date
+  prep_done_by int
+  prep_done_date datetime
+  prep_due_date date
+  prep_notes text
+  prep_user_id int
+  preparer_id int
+  review_deadline date
+  review_done_by int
+  review_done_date datetime
+  review_due_date date
+  review_notes text
+  review_result varchar
+  review_user_id int
+  reviewer_id int
+  sequence int
+  state varchar
+  template_id int
+  write_date datetime
+  write_uid int
+}
+
+Table close_task_attachment_ids_rel {
+  close_task_id int
+  ir_attachment_id int
+}
+
+Table close_task_category {
+  a1_workstream_id int
+  active boolean
+  code varchar
+  color int
+  company_id int
+  create_date datetime
+  create_uid int
+  default_approve_days int
+  default_approve_role varchar
+  default_prep_days int
+  default_prep_role varchar
+  default_review_days int
+  default_review_role varchar
+  description text
+  id int [pk]
+  name varchar
+  sequence int
+  write_date datetime
+  write_uid int
+  Note: 'category_code_unique: unique(code) (Category code must be unique)\ncode_uniq: unique(code, company_id) (Category code must be unique per company.)'
+}
+
+Table close_task_category_gl_account_ids_rel {
+  account_account_id int
+  close_task_category_id int
+}
+
+Table close_task_checklist {
+  attachment_id int
+  code varchar
+  create_date datetime
+  create_uid int
+  done_at datetime
+  done_by int
+  done_date datetime
+  evidence_type varchar
+  id int [pk]
+  instructions text
+  is_done boolean
+  is_required boolean
+  name varchar
+  notes text
+  required boolean
+  sequence int
+  task_id int
+  write_date datetime
+  write_uid int
+}
+
+Table close_task_gl_entry_ids_rel {
+  account_move_id int
+  close_task_id int
+}
+
+Table close_task_template {
+  a1_template_id int
+  active boolean
+  approval_days float
+  approval_offset int
+  approve_day_offset int
+  approver_id int
+  approver_role varchar
+  category_id int
+  code varchar
+  company_id int
+  create_date datetime
+  create_uid int
+  creates_gl_entry boolean
+  default_approve_user_id int
+  default_prep_user_id int
+  default_review_user_id int
+  description text
+  id int [pk]
+  name varchar
+  period_type varchar
+  prep_day_offset int
+  prep_days float
+  prep_offset int
+  preparer_id int
+  preparer_role varchar
+  review_day_offset int
+  review_days float
+  review_offset int
+  reviewer_id int
+  reviewer_role varchar
+  sequence int
+  write_date datetime
+  write_uid int
+  Note: 'code_uniq: unique(code, company_id) (Template code must be unique per company.)\ntemplate_code_unique: unique(code) (Template code must be unique)'
+}
+
+Table close_task_template_checklist {
+  code varchar
+  create_date datetime
+  create_uid int
+  evidence_type varchar
+  id int [pk]
+  instructions text
+  is_required boolean
+  name varchar
+  required boolean
+  sequence int
+  template_id int
+  write_date datetime
+  write_uid int
+}
+
+Table close_task_template_gl_account_ids_rel {
+  account_account_id int
+  close_task_template_id int
+}
+
+Table closing_period {
+  bir_tasks int
+  company_id int
+  completed_tasks int
+  create_date datetime
+  create_uid int
+  id int [pk]
+  last_workday date
+  month_end_tasks int
+  name varchar
+  notes text
+  overdue_tasks int
+  period_date date
+  period_month int
+  period_year int
+  progress float
+  state varchar
+  total_tasks int
+  write_date datetime
+  write_uid int
+}
+
+Table compliance_check {
+  actual_value float
+  check_type varchar
+  checked_by int
+  checked_date datetime
+  closing_id int
+  create_date datetime
+  create_uid int
+  expected_value float
+  id int [pk]
+  name varchar
+  result_text text
+  sequence int
+  status varchar
+  tolerance float
+  variance float
+  write_date datetime
+  write_uid int
+}
+
+Table crm_lead {
+  create_date datetime
+  create_uid int
+  days_in_stage int
+  id int [pk]
+  last_call_date datetime
+  last_meeting_date datetime
+  stage_entry_date datetime
+  stage_missing_fields varchar
+  stage_rule_validated boolean
+  write_date datetime
+  write_uid int
+}
+
+Table crm_stage {
+  create_date datetime
+  create_uid int
+  id int [pk]
+  ipai_automation_notes text
+  ipai_enforce_rules boolean
+  ipai_sla_days int
+  ipai_stage_color varchar
+  ipai_stage_icon varchar
+  write_date datetime
+  write_uid int
+}
+
+Table crm_stage_required_fields_rel {
+  field_id int
+  stage_id int
+}
+
+Table discuss_channel {
+  create_date datetime
+  create_uid int
+  id int [pk]
+  is_ai_channel boolean
+  write_date datetime
+  write_uid int
+}
+
+Table finance_bir_deadline {
+  active boolean
+  create_date datetime
+  create_uid int
+  deadline_date date
+  description text
+  display_name varchar
+  form_type varchar
+  id int [pk]
+  name varchar
+  period_covered varchar
+  responsible_approval_id int
+  responsible_prep_id int
+  responsible_review_id int
+  state varchar
+  target_payment_approval_date date
+  target_prep_date date
+  target_report_approval_date date
+  write_date datetime
+  write_uid int
+}
+
+Table finance_ppm_bir_calendar {
+  create_date datetime
+  create_uid int
+  description text
+  filing_deadline date
+  form_code varchar
+  form_name varchar
+  id int [pk]
+  period varchar
+  responsible_role varchar
+  write_date datetime
+  write_uid int
+  Note: 'unique_form_period: UNIQUE(form_code, period) (BIR form and period combination must be unique!)'
+}
+
+Table finance_ppm_dashboard {
+  create_date datetime
+  create_uid int
+  failures_24h int
+  id int [pk]
+  last_message text
+  last_run_at datetime
+  last_status varchar
+  name varchar
+  next_scheduled_at datetime
+  sequence int
+  status_color varchar
+  total_runs int
+  workflow_code varchar
+  write_date datetime
+  write_uid int
+}
+
+Table finance_ppm_import_wizard {
+  create_date datetime
+  create_uid int
+  error_log text
+  file_data binary
+  file_name varchar
+  file_type varchar
+  id int [pk]
+  import_summary text
+  import_type varchar
+  records_created int
+  records_failed int
+  records_skipped int
+  records_updated int
+  skip_header boolean
+  state varchar
+  update_existing boolean
+  write_date datetime
+  write_uid int
+}
+
+Table finance_ppm_logframe {
+  code varchar
+  create_date datetime
+  create_uid int
+  description text
+  id int [pk]
+  kpi_baseline varchar
+  kpi_measure varchar
+  kpi_target varchar
+  level varchar
+  measurement_frequency varchar
+  name varchar
+  parent_id int
+  parent_path varchar
+  responsible_role varchar
+  write_date datetime
+  write_uid int
+  Note: 'unique_code: UNIQUE(code) (Logframe code must be unique!)'
+}
+
+Table finance_ppm_ph_holiday {
+  create_date datetime
+  create_uid int
+  date date
+  description text
+  holiday_type varchar
+  id int [pk]
+  is_nationwide boolean
+  name varchar
+  write_date datetime
+  write_uid int
+  Note: 'unique_date_name: UNIQUE(date, name) (Holiday date and name combination must be unique!)'
+}
+
+Table finance_ppm_tdi_audit {
+  create_date datetime
+  create_uid int
+  display_name varchar
+  error_log text
+  file_name varchar
+  has_errors boolean
+  id int [pk]
+  import_date datetime
+  import_summary text
+  import_type varchar
+  records_created int
+  records_failed int
+  records_skipped int
+  records_updated int
+  state varchar
+  success_rate float
+  total_records int
+  user_id int
+  write_date datetime
+  write_uid int
+}
+
+Table finance_task {
+  approve_done boolean
+  approve_done_by int
+  approve_done_date datetime
+  approve_due_date date
+  approve_user_id int
+  bir_form_type varchar
+  bir_reference varchar
+  bir_return_id int
+  closing_id int
+  company_id int
+  create_date datetime
+  create_uid int
+  days_overdue int
+  filed_date datetime
+  filing_due_date date
+  id int [pk]
+  is_overdue boolean
+  name varchar
+  notes text
+  phase varchar
+  prep_done boolean
+  prep_done_by int
+  prep_done_date datetime
+  prep_due_date date
+  prep_user_id int
+  review_done boolean
+  review_done_by int
+  review_done_date datetime
+  review_due_date date
+  review_user_id int
+  sequence int
+  state varchar
+  task_type varchar
+  template_id int
+  write_date datetime
+  write_uid int
+}
+
+Table finance_task_template {
+  active boolean
+  approve_day_offset int
+  approve_user_id int
+  bir_form_type varchar
+  create_date datetime
+  create_uid int
+  description varchar
+  filing_day_offset int
+  frequency varchar
+  id int [pk]
+  name varchar
+  oca_module varchar
+  odoo_model varchar
+  phase varchar
+  prep_day_offset int
+  prep_user_id int
+  review_day_offset int
+  review_user_id int
+  sequence int
+  task_count int
+  task_type varchar
+  write_date datetime
+  write_uid int
+}
+
+Table finance_task_template_dependency_rel {
+  depends_on_id int
+  task_id int
+}
+
+Table hr_employee {
+  create_date datetime
+  create_uid int
+  id int [pk]
+  write_date datetime
+  write_uid int
+  x_master_control_offboarded boolean
+  x_master_control_onboarded boolean
+}
+
+Table hr_expense {
+  create_date datetime
+  create_uid int
+  id int [pk]
+  project_id int
+  requires_project boolean
+  travel_request_id int
+  write_date datetime
+  write_uid int
+  x_master_control_submitted boolean
+}
+
+Table hr_payslip {
+  id int [pk]
+  Note: 'stub for core model'
+}
+
+Table ipai_ask_ai_service {
+  create_date datetime
+  create_uid int
+  id int [pk]
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_asset {
+  active_checkout_id int
+  barcode varchar
+  category_id int
+  code varchar
+  create_date datetime
+  create_uid int
+  currency_id int
+  current_value decimal
+  custodian_id int
+  description text
+  id int [pk]
+  image varchar
+  location_id int
+  name varchar
+  purchase_date date
+  purchase_value decimal
+  state varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_asset_category {
+  allow_reservations boolean
+  asset_count int
+  code varchar
+  create_date datetime
+  create_uid int
+  description text
+  id int [pk]
+  max_checkout_days int
+  name varchar
+  requires_approval boolean
+  sequence int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_asset_checkout {
+  actual_return_date datetime
+  approval_date datetime
+  approved_by int
+  asset_id int
+  checkout_date datetime
+  checkout_notes text
+  condition_on_return varchar
+  create_date datetime
+  create_uid int
+  employee_id int
+  expected_return_date date
+  id int [pk]
+  name varchar
+  return_notes text
+  state varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_asset_reservation {
+  asset_id int
+  create_date datetime
+  create_uid int
+  employee_id int
+  end_date date
+  id int [pk]
+  name varchar
+  notes text
+  start_date date
+  state varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_audit_log {
+  action varchar
+  create_date datetime
+  create_uid int
+  display_name varchar
+  field_name varchar
+  id int [pk]
+  new_value text
+  old_value text
+  res_id int
+  res_model varchar
+  res_name varchar
+  user_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_bir_dat_wizard {
+  create_date datetime
+  create_uid int
+  currency_id int
+  date_end date
+  date_start date
+  file_data binary
+  file_name varchar
+  id int [pk]
+  record_count int
+  report_type varchar
+  state varchar
+  total_amount decimal
+  total_tax decimal
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_bir_form_schedule {
+  approval_date date
+  bir_deadline date
+  create_date datetime
+  create_uid int
+  form_code varchar
+  id int [pk]
+  period varchar
+  prep_date date
+  responsible_approval_id int
+  responsible_prep_id int
+  responsible_review_id int
+  review_date date
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_bir_process_step {
+  create_date datetime
+  create_uid int
+  detail text
+  id int [pk]
+  person_id int
+  role varchar
+  schedule_id int
+  step_no int
+  target_offset int
+  title varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_bir_schedule_item {
+  active boolean
+  bir_form varchar
+  create_date datetime
+  create_uid int
+  deadline date
+  id int [pk]
+  im_xml_id varchar
+  period_covered varchar
+  write_date datetime
+  write_uid int
+  Note: 'bir_schedule_unique: unique(bir_form, period_covered, deadline) (BIR schedule item must be unique per form/period/deadline!)'
+}
+
+Table ipai_bir_schedule_line {
+  approve_by_code varchar
+  approve_due_date date
+  bir_form varchar
+  create_date datetime
+  create_uid int
+  deadline_date date
+  id int [pk]
+  notes varchar
+  period_label varchar
+  prep_by_code varchar
+  prep_due_date date
+  review_by_code varchar
+  review_due_date date
+  write_date datetime
+  write_uid int
+  Note: 'bir_sched_unique: unique(bir_form, period_label) (BIR form+period must be unique.)'
+}
+
+Table ipai_bir_schedule_step {
+  activity_type varchar
+  business_days_before int
+  create_date datetime
+  create_uid int
+  id int [pk]
+  item_id int
+  on_or_before_deadline boolean
+  role_code varchar
+  sequence int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_close_generated_map {
+  create_date datetime
+  create_uid int
+  external_key varchar
+  generation_run_id int
+  id int [pk]
+  operation varchar
+  run_id int
+  seed_hash varchar
+  seed_hash_at_generation varchar
+  task_id int
+  template_id int
+  write_date datetime
+  write_uid int
+  Note: 'external_key_uniq: UNIQUE(external_key) (External key must be unique (prevents duplicate task creation))\nexternal_key_uniq: unique(external_key) (External key must be unique.)'
+}
+
+Table ipai_close_generation_run {
+  create_date datetime
+  create_uid int
+  created_count int
+  cycle_code varchar
+  cycle_key varchar
+  cycle_type varchar
+  dry_run boolean
+  duration_seconds int
+  end_time datetime
+  error_count int
+  id int [pk]
+  name varchar
+  obsolete_marked_count int
+  period_end date
+  period_start date
+  project_id int
+  report_json varchar
+  report_status varchar
+  seed_id varchar
+  seed_version varchar
+  start_time datetime
+  status varchar
+  task_count_created int
+  task_count_obsolete int
+  task_count_skipped int
+  task_count_updated int
+  unchanged_count int
+  unresolved_assignee_count int
+  updated_count int
+  user_id int
+  warning_count int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_close_generator {
+  create_date datetime
+  create_uid int
+  id int [pk]
+  name varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_close_task_step {
+  create_date datetime
+  create_uid int
+  default_employee_code varchar
+  id int [pk]
+  sequence int
+  step_code varchar
+  step_name varchar
+  template_id int
+  user_id int
+  write_date datetime
+  write_uid int
+  x_legacy_template_code varchar
+  Note: 'unique_template_step: UNIQUE(template_id, step_code) (Each template can only have one instance of each step code (PREP, REVIEW, APPROVAL, FILE_PAY))'
+}
+
+Table ipai_close_task_template {
+  category_code varchar
+  category_name varchar
+  category_seq int
+  create_date datetime
+  create_uid int
+  critical_path boolean
+  cycle_code varchar
+  duration_days int
+  employee_code varchar
+  id int [pk]
+  is_active boolean
+  offset_from_period_end int
+  phase_code varchar
+  phase_name varchar
+  phase_seq int
+  phase_type varchar
+  recurrence_rule varchar
+  responsible_role varchar
+  seed_hash varchar
+  step_code varchar
+  step_seq int
+  task_description text
+  task_name_template varchar
+  template_code varchar
+  template_seq int
+  template_version varchar
+  wbs_code_template varchar
+  workstream_code varchar
+  workstream_name varchar
+  workstream_seq int
+  write_date datetime
+  write_uid int
+  x_legacy_migration boolean
+  Note: 'template_code_uniq: UNIQUE(template_code, template_version) (Template code + version must be unique)'
+}
+
+Table ipai_convert_phases_wizard {
+  create_date datetime
+  create_uid int
+  id int [pk]
+  im1_keywords varchar
+  im1_name varchar
+  im2_keywords varchar
+  im2_name varchar
+  move_tasks_by_keyword boolean
+  parent_project_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_directory_person {
+  active boolean
+  code varchar
+  create_date datetime
+  create_uid int
+  email varchar
+  id int [pk]
+  name varchar
+  role varchar
+  write_date datetime
+  write_uid int
+  Note: 'code_unique: unique(code) (Directory code must be unique!)'
+}
+
+Table ipai_equipment_asset {
+  booking_count int
+  category_id int
+  company_id int
+  condition varchar
+  create_date datetime
+  create_uid int
+  id int [pk]
+  image_1920 varchar
+  incident_count int
+  location_id int
+  name varchar
+  product_id int
+  serial_number varchar
+  status varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_equipment_booking {
+  asset_id int
+  borrower_id int
+  create_date datetime
+  create_uid int
+  end_datetime datetime
+  id int [pk]
+  is_overdue boolean
+  name varchar
+  project_id int
+  start_datetime datetime
+  state varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_equipment_incident {
+  asset_id int
+  booking_id int
+  create_date datetime
+  create_uid int
+  description text
+  id int [pk]
+  name varchar
+  reported_by int
+  severity varchar
+  status varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_export_seed_wizard {
+  create_date datetime
+  create_uid int
+  export_path varchar
+  id int [pk]
+  webhook_url varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_finance_bir_schedule {
+  approval_deadline date
+  approval_task_id int
+  approver_id int
+  completion_pct float
+  create_date datetime
+  create_uid int
+  filing_deadline date
+  id int [pk]
+  logframe_id int
+  name varchar
+  period_covered varchar
+  prep_deadline date
+  prep_task_id int
+  review_deadline date
+  review_task_id int
+  reviewer_id int
+  status varchar
+  supervisor_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_finance_directory {
+  active boolean
+  code varchar
+  create_date datetime
+  create_uid int
+  email varchar
+  id int [pk]
+  name varchar
+  user_id int
+  write_date datetime
+  write_uid int
+  Note: 'code_uniq: unique(code) (Directory code must be unique.)'
+}
+
+Table ipai_finance_logframe {
+  assumptions text
+  code varchar
+  create_date datetime
+  create_uid int
+  id int [pk]
+  indicators text
+  level varchar
+  means_of_verification text
+  name varchar
+  sequence int
+  task_count int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_finance_person {
+  code varchar
+  create_date datetime
+  create_uid int
+  email varchar
+  id int [pk]
+  name varchar
+  role varchar
+  user_id int
+  write_date datetime
+  write_uid int
+  Note: 'code_unique: unique(code) (Personnel code must be unique!)'
+}
+
+Table ipai_finance_ppm_golive_checklist {
+  completed_items int
+  completion_pct float
+  create_date datetime
+  create_uid int
+  created_by int
+  director_id int
+  director_notes text
+  director_review_date datetime
+  director_signoff_date datetime
+  id int [pk]
+  name varchar
+  senior_supervisor_id int
+  senior_supervisor_notes text
+  senior_supervisor_review_date datetime
+  state varchar
+  supervisor_id int
+  supervisor_notes text
+  supervisor_review_date datetime
+  total_items int
+  version varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_finance_ppm_golive_checklist_section_ids_rel {
+  ipai_finance_ppm_golive_checklist_id int
+  ipai_finance_ppm_golive_section_id int
+}
+
+Table ipai_finance_ppm_golive_item {
+  checked_by int
+  checked_date datetime
+  create_date datetime
+  create_uid int
+  description text
+  evidence_url varchar
+  id int [pk]
+  is_checked boolean
+  is_critical boolean
+  name varchar
+  notes text
+  section_id int
+  sequence int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_finance_ppm_golive_section {
+  completed_items int
+  completion_pct float
+  create_date datetime
+  create_uid int
+  description text
+  id int [pk]
+  name varchar
+  section_type varchar
+  sequence int
+  total_items int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_finance_seed_service {
+  create_date datetime
+  create_uid int
+  id int [pk]
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_finance_seed_wizard {
+  create_date datetime
+  create_uid int
+  id int [pk]
+  strict boolean
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_finance_task_template {
+  active boolean
+  anchor varchar
+  approval_duration float
+  approve_by_code varchar
+  approved_by_id int
+  bir_form_id int
+  category varchar
+  create_date datetime
+  create_uid int
+  day_of_month int
+  default_duration_days int
+  description text
+  employee_code_id int
+  id int [pk]
+  name varchar
+  offset_days int
+  prep_by_code varchar
+  prep_duration float
+  review_by_code varchar
+  review_duration float
+  reviewed_by_id int
+  sequence int
+  task_category varchar
+  trigger_type varchar
+  write_date datetime
+  write_uid int
+  Note: 'tmpl_name_unique: unique(name, category) (Template name must be unique per category.)'
+}
+
+Table ipai_generate_bir_tasks_wizard {
+  create_date datetime
+  create_uid int
+  date_from date
+  date_to date
+  dry_run boolean
+  id int [pk]
+  program_project_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_generate_im_projects_wizard {
+  create_bir_tasks boolean
+  create_children boolean
+  create_date datetime
+  create_month_end_tasks boolean
+  create_uid int
+  id int [pk]
+  project_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_generate_month_end_wizard {
+  anchor_date date
+  create_date datetime
+  create_uid int
+  dry_run boolean
+  id int [pk]
+  program_project_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_grid_column {
+  alignment varchar
+  cell_css_class varchar
+  clickable boolean
+  column_type varchar
+  create_date datetime
+  create_uid int
+  css_class varchar
+  currency_field varchar
+  date_format varchar
+  decimal_places int
+  display_name varchar
+  editable boolean
+  field_name varchar
+  field_type varchar
+  filterable boolean
+  format_string varchar
+  grid_view_id int
+  header_css_class varchar
+  id int [pk]
+  is_action_column boolean
+  is_avatar_column boolean
+  is_primary boolean
+  is_selection_column boolean
+  label varchar
+  max_width int
+  min_width int
+  resizable boolean
+  searchable boolean
+  sequence int
+  sortable boolean
+  visible boolean
+  widget_options text
+  width int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_grid_filter {
+  active boolean
+  color varchar
+  condition_count int
+  create_date datetime
+  create_uid int
+  domain varchar
+  filter_json text
+  grid_view_id int
+  icon varchar
+  id int [pk]
+  is_default boolean
+  is_global boolean
+  name varchar
+  sequence int
+  user_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_grid_filter_condition {
+  create_date datetime
+  create_uid int
+  field_label varchar
+  field_name varchar
+  field_type varchar
+  filter_id int
+  id int [pk]
+  operator varchar
+  value_boolean boolean
+  value_char varchar
+  value_date date
+  value_datetime datetime
+  value_float float
+  value_integer int
+  value_many2one int
+  value_selection varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_grid_view {
+  active boolean
+  active_filter_id int
+  column_count int
+  config_json text
+  create_date datetime
+  create_uid int
+  enable_column_reorder boolean
+  enable_column_resize boolean
+  enable_export boolean
+  enable_quick_search boolean
+  enable_row_selection boolean
+  id int [pk]
+  model_id int
+  model_name varchar
+  name varchar
+  page_size int
+  page_size_options varchar
+  sequence int
+  show_checkboxes boolean
+  show_row_numbers boolean
+  sort_json text
+  view_type varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_grid_view_visible_columns_rel {
+  column_id int
+  grid_view_id int
+}
+
+Table ipai_import_seed_wizard {
+  create_date datetime
+  create_uid int
+  id int [pk]
+  mode varchar
+  seed_json text
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_localization_overlay {
+  active boolean
+  applies_to_code varchar
+  country varchar
+  create_date datetime
+  create_uid int
+  id int [pk]
+  patch_payload text
+  patch_type varchar
+  sequence int
+  workstream_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_month_end_closing {
+  company_id int
+  completed_tasks int
+  create_date datetime
+  create_uid int
+  id int [pk]
+  last_workday date
+  name varchar
+  overdue_tasks int
+  period_date date
+  progress float
+  state varchar
+  total_tasks int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_month_end_task {
+  approve_done boolean
+  approve_done_by int
+  approve_done_date datetime
+  approve_due_date date
+  approve_user_id int
+  closing_id int
+  create_date datetime
+  create_uid int
+  days_overdue int
+  id int [pk]
+  is_overdue boolean
+  name varchar
+  notes varchar
+  phase varchar
+  prep_done boolean
+  prep_done_by int
+  prep_done_date datetime
+  prep_due_date date
+  prep_user_id int
+  review_done boolean
+  review_done_by int
+  review_done_date datetime
+  review_due_date date
+  review_user_id int
+  sequence int
+  state varchar
+  template_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_month_end_task_template {
+  active boolean
+  approve_day_offset int
+  approve_user_id int
+  create_date datetime
+  create_uid int
+  description varchar
+  id int [pk]
+  name varchar
+  oca_module varchar
+  odoo_model varchar
+  phase varchar
+  prep_day_offset int
+  prep_user_id int
+  review_day_offset int
+  review_user_id int
+  sequence int
+  task_count int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_month_end_template {
+  active boolean
+  category varchar
+  create_date datetime
+  create_uid int
+  default_im_xml_id varchar
+  id int [pk]
+  task_base_name varchar
+  write_date datetime
+  write_uid int
+  Note: 'task_base_name_unique: unique(task_base_name) (Task base name must be unique!)'
+}
+
+Table ipai_month_end_template_step {
+  activity_type varchar
+  business_days_before int
+  create_date datetime
+  create_uid int
+  id int [pk]
+  offset_days int
+  role_code varchar
+  sequence int
+  template_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_permission {
+  active boolean
+  create_date datetime
+  create_uid int
+  group_id int
+  id int [pk]
+  name varchar
+  permission_level varchar
+  role varchar
+  scope_ref varchar
+  scope_type varchar
+  user_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_ph_holiday {
+  create_date datetime
+  create_uid int
+  date date
+  holiday_type varchar
+  id int [pk]
+  name varchar
+  write_date datetime
+  write_uid int
+  year int
+  Note: 'date_unique: UNIQUE(date) (Holiday already exists for this date!)'
+}
+
+Table ipai_ppm_task {
+  category varchar
+  code varchar
+  create_date datetime
+  create_uid int
+  due_offset_days int
+  evidence_required boolean
+  id int [pk]
+  name varchar
+  owner_role varchar
+  phase varchar
+  prep_offset int
+  requires_approval boolean
+  review_offset int
+  sap_reference varchar
+  sequence int
+  template_id int
+  write_date datetime
+  write_uid int
+  Note: 'task_code_unique: unique(code, template_id) (Task code must be unique per template.)'
+}
+
+Table ipai_ppm_task_checklist {
+  create_date datetime
+  create_uid int
+  evidence_type varchar
+  id int [pk]
+  label varchar
+  notes varchar
+  required boolean
+  sequence int
+  task_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_ppm_tasklist {
+  create_date datetime
+  create_uid int
+  id int [pk]
+  name varchar
+  period_end date
+  period_start date
+  status varchar
+  template_id int
+  workstream_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_ppm_taskrun {
+  approver_id int
+  assignee_id int
+  create_date datetime
+  create_uid int
+  done_at datetime
+  id int [pk]
+  name varchar
+  started_at datetime
+  status varchar
+  task_id int
+  tasklist_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_ppm_template {
+  code varchar
+  create_date datetime
+  create_uid int
+  id int [pk]
+  is_active boolean
+  name varchar
+  period_type varchar
+  sequence int
+  version varchar
+  workstream_id int
+  write_date datetime
+  write_uid int
+  Note: 'template_code_unique: unique(code, workstream_id) (Template code must be unique per workstream.)'
+}
+
+Table ipai_repo_export_run {
+  create_date datetime
+  create_uid int
+  export_path varchar
+  exported_at datetime
+  id int [pk]
+  name varchar
+  payload_json text
+  state varchar
+  webhook_status varchar
+  webhook_url varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_share_token {
+  active boolean
+  create_date datetime
+  create_uid int
+  created_by int
+  expires_at datetime
+  id int [pk]
+  is_public boolean
+  name varchar
+  permission_level varchar
+  scope_ref varchar
+  scope_type varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_stc_check {
+  auto_run boolean
+  category varchar
+  code varchar
+  create_date datetime
+  create_uid int
+  description text
+  id int [pk]
+  is_active boolean
+  name varchar
+  rule_json text
+  sap_reference varchar
+  sequence int
+  severity varchar
+  worklist_type_id int
+  workstream_id int
+  write_date datetime
+  write_uid int
+  Note: 'stc_check_code_unique: unique(code) (Check code must be unique.)'
+}
+
+Table ipai_stc_scenario {
+  bir_forms varchar
+  code varchar
+  create_date datetime
+  create_uid int
+  frequency varchar
+  id int [pk]
+  name varchar
+  notes text
+  run_day_offset int
+  sap_reference varchar
+  sequence int
+  workstream_id int
+  write_date datetime
+  write_uid int
+  Note: 'stc_scenario_code_unique: unique(code) (Scenario code must be unique.)'
+}
+
+Table ipai_stc_scenario_check_ids_rel {
+  ipai_stc_check_id int
+  ipai_stc_scenario_id int
+}
+
+Table ipai_stc_worklist_type {
+  code varchar
+  create_date datetime
+  create_uid int
+  description text
+  id int [pk]
+  name varchar
+  write_date datetime
+  write_uid int
+  Note: 'stc_worklist_code_unique: unique(code) (Worklist type code must be unique.)'
+}
+
+Table ipai_studio_ai_history {
+  analysis text
+  automation_id int
+  command text
+  command_type varchar
+  confidence float
+  create_date datetime
+  create_uid int
+  feedback_comment text
+  feedback_score varchar
+  field_id int
+  id int [pk]
+  model_id int
+  model_name varchar
+  result varchar
+  result_message text
+  user_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_studio_ai_wizard {
+  analysis_json text
+  command text
+  command_type varchar
+  confidence float
+  context_model_id int
+  create_date datetime
+  create_uid int
+  created_field_id int
+  field_label varchar
+  field_name varchar
+  field_required boolean
+  field_type varchar
+  history_id int
+  id int [pk]
+  is_ready boolean
+  message varchar
+  relation_model_id int
+  result_message varchar
+  selection_options text
+  state varchar
+  target_model_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_task_template_dependency_rel {
+  depends_on_id int
+  task_id int
+}
+
+Table ipai_travel_request {
+  company_id int
+  create_date datetime
+  create_uid int
+  currency_id int
+  destination varchar
+  employee_id int
+  end_date date
+  estimated_budget decimal
+  id int [pk]
+  name varchar
+  project_id int
+  purpose text
+  start_date date
+  state varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_workos_block {
+  attachment_id int
+  block_type varchar
+  callout_color varchar
+  callout_icon varchar
+  content_html varchar
+  content_json text
+  content_text text
+  create_date datetime
+  create_uid int
+  id int [pk]
+  is_checked boolean
+  is_collapsed boolean
+  name varchar
+  page_id int
+  parent_block_id int
+  sequence int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_workos_canvas {
+  active boolean
+  create_date datetime
+  create_uid int
+  id int [pk]
+  name varchar
+  nodes_json text
+  page_id int
+  viewport_json text
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_workos_comment {
+  anchor_block_id int
+  author_id int
+  content varchar
+  content_text text
+  create_date datetime
+  create_uid int
+  id int [pk]
+  is_resolved boolean
+  parent_id int
+  reply_count int
+  resolved_at datetime
+  resolved_by int
+  target_id int
+  target_model varchar
+  target_name varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_workos_database {
+  active boolean
+  create_date datetime
+  create_uid int
+  description text
+  icon varchar
+  id int [pk]
+  name varchar
+  page_id int
+  row_count int
+  space_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_workos_page {
+  active boolean
+  child_count int
+  content_preview text
+  cover_image binary
+  create_date datetime
+  create_uid int
+  icon varchar
+  id int [pk]
+  is_archived boolean
+  last_edited_by int
+  name varchar
+  parent_id int
+  parent_path varchar
+  sequence int
+  space_id int
+  template_id int
+  workspace_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_workos_property {
+  create_date datetime
+  create_uid int
+  database_id int
+  id int [pk]
+  is_title boolean
+  is_visible boolean
+  name varchar
+  options_json text
+  property_type varchar
+  related_database_id int
+  sequence int
+  width int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_workos_row {
+  active boolean
+  create_date datetime
+  create_uid int
+  database_id int
+  id int [pk]
+  name varchar
+  sequence int
+  values_json text
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_workos_search {
+  block_results text
+  create_date datetime
+  create_uid int
+  database_results text
+  id int [pk]
+  page_results text
+  query varchar
+  scope varchar
+  scope_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_workos_search_history {
+  create_date datetime
+  create_uid int
+  id int [pk]
+  query varchar
+  result_count int
+  user_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_workos_space {
+  active boolean
+  color int
+  create_date datetime
+  create_uid int
+  description text
+  icon varchar
+  id int [pk]
+  name varchar
+  page_count int
+  sequence int
+  visibility varchar
+  workspace_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_workos_template {
+  blocks_json text
+  category varchar
+  create_date datetime
+  create_uid int
+  description text
+  icon varchar
+  id int [pk]
+  is_published boolean
+  is_system boolean
+  name varchar
+  properties_json text
+  sequence int
+  views_json text
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_workos_template_tag {
+  color int
+  create_date datetime
+  create_uid int
+  id int [pk]
+  name varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_workos_template_tag_ids_rel {
+  ipai_workos_template_id int
+  ipai_workos_template_tag_id int
+}
+
+Table ipai_workos_view {
+  config_json text
+  create_date datetime
+  create_uid int
+  database_id int
+  date_property_id int
+  filter_json text
+  group_by_property_id int
+  id int [pk]
+  is_default boolean
+  is_shared boolean
+  name varchar
+  sequence int
+  sort_json text
+  user_id int
+  view_type varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_workos_view_visible_property_ids_rel {
+  ipai_workos_property_id int
+  ipai_workos_view_id int
+}
+
+Table ipai_workos_workspace {
+  active boolean
+  color int
+  create_date datetime
+  create_uid int
+  description text
+  icon varchar
+  id int [pk]
+  name varchar
+  owner_id int
+  space_count int
+  write_date datetime
+  write_uid int
+}
+
+Table ipai_workspace {
+  account_manager_id int
+  active boolean
+  brand_name varchar
+  campaign_type varchar
+  channel_mix varchar
+  client_id int
+  closing_stage varchar
+  code varchar
+  color int
+  company_id int
+  create_date datetime
+  create_uid int
+  date_end datetime
+  date_start datetime
+  engagement_count int
+  entity_code varchar
+  fiscal_period varchar
+  id int [pk]
+  industry varchar
+  invoice_count int
+  is_critical boolean
+  name varchar
+  parent_id int
+  planned_hours float
+  progress float
+  project_count int
+  remaining_hours float
+  sequence int
+  stage varchar
+  workspace_type varchar
+  write_date datetime
+  write_uid int
+  Note: 'name_company_uniq: unique(name, company_id) (Workspace name must be unique per company.)'
+}
+
+Table ipai_workspace_link {
+  create_date datetime
+  create_uid int
+  display_name varchar
+  id int [pk]
+  link_type varchar
+  res_id int
+  res_model varchar
+  workspace_id int
+  write_date datetime
+  write_uid int
+  Note: 'workspace_res_uniq: unique(workspace_id, res_model, res_id) (This record is already linked to the workspace.)'
+}
+
+Table ipai_workstream {
+  active boolean
+  code varchar
+  create_date datetime
+  create_uid int
+  description text
+  id int [pk]
+  name varchar
+  odoo_anchor varchar
+  sap_anchor varchar
+  write_date datetime
+  write_uid int
+  Note: 'workstream_code_unique: unique(code) (Workstream code must be unique.)'
+}
+
+Table ir_attachment {
+  id int [pk]
+  Note: 'stub for core model'
+}
+
+Table ir_model {
+  id int [pk]
+  Note: 'stub for core model'
+}
+
+Table ir_model_fields {
+  id int [pk]
+  Note: 'stub for core model'
+}
+
+Table ph_holiday {
+  company_id int
+  create_date datetime
+  create_uid int
+  date date
+  holiday_type varchar
+  id int [pk]
+  name varchar
+  write_date datetime
+  write_uid int
+  year int
+  Note: 'date_unique: unique(date, company_id) (Holiday date must be unique per company)'
+}
+
+Table ppm_close_task {
+  agency_code varchar
+  approval_completed_by varchar
+  approval_completed_date date
+  approval_days float
+  approval_due date
+  approver_code varchar
+  completion_notes text
+  create_date datetime
+  create_uid int
+  detailed_task text
+  id int [pk]
+  monthly_close_id int
+  name varchar
+  notes text
+  owner_code varchar
+  prep_completed_by varchar
+  prep_completed_date date
+  prep_days float
+  prep_start date
+  review_completed_by varchar
+  review_completed_date date
+  review_days float
+  review_due date
+  reviewer_code varchar
+  sequence int
+  state varchar
+  template_id int
+  total_days float
+  write_date datetime
+  write_uid int
+}
+
+Table ppm_close_template {
+  active boolean
+  agency_code varchar
+  approval_days float
+  approver_code varchar
+  create_date datetime
+  create_uid int
+  detailed_task text
+  id int [pk]
+  name varchar
+  notes text
+  owner_code varchar
+  prep_days float
+  review_days float
+  reviewer_code varchar
+  sequence int
+  task_category varchar
+  total_days float
+  write_date datetime
+  write_uid int
+}
+
+Table ppm_kpi_snapshot {
+  as_of datetime
+  create_date datetime
+  create_uid int
+  id int [pk]
+  kpi_category varchar
+  kpi_key varchar
+  kpi_label varchar
+  name varchar
+  portfolio_id int
+  program_id int
+  project_id int
+  scope varchar
+  source varchar
+  source_ref varchar
+  status varchar
+  target_value float
+  threshold_green float
+  threshold_yellow float
+  unit varchar
+  value float
+  value_text varchar
+  write_date datetime
+  write_uid int
+}
+
+Table ppm_monthly_close {
+  approval_due_date date
+  close_month date
+  create_date datetime
+  create_uid int
+  created_by_cron boolean
+  id int [pk]
+  month_end_date date
+  name varchar
+  notes text
+  prep_start_date date
+  progress_percentage float
+  review_due_date date
+  state varchar
+  task_completed int
+  task_count int
+  write_date datetime
+  write_uid int
+}
+
+Table ppm_portfolio {
+  active boolean
+  budget_variance_pct float
+  code varchar
+  create_date datetime
+  create_uid int
+  currency_id int
+  date_end date
+  date_start date
+  description varchar
+  health_score int
+  health_status varchar
+  id int [pk]
+  name varchar
+  objective text
+  owner_id int
+  program_count int
+  sequence int
+  sponsor_id int
+  total_actual decimal
+  total_budget decimal
+  write_date datetime
+  write_uid int
+  Note: 'code_unique: UNIQUE(code) (Portfolio code must be unique!)'
+}
+
+Table ppm_program {
+  active boolean
+  actual_cost decimal
+  budget decimal
+  code varchar
+  create_date datetime
+  create_uid int
+  currency_id int
+  date_end date
+  date_start date
+  description varchar
+  health_notes text
+  health_score int
+  health_status varchar
+  id int [pk]
+  name varchar
+  objectives text
+  open_high_risks int
+  portfolio_id int
+  program_manager_id int
+  project_count int
+  risk_count int
+  sequence int
+  sponsor_id int
+  write_date datetime
+  write_uid int
+  Note: 'code_unique: UNIQUE(code) (Program code must be unique!)'
+}
+
+Table ppm_program_project_rel {
+  program_id int
+  project_id int
+}
+
+Table ppm_resource_allocation {
+  allocation_pct float
+  create_date datetime
+  create_uid int
+  date_end date
+  date_start date
+  employee_id int
+  id int [pk]
+  is_overloaded boolean
+  name varchar
+  notes text
+  planned_hours float
+  program_id int
+  project_id int
+  role varchar
+  status varchar
+  task_id int
+  total_allocation float
+  user_id int
+  write_date datetime
+  write_uid int
+}
+
+Table ppm_risk {
+  assigned_to_id int
+  category varchar
+  code varchar
+  contingency_plan text
+  create_date datetime
+  create_uid int
+  currency_id int
+  date_closed date
+  date_identified date
+  date_target date
+  description text
+  id int [pk]
+  impact varchar
+  mitigation_plan text
+  mitigation_strategy varchar
+  name varchar
+  owner_id int
+  portfolio_id int
+  potential_cost decimal
+  probability varchar
+  program_id int
+  project_id int
+  risk_score int
+  scope varchar
+  severity varchar
+  status varchar
+  write_date datetime
+  write_uid int
+}
+
+Table product_category {
+  id int [pk]
+  Note: 'stub for core model'
+}
+
+Table product_product {
+  id int [pk]
+  Note: 'stub for core model'
+}
+
+Table project_category {
+  id int [pk]
+  Note: 'stub for core model'
+}
+
+Table project_milestone {
+  alert_days_before int
+  approval_date date
+  approval_required boolean
+  approver_id int
+  baseline_deadline date
+  completed_task_count int
+  completion_criteria text
+  create_date datetime
+  create_uid int
+  deliverables text
+  gate_status varchar
+  id int [pk]
+  last_alert_sent date
+  milestone_type varchar
+  risk_level varchar
+  risk_notes text
+  task_count int
+  variance_days int
+  write_date datetime
+  write_uid int
+}
+
+Table project_project {
+  actual_finish date
+  actual_start date
+  baseline_finish date
+  baseline_start date
+  clarity_id varchar
+  create_date datetime
+  create_uid int
+  critical_milestone_count int
+  health_status varchar
+  id int [pk]
+  im_code varchar
+  ipai_finance_enabled boolean
+  ipai_im_code varchar
+  ipai_is_im_project boolean
+  ipai_root_project_id int
+  is_program boolean
+  milestone_count int
+  overall_progress float
+  overall_status varchar
+  parent_id int
+  phase_count int
+  portfolio_id int
+  program_code varchar
+  program_type varchar
+  variance_finish int
+  variance_start int
+  write_date datetime
+  write_uid int
+  x_cycle_code varchar
+}
+
+Table project_task {
+  activity_type varchar
+  actual_cost float
+  actual_hours float
+  approval_duration float
+  approver_id int
+  auto_sync boolean
+  bir_approval_due_date date
+  bir_deadline date
+  bir_form varchar
+  bir_payment_due_date date
+  bir_period_label varchar
+  bir_prep_due_date date
+  bir_related boolean
+  bir_schedule_id int
+  child_task_count int
+  closing_due_date date
+  cluster varchar
+  cost_variance float
+  create_date datetime
+  create_uid int
+  critical_path boolean
+  earned_value float
+  erp_ref varchar
+  fd_id int
+  finance_category varchar
+  finance_code varchar
+  finance_deadline_type varchar
+  finance_logframe_id int
+  finance_person_id int
+  finance_supervisor_id int
+  free_float int
+  gate_approver_id int
+  gate_decision varchar
+  gate_milestone_id int
+  has_gate boolean
+  id int [pk]
+  ipai_compliance_step varchar
+  ipai_days_to_deadline int
+  ipai_owner_code varchar
+  ipai_owner_role varchar
+  ipai_status_bucket varchar
+  ipai_task_category varchar
+  ipai_template_id int
+  is_finance_ppm boolean
+  is_phase boolean
+  lag_days int
+  lead_days int
+  milestone_count int
+  owner_code varchar
+  period_covered varchar
+  phase_baseline_finish date
+  phase_baseline_start date
+  phase_progress float
+  phase_status varchar
+  phase_type varchar
+  phase_variance_days int
+  planned_hours float
+  planned_value float
+  prep_duration float
+  relative_due varchar
+  remaining_hours float
+  resource_allocation float
+  review_duration float
+  reviewer_id int
+  role_code varchar
+  schedule_variance float
+  sfm_id int
+  target_date date
+  total_float int
+  wbs_code varchar
+  write_date datetime
+  write_uid int
+  x_cycle_key varchar
+  x_external_key varchar
+  x_obsolete boolean
+  x_seed_hash varchar
+  x_step_code varchar
+  x_task_template_code varchar
+}
+
+Table project_task_checklist_item {
+  actual_hours float
+  assigned_user_id int
+  blocker_description text
+  completed_date date
+  create_date datetime
+  create_uid int
+  due_date date
+  estimated_hours float
+  id int [pk]
+  notes text
+  priority varchar
+  status varchar
+  write_date datetime
+  write_uid int
+}
+
+Table purchase_order {
+  create_date datetime
+  create_uid int
+  id int [pk]
+  write_date datetime
+  write_uid int
+  x_master_control_submitted boolean
+}
+
+Table res_company {
+  id int [pk]
+  Note: 'stub for core model'
+}
+
+Table res_config_settings {
+  create_date datetime
+  create_uid int
+  id int [pk]
+  ipai_enable_finance_project_analytics boolean
+  superset_auto_sync boolean
+  superset_connection_id int
+  superset_create_analytics_views boolean
+  superset_enable_rls boolean
+  superset_sync_interval varchar
+  write_date datetime
+  write_uid int
+}
+
+Table res_currency {
+  id int [pk]
+  Note: 'stub for core model'
+}
+
+Table res_groups {
+  id int [pk]
+  Note: 'stub for core model'
+}
+
+Table res_partner {
+  bir_registered boolean
+  bir_registration_date date
+  create_date datetime
+  create_uid int
+  id int [pk]
+  srm_overall_score float
+  srm_supplier_id int
+  srm_tier varchar
+  tax_type varchar
+  tin varchar
+  tin_branch_code varchar
+  write_date datetime
+  write_uid int
+}
+
+Table res_users {
+  create_date datetime
+  create_uid int
+  id int [pk]
+  write_date datetime
+  write_uid int
+  x_employee_code varchar
+  Note: 'x_employee_code_uniq: UNIQUE(x_employee_code) (Employee code must be unique)\nx_employee_code_unique: unique(x_employee_code) (Employee code must be unique when set!)'
+}
+
+Table srm_kpi_category {
+  active boolean
+  code varchar
+  compute_source varchar
+  create_date datetime
+  create_uid int
+  description text
+  eval_method varchar
+  id int [pk]
+  name varchar
+  sequence int
+  weight float
+  write_date datetime
+  write_uid int
+}
+
+Table srm_qualification {
+  approval_date datetime
+  approver_id int
+  checklist_complete boolean
+  completion_date date
+  create_date datetime
+  create_uid int
+  expiry_date date
+  id int [pk]
+  name varchar
+  notes text
+  qualification_type varchar
+  rejection_reason text
+  reviewer_id int
+  risk_notes text
+  risk_score float
+  start_date date
+  state varchar
+  supplier_id int
+  target_completion date
+  write_date datetime
+  write_uid int
+}
+
+Table srm_qualification_checklist {
+  completed_by int
+  completed_date date
+  create_date datetime
+  create_uid int
+  description text
+  id int [pk]
+  is_complete boolean
+  is_required boolean
+  name varchar
+  notes text
+  qualification_id int
+  sequence int
+  write_date datetime
+  write_uid int
+}
+
+Table srm_qualification_document_ids_rel {
+  ir_attachment_id int
+  srm_qualification_id int
+}
+
+Table srm_scorecard {
+  action_items text
+  as_of date
+  comments text
+  create_date datetime
+  create_uid int
+  evaluator_id int
+  grade varchar
+  id int [pk]
+  name varchar
+  overall_score float
+  period varchar
+  state varchar
+  supplier_id int
+  write_date datetime
+  write_uid int
+}
+
+Table srm_scorecard_line {
+  create_date datetime
+  create_uid int
+  evidence text
+  id int [pk]
+  kpi_category_id int
+  notes text
+  score float
+  scorecard_id int
+  sequence int
+  weight float
+  weighted_score float
+  write_date datetime
+  write_uid int
+}
+
+Table srm_supplier {
+  code varchar
+  compliance_docs_complete boolean
+  create_date datetime
+  create_uid int
+  currency_id int
+  id int [pk]
+  is_qualified boolean
+  last_audit_date date
+  latest_scorecard_id int
+  name varchar
+  next_audit_date date
+  open_po_count int
+  overall_score float
+  partner_id int
+  primary_contact_id int
+  qualification_expiry date
+  risk_level varchar
+  risk_notes text
+  sales_contact_id int
+  state varchar
+  tier varchar
+  total_po_count int
+  write_date datetime
+  write_uid int
+  ytd_spend decimal
+}
+
+Table srm_supplier_category_ids_rel {
+  product_category_id int
+  srm_supplier_id int
+}
+
+Table stock_location {
+  id int [pk]
+  Note: 'stub for core model'
+}
+
+Table superset_analytics_view {
+  active boolean
+  category varchar
+  create_date datetime
+  create_uid int
+  description text
+  id int [pk]
+  is_created boolean
+  last_refresh datetime
+  name varchar
+  required_modules varchar
+  sequence int
+  sql_definition text
+  technical_name varchar
+  write_date datetime
+  write_uid int
+}
+
+Table superset_bulk_dataset_wizard {
+  connection_id int
+  create_analytics_views boolean
+  create_date datetime
+  create_uid int
+  id int [pk]
+  preset varchar
+  write_date datetime
+  write_uid int
+}
+
+Table superset_connection {
+  access_token varchar
+  active boolean
+  api_key varchar
+  auth_method varchar
+  base_url varchar
+  create_date datetime
+  create_uid int
+  csrf_token varchar
+  dataset_count int
+  db_connection_id int
+  db_connection_name varchar
+  id int [pk]
+  last_error text
+  last_sync datetime
+  name varchar
+  password varchar
+  pg_database varchar
+  pg_host varchar
+  pg_password varchar
+  pg_port int
+  pg_schema varchar
+  pg_username varchar
+  refresh_token varchar
+  state varchar
+  token_expiry datetime
+  use_ssl boolean
+  username varchar
+  write_date datetime
+  write_uid int
+}
+
+Table superset_dataset {
+  active boolean
+  category varchar
+  column_count int
+  connection_id int
+  create_date datetime
+  create_uid int
+  custom_sql text
+  description text
+  enable_rls boolean
+  id int [pk]
+  include_all_fields boolean
+  last_sync datetime
+  model_id int
+  model_name varchar
+  name varchar
+  rls_filter_column varchar
+  sequence int
+  source_type varchar
+  superset_dataset_id int
+  sync_error text
+  sync_status varchar
+  technical_name varchar
+  view_created boolean
+  view_name varchar
+  view_sql text
+  write_date datetime
+  write_uid int
+  Note: 'technical_name_uniq: unique(technical_name) (Technical name must be unique!)'
+}
+
+Table superset_dataset_column {
+  aggregation varchar
+  column_type varchar
+  create_date datetime
+  create_uid int
+  data_type varchar
+  dataset_id int
+  description text
+  filterable boolean
+  format_string varchar
+  groupable boolean
+  id int [pk]
+  label varchar
+  name varchar
+  sequence int
+  write_date datetime
+  write_uid int
+}
+
+Table superset_dataset_field_ids_rel {
+  ir_model_fields_id int
+  superset_dataset_id int
+}
+
+Table superset_dataset_wizard {
+  category varchar
+  connection_id int
+  create_date datetime
+  create_uid int
+  create_view boolean
+  enable_rls boolean
+  id int [pk]
+  include_all_fields boolean
+  model_id int
+  name varchar
+  sync_to_superset boolean
+  technical_name varchar
+  write_date datetime
+  write_uid int
+}
+
+Table superset_dataset_wizard_field_ids_rel {
+  ir_model_fields_id int
+  superset_dataset_wizard_id int
+}
+
+Table workos_comment_mention_rel {
+  comment_id int
+  user_id int
+}
+
+Table workspace_member_rel {
+  user_id int
+  workspace_id int
+}
+
+Ref: a1_check.close_gate_template_id > close_approval_gate_template.id
+Ref: a1_check.company_id > res_company.id
+Ref: a1_check_result.check_id > a1_check.id
+Ref: a1_check_result.executed_by > res_users.id
+Ref: a1_check_result.task_id > a1_task.id
+Ref: a1_check_result_attachment_ids_rel.a1_check_result_id > a1_check_result.id
+Ref: a1_check_result_attachment_ids_rel.ir_attachment_id > ir_attachment.id
+Ref: a1_export_run.company_id > res_company.id
+Ref: a1_role.company_id > res_company.id
+Ref: a1_role.default_user_id > res_users.id
+Ref: a1_role.fallback_user_id > res_users.id
+Ref: a1_role_group_ids_rel.a1_role_id > a1_role.id
+Ref: a1_role_group_ids_rel.res_groups_id > res_groups.id
+Ref: a1_task.approval_done_by > res_users.id
+Ref: a1_task.approver_id > res_users.id
+Ref: a1_task.close_task_id > close_task.id
+Ref: a1_task.company_id > res_company.id
+Ref: a1_task.owner_id > res_users.id
+Ref: a1_task.prep_done_by > res_users.id
+Ref: a1_task.review_done_by > res_users.id
+Ref: a1_task.reviewer_id > res_users.id
+Ref: a1_task.tasklist_id > a1_tasklist.id
+Ref: a1_task.template_id > a1_template.id
+Ref: a1_task.workstream_id > a1_workstream.id
+Ref: a1_task_checklist.done_by > res_users.id
+Ref: a1_task_checklist.task_id > a1_task.id
+Ref: a1_task_checklist.template_item_id > a1_template_checklist.id
+Ref: a1_task_checklist.value_attachment_id > ir_attachment.id
+Ref: a1_tasklist.close_cycle_id > close_cycle.id
+Ref: a1_tasklist.company_id > res_company.id
+Ref: a1_template.close_template_id > close_task_template.id
+Ref: a1_template.company_id > res_company.id
+Ref: a1_template.workstream_id > a1_workstream.id
+Ref: a1_template_check_rel.check_id > a1_check.id
+Ref: a1_template_check_rel.template_id > a1_template.id
+Ref: a1_template_checklist.template_id > a1_template.id
+Ref: a1_template_step.template_id > a1_template.id
+Ref: a1_workstream.close_category_id > close_task_category.id
+Ref: a1_workstream.company_id > res_company.id
+Ref: a1_workstream.owner_role_id > a1_role.id
+Ref: a1_workstream.owner_user_id > res_users.id
+Ref: advisor_playbook_category_ids_rel.advisor_category_id > advisor_category.id
+Ref: advisor_playbook_category_ids_rel.advisor_playbook_id > advisor_playbook.id
+Ref: advisor_recommendation.category_id > advisor_category.id
+Ref: advisor_recommendation.currency_id > res_currency.id
+Ref: advisor_recommendation.owner_id > res_users.id
+Ref: advisor_recommendation.playbook_id > advisor_playbook.id
+Ref: advisor_recommendation_tag_ids_rel.advisor_recommendation_id > advisor_recommendation.id
+Ref: advisor_recommendation_tag_ids_rel.advisor_tag_id > advisor_tag.id
+Ref: advisor_score.category_id > advisor_category.id
+Ref: bir_alphalist.company_id > res_company.id
+Ref: bir_alphalist.currency_id > res_currency.id
+Ref: bir_alphalist_line.alphalist_id > bir_alphalist.id
+Ref: bir_alphalist_line.currency_id > res_currency.id
+Ref: bir_alphalist_line.partner_id > res_partner.id
+Ref: bir_filing_deadline.company_id > res_company.id
+Ref: bir_filing_deadline.return_id > bir_tax_return.id
+Ref: bir_return.company_id > res_company.id
+Ref: bir_return.currency_id > res_currency.id
+Ref: bir_return.filed_by > res_users.id
+Ref: bir_return.task_id > finance_task.id
+Ref: bir_return_line.move_id > account_move.id
+Ref: bir_return_line.partner_id > res_partner.id
+Ref: bir_return_line.return_id > bir_return.id
+Ref: bir_tax_return.company_id > res_company.id
+Ref: bir_tax_return.currency_id > res_currency.id
+Ref: bir_tax_return.filed_by > res_users.id
+Ref: bir_tax_return_line.currency_id > res_currency.id
+Ref: bir_tax_return_line.move_id > account_move.id
+Ref: bir_tax_return_line.partner_id > res_partner.id
+Ref: bir_tax_return_line.return_id > bir_tax_return.id
+Ref: bir_vat_line.currency_id > res_currency.id
+Ref: bir_vat_line.invoice_id > account_move.id
+Ref: bir_vat_line.partner_id > res_partner.id
+Ref: bir_vat_line.return_id > bir_vat_return.id
+Ref: bir_withholding_line.currency_id > res_currency.id
+Ref: bir_withholding_line.move_id > account_move.id
+Ref: bir_withholding_line.partner_id > res_partner.id
+Ref: bir_withholding_line.payslip_id > hr_payslip.id
+Ref: bir_withholding_line.return_id > bir_withholding_return.id
+Ref: close_approval_gate.approved_by > res_users.id
+Ref: close_approval_gate.approver_id > res_users.id
+Ref: close_approval_gate.approver_user_id > res_users.id
+Ref: close_approval_gate.company_id > res_company.id
+Ref: close_approval_gate.cycle_id > close_cycle.id
+Ref: close_approval_gate.template_id > close_approval_gate_template.id
+Ref: close_approval_gate_blocking_exceptions_rel.close_approval_gate_id > close_approval_gate.id
+Ref: close_approval_gate_blocking_exceptions_rel.close_exception_id > close_exception.id
+Ref: close_approval_gate_blocking_tasks_rel.close_approval_gate_id > close_approval_gate.id
+Ref: close_approval_gate_blocking_tasks_rel.close_task_id > close_task.id
+Ref: close_approval_gate_template.a1_check_id > a1_check.id
+Ref: close_approval_gate_template.company_id > res_company.id
+Ref: close_cycle.a1_tasklist_id > a1_tasklist.id
+Ref: close_cycle.closing_period_id > closing_period.id
+Ref: close_cycle.company_id > res_company.id
+Ref: close_exception.assigned_to > res_users.id
+Ref: close_exception.company_id > res_company.id
+Ref: close_exception.currency_id > res_currency.id
+Ref: close_exception.cycle_id > close_cycle.id
+Ref: close_exception.detected_by > res_users.id
+Ref: close_exception.escalated_to > res_users.id
+Ref: close_exception.related_account_id > account_account.id
+Ref: close_exception.related_move_id > account_move.id
+Ref: close_exception.related_partner_id > res_partner.id
+Ref: close_exception.reported_by > res_users.id
+Ref: close_exception.resolved_by > res_users.id
+Ref: close_exception.task_id > close_task.id
+Ref: close_task.a1_task_id > a1_task.id
+Ref: close_task.approval_done_by > res_users.id
+Ref: close_task.approve_user_id > res_users.id
+Ref: close_task.approver_id > res_users.id
+Ref: close_task.category_id > close_task_category.id
+Ref: close_task.company_id > res_company.id
+Ref: close_task.cycle_id > close_cycle.id
+Ref: close_task.prep_done_by > res_users.id
+Ref: close_task.prep_user_id > res_users.id
+Ref: close_task.preparer_id > res_users.id
+Ref: close_task.review_done_by > res_users.id
+Ref: close_task.review_user_id > res_users.id
+Ref: close_task.reviewer_id > res_users.id
+Ref: close_task.template_id > close_task_template.id
+Ref: close_task_attachment_ids_rel.close_task_id > close_task.id
+Ref: close_task_attachment_ids_rel.ir_attachment_id > ir_attachment.id
+Ref: close_task_category.a1_workstream_id > a1_workstream.id
+Ref: close_task_category.company_id > res_company.id
+Ref: close_task_category_gl_account_ids_rel.account_account_id > account_account.id
+Ref: close_task_category_gl_account_ids_rel.close_task_category_id > close_task_category.id
+Ref: close_task_checklist.attachment_id > ir_attachment.id
+Ref: close_task_checklist.done_by > res_users.id
+Ref: close_task_checklist.task_id > close_task.id
+Ref: close_task_gl_entry_ids_rel.account_move_id > account_move.id
+Ref: close_task_gl_entry_ids_rel.close_task_id > close_task.id
+Ref: close_task_template.a1_template_id > a1_template.id
+Ref: close_task_template.approver_id > res_users.id
+Ref: close_task_template.category_id > close_task_category.id
+Ref: close_task_template.company_id > res_company.id
+Ref: close_task_template.default_approve_user_id > res_users.id
+Ref: close_task_template.default_prep_user_id > res_users.id
+Ref: close_task_template.default_review_user_id > res_users.id
+Ref: close_task_template.preparer_id > res_users.id
+Ref: close_task_template.reviewer_id > res_users.id
+Ref: close_task_template_checklist.template_id > close_task_template.id
+Ref: close_task_template_gl_account_ids_rel.account_account_id > account_account.id
+Ref: close_task_template_gl_account_ids_rel.close_task_template_id > close_task_template.id
+Ref: closing_period.company_id > res_company.id
+Ref: compliance_check.checked_by > res_users.id
+Ref: compliance_check.closing_id > closing_period.id
+Ref: crm_stage_required_fields_rel.field_id > ir_model_fields.id
+Ref: crm_stage_required_fields_rel.stage_id > crm_stage.id
+Ref: finance_bir_deadline.responsible_approval_id > ipai_finance_person.id
+Ref: finance_bir_deadline.responsible_prep_id > ipai_finance_person.id
+Ref: finance_bir_deadline.responsible_review_id > ipai_finance_person.id
+Ref: finance_ppm_logframe.parent_id > finance_ppm_logframe.id
+Ref: finance_ppm_tdi_audit.user_id > res_users.id
+Ref: finance_task.approve_done_by > res_users.id
+Ref: finance_task.approve_user_id > res_users.id
+Ref: finance_task.bir_return_id > bir_return.id
+Ref: finance_task.closing_id > closing_period.id
+Ref: finance_task.prep_done_by > res_users.id
+Ref: finance_task.prep_user_id > res_users.id
+Ref: finance_task.review_done_by > res_users.id
+Ref: finance_task.review_user_id > res_users.id
+Ref: finance_task.template_id > finance_task_template.id
+Ref: finance_task_template.approve_user_id > res_users.id
+Ref: finance_task_template.prep_user_id > res_users.id
+Ref: finance_task_template.review_user_id > res_users.id
+Ref: finance_task_template_dependency_rel.depends_on_id > finance_task_template.id
+Ref: finance_task_template_dependency_rel.task_id > finance_task_template.id
+Ref: hr_expense.project_id > project_project.id
+Ref: hr_expense.travel_request_id > ipai_travel_request.id
+Ref: ipai_asset.active_checkout_id > ipai_asset_checkout.id
+Ref: ipai_asset.category_id > ipai_asset_category.id
+Ref: ipai_asset.currency_id > res_currency.id
+Ref: ipai_asset.custodian_id > hr_employee.id
+Ref: ipai_asset.location_id > stock_location.id
+Ref: ipai_asset_checkout.approved_by > res_users.id
+Ref: ipai_asset_checkout.asset_id > ipai_asset.id
+Ref: ipai_asset_checkout.employee_id > hr_employee.id
+Ref: ipai_asset_reservation.asset_id > ipai_asset.id
+Ref: ipai_asset_reservation.employee_id > hr_employee.id
+Ref: ipai_audit_log.user_id > res_users.id
+Ref: ipai_bir_dat_wizard.currency_id > res_currency.id
+Ref: ipai_bir_form_schedule.responsible_approval_id > ipai_finance_person.id
+Ref: ipai_bir_form_schedule.responsible_prep_id > ipai_finance_person.id
+Ref: ipai_bir_form_schedule.responsible_review_id > ipai_finance_person.id
+Ref: ipai_bir_process_step.person_id > ipai_finance_person.id
+Ref: ipai_bir_process_step.schedule_id > ipai_bir_form_schedule.id
+Ref: ipai_bir_schedule_step.item_id > ipai_bir_schedule_item.id
+Ref: ipai_close_generated_map.generation_run_id > ipai_close_generation_run.id
+Ref: ipai_close_generated_map.run_id > ipai_close_generation_run.id
+Ref: ipai_close_generated_map.task_id > project_task.id
+Ref: ipai_close_generated_map.template_id > ipai_close_task_template.id
+Ref: ipai_close_generation_run.project_id > project_project.id
+Ref: ipai_close_generation_run.user_id > res_users.id
+Ref: ipai_close_task_step.template_id > ipai_close_task_template.id
+Ref: ipai_close_task_step.user_id > res_users.id
+Ref: ipai_convert_phases_wizard.parent_project_id > project_project.id
+Ref: ipai_equipment_asset.category_id > product_category.id
+Ref: ipai_equipment_asset.company_id > res_company.id
+Ref: ipai_equipment_asset.location_id > stock_location.id
+Ref: ipai_equipment_asset.product_id > product_product.id
+Ref: ipai_equipment_booking.asset_id > ipai_equipment_asset.id
+Ref: ipai_equipment_booking.borrower_id > res_users.id
+Ref: ipai_equipment_booking.project_id > project_project.id
+Ref: ipai_equipment_incident.asset_id > ipai_equipment_asset.id
+Ref: ipai_equipment_incident.booking_id > ipai_equipment_booking.id
+Ref: ipai_equipment_incident.reported_by > res_users.id
+Ref: ipai_finance_bir_schedule.approval_task_id > project_task.id
+Ref: ipai_finance_bir_schedule.approver_id > res_users.id
+Ref: ipai_finance_bir_schedule.logframe_id > ipai_finance_logframe.id
+Ref: ipai_finance_bir_schedule.prep_task_id > project_task.id
+Ref: ipai_finance_bir_schedule.review_task_id > project_task.id
+Ref: ipai_finance_bir_schedule.reviewer_id > res_users.id
+Ref: ipai_finance_bir_schedule.supervisor_id > res_users.id
+Ref: ipai_finance_directory.user_id > res_users.id
+Ref: ipai_finance_person.user_id > res_users.id
+Ref: ipai_finance_ppm_golive_checklist.created_by > res_users.id
+Ref: ipai_finance_ppm_golive_checklist.director_id > res_users.id
+Ref: ipai_finance_ppm_golive_checklist.senior_supervisor_id > res_users.id
+Ref: ipai_finance_ppm_golive_checklist.supervisor_id > res_users.id
+Ref: ipai_finance_ppm_golive_checklist_section_ids_rel.ipai_finance_ppm_golive_checklist_id > ipai_finance_ppm_golive_checklist.id
+Ref: ipai_finance_ppm_golive_checklist_section_ids_rel.ipai_finance_ppm_golive_section_id > ipai_finance_ppm_golive_section.id
+Ref: ipai_finance_ppm_golive_item.checked_by > res_users.id
+Ref: ipai_finance_ppm_golive_item.section_id > ipai_finance_ppm_golive_section.id
+Ref: ipai_finance_task_template.approved_by_id > ipai_finance_person.id
+Ref: ipai_finance_task_template.bir_form_id > finance_bir_deadline.id
+Ref: ipai_finance_task_template.employee_code_id > ipai_finance_person.id
+Ref: ipai_finance_task_template.reviewed_by_id > ipai_finance_person.id
+Ref: ipai_generate_bir_tasks_wizard.program_project_id > project_project.id
+Ref: ipai_generate_im_projects_wizard.project_id > project_project.id
+Ref: ipai_generate_month_end_wizard.program_project_id > project_project.id
+Ref: ipai_grid_column.grid_view_id > ipai_grid_view.id
+Ref: ipai_grid_filter.grid_view_id > ipai_grid_view.id
+Ref: ipai_grid_filter.user_id > res_users.id
+Ref: ipai_grid_filter_condition.filter_id > ipai_grid_filter.id
+Ref: ipai_grid_view.active_filter_id > ipai_grid_filter.id
+Ref: ipai_grid_view.model_id > ir_model.id
+Ref: ipai_grid_view_visible_columns_rel.column_id > ipai_grid_column.id
+Ref: ipai_grid_view_visible_columns_rel.grid_view_id > ipai_grid_view.id
+Ref: ipai_localization_overlay.workstream_id > ipai_workstream.id
+Ref: ipai_month_end_closing.company_id > res_company.id
+Ref: ipai_month_end_task.approve_done_by > res_users.id
+Ref: ipai_month_end_task.approve_user_id > res_users.id
+Ref: ipai_month_end_task.closing_id > ipai_month_end_closing.id
+Ref: ipai_month_end_task.prep_done_by > res_users.id
+Ref: ipai_month_end_task.prep_user_id > res_users.id
+Ref: ipai_month_end_task.review_done_by > res_users.id
+Ref: ipai_month_end_task.review_user_id > res_users.id
+Ref: ipai_month_end_task.template_id > ipai_month_end_task_template.id
+Ref: ipai_month_end_task_template.approve_user_id > res_users.id
+Ref: ipai_month_end_task_template.prep_user_id > res_users.id
+Ref: ipai_month_end_task_template.review_user_id > res_users.id
+Ref: ipai_month_end_template_step.template_id > ipai_month_end_template.id
+Ref: ipai_permission.group_id > res_groups.id
+Ref: ipai_permission.user_id > res_users.id
+Ref: ipai_ppm_task.template_id > ipai_ppm_template.id
+Ref: ipai_ppm_task_checklist.task_id > ipai_ppm_task.id
+Ref: ipai_ppm_tasklist.template_id > ipai_ppm_template.id
+Ref: ipai_ppm_tasklist.workstream_id > ipai_workstream.id
+Ref: ipai_ppm_taskrun.approver_id > res_users.id
+Ref: ipai_ppm_taskrun.assignee_id > res_users.id
+Ref: ipai_ppm_taskrun.task_id > ipai_ppm_task.id
+Ref: ipai_ppm_taskrun.tasklist_id > ipai_ppm_tasklist.id
+Ref: ipai_ppm_template.workstream_id > ipai_workstream.id
+Ref: ipai_share_token.created_by > res_users.id
+Ref: ipai_stc_check.worklist_type_id > ipai_stc_worklist_type.id
+Ref: ipai_stc_check.workstream_id > ipai_workstream.id
+Ref: ipai_stc_scenario.workstream_id > ipai_workstream.id
+Ref: ipai_stc_scenario_check_ids_rel.ipai_stc_check_id > ipai_stc_check.id
+Ref: ipai_stc_scenario_check_ids_rel.ipai_stc_scenario_id > ipai_stc_scenario.id
+Ref: ipai_studio_ai_history.automation_id > base_automation.id
+Ref: ipai_studio_ai_history.field_id > ir_model_fields.id
+Ref: ipai_studio_ai_history.model_id > ir_model.id
+Ref: ipai_studio_ai_history.user_id > res_users.id
+Ref: ipai_studio_ai_wizard.context_model_id > ir_model.id
+Ref: ipai_studio_ai_wizard.created_field_id > ir_model_fields.id
+Ref: ipai_studio_ai_wizard.history_id > ipai_studio_ai_history.id
+Ref: ipai_studio_ai_wizard.relation_model_id > ir_model.id
+Ref: ipai_studio_ai_wizard.target_model_id > ir_model.id
+Ref: ipai_task_template_dependency_rel.depends_on_id > ipai_month_end_task_template.id
+Ref: ipai_task_template_dependency_rel.task_id > ipai_month_end_task_template.id
+Ref: ipai_travel_request.company_id > res_company.id
+Ref: ipai_travel_request.currency_id > res_currency.id
+Ref: ipai_travel_request.employee_id > hr_employee.id
+Ref: ipai_travel_request.project_id > project_project.id
+Ref: ipai_workos_block.attachment_id > ir_attachment.id
+Ref: ipai_workos_block.page_id > ipai_workos_page.id
+Ref: ipai_workos_block.parent_block_id > ipai_workos_block.id
+Ref: ipai_workos_canvas.page_id > ipai_workos_page.id
+Ref: ipai_workos_comment.author_id > res_users.id
+Ref: ipai_workos_comment.parent_id > ipai_workos_comment.id
+Ref: ipai_workos_comment.resolved_by > res_users.id
+Ref: ipai_workos_database.page_id > ipai_workos_page.id
+Ref: ipai_workos_database.space_id > ipai_workos_space.id
+Ref: ipai_workos_page.last_edited_by > res_users.id
+Ref: ipai_workos_page.parent_id > ipai_workos_page.id
+Ref: ipai_workos_page.space_id > ipai_workos_space.id
+Ref: ipai_workos_page.template_id > ipai_workos_template.id
+Ref: ipai_workos_page.workspace_id > ipai_workos_workspace.id
+Ref: ipai_workos_property.database_id > ipai_workos_database.id
+Ref: ipai_workos_property.related_database_id > ipai_workos_database.id
+Ref: ipai_workos_row.database_id > ipai_workos_database.id
+Ref: ipai_workos_search_history.user_id > res_users.id
+Ref: ipai_workos_space.workspace_id > ipai_workos_workspace.id
+Ref: ipai_workos_template_tag_ids_rel.ipai_workos_template_id > ipai_workos_template.id
+Ref: ipai_workos_template_tag_ids_rel.ipai_workos_template_tag_id > ipai_workos_template_tag.id
+Ref: ipai_workos_view.database_id > ipai_workos_database.id
+Ref: ipai_workos_view.date_property_id > ipai_workos_property.id
+Ref: ipai_workos_view.group_by_property_id > ipai_workos_property.id
+Ref: ipai_workos_view.user_id > res_users.id
+Ref: ipai_workos_view_visible_property_ids_rel.ipai_workos_property_id > ipai_workos_property.id
+Ref: ipai_workos_view_visible_property_ids_rel.ipai_workos_view_id > ipai_workos_view.id
+Ref: ipai_workos_workspace.owner_id > res_users.id
+Ref: ipai_workspace.account_manager_id > res_users.id
+Ref: ipai_workspace.client_id > res_partner.id
+Ref: ipai_workspace.company_id > res_company.id
+Ref: ipai_workspace.parent_id > ipai_workspace.id
+Ref: ipai_workspace_link.workspace_id > ipai_workspace.id
+Ref: ph_holiday.company_id > res_company.id
+Ref: ppm_close_task.monthly_close_id > ppm_monthly_close.id
+Ref: ppm_close_task.template_id > ppm_close_template.id
+Ref: ppm_kpi_snapshot.portfolio_id > ppm_portfolio.id
+Ref: ppm_kpi_snapshot.program_id > ppm_program.id
+Ref: ppm_kpi_snapshot.project_id > project_project.id
+Ref: ppm_portfolio.currency_id > res_currency.id
+Ref: ppm_portfolio.owner_id > res_users.id
+Ref: ppm_portfolio.sponsor_id > res_users.id
+Ref: ppm_program.currency_id > res_currency.id
+Ref: ppm_program.portfolio_id > ppm_portfolio.id
+Ref: ppm_program.program_manager_id > res_users.id
+Ref: ppm_program.sponsor_id > res_users.id
+Ref: ppm_program_project_rel.program_id > ppm_program.id
+Ref: ppm_program_project_rel.program_id > ppm_program.id
+Ref: ppm_program_project_rel.project_id > project_project.id
+Ref: ppm_program_project_rel.project_id > project_project.id
+Ref: ppm_resource_allocation.employee_id > hr_employee.id
+Ref: ppm_resource_allocation.program_id > ppm_program.id
+Ref: ppm_resource_allocation.project_id > project_project.id
+Ref: ppm_resource_allocation.task_id > project_task.id
+Ref: ppm_risk.assigned_to_id > res_users.id
+Ref: ppm_risk.currency_id > res_currency.id
+Ref: ppm_risk.owner_id > res_users.id
+Ref: ppm_risk.portfolio_id > ppm_portfolio.id
+Ref: ppm_risk.program_id > ppm_program.id
+Ref: ppm_risk.project_id > project_project.id
+Ref: project_milestone.approver_id > res_users.id
+Ref: project_project.ipai_root_project_id > project_project.id
+Ref: project_project.parent_id > project_project.id
+Ref: project_project.portfolio_id > project_category.id
+Ref: project_task.approver_id > res_users.id
+Ref: project_task.bir_schedule_id > ipai_finance_bir_schedule.id
+Ref: project_task.fd_id > res_users.id
+Ref: project_task.finance_logframe_id > ipai_finance_logframe.id
+Ref: project_task.finance_person_id > ipai_finance_person.id
+Ref: project_task.finance_supervisor_id > res_users.id
+Ref: project_task.gate_approver_id > res_users.id
+Ref: project_task.gate_milestone_id > project_milestone.id
+Ref: project_task.ipai_template_id > ipai_finance_task_template.id
+Ref: project_task.reviewer_id > res_users.id
+Ref: project_task.sfm_id > res_users.id
+Ref: project_task_checklist_item.assigned_user_id > res_users.id
+Ref: res_config_settings.superset_connection_id > superset_connection.id
+Ref: res_partner.srm_supplier_id > srm_supplier.id
+Ref: srm_qualification.approver_id > res_users.id
+Ref: srm_qualification.reviewer_id > res_users.id
+Ref: srm_qualification.supplier_id > srm_supplier.id
+Ref: srm_qualification_checklist.completed_by > res_users.id
+Ref: srm_qualification_checklist.qualification_id > srm_qualification.id
+Ref: srm_qualification_document_ids_rel.ir_attachment_id > ir_attachment.id
+Ref: srm_qualification_document_ids_rel.srm_qualification_id > srm_qualification.id
+Ref: srm_scorecard.evaluator_id > res_users.id
+Ref: srm_scorecard.supplier_id > srm_supplier.id
+Ref: srm_scorecard_line.kpi_category_id > srm_kpi_category.id
+Ref: srm_scorecard_line.scorecard_id > srm_scorecard.id
+Ref: srm_supplier.currency_id > res_currency.id
+Ref: srm_supplier.latest_scorecard_id > srm_scorecard.id
+Ref: srm_supplier.partner_id > res_partner.id
+Ref: srm_supplier.primary_contact_id > res_partner.id
+Ref: srm_supplier.sales_contact_id > res_partner.id
+Ref: srm_supplier_category_ids_rel.product_category_id > product_category.id
+Ref: srm_supplier_category_ids_rel.srm_supplier_id > srm_supplier.id
+Ref: superset_bulk_dataset_wizard.connection_id > superset_connection.id
+Ref: superset_dataset.connection_id > superset_connection.id
+Ref: superset_dataset.model_id > ir_model.id
+Ref: superset_dataset_column.dataset_id > superset_dataset.id
+Ref: superset_dataset_field_ids_rel.ir_model_fields_id > ir_model_fields.id
+Ref: superset_dataset_field_ids_rel.superset_dataset_id > superset_dataset.id
+Ref: superset_dataset_wizard.connection_id > superset_connection.id
+Ref: superset_dataset_wizard.model_id > ir_model.id
+Ref: superset_dataset_wizard_field_ids_rel.ir_model_fields_id > ir_model_fields.id
+Ref: superset_dataset_wizard_field_ids_rel.superset_dataset_wizard_id > superset_dataset_wizard.id
+Ref: workos_comment_mention_rel.comment_id > ipai_workos_comment.id
+Ref: workos_comment_mention_rel.user_id > res_users.id
+Ref: workspace_member_rel.user_id > res_users.id
+Ref: workspace_member_rel.workspace_id > ipai_workos_workspace.id

--- a/docs/data-model/ODOO_ERD.mmd
+++ b/docs/data-model/ODOO_ERD.mmd
@@ -1,0 +1,3510 @@
+erDiagram
+  a1_check {
+    boolean active
+    varchar check_type
+    int close_gate_template_id
+    varchar code
+    int company_id
+    datetime create_date
+    int create_uid
+    varchar description
+    text fail_action
+    int id
+    varchar name
+    text pass_criteria
+    int sequence
+    varchar severity
+    datetime write_date
+    int write_uid
+  }
+  a1_check_result {
+    int check_id
+    datetime create_date
+    int create_uid
+    varchar evidence
+    int executed_by
+    datetime executed_date
+    int id
+    varchar result
+    text result_notes
+    int task_id
+    datetime write_date
+    int write_uid
+  }
+  a1_check_result_attachment_ids_rel {
+    int a1_check_result_id
+    int ir_attachment_id
+  }
+  a1_export_run {
+    int company_id
+    datetime create_date
+    int create_uid
+    int created_count
+    int error_count
+    int id
+    text log
+    varchar run_type
+    varchar seed_hash
+    text seed_json
+    varchar status
+    int unchanged_count
+    int updated_count
+    varchar webhook_url
+    datetime write_date
+    int write_uid
+  }
+  a1_role {
+    boolean active
+    varchar code
+    int company_id
+    datetime create_date
+    int create_uid
+    int default_user_id
+    text description
+    int fallback_user_id
+    int id
+    varchar name
+    int sequence
+    datetime write_date
+    int write_uid
+  }
+  a1_role_group_ids_rel {
+    int a1_role_id
+    int res_groups_id
+  }
+  a1_task {
+    date approval_deadline
+    int approval_done_by
+    datetime approval_done_date
+    int approver_id
+    varchar approver_role
+    float checklist_progress
+    int close_task_id
+    int company_id
+    datetime create_date
+    int create_uid
+    varchar external_key
+    int id
+    varchar name
+    varchar notes
+    int owner_id
+    varchar owner_role
+    date prep_deadline
+    int prep_done_by
+    datetime prep_done_date
+    date review_deadline
+    int review_done_by
+    datetime review_done_date
+    int reviewer_id
+    varchar reviewer_role
+    int sequence
+    varchar state
+    int tasklist_id
+    int template_id
+    int workstream_id
+    datetime write_date
+    int write_uid
+  }
+  a1_task_checklist {
+    varchar code
+    datetime create_date
+    int create_uid
+    int done_by
+    datetime done_date
+    int id
+    boolean is_done
+    boolean is_required
+    varchar item_type
+    varchar name
+    int sequence
+    int task_id
+    int template_item_id
+    int value_attachment_id
+    text value_text
+    datetime write_date
+    int write_uid
+  }
+  a1_tasklist {
+    int close_cycle_id
+    int company_id
+    datetime create_date
+    int create_uid
+    int id
+    varchar name
+    varchar notes
+    date period_end
+    varchar period_label
+    date period_start
+    float progress
+    varchar state
+    int task_count
+    int task_done_count
+    varchar webhook_url
+    datetime write_date
+    int write_uid
+  }
+  a1_template {
+    boolean active
+    float approval_days
+    varchar approver_role
+    int close_template_id
+    varchar code
+    int company_id
+    datetime create_date
+    int create_uid
+    varchar description
+    int id
+    varchar name
+    varchar owner_role
+    varchar phase_code
+    float prep_days
+    float review_days
+    varchar reviewer_role
+    int sequence
+    float total_days
+    int workstream_id
+    datetime write_date
+    int write_uid
+  }
+  a1_template_check_rel {
+    int check_id
+    int template_id
+  }
+  a1_template_checklist {
+    varchar code
+    datetime create_date
+    int create_uid
+    int id
+    text instructions
+    boolean is_required
+    varchar item_type
+    varchar name
+    int sequence
+    int template_id
+    datetime write_date
+    int write_uid
+  }
+  a1_template_step {
+    varchar assignee_role
+    varchar code
+    datetime create_date
+    int create_uid
+    int deadline_offset_days
+    float effort_days
+    int id
+    varchar name
+    int sequence
+    int template_id
+    datetime write_date
+    int write_uid
+  }
+  a1_workstream {
+    boolean active
+    int close_category_id
+    varchar code
+    int company_id
+    datetime create_date
+    int create_uid
+    varchar description
+    int id
+    varchar name
+    int owner_role_id
+    int owner_user_id
+    varchar phase_code
+    int sequence
+    int template_count
+    datetime write_date
+    int write_uid
+  }
+  account_account {
+    int id
+  }
+  account_move {
+    date bir_2307_date
+    boolean bir_2307_generated
+    datetime create_date
+    int create_uid
+    decimal ewt_amount
+    int id
+    datetime write_date
+    int write_uid
+  }
+  advisor_category {
+    boolean active
+    varchar code
+    int color
+    datetime create_date
+    int create_uid
+    text description
+    int high_count
+    varchar icon
+    int id
+    int latest_score
+    varchar name
+    int open_count
+    int recommendation_count
+    int sequence
+    datetime write_date
+    int write_uid
+  }
+  advisor_playbook {
+    boolean active
+    varchar automation_kind
+    text automation_params
+    varchar automation_ref
+    varchar code
+    datetime create_date
+    int create_uid
+    text description
+    int id
+    varchar name
+    int recommendation_count
+    text steps_md
+    datetime write_date
+    int write_uid
+  }
+  advisor_playbook_category_ids_rel {
+    int advisor_category_id
+    int advisor_playbook_id
+  }
+  advisor_recommendation {
+    varchar category_code
+    int category_id
+    float confidence
+    datetime create_date
+    int create_uid
+    int currency_id
+    date date_due
+    date date_resolved
+    text description
+    decimal estimated_savings
+    text evidence
+    varchar external_link
+    int id
+    int impact_score
+    varchar name
+    int owner_id
+    int playbook_id
+    text remediation_steps
+    varchar resource_ref
+    varchar resource_type
+    varchar severity
+    int severity_order
+    date snooze_until
+    varchar source
+    varchar status
+    datetime write_date
+    int write_uid
+  }
+  advisor_recommendation_tag_ids_rel {
+    int advisor_recommendation_id
+    int advisor_tag_id
+  }
+  advisor_score {
+    datetime as_of
+    varchar category_code
+    int category_id
+    datetime create_date
+    int create_uid
+    int critical_count
+    int high_count
+    int id
+    text inputs_json
+    int open_count
+    int resolved_count
+    int score
+    datetime write_date
+    int write_uid
+  }
+  advisor_tag {
+    int color
+    datetime create_date
+    int create_uid
+    int id
+    varchar name
+    datetime write_date
+    int write_uid
+  }
+  base_automation {
+    int id
+  }
+  bir_alphalist {
+    int company_id
+    datetime create_date
+    int create_uid
+    int currency_id
+    int fiscal_year
+    varchar form_type
+    int id
+    varchar name
+    varchar state
+    decimal total_gross
+    decimal total_wht
+    datetime write_date
+    int write_uid
+  }
+  bir_alphalist_line {
+    int alphalist_id
+    datetime create_date
+    int create_uid
+    int currency_id
+    decimal gross_income
+    int id
+    varchar income_type
+    int partner_id
+    varchar tin
+    decimal wht_amount
+    datetime write_date
+    int write_uid
+  }
+  bir_filing_deadline {
+    int company_id
+    datetime create_date
+    int create_uid
+    date deadline_date
+    varchar form_type
+    int id
+    varchar name
+    int period_month
+    int period_year
+    date reminder_date
+    int return_id
+    varchar state
+    datetime write_date
+    int write_uid
+  }
+  bir_return {
+    varchar bir_reference
+    int company_id
+    datetime create_date
+    int create_uid
+    int currency_id
+    decimal exempt_sales
+    int filed_by
+    datetime filed_date
+    varchar form_type
+    int id
+    decimal input_vat
+    decimal interest
+    varchar name
+    text notes
+    decimal output_vat
+    date payment_date
+    varchar payment_reference
+    decimal penalty
+    date period_end
+    date period_start
+    varchar state
+    int task_id
+    decimal tax_base
+    decimal tax_credits
+    decimal tax_due
+    decimal tax_payable
+    decimal total_due
+    decimal total_payments
+    decimal total_wht
+    decimal vatable_sales
+    datetime write_date
+    int write_uid
+    decimal zero_rated_sales
+  }
+  bir_return_line {
+    decimal amount
+    datetime create_date
+    int create_uid
+    int currency_id
+    varchar description
+    int id
+    int move_id
+    int partner_id
+    int return_id
+    int sequence
+    decimal tax_amount
+    varchar tin
+    datetime write_date
+    int write_uid
+  }
+  bir_tax_return {
+    varchar bir_reference
+    int company_id
+    datetime create_date
+    int create_uid
+    int currency_id
+    int days_until_due
+    date due_date
+    int filed_by
+    datetime filed_date
+    varchar form_type
+    varchar frequency
+    int id
+    decimal interest
+    boolean is_overdue
+    varchar name
+    text notes
+    date payment_date
+    varchar payment_reference
+    decimal penalty
+    date period_end
+    date period_start
+    varchar state
+    decimal tax_base
+    varchar tax_category
+    decimal tax_credits
+    decimal tax_due
+    decimal tax_payable
+    decimal total_amount_due
+    datetime write_date
+    int write_uid
+  }
+  bir_tax_return_line {
+    datetime create_date
+    int create_uid
+    int currency_id
+    varchar description
+    int id
+    int move_id
+    int partner_id
+    int return_id
+    int sequence
+    decimal tax_amount
+    decimal tax_base
+    float tax_rate
+    varchar tin
+    datetime write_date
+    int write_uid
+  }
+  bir_vat_line {
+    decimal amount_untaxed
+    datetime create_date
+    int create_uid
+    int currency_id
+    int id
+    date invoice_date
+    int invoice_id
+    varchar line_type
+    int partner_id
+    int return_id
+    varchar tin
+    decimal vat_amount
+    varchar vat_category
+    datetime write_date
+    int write_uid
+  }
+  bir_vat_return {
+    datetime create_date
+    int create_uid
+    decimal excess_input_vat
+    decimal excess_input_vat_previous
+    decimal exempt_sales
+    int id
+    decimal importations
+    decimal net_vat_payable
+    decimal output_vat
+    decimal purchase_of_services
+    decimal total_input_vat
+    decimal total_sales
+    decimal vatable_purchases
+    decimal vatable_sales
+    datetime write_date
+    int write_uid
+    decimal zero_rated_sales
+  }
+  bir_withholding_line {
+    datetime create_date
+    int create_uid
+    int currency_id
+    decimal gross_income
+    int id
+    varchar income_type
+    int move_id
+    int partner_id
+    int payslip_id
+    int return_id
+    varchar tin
+    decimal wht_amount
+    float wht_rate
+    datetime write_date
+    int write_uid
+  }
+  bir_withholding_return {
+    decimal compensation_tax_withheld
+    datetime create_date
+    int create_uid
+    int employee_count
+    decimal expanded_wht_amount
+    decimal final_wht_amount
+    int id
+    decimal taxable_compensation
+    decimal total_compensation
+    decimal total_payments
+    varchar withholding_type
+    datetime write_date
+    int write_uid
+  }
+  close_approval_gate {
+    float actual_value
+    text approval_notes
+    int approved_by
+    datetime approved_date
+    int approver_id
+    varchar approver_role
+    int approver_user_id
+    boolean block_on_exceptions
+    text block_reason
+    text blocking_reason
+    int company_id
+    datetime create_date
+    int create_uid
+    int cycle_id
+    int gate_level
+    varchar gate_type
+    int id
+    float min_completion_pct
+    varchar name
+    varchar notes
+    int required_approvals
+    varchar required_task_states
+    int sequence
+    varchar state
+    int template_id
+    float threshold_value
+    datetime write_date
+    int write_uid
+  }
+  close_approval_gate_blocking_exceptions_rel {
+    int close_approval_gate_id
+    int close_exception_id
+  }
+  close_approval_gate_blocking_tasks_rel {
+    int close_approval_gate_id
+    int close_task_id
+  }
+  close_approval_gate_template {
+    int a1_check_id
+    boolean active
+    varchar code
+    int company_id
+    datetime create_date
+    int create_uid
+    varchar description
+    varchar gate_type
+    int id
+    varchar name
+    text pass_criteria
+    int sequence
+    datetime write_date
+    int write_uid
+  }
+  close_cycle {
+    int a1_tasklist_id
+    date close_actual_date
+    date close_start_date
+    date close_target_date
+    int closing_period_id
+    int company_id
+    datetime create_date
+    int create_uid
+    int cycle_time_days
+    int exception_count
+    boolean gates_ready
+    int id
+    varchar name
+    varchar notes
+    int open_exception_count
+    date period_end
+    varchar period_label
+    date period_start
+    varchar period_type
+    float progress
+    varchar state
+    float task_completion_pct
+    int task_count
+    int task_done_count
+    varchar webhook_url
+    datetime write_date
+    int write_uid
+  }
+  close_exception {
+    decimal amount
+    int assigned_to
+    int company_id
+    datetime create_date
+    int create_uid
+    int currency_id
+    int cycle_id
+    text description
+    int detected_by
+    datetime detected_date
+    datetime escalated_date
+    int escalated_to
+    int escalation_count
+    datetime escalation_deadline
+    int escalation_level
+    varchar exception_type
+    int id
+    datetime last_escalated
+    varchar name
+    int related_account_id
+    int related_move_id
+    int related_partner_id
+    int reported_by
+    varchar resolution
+    text resolution_action
+    int resolved_by
+    datetime resolved_date
+    text root_cause
+    varchar severity
+    varchar state
+    int task_id
+    float variance_pct
+    datetime write_date
+    int write_uid
+  }
+  close_task {
+    int a1_task_id
+    date approval_deadline
+    int approval_done_by
+    datetime approval_done_date
+    datetime approve_done_date
+    date approve_due_date
+    text approve_notes
+    int approve_user_id
+    int approver_id
+    int category_id
+    float checklist_done_pct
+    float checklist_progress
+    int company_id
+    datetime create_date
+    int create_uid
+    int cycle_id
+    int days_overdue
+    text description
+    varchar external_key
+    int gl_entry_count
+    boolean has_exceptions
+    boolean has_open_exceptions
+    int id
+    boolean is_overdue
+    varchar name
+    varchar notes
+    date prep_deadline
+    int prep_done_by
+    datetime prep_done_date
+    date prep_due_date
+    text prep_notes
+    int prep_user_id
+    int preparer_id
+    date review_deadline
+    int review_done_by
+    datetime review_done_date
+    date review_due_date
+    text review_notes
+    varchar review_result
+    int review_user_id
+    int reviewer_id
+    int sequence
+    varchar state
+    int template_id
+    datetime write_date
+    int write_uid
+  }
+  close_task_attachment_ids_rel {
+    int close_task_id
+    int ir_attachment_id
+  }
+  close_task_category {
+    int a1_workstream_id
+    boolean active
+    varchar code
+    int color
+    int company_id
+    datetime create_date
+    int create_uid
+    int default_approve_days
+    varchar default_approve_role
+    int default_prep_days
+    varchar default_prep_role
+    int default_review_days
+    varchar default_review_role
+    text description
+    int id
+    varchar name
+    int sequence
+    datetime write_date
+    int write_uid
+  }
+  close_task_category_gl_account_ids_rel {
+    int account_account_id
+    int close_task_category_id
+  }
+  close_task_checklist {
+    int attachment_id
+    varchar code
+    datetime create_date
+    int create_uid
+    datetime done_at
+    int done_by
+    datetime done_date
+    varchar evidence_type
+    int id
+    text instructions
+    boolean is_done
+    boolean is_required
+    varchar name
+    text notes
+    boolean required
+    int sequence
+    int task_id
+    datetime write_date
+    int write_uid
+  }
+  close_task_gl_entry_ids_rel {
+    int account_move_id
+    int close_task_id
+  }
+  close_task_template {
+    int a1_template_id
+    boolean active
+    float approval_days
+    int approval_offset
+    int approve_day_offset
+    int approver_id
+    varchar approver_role
+    int category_id
+    varchar code
+    int company_id
+    datetime create_date
+    int create_uid
+    boolean creates_gl_entry
+    int default_approve_user_id
+    int default_prep_user_id
+    int default_review_user_id
+    text description
+    int id
+    varchar name
+    varchar period_type
+    int prep_day_offset
+    float prep_days
+    int prep_offset
+    int preparer_id
+    varchar preparer_role
+    int review_day_offset
+    float review_days
+    int review_offset
+    int reviewer_id
+    varchar reviewer_role
+    int sequence
+    datetime write_date
+    int write_uid
+  }
+  close_task_template_checklist {
+    varchar code
+    datetime create_date
+    int create_uid
+    varchar evidence_type
+    int id
+    text instructions
+    boolean is_required
+    varchar name
+    boolean required
+    int sequence
+    int template_id
+    datetime write_date
+    int write_uid
+  }
+  close_task_template_gl_account_ids_rel {
+    int account_account_id
+    int close_task_template_id
+  }
+  closing_period {
+    int bir_tasks
+    int company_id
+    int completed_tasks
+    datetime create_date
+    int create_uid
+    int id
+    date last_workday
+    int month_end_tasks
+    varchar name
+    text notes
+    int overdue_tasks
+    date period_date
+    int period_month
+    int period_year
+    float progress
+    varchar state
+    int total_tasks
+    datetime write_date
+    int write_uid
+  }
+  compliance_check {
+    float actual_value
+    varchar check_type
+    int checked_by
+    datetime checked_date
+    int closing_id
+    datetime create_date
+    int create_uid
+    float expected_value
+    int id
+    varchar name
+    text result_text
+    int sequence
+    varchar status
+    float tolerance
+    float variance
+    datetime write_date
+    int write_uid
+  }
+  crm_lead {
+    datetime create_date
+    int create_uid
+    int days_in_stage
+    int id
+    datetime last_call_date
+    datetime last_meeting_date
+    datetime stage_entry_date
+    varchar stage_missing_fields
+    boolean stage_rule_validated
+    datetime write_date
+    int write_uid
+  }
+  crm_stage {
+    datetime create_date
+    int create_uid
+    int id
+    text ipai_automation_notes
+    boolean ipai_enforce_rules
+    int ipai_sla_days
+    varchar ipai_stage_color
+    varchar ipai_stage_icon
+    datetime write_date
+    int write_uid
+  }
+  crm_stage_required_fields_rel {
+    int field_id
+    int stage_id
+  }
+  discuss_channel {
+    datetime create_date
+    int create_uid
+    int id
+    boolean is_ai_channel
+    datetime write_date
+    int write_uid
+  }
+  finance_bir_deadline {
+    boolean active
+    datetime create_date
+    int create_uid
+    date deadline_date
+    text description
+    varchar display_name
+    varchar form_type
+    int id
+    varchar name
+    varchar period_covered
+    int responsible_approval_id
+    int responsible_prep_id
+    int responsible_review_id
+    varchar state
+    date target_payment_approval_date
+    date target_prep_date
+    date target_report_approval_date
+    datetime write_date
+    int write_uid
+  }
+  finance_ppm_bir_calendar {
+    datetime create_date
+    int create_uid
+    text description
+    date filing_deadline
+    varchar form_code
+    varchar form_name
+    int id
+    varchar period
+    varchar responsible_role
+    datetime write_date
+    int write_uid
+  }
+  finance_ppm_dashboard {
+    datetime create_date
+    int create_uid
+    int failures_24h
+    int id
+    text last_message
+    datetime last_run_at
+    varchar last_status
+    varchar name
+    datetime next_scheduled_at
+    int sequence
+    varchar status_color
+    int total_runs
+    varchar workflow_code
+    datetime write_date
+    int write_uid
+  }
+  finance_ppm_import_wizard {
+    datetime create_date
+    int create_uid
+    text error_log
+    binary file_data
+    varchar file_name
+    varchar file_type
+    int id
+    text import_summary
+    varchar import_type
+    int records_created
+    int records_failed
+    int records_skipped
+    int records_updated
+    boolean skip_header
+    varchar state
+    boolean update_existing
+    datetime write_date
+    int write_uid
+  }
+  finance_ppm_logframe {
+    varchar code
+    datetime create_date
+    int create_uid
+    text description
+    int id
+    varchar kpi_baseline
+    varchar kpi_measure
+    varchar kpi_target
+    varchar level
+    varchar measurement_frequency
+    varchar name
+    int parent_id
+    varchar parent_path
+    varchar responsible_role
+    datetime write_date
+    int write_uid
+  }
+  finance_ppm_ph_holiday {
+    datetime create_date
+    int create_uid
+    date date
+    text description
+    varchar holiday_type
+    int id
+    boolean is_nationwide
+    varchar name
+    datetime write_date
+    int write_uid
+  }
+  finance_ppm_tdi_audit {
+    datetime create_date
+    int create_uid
+    varchar display_name
+    text error_log
+    varchar file_name
+    boolean has_errors
+    int id
+    datetime import_date
+    text import_summary
+    varchar import_type
+    int records_created
+    int records_failed
+    int records_skipped
+    int records_updated
+    varchar state
+    float success_rate
+    int total_records
+    int user_id
+    datetime write_date
+    int write_uid
+  }
+  finance_task {
+    boolean approve_done
+    int approve_done_by
+    datetime approve_done_date
+    date approve_due_date
+    int approve_user_id
+    varchar bir_form_type
+    varchar bir_reference
+    int bir_return_id
+    int closing_id
+    int company_id
+    datetime create_date
+    int create_uid
+    int days_overdue
+    datetime filed_date
+    date filing_due_date
+    int id
+    boolean is_overdue
+    varchar name
+    text notes
+    varchar phase
+    boolean prep_done
+    int prep_done_by
+    datetime prep_done_date
+    date prep_due_date
+    int prep_user_id
+    boolean review_done
+    int review_done_by
+    datetime review_done_date
+    date review_due_date
+    int review_user_id
+    int sequence
+    varchar state
+    varchar task_type
+    int template_id
+    datetime write_date
+    int write_uid
+  }
+  finance_task_template {
+    boolean active
+    int approve_day_offset
+    int approve_user_id
+    varchar bir_form_type
+    datetime create_date
+    int create_uid
+    varchar description
+    int filing_day_offset
+    varchar frequency
+    int id
+    varchar name
+    varchar oca_module
+    varchar odoo_model
+    varchar phase
+    int prep_day_offset
+    int prep_user_id
+    int review_day_offset
+    int review_user_id
+    int sequence
+    int task_count
+    varchar task_type
+    datetime write_date
+    int write_uid
+  }
+  finance_task_template_dependency_rel {
+    int depends_on_id
+    int task_id
+  }
+  hr_employee {
+    datetime create_date
+    int create_uid
+    int id
+    datetime write_date
+    int write_uid
+    boolean x_master_control_offboarded
+    boolean x_master_control_onboarded
+  }
+  hr_expense {
+    datetime create_date
+    int create_uid
+    int id
+    int project_id
+    boolean requires_project
+    int travel_request_id
+    datetime write_date
+    int write_uid
+    boolean x_master_control_submitted
+  }
+  hr_payslip {
+    int id
+  }
+  ipai_ask_ai_service {
+    datetime create_date
+    int create_uid
+    int id
+    datetime write_date
+    int write_uid
+  }
+  ipai_asset {
+    int active_checkout_id
+    varchar barcode
+    int category_id
+    varchar code
+    datetime create_date
+    int create_uid
+    int currency_id
+    decimal current_value
+    int custodian_id
+    text description
+    int id
+    varchar image
+    int location_id
+    varchar name
+    date purchase_date
+    decimal purchase_value
+    varchar state
+    datetime write_date
+    int write_uid
+  }
+  ipai_asset_category {
+    boolean allow_reservations
+    int asset_count
+    varchar code
+    datetime create_date
+    int create_uid
+    text description
+    int id
+    int max_checkout_days
+    varchar name
+    boolean requires_approval
+    int sequence
+    datetime write_date
+    int write_uid
+  }
+  ipai_asset_checkout {
+    datetime actual_return_date
+    datetime approval_date
+    int approved_by
+    int asset_id
+    datetime checkout_date
+    text checkout_notes
+    varchar condition_on_return
+    datetime create_date
+    int create_uid
+    int employee_id
+    date expected_return_date
+    int id
+    varchar name
+    text return_notes
+    varchar state
+    datetime write_date
+    int write_uid
+  }
+  ipai_asset_reservation {
+    int asset_id
+    datetime create_date
+    int create_uid
+    int employee_id
+    date end_date
+    int id
+    varchar name
+    text notes
+    date start_date
+    varchar state
+    datetime write_date
+    int write_uid
+  }
+  ipai_audit_log {
+    varchar action
+    datetime create_date
+    int create_uid
+    varchar display_name
+    varchar field_name
+    int id
+    text new_value
+    text old_value
+    int res_id
+    varchar res_model
+    varchar res_name
+    int user_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_bir_dat_wizard {
+    datetime create_date
+    int create_uid
+    int currency_id
+    date date_end
+    date date_start
+    binary file_data
+    varchar file_name
+    int id
+    int record_count
+    varchar report_type
+    varchar state
+    decimal total_amount
+    decimal total_tax
+    datetime write_date
+    int write_uid
+  }
+  ipai_bir_form_schedule {
+    date approval_date
+    date bir_deadline
+    datetime create_date
+    int create_uid
+    varchar form_code
+    int id
+    varchar period
+    date prep_date
+    int responsible_approval_id
+    int responsible_prep_id
+    int responsible_review_id
+    date review_date
+    datetime write_date
+    int write_uid
+  }
+  ipai_bir_process_step {
+    datetime create_date
+    int create_uid
+    text detail
+    int id
+    int person_id
+    varchar role
+    int schedule_id
+    int step_no
+    int target_offset
+    varchar title
+    datetime write_date
+    int write_uid
+  }
+  ipai_bir_schedule_item {
+    boolean active
+    varchar bir_form
+    datetime create_date
+    int create_uid
+    date deadline
+    int id
+    varchar im_xml_id
+    varchar period_covered
+    datetime write_date
+    int write_uid
+  }
+  ipai_bir_schedule_line {
+    varchar approve_by_code
+    date approve_due_date
+    varchar bir_form
+    datetime create_date
+    int create_uid
+    date deadline_date
+    int id
+    varchar notes
+    varchar period_label
+    varchar prep_by_code
+    date prep_due_date
+    varchar review_by_code
+    date review_due_date
+    datetime write_date
+    int write_uid
+  }
+  ipai_bir_schedule_step {
+    varchar activity_type
+    int business_days_before
+    datetime create_date
+    int create_uid
+    int id
+    int item_id
+    boolean on_or_before_deadline
+    varchar role_code
+    int sequence
+    datetime write_date
+    int write_uid
+  }
+  ipai_close_generated_map {
+    datetime create_date
+    int create_uid
+    varchar external_key
+    int generation_run_id
+    int id
+    varchar operation
+    int run_id
+    varchar seed_hash
+    varchar seed_hash_at_generation
+    int task_id
+    int template_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_close_generation_run {
+    datetime create_date
+    int create_uid
+    int created_count
+    varchar cycle_code
+    varchar cycle_key
+    varchar cycle_type
+    boolean dry_run
+    int duration_seconds
+    datetime end_time
+    int error_count
+    int id
+    varchar name
+    int obsolete_marked_count
+    date period_end
+    date period_start
+    int project_id
+    varchar report_json
+    varchar report_status
+    varchar seed_id
+    varchar seed_version
+    datetime start_time
+    varchar status
+    int task_count_created
+    int task_count_obsolete
+    int task_count_skipped
+    int task_count_updated
+    int unchanged_count
+    int unresolved_assignee_count
+    int updated_count
+    int user_id
+    int warning_count
+    datetime write_date
+    int write_uid
+  }
+  ipai_close_generator {
+    datetime create_date
+    int create_uid
+    int id
+    varchar name
+    datetime write_date
+    int write_uid
+  }
+  ipai_close_task_step {
+    datetime create_date
+    int create_uid
+    varchar default_employee_code
+    int id
+    int sequence
+    varchar step_code
+    varchar step_name
+    int template_id
+    int user_id
+    datetime write_date
+    int write_uid
+    varchar x_legacy_template_code
+  }
+  ipai_close_task_template {
+    varchar category_code
+    varchar category_name
+    int category_seq
+    datetime create_date
+    int create_uid
+    boolean critical_path
+    varchar cycle_code
+    int duration_days
+    varchar employee_code
+    int id
+    boolean is_active
+    int offset_from_period_end
+    varchar phase_code
+    varchar phase_name
+    int phase_seq
+    varchar phase_type
+    varchar recurrence_rule
+    varchar responsible_role
+    varchar seed_hash
+    varchar step_code
+    int step_seq
+    text task_description
+    varchar task_name_template
+    varchar template_code
+    int template_seq
+    varchar template_version
+    varchar wbs_code_template
+    varchar workstream_code
+    varchar workstream_name
+    int workstream_seq
+    datetime write_date
+    int write_uid
+    boolean x_legacy_migration
+  }
+  ipai_convert_phases_wizard {
+    datetime create_date
+    int create_uid
+    int id
+    varchar im1_keywords
+    varchar im1_name
+    varchar im2_keywords
+    varchar im2_name
+    boolean move_tasks_by_keyword
+    int parent_project_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_directory_person {
+    boolean active
+    varchar code
+    datetime create_date
+    int create_uid
+    varchar email
+    int id
+    varchar name
+    varchar role
+    datetime write_date
+    int write_uid
+  }
+  ipai_equipment_asset {
+    int booking_count
+    int category_id
+    int company_id
+    varchar condition
+    datetime create_date
+    int create_uid
+    int id
+    varchar image_1920
+    int incident_count
+    int location_id
+    varchar name
+    int product_id
+    varchar serial_number
+    varchar status
+    datetime write_date
+    int write_uid
+  }
+  ipai_equipment_booking {
+    int asset_id
+    int borrower_id
+    datetime create_date
+    int create_uid
+    datetime end_datetime
+    int id
+    boolean is_overdue
+    varchar name
+    int project_id
+    datetime start_datetime
+    varchar state
+    datetime write_date
+    int write_uid
+  }
+  ipai_equipment_incident {
+    int asset_id
+    int booking_id
+    datetime create_date
+    int create_uid
+    text description
+    int id
+    varchar name
+    int reported_by
+    varchar severity
+    varchar status
+    datetime write_date
+    int write_uid
+  }
+  ipai_export_seed_wizard {
+    datetime create_date
+    int create_uid
+    varchar export_path
+    int id
+    varchar webhook_url
+    datetime write_date
+    int write_uid
+  }
+  ipai_finance_bir_schedule {
+    date approval_deadline
+    int approval_task_id
+    int approver_id
+    float completion_pct
+    datetime create_date
+    int create_uid
+    date filing_deadline
+    int id
+    int logframe_id
+    varchar name
+    varchar period_covered
+    date prep_deadline
+    int prep_task_id
+    date review_deadline
+    int review_task_id
+    int reviewer_id
+    varchar status
+    int supervisor_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_finance_directory {
+    boolean active
+    varchar code
+    datetime create_date
+    int create_uid
+    varchar email
+    int id
+    varchar name
+    int user_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_finance_logframe {
+    text assumptions
+    varchar code
+    datetime create_date
+    int create_uid
+    int id
+    text indicators
+    varchar level
+    text means_of_verification
+    varchar name
+    int sequence
+    int task_count
+    datetime write_date
+    int write_uid
+  }
+  ipai_finance_person {
+    varchar code
+    datetime create_date
+    int create_uid
+    varchar email
+    int id
+    varchar name
+    varchar role
+    int user_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_finance_ppm_golive_checklist {
+    int completed_items
+    float completion_pct
+    datetime create_date
+    int create_uid
+    int created_by
+    int director_id
+    text director_notes
+    datetime director_review_date
+    datetime director_signoff_date
+    int id
+    varchar name
+    int senior_supervisor_id
+    text senior_supervisor_notes
+    datetime senior_supervisor_review_date
+    varchar state
+    int supervisor_id
+    text supervisor_notes
+    datetime supervisor_review_date
+    int total_items
+    varchar version
+    datetime write_date
+    int write_uid
+  }
+  ipai_finance_ppm_golive_checklist_section_ids_rel {
+    int ipai_finance_ppm_golive_checklist_id
+    int ipai_finance_ppm_golive_section_id
+  }
+  ipai_finance_ppm_golive_item {
+    int checked_by
+    datetime checked_date
+    datetime create_date
+    int create_uid
+    text description
+    varchar evidence_url
+    int id
+    boolean is_checked
+    boolean is_critical
+    varchar name
+    text notes
+    int section_id
+    int sequence
+    datetime write_date
+    int write_uid
+  }
+  ipai_finance_ppm_golive_section {
+    int completed_items
+    float completion_pct
+    datetime create_date
+    int create_uid
+    text description
+    int id
+    varchar name
+    varchar section_type
+    int sequence
+    int total_items
+    datetime write_date
+    int write_uid
+  }
+  ipai_finance_seed_service {
+    datetime create_date
+    int create_uid
+    int id
+    datetime write_date
+    int write_uid
+  }
+  ipai_finance_seed_wizard {
+    datetime create_date
+    int create_uid
+    int id
+    boolean strict
+    datetime write_date
+    int write_uid
+  }
+  ipai_finance_task_template {
+    boolean active
+    varchar anchor
+    float approval_duration
+    varchar approve_by_code
+    int approved_by_id
+    int bir_form_id
+    varchar category
+    datetime create_date
+    int create_uid
+    int day_of_month
+    int default_duration_days
+    text description
+    int employee_code_id
+    int id
+    varchar name
+    int offset_days
+    varchar prep_by_code
+    float prep_duration
+    varchar review_by_code
+    float review_duration
+    int reviewed_by_id
+    int sequence
+    varchar task_category
+    varchar trigger_type
+    datetime write_date
+    int write_uid
+  }
+  ipai_generate_bir_tasks_wizard {
+    datetime create_date
+    int create_uid
+    date date_from
+    date date_to
+    boolean dry_run
+    int id
+    int program_project_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_generate_im_projects_wizard {
+    boolean create_bir_tasks
+    boolean create_children
+    datetime create_date
+    boolean create_month_end_tasks
+    int create_uid
+    int id
+    int project_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_generate_month_end_wizard {
+    date anchor_date
+    datetime create_date
+    int create_uid
+    boolean dry_run
+    int id
+    int program_project_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_grid_column {
+    varchar alignment
+    varchar cell_css_class
+    boolean clickable
+    varchar column_type
+    datetime create_date
+    int create_uid
+    varchar css_class
+    varchar currency_field
+    varchar date_format
+    int decimal_places
+    varchar display_name
+    boolean editable
+    varchar field_name
+    varchar field_type
+    boolean filterable
+    varchar format_string
+    int grid_view_id
+    varchar header_css_class
+    int id
+    boolean is_action_column
+    boolean is_avatar_column
+    boolean is_primary
+    boolean is_selection_column
+    varchar label
+    int max_width
+    int min_width
+    boolean resizable
+    boolean searchable
+    int sequence
+    boolean sortable
+    boolean visible
+    text widget_options
+    int width
+    datetime write_date
+    int write_uid
+  }
+  ipai_grid_filter {
+    boolean active
+    varchar color
+    int condition_count
+    datetime create_date
+    int create_uid
+    varchar domain
+    text filter_json
+    int grid_view_id
+    varchar icon
+    int id
+    boolean is_default
+    boolean is_global
+    varchar name
+    int sequence
+    int user_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_grid_filter_condition {
+    datetime create_date
+    int create_uid
+    varchar field_label
+    varchar field_name
+    varchar field_type
+    int filter_id
+    int id
+    varchar operator
+    boolean value_boolean
+    varchar value_char
+    date value_date
+    datetime value_datetime
+    float value_float
+    int value_integer
+    int value_many2one
+    varchar value_selection
+    datetime write_date
+    int write_uid
+  }
+  ipai_grid_view {
+    boolean active
+    int active_filter_id
+    int column_count
+    text config_json
+    datetime create_date
+    int create_uid
+    boolean enable_column_reorder
+    boolean enable_column_resize
+    boolean enable_export
+    boolean enable_quick_search
+    boolean enable_row_selection
+    int id
+    int model_id
+    varchar model_name
+    varchar name
+    int page_size
+    varchar page_size_options
+    int sequence
+    boolean show_checkboxes
+    boolean show_row_numbers
+    text sort_json
+    varchar view_type
+    datetime write_date
+    int write_uid
+  }
+  ipai_grid_view_visible_columns_rel {
+    int column_id
+    int grid_view_id
+  }
+  ipai_import_seed_wizard {
+    datetime create_date
+    int create_uid
+    int id
+    varchar mode
+    text seed_json
+    datetime write_date
+    int write_uid
+  }
+  ipai_localization_overlay {
+    boolean active
+    varchar applies_to_code
+    varchar country
+    datetime create_date
+    int create_uid
+    int id
+    text patch_payload
+    varchar patch_type
+    int sequence
+    int workstream_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_month_end_closing {
+    int company_id
+    int completed_tasks
+    datetime create_date
+    int create_uid
+    int id
+    date last_workday
+    varchar name
+    int overdue_tasks
+    date period_date
+    float progress
+    varchar state
+    int total_tasks
+    datetime write_date
+    int write_uid
+  }
+  ipai_month_end_task {
+    boolean approve_done
+    int approve_done_by
+    datetime approve_done_date
+    date approve_due_date
+    int approve_user_id
+    int closing_id
+    datetime create_date
+    int create_uid
+    int days_overdue
+    int id
+    boolean is_overdue
+    varchar name
+    varchar notes
+    varchar phase
+    boolean prep_done
+    int prep_done_by
+    datetime prep_done_date
+    date prep_due_date
+    int prep_user_id
+    boolean review_done
+    int review_done_by
+    datetime review_done_date
+    date review_due_date
+    int review_user_id
+    int sequence
+    varchar state
+    int template_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_month_end_task_template {
+    boolean active
+    int approve_day_offset
+    int approve_user_id
+    datetime create_date
+    int create_uid
+    varchar description
+    int id
+    varchar name
+    varchar oca_module
+    varchar odoo_model
+    varchar phase
+    int prep_day_offset
+    int prep_user_id
+    int review_day_offset
+    int review_user_id
+    int sequence
+    int task_count
+    datetime write_date
+    int write_uid
+  }
+  ipai_month_end_template {
+    boolean active
+    varchar category
+    datetime create_date
+    int create_uid
+    varchar default_im_xml_id
+    int id
+    varchar task_base_name
+    datetime write_date
+    int write_uid
+  }
+  ipai_month_end_template_step {
+    varchar activity_type
+    int business_days_before
+    datetime create_date
+    int create_uid
+    int id
+    int offset_days
+    varchar role_code
+    int sequence
+    int template_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_permission {
+    boolean active
+    datetime create_date
+    int create_uid
+    int group_id
+    int id
+    varchar name
+    varchar permission_level
+    varchar role
+    varchar scope_ref
+    varchar scope_type
+    int user_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_ph_holiday {
+    datetime create_date
+    int create_uid
+    date date
+    varchar holiday_type
+    int id
+    varchar name
+    datetime write_date
+    int write_uid
+    int year
+  }
+  ipai_ppm_task {
+    varchar category
+    varchar code
+    datetime create_date
+    int create_uid
+    int due_offset_days
+    boolean evidence_required
+    int id
+    varchar name
+    varchar owner_role
+    varchar phase
+    int prep_offset
+    boolean requires_approval
+    int review_offset
+    varchar sap_reference
+    int sequence
+    int template_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_ppm_task_checklist {
+    datetime create_date
+    int create_uid
+    varchar evidence_type
+    int id
+    varchar label
+    varchar notes
+    boolean required
+    int sequence
+    int task_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_ppm_tasklist {
+    datetime create_date
+    int create_uid
+    int id
+    varchar name
+    date period_end
+    date period_start
+    varchar status
+    int template_id
+    int workstream_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_ppm_taskrun {
+    int approver_id
+    int assignee_id
+    datetime create_date
+    int create_uid
+    datetime done_at
+    int id
+    varchar name
+    datetime started_at
+    varchar status
+    int task_id
+    int tasklist_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_ppm_template {
+    varchar code
+    datetime create_date
+    int create_uid
+    int id
+    boolean is_active
+    varchar name
+    varchar period_type
+    int sequence
+    varchar version
+    int workstream_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_repo_export_run {
+    datetime create_date
+    int create_uid
+    varchar export_path
+    datetime exported_at
+    int id
+    varchar name
+    text payload_json
+    varchar state
+    varchar webhook_status
+    varchar webhook_url
+    datetime write_date
+    int write_uid
+  }
+  ipai_share_token {
+    boolean active
+    datetime create_date
+    int create_uid
+    int created_by
+    datetime expires_at
+    int id
+    boolean is_public
+    varchar name
+    varchar permission_level
+    varchar scope_ref
+    varchar scope_type
+    datetime write_date
+    int write_uid
+  }
+  ipai_stc_check {
+    boolean auto_run
+    varchar category
+    varchar code
+    datetime create_date
+    int create_uid
+    text description
+    int id
+    boolean is_active
+    varchar name
+    text rule_json
+    varchar sap_reference
+    int sequence
+    varchar severity
+    int worklist_type_id
+    int workstream_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_stc_scenario {
+    varchar bir_forms
+    varchar code
+    datetime create_date
+    int create_uid
+    varchar frequency
+    int id
+    varchar name
+    text notes
+    int run_day_offset
+    varchar sap_reference
+    int sequence
+    int workstream_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_stc_scenario_check_ids_rel {
+    int ipai_stc_check_id
+    int ipai_stc_scenario_id
+  }
+  ipai_stc_worklist_type {
+    varchar code
+    datetime create_date
+    int create_uid
+    text description
+    int id
+    varchar name
+    datetime write_date
+    int write_uid
+  }
+  ipai_studio_ai_history {
+    text analysis
+    int automation_id
+    text command
+    varchar command_type
+    float confidence
+    datetime create_date
+    int create_uid
+    text feedback_comment
+    varchar feedback_score
+    int field_id
+    int id
+    int model_id
+    varchar model_name
+    varchar result
+    text result_message
+    int user_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_studio_ai_wizard {
+    text analysis_json
+    text command
+    varchar command_type
+    float confidence
+    int context_model_id
+    datetime create_date
+    int create_uid
+    int created_field_id
+    varchar field_label
+    varchar field_name
+    boolean field_required
+    varchar field_type
+    int history_id
+    int id
+    boolean is_ready
+    varchar message
+    int relation_model_id
+    varchar result_message
+    text selection_options
+    varchar state
+    int target_model_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_task_template_dependency_rel {
+    int depends_on_id
+    int task_id
+  }
+  ipai_travel_request {
+    int company_id
+    datetime create_date
+    int create_uid
+    int currency_id
+    varchar destination
+    int employee_id
+    date end_date
+    decimal estimated_budget
+    int id
+    varchar name
+    int project_id
+    text purpose
+    date start_date
+    varchar state
+    datetime write_date
+    int write_uid
+  }
+  ipai_workos_block {
+    int attachment_id
+    varchar block_type
+    varchar callout_color
+    varchar callout_icon
+    varchar content_html
+    text content_json
+    text content_text
+    datetime create_date
+    int create_uid
+    int id
+    boolean is_checked
+    boolean is_collapsed
+    varchar name
+    int page_id
+    int parent_block_id
+    int sequence
+    datetime write_date
+    int write_uid
+  }
+  ipai_workos_canvas {
+    boolean active
+    datetime create_date
+    int create_uid
+    int id
+    varchar name
+    text nodes_json
+    int page_id
+    text viewport_json
+    datetime write_date
+    int write_uid
+  }
+  ipai_workos_comment {
+    int anchor_block_id
+    int author_id
+    varchar content
+    text content_text
+    datetime create_date
+    int create_uid
+    int id
+    boolean is_resolved
+    int parent_id
+    int reply_count
+    datetime resolved_at
+    int resolved_by
+    int target_id
+    varchar target_model
+    varchar target_name
+    datetime write_date
+    int write_uid
+  }
+  ipai_workos_database {
+    boolean active
+    datetime create_date
+    int create_uid
+    text description
+    varchar icon
+    int id
+    varchar name
+    int page_id
+    int row_count
+    int space_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_workos_page {
+    boolean active
+    int child_count
+    text content_preview
+    binary cover_image
+    datetime create_date
+    int create_uid
+    varchar icon
+    int id
+    boolean is_archived
+    int last_edited_by
+    varchar name
+    int parent_id
+    varchar parent_path
+    int sequence
+    int space_id
+    int template_id
+    int workspace_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_workos_property {
+    datetime create_date
+    int create_uid
+    int database_id
+    int id
+    boolean is_title
+    boolean is_visible
+    varchar name
+    text options_json
+    varchar property_type
+    int related_database_id
+    int sequence
+    int width
+    datetime write_date
+    int write_uid
+  }
+  ipai_workos_row {
+    boolean active
+    datetime create_date
+    int create_uid
+    int database_id
+    int id
+    varchar name
+    int sequence
+    text values_json
+    datetime write_date
+    int write_uid
+  }
+  ipai_workos_search {
+    text block_results
+    datetime create_date
+    int create_uid
+    text database_results
+    int id
+    text page_results
+    varchar query
+    varchar scope
+    int scope_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_workos_search_history {
+    datetime create_date
+    int create_uid
+    int id
+    varchar query
+    int result_count
+    int user_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_workos_space {
+    boolean active
+    int color
+    datetime create_date
+    int create_uid
+    text description
+    varchar icon
+    int id
+    varchar name
+    int page_count
+    int sequence
+    varchar visibility
+    int workspace_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_workos_template {
+    text blocks_json
+    varchar category
+    datetime create_date
+    int create_uid
+    text description
+    varchar icon
+    int id
+    boolean is_published
+    boolean is_system
+    varchar name
+    text properties_json
+    int sequence
+    text views_json
+    datetime write_date
+    int write_uid
+  }
+  ipai_workos_template_tag {
+    int color
+    datetime create_date
+    int create_uid
+    int id
+    varchar name
+    datetime write_date
+    int write_uid
+  }
+  ipai_workos_template_tag_ids_rel {
+    int ipai_workos_template_id
+    int ipai_workos_template_tag_id
+  }
+  ipai_workos_view {
+    text config_json
+    datetime create_date
+    int create_uid
+    int database_id
+    int date_property_id
+    text filter_json
+    int group_by_property_id
+    int id
+    boolean is_default
+    boolean is_shared
+    varchar name
+    int sequence
+    text sort_json
+    int user_id
+    varchar view_type
+    datetime write_date
+    int write_uid
+  }
+  ipai_workos_view_visible_property_ids_rel {
+    int ipai_workos_property_id
+    int ipai_workos_view_id
+  }
+  ipai_workos_workspace {
+    boolean active
+    int color
+    datetime create_date
+    int create_uid
+    text description
+    varchar icon
+    int id
+    varchar name
+    int owner_id
+    int space_count
+    datetime write_date
+    int write_uid
+  }
+  ipai_workspace {
+    int account_manager_id
+    boolean active
+    varchar brand_name
+    varchar campaign_type
+    varchar channel_mix
+    int client_id
+    varchar closing_stage
+    varchar code
+    int color
+    int company_id
+    datetime create_date
+    int create_uid
+    datetime date_end
+    datetime date_start
+    int engagement_count
+    varchar entity_code
+    varchar fiscal_period
+    int id
+    varchar industry
+    int invoice_count
+    boolean is_critical
+    varchar name
+    int parent_id
+    float planned_hours
+    float progress
+    int project_count
+    float remaining_hours
+    int sequence
+    varchar stage
+    varchar workspace_type
+    datetime write_date
+    int write_uid
+  }
+  ipai_workspace_link {
+    datetime create_date
+    int create_uid
+    varchar display_name
+    int id
+    varchar link_type
+    int res_id
+    varchar res_model
+    int workspace_id
+    datetime write_date
+    int write_uid
+  }
+  ipai_workstream {
+    boolean active
+    varchar code
+    datetime create_date
+    int create_uid
+    text description
+    int id
+    varchar name
+    varchar odoo_anchor
+    varchar sap_anchor
+    datetime write_date
+    int write_uid
+  }
+  ir_attachment {
+    int id
+  }
+  ir_model {
+    int id
+  }
+  ir_model_fields {
+    int id
+  }
+  ph_holiday {
+    int company_id
+    datetime create_date
+    int create_uid
+    date date
+    varchar holiday_type
+    int id
+    varchar name
+    datetime write_date
+    int write_uid
+    int year
+  }
+  ppm_close_task {
+    varchar agency_code
+    varchar approval_completed_by
+    date approval_completed_date
+    float approval_days
+    date approval_due
+    varchar approver_code
+    text completion_notes
+    datetime create_date
+    int create_uid
+    text detailed_task
+    int id
+    int monthly_close_id
+    varchar name
+    text notes
+    varchar owner_code
+    varchar prep_completed_by
+    date prep_completed_date
+    float prep_days
+    date prep_start
+    varchar review_completed_by
+    date review_completed_date
+    float review_days
+    date review_due
+    varchar reviewer_code
+    int sequence
+    varchar state
+    int template_id
+    float total_days
+    datetime write_date
+    int write_uid
+  }
+  ppm_close_template {
+    boolean active
+    varchar agency_code
+    float approval_days
+    varchar approver_code
+    datetime create_date
+    int create_uid
+    text detailed_task
+    int id
+    varchar name
+    text notes
+    varchar owner_code
+    float prep_days
+    float review_days
+    varchar reviewer_code
+    int sequence
+    varchar task_category
+    float total_days
+    datetime write_date
+    int write_uid
+  }
+  ppm_kpi_snapshot {
+    datetime as_of
+    datetime create_date
+    int create_uid
+    int id
+    varchar kpi_category
+    varchar kpi_key
+    varchar kpi_label
+    varchar name
+    int portfolio_id
+    int program_id
+    int project_id
+    varchar scope
+    varchar source
+    varchar source_ref
+    varchar status
+    float target_value
+    float threshold_green
+    float threshold_yellow
+    varchar unit
+    float value
+    varchar value_text
+    datetime write_date
+    int write_uid
+  }
+  ppm_monthly_close {
+    date approval_due_date
+    date close_month
+    datetime create_date
+    int create_uid
+    boolean created_by_cron
+    int id
+    date month_end_date
+    varchar name
+    text notes
+    date prep_start_date
+    float progress_percentage
+    date review_due_date
+    varchar state
+    int task_completed
+    int task_count
+    datetime write_date
+    int write_uid
+  }
+  ppm_portfolio {
+    boolean active
+    float budget_variance_pct
+    varchar code
+    datetime create_date
+    int create_uid
+    int currency_id
+    date date_end
+    date date_start
+    varchar description
+    int health_score
+    varchar health_status
+    int id
+    varchar name
+    text objective
+    int owner_id
+    int program_count
+    int sequence
+    int sponsor_id
+    decimal total_actual
+    decimal total_budget
+    datetime write_date
+    int write_uid
+  }
+  ppm_program {
+    boolean active
+    decimal actual_cost
+    decimal budget
+    varchar code
+    datetime create_date
+    int create_uid
+    int currency_id
+    date date_end
+    date date_start
+    varchar description
+    text health_notes
+    int health_score
+    varchar health_status
+    int id
+    varchar name
+    text objectives
+    int open_high_risks
+    int portfolio_id
+    int program_manager_id
+    int project_count
+    int risk_count
+    int sequence
+    int sponsor_id
+    datetime write_date
+    int write_uid
+  }
+  ppm_program_project_rel {
+    int program_id
+    int project_id
+  }
+  ppm_resource_allocation {
+    float allocation_pct
+    datetime create_date
+    int create_uid
+    date date_end
+    date date_start
+    int employee_id
+    int id
+    boolean is_overloaded
+    varchar name
+    text notes
+    float planned_hours
+    int program_id
+    int project_id
+    varchar role
+    varchar status
+    int task_id
+    float total_allocation
+    int user_id
+    datetime write_date
+    int write_uid
+  }
+  ppm_risk {
+    int assigned_to_id
+    varchar category
+    varchar code
+    text contingency_plan
+    datetime create_date
+    int create_uid
+    int currency_id
+    date date_closed
+    date date_identified
+    date date_target
+    text description
+    int id
+    varchar impact
+    text mitigation_plan
+    varchar mitigation_strategy
+    varchar name
+    int owner_id
+    int portfolio_id
+    decimal potential_cost
+    varchar probability
+    int program_id
+    int project_id
+    int risk_score
+    varchar scope
+    varchar severity
+    varchar status
+    datetime write_date
+    int write_uid
+  }
+  product_category {
+    int id
+  }
+  product_product {
+    int id
+  }
+  project_category {
+    int id
+  }
+  project_milestone {
+    int alert_days_before
+    date approval_date
+    boolean approval_required
+    int approver_id
+    date baseline_deadline
+    int completed_task_count
+    text completion_criteria
+    datetime create_date
+    int create_uid
+    text deliverables
+    varchar gate_status
+    int id
+    date last_alert_sent
+    varchar milestone_type
+    varchar risk_level
+    text risk_notes
+    int task_count
+    int variance_days
+    datetime write_date
+    int write_uid
+  }
+  project_project {
+    date actual_finish
+    date actual_start
+    date baseline_finish
+    date baseline_start
+    varchar clarity_id
+    datetime create_date
+    int create_uid
+    int critical_milestone_count
+    varchar health_status
+    int id
+    varchar im_code
+    boolean ipai_finance_enabled
+    varchar ipai_im_code
+    boolean ipai_is_im_project
+    int ipai_root_project_id
+    boolean is_program
+    int milestone_count
+    float overall_progress
+    varchar overall_status
+    int parent_id
+    int phase_count
+    int portfolio_id
+    varchar program_code
+    varchar program_type
+    int variance_finish
+    int variance_start
+    datetime write_date
+    int write_uid
+    varchar x_cycle_code
+  }
+  project_task {
+    varchar activity_type
+    float actual_cost
+    float actual_hours
+    float approval_duration
+    int approver_id
+    boolean auto_sync
+    date bir_approval_due_date
+    date bir_deadline
+    varchar bir_form
+    date bir_payment_due_date
+    varchar bir_period_label
+    date bir_prep_due_date
+    boolean bir_related
+    int bir_schedule_id
+    int child_task_count
+    date closing_due_date
+    varchar cluster
+    float cost_variance
+    datetime create_date
+    int create_uid
+    boolean critical_path
+    float earned_value
+    varchar erp_ref
+    int fd_id
+    varchar finance_category
+    varchar finance_code
+    varchar finance_deadline_type
+    int finance_logframe_id
+    int finance_person_id
+    int finance_supervisor_id
+    int free_float
+    int gate_approver_id
+    varchar gate_decision
+    int gate_milestone_id
+    boolean has_gate
+    int id
+    varchar ipai_compliance_step
+    int ipai_days_to_deadline
+    varchar ipai_owner_code
+    varchar ipai_owner_role
+    varchar ipai_status_bucket
+    varchar ipai_task_category
+    int ipai_template_id
+    boolean is_finance_ppm
+    boolean is_phase
+    int lag_days
+    int lead_days
+    int milestone_count
+    varchar owner_code
+    varchar period_covered
+    date phase_baseline_finish
+    date phase_baseline_start
+    float phase_progress
+    varchar phase_status
+    varchar phase_type
+    int phase_variance_days
+    float planned_hours
+    float planned_value
+    float prep_duration
+    varchar relative_due
+    float remaining_hours
+    float resource_allocation
+    float review_duration
+    int reviewer_id
+    varchar role_code
+    float schedule_variance
+    int sfm_id
+    date target_date
+    int total_float
+    varchar wbs_code
+    datetime write_date
+    int write_uid
+    varchar x_cycle_key
+    varchar x_external_key
+    boolean x_obsolete
+    varchar x_seed_hash
+    varchar x_step_code
+    varchar x_task_template_code
+  }
+  project_task_checklist_item {
+    float actual_hours
+    int assigned_user_id
+    text blocker_description
+    date completed_date
+    datetime create_date
+    int create_uid
+    date due_date
+    float estimated_hours
+    int id
+    text notes
+    varchar priority
+    varchar status
+    datetime write_date
+    int write_uid
+  }
+  purchase_order {
+    datetime create_date
+    int create_uid
+    int id
+    datetime write_date
+    int write_uid
+    boolean x_master_control_submitted
+  }
+  res_company {
+    int id
+  }
+  res_config_settings {
+    datetime create_date
+    int create_uid
+    int id
+    boolean ipai_enable_finance_project_analytics
+    boolean superset_auto_sync
+    int superset_connection_id
+    boolean superset_create_analytics_views
+    boolean superset_enable_rls
+    varchar superset_sync_interval
+    datetime write_date
+    int write_uid
+  }
+  res_currency {
+    int id
+  }
+  res_groups {
+    int id
+  }
+  res_partner {
+    boolean bir_registered
+    date bir_registration_date
+    datetime create_date
+    int create_uid
+    int id
+    float srm_overall_score
+    int srm_supplier_id
+    varchar srm_tier
+    varchar tax_type
+    varchar tin
+    varchar tin_branch_code
+    datetime write_date
+    int write_uid
+  }
+  res_users {
+    datetime create_date
+    int create_uid
+    int id
+    datetime write_date
+    int write_uid
+    varchar x_employee_code
+  }
+  srm_kpi_category {
+    boolean active
+    varchar code
+    varchar compute_source
+    datetime create_date
+    int create_uid
+    text description
+    varchar eval_method
+    int id
+    varchar name
+    int sequence
+    float weight
+    datetime write_date
+    int write_uid
+  }
+  srm_qualification {
+    datetime approval_date
+    int approver_id
+    boolean checklist_complete
+    date completion_date
+    datetime create_date
+    int create_uid
+    date expiry_date
+    int id
+    varchar name
+    text notes
+    varchar qualification_type
+    text rejection_reason
+    int reviewer_id
+    text risk_notes
+    float risk_score
+    date start_date
+    varchar state
+    int supplier_id
+    date target_completion
+    datetime write_date
+    int write_uid
+  }
+  srm_qualification_checklist {
+    int completed_by
+    date completed_date
+    datetime create_date
+    int create_uid
+    text description
+    int id
+    boolean is_complete
+    boolean is_required
+    varchar name
+    text notes
+    int qualification_id
+    int sequence
+    datetime write_date
+    int write_uid
+  }
+  srm_qualification_document_ids_rel {
+    int ir_attachment_id
+    int srm_qualification_id
+  }
+  srm_scorecard {
+    text action_items
+    date as_of
+    text comments
+    datetime create_date
+    int create_uid
+    int evaluator_id
+    varchar grade
+    int id
+    varchar name
+    float overall_score
+    varchar period
+    varchar state
+    int supplier_id
+    datetime write_date
+    int write_uid
+  }
+  srm_scorecard_line {
+    datetime create_date
+    int create_uid
+    text evidence
+    int id
+    int kpi_category_id
+    text notes
+    float score
+    int scorecard_id
+    int sequence
+    float weight
+    float weighted_score
+    datetime write_date
+    int write_uid
+  }
+  srm_supplier {
+    varchar code
+    boolean compliance_docs_complete
+    datetime create_date
+    int create_uid
+    int currency_id
+    int id
+    boolean is_qualified
+    date last_audit_date
+    int latest_scorecard_id
+    varchar name
+    date next_audit_date
+    int open_po_count
+    float overall_score
+    int partner_id
+    int primary_contact_id
+    date qualification_expiry
+    varchar risk_level
+    text risk_notes
+    int sales_contact_id
+    varchar state
+    varchar tier
+    int total_po_count
+    datetime write_date
+    int write_uid
+    decimal ytd_spend
+  }
+  srm_supplier_category_ids_rel {
+    int product_category_id
+    int srm_supplier_id
+  }
+  stock_location {
+    int id
+  }
+  superset_analytics_view {
+    boolean active
+    varchar category
+    datetime create_date
+    int create_uid
+    text description
+    int id
+    boolean is_created
+    datetime last_refresh
+    varchar name
+    varchar required_modules
+    int sequence
+    text sql_definition
+    varchar technical_name
+    datetime write_date
+    int write_uid
+  }
+  superset_bulk_dataset_wizard {
+    int connection_id
+    boolean create_analytics_views
+    datetime create_date
+    int create_uid
+    int id
+    varchar preset
+    datetime write_date
+    int write_uid
+  }
+  superset_connection {
+    varchar access_token
+    boolean active
+    varchar api_key
+    varchar auth_method
+    varchar base_url
+    datetime create_date
+    int create_uid
+    varchar csrf_token
+    int dataset_count
+    int db_connection_id
+    varchar db_connection_name
+    int id
+    text last_error
+    datetime last_sync
+    varchar name
+    varchar password
+    varchar pg_database
+    varchar pg_host
+    varchar pg_password
+    int pg_port
+    varchar pg_schema
+    varchar pg_username
+    varchar refresh_token
+    varchar state
+    datetime token_expiry
+    boolean use_ssl
+    varchar username
+    datetime write_date
+    int write_uid
+  }
+  superset_dataset {
+    boolean active
+    varchar category
+    int column_count
+    int connection_id
+    datetime create_date
+    int create_uid
+    text custom_sql
+    text description
+    boolean enable_rls
+    int id
+    boolean include_all_fields
+    datetime last_sync
+    int model_id
+    varchar model_name
+    varchar name
+    varchar rls_filter_column
+    int sequence
+    varchar source_type
+    int superset_dataset_id
+    text sync_error
+    varchar sync_status
+    varchar technical_name
+    boolean view_created
+    varchar view_name
+    text view_sql
+    datetime write_date
+    int write_uid
+  }
+  superset_dataset_column {
+    varchar aggregation
+    varchar column_type
+    datetime create_date
+    int create_uid
+    varchar data_type
+    int dataset_id
+    text description
+    boolean filterable
+    varchar format_string
+    boolean groupable
+    int id
+    varchar label
+    varchar name
+    int sequence
+    datetime write_date
+    int write_uid
+  }
+  superset_dataset_field_ids_rel {
+    int ir_model_fields_id
+    int superset_dataset_id
+  }
+  superset_dataset_wizard {
+    varchar category
+    int connection_id
+    datetime create_date
+    int create_uid
+    boolean create_view
+    boolean enable_rls
+    int id
+    boolean include_all_fields
+    int model_id
+    varchar name
+    boolean sync_to_superset
+    varchar technical_name
+    datetime write_date
+    int write_uid
+  }
+  superset_dataset_wizard_field_ids_rel {
+    int ir_model_fields_id
+    int superset_dataset_wizard_id
+  }
+  workos_comment_mention_rel {
+    int comment_id
+    int user_id
+  }
+  workspace_member_rel {
+    int user_id
+    int workspace_id
+  }
+  a1_check ||--o{ close_approval_gate_template : "close_gate_template_id"
+  a1_check ||--o{ res_company : "company_id"
+  a1_check_result ||--o{ a1_check : "check_id"
+  a1_check_result ||--o{ res_users : "executed_by"
+  a1_check_result ||--o{ a1_task : "task_id"
+  a1_check_result_attachment_ids_rel ||--o{ a1_check_result : "a1_check_result_id"
+  a1_check_result_attachment_ids_rel ||--o{ ir_attachment : "ir_attachment_id"
+  a1_export_run ||--o{ res_company : "company_id"
+  a1_role ||--o{ res_company : "company_id"
+  a1_role ||--o{ res_users : "default_user_id"
+  a1_role ||--o{ res_users : "fallback_user_id"
+  a1_role_group_ids_rel ||--o{ a1_role : "a1_role_id"
+  a1_role_group_ids_rel ||--o{ res_groups : "res_groups_id"
+  a1_task ||--o{ res_users : "approval_done_by"
+  a1_task ||--o{ res_users : "approver_id"
+  a1_task ||--o{ close_task : "close_task_id"
+  a1_task ||--o{ res_company : "company_id"
+  a1_task ||--o{ res_users : "owner_id"
+  a1_task ||--o{ res_users : "prep_done_by"
+  a1_task ||--o{ res_users : "review_done_by"
+  a1_task ||--o{ res_users : "reviewer_id"
+  a1_task ||--o{ a1_tasklist : "tasklist_id"
+  a1_task ||--o{ a1_template : "template_id"
+  a1_task ||--o{ a1_workstream : "workstream_id"
+  a1_task_checklist ||--o{ res_users : "done_by"
+  a1_task_checklist ||--o{ a1_task : "task_id"
+  a1_task_checklist ||--o{ a1_template_checklist : "template_item_id"
+  a1_task_checklist ||--o{ ir_attachment : "value_attachment_id"
+  a1_tasklist ||--o{ close_cycle : "close_cycle_id"
+  a1_tasklist ||--o{ res_company : "company_id"
+  a1_template ||--o{ close_task_template : "close_template_id"
+  a1_template ||--o{ res_company : "company_id"
+  a1_template ||--o{ a1_workstream : "workstream_id"
+  a1_template_check_rel ||--o{ a1_check : "check_id"
+  a1_template_check_rel ||--o{ a1_template : "template_id"
+  a1_template_checklist ||--o{ a1_template : "template_id"
+  a1_template_step ||--o{ a1_template : "template_id"
+  a1_workstream ||--o{ close_task_category : "close_category_id"
+  a1_workstream ||--o{ res_company : "company_id"
+  a1_workstream ||--o{ a1_role : "owner_role_id"
+  a1_workstream ||--o{ res_users : "owner_user_id"
+  advisor_playbook_category_ids_rel ||--o{ advisor_category : "advisor_category_id"
+  advisor_playbook_category_ids_rel ||--o{ advisor_playbook : "advisor_playbook_id"
+  advisor_recommendation ||--o{ advisor_category : "category_id"
+  advisor_recommendation ||--o{ res_currency : "currency_id"
+  advisor_recommendation ||--o{ res_users : "owner_id"
+  advisor_recommendation ||--o{ advisor_playbook : "playbook_id"
+  advisor_recommendation_tag_ids_rel ||--o{ advisor_recommendation : "advisor_recommendation_id"
+  advisor_recommendation_tag_ids_rel ||--o{ advisor_tag : "advisor_tag_id"
+  advisor_score ||--o{ advisor_category : "category_id"
+  bir_alphalist ||--o{ res_company : "company_id"
+  bir_alphalist ||--o{ res_currency : "currency_id"
+  bir_alphalist_line ||--o{ bir_alphalist : "alphalist_id"
+  bir_alphalist_line ||--o{ res_currency : "currency_id"
+  bir_alphalist_line ||--o{ res_partner : "partner_id"
+  bir_filing_deadline ||--o{ res_company : "company_id"
+  bir_filing_deadline ||--o{ bir_tax_return : "return_id"
+  bir_return ||--o{ res_company : "company_id"
+  bir_return ||--o{ res_currency : "currency_id"
+  bir_return ||--o{ res_users : "filed_by"
+  bir_return ||--o{ finance_task : "task_id"
+  bir_return_line ||--o{ account_move : "move_id"
+  bir_return_line ||--o{ res_partner : "partner_id"
+  bir_return_line ||--o{ bir_return : "return_id"
+  bir_tax_return ||--o{ res_company : "company_id"
+  bir_tax_return ||--o{ res_currency : "currency_id"
+  bir_tax_return ||--o{ res_users : "filed_by"
+  bir_tax_return_line ||--o{ res_currency : "currency_id"
+  bir_tax_return_line ||--o{ account_move : "move_id"
+  bir_tax_return_line ||--o{ res_partner : "partner_id"
+  bir_tax_return_line ||--o{ bir_tax_return : "return_id"
+  bir_vat_line ||--o{ res_currency : "currency_id"
+  bir_vat_line ||--o{ account_move : "invoice_id"
+  bir_vat_line ||--o{ res_partner : "partner_id"
+  bir_vat_line ||--o{ bir_vat_return : "return_id"
+  bir_withholding_line ||--o{ res_currency : "currency_id"
+  bir_withholding_line ||--o{ account_move : "move_id"
+  bir_withholding_line ||--o{ res_partner : "partner_id"
+  bir_withholding_line ||--o{ hr_payslip : "payslip_id"
+  bir_withholding_line ||--o{ bir_withholding_return : "return_id"
+  close_approval_gate ||--o{ res_users : "approved_by"
+  close_approval_gate ||--o{ res_users : "approver_id"
+  close_approval_gate ||--o{ res_users : "approver_user_id"
+  close_approval_gate ||--o{ res_company : "company_id"
+  close_approval_gate ||--o{ close_cycle : "cycle_id"
+  close_approval_gate ||--o{ close_approval_gate_template : "template_id"
+  close_approval_gate_blocking_exceptions_rel ||--o{ close_approval_gate : "close_approval_gate_id"
+  close_approval_gate_blocking_exceptions_rel ||--o{ close_exception : "close_exception_id"
+  close_approval_gate_blocking_tasks_rel ||--o{ close_approval_gate : "close_approval_gate_id"
+  close_approval_gate_blocking_tasks_rel ||--o{ close_task : "close_task_id"
+  close_approval_gate_template ||--o{ a1_check : "a1_check_id"
+  close_approval_gate_template ||--o{ res_company : "company_id"
+  close_cycle ||--o{ a1_tasklist : "a1_tasklist_id"
+  close_cycle ||--o{ closing_period : "closing_period_id"
+  close_cycle ||--o{ res_company : "company_id"
+  close_exception ||--o{ res_users : "assigned_to"
+  close_exception ||--o{ res_company : "company_id"
+  close_exception ||--o{ res_currency : "currency_id"
+  close_exception ||--o{ close_cycle : "cycle_id"
+  close_exception ||--o{ res_users : "detected_by"
+  close_exception ||--o{ res_users : "escalated_to"
+  close_exception ||--o{ account_account : "related_account_id"
+  close_exception ||--o{ account_move : "related_move_id"
+  close_exception ||--o{ res_partner : "related_partner_id"
+  close_exception ||--o{ res_users : "reported_by"
+  close_exception ||--o{ res_users : "resolved_by"
+  close_exception ||--o{ close_task : "task_id"
+  close_task ||--o{ a1_task : "a1_task_id"
+  close_task ||--o{ res_users : "approval_done_by"
+  close_task ||--o{ res_users : "approve_user_id"
+  close_task ||--o{ res_users : "approver_id"
+  close_task ||--o{ close_task_category : "category_id"
+  close_task ||--o{ res_company : "company_id"
+  close_task ||--o{ close_cycle : "cycle_id"
+  close_task ||--o{ res_users : "prep_done_by"
+  close_task ||--o{ res_users : "prep_user_id"
+  close_task ||--o{ res_users : "preparer_id"
+  close_task ||--o{ res_users : "review_done_by"
+  close_task ||--o{ res_users : "review_user_id"
+  close_task ||--o{ res_users : "reviewer_id"
+  close_task ||--o{ close_task_template : "template_id"
+  close_task_attachment_ids_rel ||--o{ close_task : "close_task_id"
+  close_task_attachment_ids_rel ||--o{ ir_attachment : "ir_attachment_id"
+  close_task_category ||--o{ a1_workstream : "a1_workstream_id"
+  close_task_category ||--o{ res_company : "company_id"
+  close_task_category_gl_account_ids_rel ||--o{ account_account : "account_account_id"
+  close_task_category_gl_account_ids_rel ||--o{ close_task_category : "close_task_category_id"
+  close_task_checklist ||--o{ ir_attachment : "attachment_id"
+  close_task_checklist ||--o{ res_users : "done_by"
+  close_task_checklist ||--o{ close_task : "task_id"
+  close_task_gl_entry_ids_rel ||--o{ account_move : "account_move_id"
+  close_task_gl_entry_ids_rel ||--o{ close_task : "close_task_id"
+  close_task_template ||--o{ a1_template : "a1_template_id"
+  close_task_template ||--o{ res_users : "approver_id"
+  close_task_template ||--o{ close_task_category : "category_id"
+  close_task_template ||--o{ res_company : "company_id"
+  close_task_template ||--o{ res_users : "default_approve_user_id"
+  close_task_template ||--o{ res_users : "default_prep_user_id"
+  close_task_template ||--o{ res_users : "default_review_user_id"
+  close_task_template ||--o{ res_users : "preparer_id"
+  close_task_template ||--o{ res_users : "reviewer_id"
+  close_task_template_checklist ||--o{ close_task_template : "template_id"
+  close_task_template_gl_account_ids_rel ||--o{ account_account : "account_account_id"
+  close_task_template_gl_account_ids_rel ||--o{ close_task_template : "close_task_template_id"
+  closing_period ||--o{ res_company : "company_id"
+  compliance_check ||--o{ res_users : "checked_by"
+  compliance_check ||--o{ closing_period : "closing_id"
+  crm_stage_required_fields_rel ||--o{ ir_model_fields : "field_id"
+  crm_stage_required_fields_rel ||--o{ crm_stage : "stage_id"
+  finance_bir_deadline ||--o{ ipai_finance_person : "responsible_approval_id"
+  finance_bir_deadline ||--o{ ipai_finance_person : "responsible_prep_id"
+  finance_bir_deadline ||--o{ ipai_finance_person : "responsible_review_id"
+  finance_ppm_logframe ||--o{ finance_ppm_logframe : "parent_id"
+  finance_ppm_tdi_audit ||--o{ res_users : "user_id"
+  finance_task ||--o{ res_users : "approve_done_by"
+  finance_task ||--o{ res_users : "approve_user_id"
+  finance_task ||--o{ bir_return : "bir_return_id"
+  finance_task ||--o{ closing_period : "closing_id"
+  finance_task ||--o{ res_users : "prep_done_by"
+  finance_task ||--o{ res_users : "prep_user_id"
+  finance_task ||--o{ res_users : "review_done_by"
+  finance_task ||--o{ res_users : "review_user_id"
+  finance_task ||--o{ finance_task_template : "template_id"
+  finance_task_template ||--o{ res_users : "approve_user_id"
+  finance_task_template ||--o{ res_users : "prep_user_id"
+  finance_task_template ||--o{ res_users : "review_user_id"
+  finance_task_template_dependency_rel ||--o{ finance_task_template : "depends_on_id"
+  finance_task_template_dependency_rel ||--o{ finance_task_template : "task_id"
+  hr_expense ||--o{ project_project : "project_id"
+  hr_expense ||--o{ ipai_travel_request : "travel_request_id"
+  ipai_asset ||--o{ ipai_asset_checkout : "active_checkout_id"
+  ipai_asset ||--o{ ipai_asset_category : "category_id"
+  ipai_asset ||--o{ res_currency : "currency_id"
+  ipai_asset ||--o{ hr_employee : "custodian_id"
+  ipai_asset ||--o{ stock_location : "location_id"
+  ipai_asset_checkout ||--o{ res_users : "approved_by"
+  ipai_asset_checkout ||--o{ ipai_asset : "asset_id"
+  ipai_asset_checkout ||--o{ hr_employee : "employee_id"
+  ipai_asset_reservation ||--o{ ipai_asset : "asset_id"
+  ipai_asset_reservation ||--o{ hr_employee : "employee_id"
+  ipai_audit_log ||--o{ res_users : "user_id"
+  ipai_bir_dat_wizard ||--o{ res_currency : "currency_id"
+  ipai_bir_form_schedule ||--o{ ipai_finance_person : "responsible_approval_id"
+  ipai_bir_form_schedule ||--o{ ipai_finance_person : "responsible_prep_id"
+  ipai_bir_form_schedule ||--o{ ipai_finance_person : "responsible_review_id"
+  ipai_bir_process_step ||--o{ ipai_finance_person : "person_id"
+  ipai_bir_process_step ||--o{ ipai_bir_form_schedule : "schedule_id"
+  ipai_bir_schedule_step ||--o{ ipai_bir_schedule_item : "item_id"
+  ipai_close_generated_map ||--o{ ipai_close_generation_run : "generation_run_id"
+  ipai_close_generated_map ||--o{ ipai_close_generation_run : "run_id"
+  ipai_close_generated_map ||--o{ project_task : "task_id"
+  ipai_close_generated_map ||--o{ ipai_close_task_template : "template_id"
+  ipai_close_generation_run ||--o{ project_project : "project_id"
+  ipai_close_generation_run ||--o{ res_users : "user_id"
+  ipai_close_task_step ||--o{ ipai_close_task_template : "template_id"
+  ipai_close_task_step ||--o{ res_users : "user_id"
+  ipai_convert_phases_wizard ||--o{ project_project : "parent_project_id"
+  ipai_equipment_asset ||--o{ product_category : "category_id"
+  ipai_equipment_asset ||--o{ res_company : "company_id"
+  ipai_equipment_asset ||--o{ stock_location : "location_id"
+  ipai_equipment_asset ||--o{ product_product : "product_id"
+  ipai_equipment_booking ||--o{ ipai_equipment_asset : "asset_id"
+  ipai_equipment_booking ||--o{ res_users : "borrower_id"
+  ipai_equipment_booking ||--o{ project_project : "project_id"
+  ipai_equipment_incident ||--o{ ipai_equipment_asset : "asset_id"
+  ipai_equipment_incident ||--o{ ipai_equipment_booking : "booking_id"
+  ipai_equipment_incident ||--o{ res_users : "reported_by"
+  ipai_finance_bir_schedule ||--o{ project_task : "approval_task_id"
+  ipai_finance_bir_schedule ||--o{ res_users : "approver_id"
+  ipai_finance_bir_schedule ||--o{ ipai_finance_logframe : "logframe_id"
+  ipai_finance_bir_schedule ||--o{ project_task : "prep_task_id"
+  ipai_finance_bir_schedule ||--o{ project_task : "review_task_id"
+  ipai_finance_bir_schedule ||--o{ res_users : "reviewer_id"
+  ipai_finance_bir_schedule ||--o{ res_users : "supervisor_id"
+  ipai_finance_directory ||--o{ res_users : "user_id"
+  ipai_finance_person ||--o{ res_users : "user_id"
+  ipai_finance_ppm_golive_checklist ||--o{ res_users : "created_by"
+  ipai_finance_ppm_golive_checklist ||--o{ res_users : "director_id"
+  ipai_finance_ppm_golive_checklist ||--o{ res_users : "senior_supervisor_id"
+  ipai_finance_ppm_golive_checklist ||--o{ res_users : "supervisor_id"
+  ipai_finance_ppm_golive_checklist_section_ids_rel ||--o{ ipai_finance_ppm_golive_checklist : "ipai_finance_ppm_golive_checklist_id"
+  ipai_finance_ppm_golive_checklist_section_ids_rel ||--o{ ipai_finance_ppm_golive_section : "ipai_finance_ppm_golive_section_id"
+  ipai_finance_ppm_golive_item ||--o{ res_users : "checked_by"
+  ipai_finance_ppm_golive_item ||--o{ ipai_finance_ppm_golive_section : "section_id"
+  ipai_finance_task_template ||--o{ ipai_finance_person : "approved_by_id"
+  ipai_finance_task_template ||--o{ finance_bir_deadline : "bir_form_id"
+  ipai_finance_task_template ||--o{ ipai_finance_person : "employee_code_id"
+  ipai_finance_task_template ||--o{ ipai_finance_person : "reviewed_by_id"
+  ipai_generate_bir_tasks_wizard ||--o{ project_project : "program_project_id"
+  ipai_generate_im_projects_wizard ||--o{ project_project : "project_id"
+  ipai_generate_month_end_wizard ||--o{ project_project : "program_project_id"
+  ipai_grid_column ||--o{ ipai_grid_view : "grid_view_id"
+  ipai_grid_filter ||--o{ ipai_grid_view : "grid_view_id"
+  ipai_grid_filter ||--o{ res_users : "user_id"
+  ipai_grid_filter_condition ||--o{ ipai_grid_filter : "filter_id"
+  ipai_grid_view ||--o{ ipai_grid_filter : "active_filter_id"
+  ipai_grid_view ||--o{ ir_model : "model_id"
+  ipai_grid_view_visible_columns_rel ||--o{ ipai_grid_column : "column_id"
+  ipai_grid_view_visible_columns_rel ||--o{ ipai_grid_view : "grid_view_id"
+  ipai_localization_overlay ||--o{ ipai_workstream : "workstream_id"
+  ipai_month_end_closing ||--o{ res_company : "company_id"
+  ipai_month_end_task ||--o{ res_users : "approve_done_by"
+  ipai_month_end_task ||--o{ res_users : "approve_user_id"
+  ipai_month_end_task ||--o{ ipai_month_end_closing : "closing_id"
+  ipai_month_end_task ||--o{ res_users : "prep_done_by"
+  ipai_month_end_task ||--o{ res_users : "prep_user_id"
+  ipai_month_end_task ||--o{ res_users : "review_done_by"
+  ipai_month_end_task ||--o{ res_users : "review_user_id"
+  ipai_month_end_task ||--o{ ipai_month_end_task_template : "template_id"
+  ipai_month_end_task_template ||--o{ res_users : "approve_user_id"
+  ipai_month_end_task_template ||--o{ res_users : "prep_user_id"
+  ipai_month_end_task_template ||--o{ res_users : "review_user_id"
+  ipai_month_end_template_step ||--o{ ipai_month_end_template : "template_id"
+  ipai_permission ||--o{ res_groups : "group_id"
+  ipai_permission ||--o{ res_users : "user_id"
+  ipai_ppm_task ||--o{ ipai_ppm_template : "template_id"
+  ipai_ppm_task_checklist ||--o{ ipai_ppm_task : "task_id"
+  ipai_ppm_tasklist ||--o{ ipai_ppm_template : "template_id"
+  ipai_ppm_tasklist ||--o{ ipai_workstream : "workstream_id"
+  ipai_ppm_taskrun ||--o{ res_users : "approver_id"
+  ipai_ppm_taskrun ||--o{ res_users : "assignee_id"
+  ipai_ppm_taskrun ||--o{ ipai_ppm_task : "task_id"
+  ipai_ppm_taskrun ||--o{ ipai_ppm_tasklist : "tasklist_id"
+  ipai_ppm_template ||--o{ ipai_workstream : "workstream_id"
+  ipai_share_token ||--o{ res_users : "created_by"
+  ipai_stc_check ||--o{ ipai_stc_worklist_type : "worklist_type_id"
+  ipai_stc_check ||--o{ ipai_workstream : "workstream_id"
+  ipai_stc_scenario ||--o{ ipai_workstream : "workstream_id"
+  ipai_stc_scenario_check_ids_rel ||--o{ ipai_stc_check : "ipai_stc_check_id"
+  ipai_stc_scenario_check_ids_rel ||--o{ ipai_stc_scenario : "ipai_stc_scenario_id"
+  ipai_studio_ai_history ||--o{ base_automation : "automation_id"
+  ipai_studio_ai_history ||--o{ ir_model_fields : "field_id"
+  ipai_studio_ai_history ||--o{ ir_model : "model_id"
+  ipai_studio_ai_history ||--o{ res_users : "user_id"
+  ipai_studio_ai_wizard ||--o{ ir_model : "context_model_id"
+  ipai_studio_ai_wizard ||--o{ ir_model_fields : "created_field_id"
+  ipai_studio_ai_wizard ||--o{ ipai_studio_ai_history : "history_id"
+  ipai_studio_ai_wizard ||--o{ ir_model : "relation_model_id"
+  ipai_studio_ai_wizard ||--o{ ir_model : "target_model_id"
+  ipai_task_template_dependency_rel ||--o{ ipai_month_end_task_template : "depends_on_id"
+  ipai_task_template_dependency_rel ||--o{ ipai_month_end_task_template : "task_id"
+  ipai_travel_request ||--o{ res_company : "company_id"
+  ipai_travel_request ||--o{ res_currency : "currency_id"
+  ipai_travel_request ||--o{ hr_employee : "employee_id"
+  ipai_travel_request ||--o{ project_project : "project_id"
+  ipai_workos_block ||--o{ ir_attachment : "attachment_id"
+  ipai_workos_block ||--o{ ipai_workos_page : "page_id"
+  ipai_workos_block ||--o{ ipai_workos_block : "parent_block_id"
+  ipai_workos_canvas ||--o{ ipai_workos_page : "page_id"
+  ipai_workos_comment ||--o{ res_users : "author_id"
+  ipai_workos_comment ||--o{ ipai_workos_comment : "parent_id"
+  ipai_workos_comment ||--o{ res_users : "resolved_by"
+  ipai_workos_database ||--o{ ipai_workos_page : "page_id"
+  ipai_workos_database ||--o{ ipai_workos_space : "space_id"
+  ipai_workos_page ||--o{ res_users : "last_edited_by"
+  ipai_workos_page ||--o{ ipai_workos_page : "parent_id"
+  ipai_workos_page ||--o{ ipai_workos_space : "space_id"
+  ipai_workos_page ||--o{ ipai_workos_template : "template_id"
+  ipai_workos_page ||--o{ ipai_workos_workspace : "workspace_id"
+  ipai_workos_property ||--o{ ipai_workos_database : "database_id"
+  ipai_workos_property ||--o{ ipai_workos_database : "related_database_id"
+  ipai_workos_row ||--o{ ipai_workos_database : "database_id"
+  ipai_workos_search_history ||--o{ res_users : "user_id"
+  ipai_workos_space ||--o{ ipai_workos_workspace : "workspace_id"
+  ipai_workos_template_tag_ids_rel ||--o{ ipai_workos_template : "ipai_workos_template_id"
+  ipai_workos_template_tag_ids_rel ||--o{ ipai_workos_template_tag : "ipai_workos_template_tag_id"
+  ipai_workos_view ||--o{ ipai_workos_database : "database_id"
+  ipai_workos_view ||--o{ ipai_workos_property : "date_property_id"
+  ipai_workos_view ||--o{ ipai_workos_property : "group_by_property_id"
+  ipai_workos_view ||--o{ res_users : "user_id"
+  ipai_workos_view_visible_property_ids_rel ||--o{ ipai_workos_property : "ipai_workos_property_id"
+  ipai_workos_view_visible_property_ids_rel ||--o{ ipai_workos_view : "ipai_workos_view_id"
+  ipai_workos_workspace ||--o{ res_users : "owner_id"
+  ipai_workspace ||--o{ res_users : "account_manager_id"
+  ipai_workspace ||--o{ res_partner : "client_id"
+  ipai_workspace ||--o{ res_company : "company_id"
+  ipai_workspace ||--o{ ipai_workspace : "parent_id"
+  ipai_workspace_link ||--o{ ipai_workspace : "workspace_id"
+  ph_holiday ||--o{ res_company : "company_id"
+  ppm_close_task ||--o{ ppm_monthly_close : "monthly_close_id"
+  ppm_close_task ||--o{ ppm_close_template : "template_id"
+  ppm_kpi_snapshot ||--o{ ppm_portfolio : "portfolio_id"
+  ppm_kpi_snapshot ||--o{ ppm_program : "program_id"
+  ppm_kpi_snapshot ||--o{ project_project : "project_id"
+  ppm_portfolio ||--o{ res_currency : "currency_id"
+  ppm_portfolio ||--o{ res_users : "owner_id"
+  ppm_portfolio ||--o{ res_users : "sponsor_id"
+  ppm_program ||--o{ res_currency : "currency_id"
+  ppm_program ||--o{ ppm_portfolio : "portfolio_id"
+  ppm_program ||--o{ res_users : "program_manager_id"
+  ppm_program ||--o{ res_users : "sponsor_id"
+  ppm_program_project_rel ||--o{ ppm_program : "program_id"
+  ppm_program_project_rel ||--o{ ppm_program : "program_id"
+  ppm_program_project_rel ||--o{ project_project : "project_id"
+  ppm_program_project_rel ||--o{ project_project : "project_id"
+  ppm_resource_allocation ||--o{ hr_employee : "employee_id"
+  ppm_resource_allocation ||--o{ ppm_program : "program_id"
+  ppm_resource_allocation ||--o{ project_project : "project_id"
+  ppm_resource_allocation ||--o{ project_task : "task_id"
+  ppm_risk ||--o{ res_users : "assigned_to_id"
+  ppm_risk ||--o{ res_currency : "currency_id"
+  ppm_risk ||--o{ res_users : "owner_id"
+  ppm_risk ||--o{ ppm_portfolio : "portfolio_id"
+  ppm_risk ||--o{ ppm_program : "program_id"
+  ppm_risk ||--o{ project_project : "project_id"
+  project_milestone ||--o{ res_users : "approver_id"
+  project_project ||--o{ project_project : "ipai_root_project_id"
+  project_project ||--o{ project_project : "parent_id"
+  project_project ||--o{ project_category : "portfolio_id"
+  project_task ||--o{ res_users : "approver_id"
+  project_task ||--o{ ipai_finance_bir_schedule : "bir_schedule_id"
+  project_task ||--o{ res_users : "fd_id"
+  project_task ||--o{ ipai_finance_logframe : "finance_logframe_id"
+  project_task ||--o{ ipai_finance_person : "finance_person_id"
+  project_task ||--o{ res_users : "finance_supervisor_id"
+  project_task ||--o{ res_users : "gate_approver_id"
+  project_task ||--o{ project_milestone : "gate_milestone_id"
+  project_task ||--o{ ipai_finance_task_template : "ipai_template_id"
+  project_task ||--o{ res_users : "reviewer_id"
+  project_task ||--o{ res_users : "sfm_id"
+  project_task_checklist_item ||--o{ res_users : "assigned_user_id"
+  res_config_settings ||--o{ superset_connection : "superset_connection_id"
+  res_partner ||--o{ srm_supplier : "srm_supplier_id"
+  srm_qualification ||--o{ res_users : "approver_id"
+  srm_qualification ||--o{ res_users : "reviewer_id"
+  srm_qualification ||--o{ srm_supplier : "supplier_id"
+  srm_qualification_checklist ||--o{ res_users : "completed_by"
+  srm_qualification_checklist ||--o{ srm_qualification : "qualification_id"
+  srm_qualification_document_ids_rel ||--o{ ir_attachment : "ir_attachment_id"
+  srm_qualification_document_ids_rel ||--o{ srm_qualification : "srm_qualification_id"
+  srm_scorecard ||--o{ res_users : "evaluator_id"
+  srm_scorecard ||--o{ srm_supplier : "supplier_id"
+  srm_scorecard_line ||--o{ srm_kpi_category : "kpi_category_id"
+  srm_scorecard_line ||--o{ srm_scorecard : "scorecard_id"
+  srm_supplier ||--o{ res_currency : "currency_id"
+  srm_supplier ||--o{ srm_scorecard : "latest_scorecard_id"
+  srm_supplier ||--o{ res_partner : "partner_id"
+  srm_supplier ||--o{ res_partner : "primary_contact_id"
+  srm_supplier ||--o{ res_partner : "sales_contact_id"
+  srm_supplier_category_ids_rel ||--o{ product_category : "product_category_id"
+  srm_supplier_category_ids_rel ||--o{ srm_supplier : "srm_supplier_id"
+  superset_bulk_dataset_wizard ||--o{ superset_connection : "connection_id"
+  superset_dataset ||--o{ superset_connection : "connection_id"
+  superset_dataset ||--o{ ir_model : "model_id"
+  superset_dataset_column ||--o{ superset_dataset : "dataset_id"
+  superset_dataset_field_ids_rel ||--o{ ir_model_fields : "ir_model_fields_id"
+  superset_dataset_field_ids_rel ||--o{ superset_dataset : "superset_dataset_id"
+  superset_dataset_wizard ||--o{ superset_connection : "connection_id"
+  superset_dataset_wizard ||--o{ ir_model : "model_id"
+  superset_dataset_wizard_field_ids_rel ||--o{ ir_model_fields : "ir_model_fields_id"
+  superset_dataset_wizard_field_ids_rel ||--o{ superset_dataset_wizard : "superset_dataset_wizard_id"
+  workos_comment_mention_rel ||--o{ ipai_workos_comment : "comment_id"
+  workos_comment_mention_rel ||--o{ res_users : "user_id"
+  workspace_member_rel ||--o{ res_users : "user_id"
+  workspace_member_rel ||--o{ ipai_workos_workspace : "workspace_id"

--- a/docs/data-model/ODOO_ERD.puml
+++ b/docs/data-model/ODOO_ERD.puml
@@ -1,0 +1,3513 @@
+@startuml
+hide circle
+skinparam linetype ortho
+entity a1_check {
+  boolean active
+  varchar check_type
+  int close_gate_template_id
+  varchar code
+  int company_id
+  datetime create_date
+  int create_uid
+  varchar description
+  text fail_action
+  int id
+  varchar name
+  text pass_criteria
+  int sequence
+  varchar severity
+  datetime write_date
+  int write_uid
+}
+entity a1_check_result {
+  int check_id
+  datetime create_date
+  int create_uid
+  varchar evidence
+  int executed_by
+  datetime executed_date
+  int id
+  varchar result
+  text result_notes
+  int task_id
+  datetime write_date
+  int write_uid
+}
+entity a1_check_result_attachment_ids_rel {
+  int a1_check_result_id
+  int ir_attachment_id
+}
+entity a1_export_run {
+  int company_id
+  datetime create_date
+  int create_uid
+  int created_count
+  int error_count
+  int id
+  text log
+  varchar run_type
+  varchar seed_hash
+  text seed_json
+  varchar status
+  int unchanged_count
+  int updated_count
+  varchar webhook_url
+  datetime write_date
+  int write_uid
+}
+entity a1_role {
+  boolean active
+  varchar code
+  int company_id
+  datetime create_date
+  int create_uid
+  int default_user_id
+  text description
+  int fallback_user_id
+  int id
+  varchar name
+  int sequence
+  datetime write_date
+  int write_uid
+}
+entity a1_role_group_ids_rel {
+  int a1_role_id
+  int res_groups_id
+}
+entity a1_task {
+  date approval_deadline
+  int approval_done_by
+  datetime approval_done_date
+  int approver_id
+  varchar approver_role
+  float checklist_progress
+  int close_task_id
+  int company_id
+  datetime create_date
+  int create_uid
+  varchar external_key
+  int id
+  varchar name
+  varchar notes
+  int owner_id
+  varchar owner_role
+  date prep_deadline
+  int prep_done_by
+  datetime prep_done_date
+  date review_deadline
+  int review_done_by
+  datetime review_done_date
+  int reviewer_id
+  varchar reviewer_role
+  int sequence
+  varchar state
+  int tasklist_id
+  int template_id
+  int workstream_id
+  datetime write_date
+  int write_uid
+}
+entity a1_task_checklist {
+  varchar code
+  datetime create_date
+  int create_uid
+  int done_by
+  datetime done_date
+  int id
+  boolean is_done
+  boolean is_required
+  varchar item_type
+  varchar name
+  int sequence
+  int task_id
+  int template_item_id
+  int value_attachment_id
+  text value_text
+  datetime write_date
+  int write_uid
+}
+entity a1_tasklist {
+  int close_cycle_id
+  int company_id
+  datetime create_date
+  int create_uid
+  int id
+  varchar name
+  varchar notes
+  date period_end
+  varchar period_label
+  date period_start
+  float progress
+  varchar state
+  int task_count
+  int task_done_count
+  varchar webhook_url
+  datetime write_date
+  int write_uid
+}
+entity a1_template {
+  boolean active
+  float approval_days
+  varchar approver_role
+  int close_template_id
+  varchar code
+  int company_id
+  datetime create_date
+  int create_uid
+  varchar description
+  int id
+  varchar name
+  varchar owner_role
+  varchar phase_code
+  float prep_days
+  float review_days
+  varchar reviewer_role
+  int sequence
+  float total_days
+  int workstream_id
+  datetime write_date
+  int write_uid
+}
+entity a1_template_check_rel {
+  int check_id
+  int template_id
+}
+entity a1_template_checklist {
+  varchar code
+  datetime create_date
+  int create_uid
+  int id
+  text instructions
+  boolean is_required
+  varchar item_type
+  varchar name
+  int sequence
+  int template_id
+  datetime write_date
+  int write_uid
+}
+entity a1_template_step {
+  varchar assignee_role
+  varchar code
+  datetime create_date
+  int create_uid
+  int deadline_offset_days
+  float effort_days
+  int id
+  varchar name
+  int sequence
+  int template_id
+  datetime write_date
+  int write_uid
+}
+entity a1_workstream {
+  boolean active
+  int close_category_id
+  varchar code
+  int company_id
+  datetime create_date
+  int create_uid
+  varchar description
+  int id
+  varchar name
+  int owner_role_id
+  int owner_user_id
+  varchar phase_code
+  int sequence
+  int template_count
+  datetime write_date
+  int write_uid
+}
+entity account_account {
+  int id
+}
+entity account_move {
+  date bir_2307_date
+  boolean bir_2307_generated
+  datetime create_date
+  int create_uid
+  decimal ewt_amount
+  int id
+  datetime write_date
+  int write_uid
+}
+entity advisor_category {
+  boolean active
+  varchar code
+  int color
+  datetime create_date
+  int create_uid
+  text description
+  int high_count
+  varchar icon
+  int id
+  int latest_score
+  varchar name
+  int open_count
+  int recommendation_count
+  int sequence
+  datetime write_date
+  int write_uid
+}
+entity advisor_playbook {
+  boolean active
+  varchar automation_kind
+  text automation_params
+  varchar automation_ref
+  varchar code
+  datetime create_date
+  int create_uid
+  text description
+  int id
+  varchar name
+  int recommendation_count
+  text steps_md
+  datetime write_date
+  int write_uid
+}
+entity advisor_playbook_category_ids_rel {
+  int advisor_category_id
+  int advisor_playbook_id
+}
+entity advisor_recommendation {
+  varchar category_code
+  int category_id
+  float confidence
+  datetime create_date
+  int create_uid
+  int currency_id
+  date date_due
+  date date_resolved
+  text description
+  decimal estimated_savings
+  text evidence
+  varchar external_link
+  int id
+  int impact_score
+  varchar name
+  int owner_id
+  int playbook_id
+  text remediation_steps
+  varchar resource_ref
+  varchar resource_type
+  varchar severity
+  int severity_order
+  date snooze_until
+  varchar source
+  varchar status
+  datetime write_date
+  int write_uid
+}
+entity advisor_recommendation_tag_ids_rel {
+  int advisor_recommendation_id
+  int advisor_tag_id
+}
+entity advisor_score {
+  datetime as_of
+  varchar category_code
+  int category_id
+  datetime create_date
+  int create_uid
+  int critical_count
+  int high_count
+  int id
+  text inputs_json
+  int open_count
+  int resolved_count
+  int score
+  datetime write_date
+  int write_uid
+}
+entity advisor_tag {
+  int color
+  datetime create_date
+  int create_uid
+  int id
+  varchar name
+  datetime write_date
+  int write_uid
+}
+entity base_automation {
+  int id
+}
+entity bir_alphalist {
+  int company_id
+  datetime create_date
+  int create_uid
+  int currency_id
+  int fiscal_year
+  varchar form_type
+  int id
+  varchar name
+  varchar state
+  decimal total_gross
+  decimal total_wht
+  datetime write_date
+  int write_uid
+}
+entity bir_alphalist_line {
+  int alphalist_id
+  datetime create_date
+  int create_uid
+  int currency_id
+  decimal gross_income
+  int id
+  varchar income_type
+  int partner_id
+  varchar tin
+  decimal wht_amount
+  datetime write_date
+  int write_uid
+}
+entity bir_filing_deadline {
+  int company_id
+  datetime create_date
+  int create_uid
+  date deadline_date
+  varchar form_type
+  int id
+  varchar name
+  int period_month
+  int period_year
+  date reminder_date
+  int return_id
+  varchar state
+  datetime write_date
+  int write_uid
+}
+entity bir_return {
+  varchar bir_reference
+  int company_id
+  datetime create_date
+  int create_uid
+  int currency_id
+  decimal exempt_sales
+  int filed_by
+  datetime filed_date
+  varchar form_type
+  int id
+  decimal input_vat
+  decimal interest
+  varchar name
+  text notes
+  decimal output_vat
+  date payment_date
+  varchar payment_reference
+  decimal penalty
+  date period_end
+  date period_start
+  varchar state
+  int task_id
+  decimal tax_base
+  decimal tax_credits
+  decimal tax_due
+  decimal tax_payable
+  decimal total_due
+  decimal total_payments
+  decimal total_wht
+  decimal vatable_sales
+  datetime write_date
+  int write_uid
+  decimal zero_rated_sales
+}
+entity bir_return_line {
+  decimal amount
+  datetime create_date
+  int create_uid
+  int currency_id
+  varchar description
+  int id
+  int move_id
+  int partner_id
+  int return_id
+  int sequence
+  decimal tax_amount
+  varchar tin
+  datetime write_date
+  int write_uid
+}
+entity bir_tax_return {
+  varchar bir_reference
+  int company_id
+  datetime create_date
+  int create_uid
+  int currency_id
+  int days_until_due
+  date due_date
+  int filed_by
+  datetime filed_date
+  varchar form_type
+  varchar frequency
+  int id
+  decimal interest
+  boolean is_overdue
+  varchar name
+  text notes
+  date payment_date
+  varchar payment_reference
+  decimal penalty
+  date period_end
+  date period_start
+  varchar state
+  decimal tax_base
+  varchar tax_category
+  decimal tax_credits
+  decimal tax_due
+  decimal tax_payable
+  decimal total_amount_due
+  datetime write_date
+  int write_uid
+}
+entity bir_tax_return_line {
+  datetime create_date
+  int create_uid
+  int currency_id
+  varchar description
+  int id
+  int move_id
+  int partner_id
+  int return_id
+  int sequence
+  decimal tax_amount
+  decimal tax_base
+  float tax_rate
+  varchar tin
+  datetime write_date
+  int write_uid
+}
+entity bir_vat_line {
+  decimal amount_untaxed
+  datetime create_date
+  int create_uid
+  int currency_id
+  int id
+  date invoice_date
+  int invoice_id
+  varchar line_type
+  int partner_id
+  int return_id
+  varchar tin
+  decimal vat_amount
+  varchar vat_category
+  datetime write_date
+  int write_uid
+}
+entity bir_vat_return {
+  datetime create_date
+  int create_uid
+  decimal excess_input_vat
+  decimal excess_input_vat_previous
+  decimal exempt_sales
+  int id
+  decimal importations
+  decimal net_vat_payable
+  decimal output_vat
+  decimal purchase_of_services
+  decimal total_input_vat
+  decimal total_sales
+  decimal vatable_purchases
+  decimal vatable_sales
+  datetime write_date
+  int write_uid
+  decimal zero_rated_sales
+}
+entity bir_withholding_line {
+  datetime create_date
+  int create_uid
+  int currency_id
+  decimal gross_income
+  int id
+  varchar income_type
+  int move_id
+  int partner_id
+  int payslip_id
+  int return_id
+  varchar tin
+  decimal wht_amount
+  float wht_rate
+  datetime write_date
+  int write_uid
+}
+entity bir_withholding_return {
+  decimal compensation_tax_withheld
+  datetime create_date
+  int create_uid
+  int employee_count
+  decimal expanded_wht_amount
+  decimal final_wht_amount
+  int id
+  decimal taxable_compensation
+  decimal total_compensation
+  decimal total_payments
+  varchar withholding_type
+  datetime write_date
+  int write_uid
+}
+entity close_approval_gate {
+  float actual_value
+  text approval_notes
+  int approved_by
+  datetime approved_date
+  int approver_id
+  varchar approver_role
+  int approver_user_id
+  boolean block_on_exceptions
+  text block_reason
+  text blocking_reason
+  int company_id
+  datetime create_date
+  int create_uid
+  int cycle_id
+  int gate_level
+  varchar gate_type
+  int id
+  float min_completion_pct
+  varchar name
+  varchar notes
+  int required_approvals
+  varchar required_task_states
+  int sequence
+  varchar state
+  int template_id
+  float threshold_value
+  datetime write_date
+  int write_uid
+}
+entity close_approval_gate_blocking_exceptions_rel {
+  int close_approval_gate_id
+  int close_exception_id
+}
+entity close_approval_gate_blocking_tasks_rel {
+  int close_approval_gate_id
+  int close_task_id
+}
+entity close_approval_gate_template {
+  int a1_check_id
+  boolean active
+  varchar code
+  int company_id
+  datetime create_date
+  int create_uid
+  varchar description
+  varchar gate_type
+  int id
+  varchar name
+  text pass_criteria
+  int sequence
+  datetime write_date
+  int write_uid
+}
+entity close_cycle {
+  int a1_tasklist_id
+  date close_actual_date
+  date close_start_date
+  date close_target_date
+  int closing_period_id
+  int company_id
+  datetime create_date
+  int create_uid
+  int cycle_time_days
+  int exception_count
+  boolean gates_ready
+  int id
+  varchar name
+  varchar notes
+  int open_exception_count
+  date period_end
+  varchar period_label
+  date period_start
+  varchar period_type
+  float progress
+  varchar state
+  float task_completion_pct
+  int task_count
+  int task_done_count
+  varchar webhook_url
+  datetime write_date
+  int write_uid
+}
+entity close_exception {
+  decimal amount
+  int assigned_to
+  int company_id
+  datetime create_date
+  int create_uid
+  int currency_id
+  int cycle_id
+  text description
+  int detected_by
+  datetime detected_date
+  datetime escalated_date
+  int escalated_to
+  int escalation_count
+  datetime escalation_deadline
+  int escalation_level
+  varchar exception_type
+  int id
+  datetime last_escalated
+  varchar name
+  int related_account_id
+  int related_move_id
+  int related_partner_id
+  int reported_by
+  varchar resolution
+  text resolution_action
+  int resolved_by
+  datetime resolved_date
+  text root_cause
+  varchar severity
+  varchar state
+  int task_id
+  float variance_pct
+  datetime write_date
+  int write_uid
+}
+entity close_task {
+  int a1_task_id
+  date approval_deadline
+  int approval_done_by
+  datetime approval_done_date
+  datetime approve_done_date
+  date approve_due_date
+  text approve_notes
+  int approve_user_id
+  int approver_id
+  int category_id
+  float checklist_done_pct
+  float checklist_progress
+  int company_id
+  datetime create_date
+  int create_uid
+  int cycle_id
+  int days_overdue
+  text description
+  varchar external_key
+  int gl_entry_count
+  boolean has_exceptions
+  boolean has_open_exceptions
+  int id
+  boolean is_overdue
+  varchar name
+  varchar notes
+  date prep_deadline
+  int prep_done_by
+  datetime prep_done_date
+  date prep_due_date
+  text prep_notes
+  int prep_user_id
+  int preparer_id
+  date review_deadline
+  int review_done_by
+  datetime review_done_date
+  date review_due_date
+  text review_notes
+  varchar review_result
+  int review_user_id
+  int reviewer_id
+  int sequence
+  varchar state
+  int template_id
+  datetime write_date
+  int write_uid
+}
+entity close_task_attachment_ids_rel {
+  int close_task_id
+  int ir_attachment_id
+}
+entity close_task_category {
+  int a1_workstream_id
+  boolean active
+  varchar code
+  int color
+  int company_id
+  datetime create_date
+  int create_uid
+  int default_approve_days
+  varchar default_approve_role
+  int default_prep_days
+  varchar default_prep_role
+  int default_review_days
+  varchar default_review_role
+  text description
+  int id
+  varchar name
+  int sequence
+  datetime write_date
+  int write_uid
+}
+entity close_task_category_gl_account_ids_rel {
+  int account_account_id
+  int close_task_category_id
+}
+entity close_task_checklist {
+  int attachment_id
+  varchar code
+  datetime create_date
+  int create_uid
+  datetime done_at
+  int done_by
+  datetime done_date
+  varchar evidence_type
+  int id
+  text instructions
+  boolean is_done
+  boolean is_required
+  varchar name
+  text notes
+  boolean required
+  int sequence
+  int task_id
+  datetime write_date
+  int write_uid
+}
+entity close_task_gl_entry_ids_rel {
+  int account_move_id
+  int close_task_id
+}
+entity close_task_template {
+  int a1_template_id
+  boolean active
+  float approval_days
+  int approval_offset
+  int approve_day_offset
+  int approver_id
+  varchar approver_role
+  int category_id
+  varchar code
+  int company_id
+  datetime create_date
+  int create_uid
+  boolean creates_gl_entry
+  int default_approve_user_id
+  int default_prep_user_id
+  int default_review_user_id
+  text description
+  int id
+  varchar name
+  varchar period_type
+  int prep_day_offset
+  float prep_days
+  int prep_offset
+  int preparer_id
+  varchar preparer_role
+  int review_day_offset
+  float review_days
+  int review_offset
+  int reviewer_id
+  varchar reviewer_role
+  int sequence
+  datetime write_date
+  int write_uid
+}
+entity close_task_template_checklist {
+  varchar code
+  datetime create_date
+  int create_uid
+  varchar evidence_type
+  int id
+  text instructions
+  boolean is_required
+  varchar name
+  boolean required
+  int sequence
+  int template_id
+  datetime write_date
+  int write_uid
+}
+entity close_task_template_gl_account_ids_rel {
+  int account_account_id
+  int close_task_template_id
+}
+entity closing_period {
+  int bir_tasks
+  int company_id
+  int completed_tasks
+  datetime create_date
+  int create_uid
+  int id
+  date last_workday
+  int month_end_tasks
+  varchar name
+  text notes
+  int overdue_tasks
+  date period_date
+  int period_month
+  int period_year
+  float progress
+  varchar state
+  int total_tasks
+  datetime write_date
+  int write_uid
+}
+entity compliance_check {
+  float actual_value
+  varchar check_type
+  int checked_by
+  datetime checked_date
+  int closing_id
+  datetime create_date
+  int create_uid
+  float expected_value
+  int id
+  varchar name
+  text result_text
+  int sequence
+  varchar status
+  float tolerance
+  float variance
+  datetime write_date
+  int write_uid
+}
+entity crm_lead {
+  datetime create_date
+  int create_uid
+  int days_in_stage
+  int id
+  datetime last_call_date
+  datetime last_meeting_date
+  datetime stage_entry_date
+  varchar stage_missing_fields
+  boolean stage_rule_validated
+  datetime write_date
+  int write_uid
+}
+entity crm_stage {
+  datetime create_date
+  int create_uid
+  int id
+  text ipai_automation_notes
+  boolean ipai_enforce_rules
+  int ipai_sla_days
+  varchar ipai_stage_color
+  varchar ipai_stage_icon
+  datetime write_date
+  int write_uid
+}
+entity crm_stage_required_fields_rel {
+  int field_id
+  int stage_id
+}
+entity discuss_channel {
+  datetime create_date
+  int create_uid
+  int id
+  boolean is_ai_channel
+  datetime write_date
+  int write_uid
+}
+entity finance_bir_deadline {
+  boolean active
+  datetime create_date
+  int create_uid
+  date deadline_date
+  text description
+  varchar display_name
+  varchar form_type
+  int id
+  varchar name
+  varchar period_covered
+  int responsible_approval_id
+  int responsible_prep_id
+  int responsible_review_id
+  varchar state
+  date target_payment_approval_date
+  date target_prep_date
+  date target_report_approval_date
+  datetime write_date
+  int write_uid
+}
+entity finance_ppm_bir_calendar {
+  datetime create_date
+  int create_uid
+  text description
+  date filing_deadline
+  varchar form_code
+  varchar form_name
+  int id
+  varchar period
+  varchar responsible_role
+  datetime write_date
+  int write_uid
+}
+entity finance_ppm_dashboard {
+  datetime create_date
+  int create_uid
+  int failures_24h
+  int id
+  text last_message
+  datetime last_run_at
+  varchar last_status
+  varchar name
+  datetime next_scheduled_at
+  int sequence
+  varchar status_color
+  int total_runs
+  varchar workflow_code
+  datetime write_date
+  int write_uid
+}
+entity finance_ppm_import_wizard {
+  datetime create_date
+  int create_uid
+  text error_log
+  binary file_data
+  varchar file_name
+  varchar file_type
+  int id
+  text import_summary
+  varchar import_type
+  int records_created
+  int records_failed
+  int records_skipped
+  int records_updated
+  boolean skip_header
+  varchar state
+  boolean update_existing
+  datetime write_date
+  int write_uid
+}
+entity finance_ppm_logframe {
+  varchar code
+  datetime create_date
+  int create_uid
+  text description
+  int id
+  varchar kpi_baseline
+  varchar kpi_measure
+  varchar kpi_target
+  varchar level
+  varchar measurement_frequency
+  varchar name
+  int parent_id
+  varchar parent_path
+  varchar responsible_role
+  datetime write_date
+  int write_uid
+}
+entity finance_ppm_ph_holiday {
+  datetime create_date
+  int create_uid
+  date date
+  text description
+  varchar holiday_type
+  int id
+  boolean is_nationwide
+  varchar name
+  datetime write_date
+  int write_uid
+}
+entity finance_ppm_tdi_audit {
+  datetime create_date
+  int create_uid
+  varchar display_name
+  text error_log
+  varchar file_name
+  boolean has_errors
+  int id
+  datetime import_date
+  text import_summary
+  varchar import_type
+  int records_created
+  int records_failed
+  int records_skipped
+  int records_updated
+  varchar state
+  float success_rate
+  int total_records
+  int user_id
+  datetime write_date
+  int write_uid
+}
+entity finance_task {
+  boolean approve_done
+  int approve_done_by
+  datetime approve_done_date
+  date approve_due_date
+  int approve_user_id
+  varchar bir_form_type
+  varchar bir_reference
+  int bir_return_id
+  int closing_id
+  int company_id
+  datetime create_date
+  int create_uid
+  int days_overdue
+  datetime filed_date
+  date filing_due_date
+  int id
+  boolean is_overdue
+  varchar name
+  text notes
+  varchar phase
+  boolean prep_done
+  int prep_done_by
+  datetime prep_done_date
+  date prep_due_date
+  int prep_user_id
+  boolean review_done
+  int review_done_by
+  datetime review_done_date
+  date review_due_date
+  int review_user_id
+  int sequence
+  varchar state
+  varchar task_type
+  int template_id
+  datetime write_date
+  int write_uid
+}
+entity finance_task_template {
+  boolean active
+  int approve_day_offset
+  int approve_user_id
+  varchar bir_form_type
+  datetime create_date
+  int create_uid
+  varchar description
+  int filing_day_offset
+  varchar frequency
+  int id
+  varchar name
+  varchar oca_module
+  varchar odoo_model
+  varchar phase
+  int prep_day_offset
+  int prep_user_id
+  int review_day_offset
+  int review_user_id
+  int sequence
+  int task_count
+  varchar task_type
+  datetime write_date
+  int write_uid
+}
+entity finance_task_template_dependency_rel {
+  int depends_on_id
+  int task_id
+}
+entity hr_employee {
+  datetime create_date
+  int create_uid
+  int id
+  datetime write_date
+  int write_uid
+  boolean x_master_control_offboarded
+  boolean x_master_control_onboarded
+}
+entity hr_expense {
+  datetime create_date
+  int create_uid
+  int id
+  int project_id
+  boolean requires_project
+  int travel_request_id
+  datetime write_date
+  int write_uid
+  boolean x_master_control_submitted
+}
+entity hr_payslip {
+  int id
+}
+entity ipai_ask_ai_service {
+  datetime create_date
+  int create_uid
+  int id
+  datetime write_date
+  int write_uid
+}
+entity ipai_asset {
+  int active_checkout_id
+  varchar barcode
+  int category_id
+  varchar code
+  datetime create_date
+  int create_uid
+  int currency_id
+  decimal current_value
+  int custodian_id
+  text description
+  int id
+  varchar image
+  int location_id
+  varchar name
+  date purchase_date
+  decimal purchase_value
+  varchar state
+  datetime write_date
+  int write_uid
+}
+entity ipai_asset_category {
+  boolean allow_reservations
+  int asset_count
+  varchar code
+  datetime create_date
+  int create_uid
+  text description
+  int id
+  int max_checkout_days
+  varchar name
+  boolean requires_approval
+  int sequence
+  datetime write_date
+  int write_uid
+}
+entity ipai_asset_checkout {
+  datetime actual_return_date
+  datetime approval_date
+  int approved_by
+  int asset_id
+  datetime checkout_date
+  text checkout_notes
+  varchar condition_on_return
+  datetime create_date
+  int create_uid
+  int employee_id
+  date expected_return_date
+  int id
+  varchar name
+  text return_notes
+  varchar state
+  datetime write_date
+  int write_uid
+}
+entity ipai_asset_reservation {
+  int asset_id
+  datetime create_date
+  int create_uid
+  int employee_id
+  date end_date
+  int id
+  varchar name
+  text notes
+  date start_date
+  varchar state
+  datetime write_date
+  int write_uid
+}
+entity ipai_audit_log {
+  varchar action
+  datetime create_date
+  int create_uid
+  varchar display_name
+  varchar field_name
+  int id
+  text new_value
+  text old_value
+  int res_id
+  varchar res_model
+  varchar res_name
+  int user_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_bir_dat_wizard {
+  datetime create_date
+  int create_uid
+  int currency_id
+  date date_end
+  date date_start
+  binary file_data
+  varchar file_name
+  int id
+  int record_count
+  varchar report_type
+  varchar state
+  decimal total_amount
+  decimal total_tax
+  datetime write_date
+  int write_uid
+}
+entity ipai_bir_form_schedule {
+  date approval_date
+  date bir_deadline
+  datetime create_date
+  int create_uid
+  varchar form_code
+  int id
+  varchar period
+  date prep_date
+  int responsible_approval_id
+  int responsible_prep_id
+  int responsible_review_id
+  date review_date
+  datetime write_date
+  int write_uid
+}
+entity ipai_bir_process_step {
+  datetime create_date
+  int create_uid
+  text detail
+  int id
+  int person_id
+  varchar role
+  int schedule_id
+  int step_no
+  int target_offset
+  varchar title
+  datetime write_date
+  int write_uid
+}
+entity ipai_bir_schedule_item {
+  boolean active
+  varchar bir_form
+  datetime create_date
+  int create_uid
+  date deadline
+  int id
+  varchar im_xml_id
+  varchar period_covered
+  datetime write_date
+  int write_uid
+}
+entity ipai_bir_schedule_line {
+  varchar approve_by_code
+  date approve_due_date
+  varchar bir_form
+  datetime create_date
+  int create_uid
+  date deadline_date
+  int id
+  varchar notes
+  varchar period_label
+  varchar prep_by_code
+  date prep_due_date
+  varchar review_by_code
+  date review_due_date
+  datetime write_date
+  int write_uid
+}
+entity ipai_bir_schedule_step {
+  varchar activity_type
+  int business_days_before
+  datetime create_date
+  int create_uid
+  int id
+  int item_id
+  boolean on_or_before_deadline
+  varchar role_code
+  int sequence
+  datetime write_date
+  int write_uid
+}
+entity ipai_close_generated_map {
+  datetime create_date
+  int create_uid
+  varchar external_key
+  int generation_run_id
+  int id
+  varchar operation
+  int run_id
+  varchar seed_hash
+  varchar seed_hash_at_generation
+  int task_id
+  int template_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_close_generation_run {
+  datetime create_date
+  int create_uid
+  int created_count
+  varchar cycle_code
+  varchar cycle_key
+  varchar cycle_type
+  boolean dry_run
+  int duration_seconds
+  datetime end_time
+  int error_count
+  int id
+  varchar name
+  int obsolete_marked_count
+  date period_end
+  date period_start
+  int project_id
+  varchar report_json
+  varchar report_status
+  varchar seed_id
+  varchar seed_version
+  datetime start_time
+  varchar status
+  int task_count_created
+  int task_count_obsolete
+  int task_count_skipped
+  int task_count_updated
+  int unchanged_count
+  int unresolved_assignee_count
+  int updated_count
+  int user_id
+  int warning_count
+  datetime write_date
+  int write_uid
+}
+entity ipai_close_generator {
+  datetime create_date
+  int create_uid
+  int id
+  varchar name
+  datetime write_date
+  int write_uid
+}
+entity ipai_close_task_step {
+  datetime create_date
+  int create_uid
+  varchar default_employee_code
+  int id
+  int sequence
+  varchar step_code
+  varchar step_name
+  int template_id
+  int user_id
+  datetime write_date
+  int write_uid
+  varchar x_legacy_template_code
+}
+entity ipai_close_task_template {
+  varchar category_code
+  varchar category_name
+  int category_seq
+  datetime create_date
+  int create_uid
+  boolean critical_path
+  varchar cycle_code
+  int duration_days
+  varchar employee_code
+  int id
+  boolean is_active
+  int offset_from_period_end
+  varchar phase_code
+  varchar phase_name
+  int phase_seq
+  varchar phase_type
+  varchar recurrence_rule
+  varchar responsible_role
+  varchar seed_hash
+  varchar step_code
+  int step_seq
+  text task_description
+  varchar task_name_template
+  varchar template_code
+  int template_seq
+  varchar template_version
+  varchar wbs_code_template
+  varchar workstream_code
+  varchar workstream_name
+  int workstream_seq
+  datetime write_date
+  int write_uid
+  boolean x_legacy_migration
+}
+entity ipai_convert_phases_wizard {
+  datetime create_date
+  int create_uid
+  int id
+  varchar im1_keywords
+  varchar im1_name
+  varchar im2_keywords
+  varchar im2_name
+  boolean move_tasks_by_keyword
+  int parent_project_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_directory_person {
+  boolean active
+  varchar code
+  datetime create_date
+  int create_uid
+  varchar email
+  int id
+  varchar name
+  varchar role
+  datetime write_date
+  int write_uid
+}
+entity ipai_equipment_asset {
+  int booking_count
+  int category_id
+  int company_id
+  varchar condition
+  datetime create_date
+  int create_uid
+  int id
+  varchar image_1920
+  int incident_count
+  int location_id
+  varchar name
+  int product_id
+  varchar serial_number
+  varchar status
+  datetime write_date
+  int write_uid
+}
+entity ipai_equipment_booking {
+  int asset_id
+  int borrower_id
+  datetime create_date
+  int create_uid
+  datetime end_datetime
+  int id
+  boolean is_overdue
+  varchar name
+  int project_id
+  datetime start_datetime
+  varchar state
+  datetime write_date
+  int write_uid
+}
+entity ipai_equipment_incident {
+  int asset_id
+  int booking_id
+  datetime create_date
+  int create_uid
+  text description
+  int id
+  varchar name
+  int reported_by
+  varchar severity
+  varchar status
+  datetime write_date
+  int write_uid
+}
+entity ipai_export_seed_wizard {
+  datetime create_date
+  int create_uid
+  varchar export_path
+  int id
+  varchar webhook_url
+  datetime write_date
+  int write_uid
+}
+entity ipai_finance_bir_schedule {
+  date approval_deadline
+  int approval_task_id
+  int approver_id
+  float completion_pct
+  datetime create_date
+  int create_uid
+  date filing_deadline
+  int id
+  int logframe_id
+  varchar name
+  varchar period_covered
+  date prep_deadline
+  int prep_task_id
+  date review_deadline
+  int review_task_id
+  int reviewer_id
+  varchar status
+  int supervisor_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_finance_directory {
+  boolean active
+  varchar code
+  datetime create_date
+  int create_uid
+  varchar email
+  int id
+  varchar name
+  int user_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_finance_logframe {
+  text assumptions
+  varchar code
+  datetime create_date
+  int create_uid
+  int id
+  text indicators
+  varchar level
+  text means_of_verification
+  varchar name
+  int sequence
+  int task_count
+  datetime write_date
+  int write_uid
+}
+entity ipai_finance_person {
+  varchar code
+  datetime create_date
+  int create_uid
+  varchar email
+  int id
+  varchar name
+  varchar role
+  int user_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_finance_ppm_golive_checklist {
+  int completed_items
+  float completion_pct
+  datetime create_date
+  int create_uid
+  int created_by
+  int director_id
+  text director_notes
+  datetime director_review_date
+  datetime director_signoff_date
+  int id
+  varchar name
+  int senior_supervisor_id
+  text senior_supervisor_notes
+  datetime senior_supervisor_review_date
+  varchar state
+  int supervisor_id
+  text supervisor_notes
+  datetime supervisor_review_date
+  int total_items
+  varchar version
+  datetime write_date
+  int write_uid
+}
+entity ipai_finance_ppm_golive_checklist_section_ids_rel {
+  int ipai_finance_ppm_golive_checklist_id
+  int ipai_finance_ppm_golive_section_id
+}
+entity ipai_finance_ppm_golive_item {
+  int checked_by
+  datetime checked_date
+  datetime create_date
+  int create_uid
+  text description
+  varchar evidence_url
+  int id
+  boolean is_checked
+  boolean is_critical
+  varchar name
+  text notes
+  int section_id
+  int sequence
+  datetime write_date
+  int write_uid
+}
+entity ipai_finance_ppm_golive_section {
+  int completed_items
+  float completion_pct
+  datetime create_date
+  int create_uid
+  text description
+  int id
+  varchar name
+  varchar section_type
+  int sequence
+  int total_items
+  datetime write_date
+  int write_uid
+}
+entity ipai_finance_seed_service {
+  datetime create_date
+  int create_uid
+  int id
+  datetime write_date
+  int write_uid
+}
+entity ipai_finance_seed_wizard {
+  datetime create_date
+  int create_uid
+  int id
+  boolean strict
+  datetime write_date
+  int write_uid
+}
+entity ipai_finance_task_template {
+  boolean active
+  varchar anchor
+  float approval_duration
+  varchar approve_by_code
+  int approved_by_id
+  int bir_form_id
+  varchar category
+  datetime create_date
+  int create_uid
+  int day_of_month
+  int default_duration_days
+  text description
+  int employee_code_id
+  int id
+  varchar name
+  int offset_days
+  varchar prep_by_code
+  float prep_duration
+  varchar review_by_code
+  float review_duration
+  int reviewed_by_id
+  int sequence
+  varchar task_category
+  varchar trigger_type
+  datetime write_date
+  int write_uid
+}
+entity ipai_generate_bir_tasks_wizard {
+  datetime create_date
+  int create_uid
+  date date_from
+  date date_to
+  boolean dry_run
+  int id
+  int program_project_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_generate_im_projects_wizard {
+  boolean create_bir_tasks
+  boolean create_children
+  datetime create_date
+  boolean create_month_end_tasks
+  int create_uid
+  int id
+  int project_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_generate_month_end_wizard {
+  date anchor_date
+  datetime create_date
+  int create_uid
+  boolean dry_run
+  int id
+  int program_project_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_grid_column {
+  varchar alignment
+  varchar cell_css_class
+  boolean clickable
+  varchar column_type
+  datetime create_date
+  int create_uid
+  varchar css_class
+  varchar currency_field
+  varchar date_format
+  int decimal_places
+  varchar display_name
+  boolean editable
+  varchar field_name
+  varchar field_type
+  boolean filterable
+  varchar format_string
+  int grid_view_id
+  varchar header_css_class
+  int id
+  boolean is_action_column
+  boolean is_avatar_column
+  boolean is_primary
+  boolean is_selection_column
+  varchar label
+  int max_width
+  int min_width
+  boolean resizable
+  boolean searchable
+  int sequence
+  boolean sortable
+  boolean visible
+  text widget_options
+  int width
+  datetime write_date
+  int write_uid
+}
+entity ipai_grid_filter {
+  boolean active
+  varchar color
+  int condition_count
+  datetime create_date
+  int create_uid
+  varchar domain
+  text filter_json
+  int grid_view_id
+  varchar icon
+  int id
+  boolean is_default
+  boolean is_global
+  varchar name
+  int sequence
+  int user_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_grid_filter_condition {
+  datetime create_date
+  int create_uid
+  varchar field_label
+  varchar field_name
+  varchar field_type
+  int filter_id
+  int id
+  varchar operator
+  boolean value_boolean
+  varchar value_char
+  date value_date
+  datetime value_datetime
+  float value_float
+  int value_integer
+  int value_many2one
+  varchar value_selection
+  datetime write_date
+  int write_uid
+}
+entity ipai_grid_view {
+  boolean active
+  int active_filter_id
+  int column_count
+  text config_json
+  datetime create_date
+  int create_uid
+  boolean enable_column_reorder
+  boolean enable_column_resize
+  boolean enable_export
+  boolean enable_quick_search
+  boolean enable_row_selection
+  int id
+  int model_id
+  varchar model_name
+  varchar name
+  int page_size
+  varchar page_size_options
+  int sequence
+  boolean show_checkboxes
+  boolean show_row_numbers
+  text sort_json
+  varchar view_type
+  datetime write_date
+  int write_uid
+}
+entity ipai_grid_view_visible_columns_rel {
+  int column_id
+  int grid_view_id
+}
+entity ipai_import_seed_wizard {
+  datetime create_date
+  int create_uid
+  int id
+  varchar mode
+  text seed_json
+  datetime write_date
+  int write_uid
+}
+entity ipai_localization_overlay {
+  boolean active
+  varchar applies_to_code
+  varchar country
+  datetime create_date
+  int create_uid
+  int id
+  text patch_payload
+  varchar patch_type
+  int sequence
+  int workstream_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_month_end_closing {
+  int company_id
+  int completed_tasks
+  datetime create_date
+  int create_uid
+  int id
+  date last_workday
+  varchar name
+  int overdue_tasks
+  date period_date
+  float progress
+  varchar state
+  int total_tasks
+  datetime write_date
+  int write_uid
+}
+entity ipai_month_end_task {
+  boolean approve_done
+  int approve_done_by
+  datetime approve_done_date
+  date approve_due_date
+  int approve_user_id
+  int closing_id
+  datetime create_date
+  int create_uid
+  int days_overdue
+  int id
+  boolean is_overdue
+  varchar name
+  varchar notes
+  varchar phase
+  boolean prep_done
+  int prep_done_by
+  datetime prep_done_date
+  date prep_due_date
+  int prep_user_id
+  boolean review_done
+  int review_done_by
+  datetime review_done_date
+  date review_due_date
+  int review_user_id
+  int sequence
+  varchar state
+  int template_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_month_end_task_template {
+  boolean active
+  int approve_day_offset
+  int approve_user_id
+  datetime create_date
+  int create_uid
+  varchar description
+  int id
+  varchar name
+  varchar oca_module
+  varchar odoo_model
+  varchar phase
+  int prep_day_offset
+  int prep_user_id
+  int review_day_offset
+  int review_user_id
+  int sequence
+  int task_count
+  datetime write_date
+  int write_uid
+}
+entity ipai_month_end_template {
+  boolean active
+  varchar category
+  datetime create_date
+  int create_uid
+  varchar default_im_xml_id
+  int id
+  varchar task_base_name
+  datetime write_date
+  int write_uid
+}
+entity ipai_month_end_template_step {
+  varchar activity_type
+  int business_days_before
+  datetime create_date
+  int create_uid
+  int id
+  int offset_days
+  varchar role_code
+  int sequence
+  int template_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_permission {
+  boolean active
+  datetime create_date
+  int create_uid
+  int group_id
+  int id
+  varchar name
+  varchar permission_level
+  varchar role
+  varchar scope_ref
+  varchar scope_type
+  int user_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_ph_holiday {
+  datetime create_date
+  int create_uid
+  date date
+  varchar holiday_type
+  int id
+  varchar name
+  datetime write_date
+  int write_uid
+  int year
+}
+entity ipai_ppm_task {
+  varchar category
+  varchar code
+  datetime create_date
+  int create_uid
+  int due_offset_days
+  boolean evidence_required
+  int id
+  varchar name
+  varchar owner_role
+  varchar phase
+  int prep_offset
+  boolean requires_approval
+  int review_offset
+  varchar sap_reference
+  int sequence
+  int template_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_ppm_task_checklist {
+  datetime create_date
+  int create_uid
+  varchar evidence_type
+  int id
+  varchar label
+  varchar notes
+  boolean required
+  int sequence
+  int task_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_ppm_tasklist {
+  datetime create_date
+  int create_uid
+  int id
+  varchar name
+  date period_end
+  date period_start
+  varchar status
+  int template_id
+  int workstream_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_ppm_taskrun {
+  int approver_id
+  int assignee_id
+  datetime create_date
+  int create_uid
+  datetime done_at
+  int id
+  varchar name
+  datetime started_at
+  varchar status
+  int task_id
+  int tasklist_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_ppm_template {
+  varchar code
+  datetime create_date
+  int create_uid
+  int id
+  boolean is_active
+  varchar name
+  varchar period_type
+  int sequence
+  varchar version
+  int workstream_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_repo_export_run {
+  datetime create_date
+  int create_uid
+  varchar export_path
+  datetime exported_at
+  int id
+  varchar name
+  text payload_json
+  varchar state
+  varchar webhook_status
+  varchar webhook_url
+  datetime write_date
+  int write_uid
+}
+entity ipai_share_token {
+  boolean active
+  datetime create_date
+  int create_uid
+  int created_by
+  datetime expires_at
+  int id
+  boolean is_public
+  varchar name
+  varchar permission_level
+  varchar scope_ref
+  varchar scope_type
+  datetime write_date
+  int write_uid
+}
+entity ipai_stc_check {
+  boolean auto_run
+  varchar category
+  varchar code
+  datetime create_date
+  int create_uid
+  text description
+  int id
+  boolean is_active
+  varchar name
+  text rule_json
+  varchar sap_reference
+  int sequence
+  varchar severity
+  int worklist_type_id
+  int workstream_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_stc_scenario {
+  varchar bir_forms
+  varchar code
+  datetime create_date
+  int create_uid
+  varchar frequency
+  int id
+  varchar name
+  text notes
+  int run_day_offset
+  varchar sap_reference
+  int sequence
+  int workstream_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_stc_scenario_check_ids_rel {
+  int ipai_stc_check_id
+  int ipai_stc_scenario_id
+}
+entity ipai_stc_worklist_type {
+  varchar code
+  datetime create_date
+  int create_uid
+  text description
+  int id
+  varchar name
+  datetime write_date
+  int write_uid
+}
+entity ipai_studio_ai_history {
+  text analysis
+  int automation_id
+  text command
+  varchar command_type
+  float confidence
+  datetime create_date
+  int create_uid
+  text feedback_comment
+  varchar feedback_score
+  int field_id
+  int id
+  int model_id
+  varchar model_name
+  varchar result
+  text result_message
+  int user_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_studio_ai_wizard {
+  text analysis_json
+  text command
+  varchar command_type
+  float confidence
+  int context_model_id
+  datetime create_date
+  int create_uid
+  int created_field_id
+  varchar field_label
+  varchar field_name
+  boolean field_required
+  varchar field_type
+  int history_id
+  int id
+  boolean is_ready
+  varchar message
+  int relation_model_id
+  varchar result_message
+  text selection_options
+  varchar state
+  int target_model_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_task_template_dependency_rel {
+  int depends_on_id
+  int task_id
+}
+entity ipai_travel_request {
+  int company_id
+  datetime create_date
+  int create_uid
+  int currency_id
+  varchar destination
+  int employee_id
+  date end_date
+  decimal estimated_budget
+  int id
+  varchar name
+  int project_id
+  text purpose
+  date start_date
+  varchar state
+  datetime write_date
+  int write_uid
+}
+entity ipai_workos_block {
+  int attachment_id
+  varchar block_type
+  varchar callout_color
+  varchar callout_icon
+  varchar content_html
+  text content_json
+  text content_text
+  datetime create_date
+  int create_uid
+  int id
+  boolean is_checked
+  boolean is_collapsed
+  varchar name
+  int page_id
+  int parent_block_id
+  int sequence
+  datetime write_date
+  int write_uid
+}
+entity ipai_workos_canvas {
+  boolean active
+  datetime create_date
+  int create_uid
+  int id
+  varchar name
+  text nodes_json
+  int page_id
+  text viewport_json
+  datetime write_date
+  int write_uid
+}
+entity ipai_workos_comment {
+  int anchor_block_id
+  int author_id
+  varchar content
+  text content_text
+  datetime create_date
+  int create_uid
+  int id
+  boolean is_resolved
+  int parent_id
+  int reply_count
+  datetime resolved_at
+  int resolved_by
+  int target_id
+  varchar target_model
+  varchar target_name
+  datetime write_date
+  int write_uid
+}
+entity ipai_workos_database {
+  boolean active
+  datetime create_date
+  int create_uid
+  text description
+  varchar icon
+  int id
+  varchar name
+  int page_id
+  int row_count
+  int space_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_workos_page {
+  boolean active
+  int child_count
+  text content_preview
+  binary cover_image
+  datetime create_date
+  int create_uid
+  varchar icon
+  int id
+  boolean is_archived
+  int last_edited_by
+  varchar name
+  int parent_id
+  varchar parent_path
+  int sequence
+  int space_id
+  int template_id
+  int workspace_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_workos_property {
+  datetime create_date
+  int create_uid
+  int database_id
+  int id
+  boolean is_title
+  boolean is_visible
+  varchar name
+  text options_json
+  varchar property_type
+  int related_database_id
+  int sequence
+  int width
+  datetime write_date
+  int write_uid
+}
+entity ipai_workos_row {
+  boolean active
+  datetime create_date
+  int create_uid
+  int database_id
+  int id
+  varchar name
+  int sequence
+  text values_json
+  datetime write_date
+  int write_uid
+}
+entity ipai_workos_search {
+  text block_results
+  datetime create_date
+  int create_uid
+  text database_results
+  int id
+  text page_results
+  varchar query
+  varchar scope
+  int scope_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_workos_search_history {
+  datetime create_date
+  int create_uid
+  int id
+  varchar query
+  int result_count
+  int user_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_workos_space {
+  boolean active
+  int color
+  datetime create_date
+  int create_uid
+  text description
+  varchar icon
+  int id
+  varchar name
+  int page_count
+  int sequence
+  varchar visibility
+  int workspace_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_workos_template {
+  text blocks_json
+  varchar category
+  datetime create_date
+  int create_uid
+  text description
+  varchar icon
+  int id
+  boolean is_published
+  boolean is_system
+  varchar name
+  text properties_json
+  int sequence
+  text views_json
+  datetime write_date
+  int write_uid
+}
+entity ipai_workos_template_tag {
+  int color
+  datetime create_date
+  int create_uid
+  int id
+  varchar name
+  datetime write_date
+  int write_uid
+}
+entity ipai_workos_template_tag_ids_rel {
+  int ipai_workos_template_id
+  int ipai_workos_template_tag_id
+}
+entity ipai_workos_view {
+  text config_json
+  datetime create_date
+  int create_uid
+  int database_id
+  int date_property_id
+  text filter_json
+  int group_by_property_id
+  int id
+  boolean is_default
+  boolean is_shared
+  varchar name
+  int sequence
+  text sort_json
+  int user_id
+  varchar view_type
+  datetime write_date
+  int write_uid
+}
+entity ipai_workos_view_visible_property_ids_rel {
+  int ipai_workos_property_id
+  int ipai_workos_view_id
+}
+entity ipai_workos_workspace {
+  boolean active
+  int color
+  datetime create_date
+  int create_uid
+  text description
+  varchar icon
+  int id
+  varchar name
+  int owner_id
+  int space_count
+  datetime write_date
+  int write_uid
+}
+entity ipai_workspace {
+  int account_manager_id
+  boolean active
+  varchar brand_name
+  varchar campaign_type
+  varchar channel_mix
+  int client_id
+  varchar closing_stage
+  varchar code
+  int color
+  int company_id
+  datetime create_date
+  int create_uid
+  datetime date_end
+  datetime date_start
+  int engagement_count
+  varchar entity_code
+  varchar fiscal_period
+  int id
+  varchar industry
+  int invoice_count
+  boolean is_critical
+  varchar name
+  int parent_id
+  float planned_hours
+  float progress
+  int project_count
+  float remaining_hours
+  int sequence
+  varchar stage
+  varchar workspace_type
+  datetime write_date
+  int write_uid
+}
+entity ipai_workspace_link {
+  datetime create_date
+  int create_uid
+  varchar display_name
+  int id
+  varchar link_type
+  int res_id
+  varchar res_model
+  int workspace_id
+  datetime write_date
+  int write_uid
+}
+entity ipai_workstream {
+  boolean active
+  varchar code
+  datetime create_date
+  int create_uid
+  text description
+  int id
+  varchar name
+  varchar odoo_anchor
+  varchar sap_anchor
+  datetime write_date
+  int write_uid
+}
+entity ir_attachment {
+  int id
+}
+entity ir_model {
+  int id
+}
+entity ir_model_fields {
+  int id
+}
+entity ph_holiday {
+  int company_id
+  datetime create_date
+  int create_uid
+  date date
+  varchar holiday_type
+  int id
+  varchar name
+  datetime write_date
+  int write_uid
+  int year
+}
+entity ppm_close_task {
+  varchar agency_code
+  varchar approval_completed_by
+  date approval_completed_date
+  float approval_days
+  date approval_due
+  varchar approver_code
+  text completion_notes
+  datetime create_date
+  int create_uid
+  text detailed_task
+  int id
+  int monthly_close_id
+  varchar name
+  text notes
+  varchar owner_code
+  varchar prep_completed_by
+  date prep_completed_date
+  float prep_days
+  date prep_start
+  varchar review_completed_by
+  date review_completed_date
+  float review_days
+  date review_due
+  varchar reviewer_code
+  int sequence
+  varchar state
+  int template_id
+  float total_days
+  datetime write_date
+  int write_uid
+}
+entity ppm_close_template {
+  boolean active
+  varchar agency_code
+  float approval_days
+  varchar approver_code
+  datetime create_date
+  int create_uid
+  text detailed_task
+  int id
+  varchar name
+  text notes
+  varchar owner_code
+  float prep_days
+  float review_days
+  varchar reviewer_code
+  int sequence
+  varchar task_category
+  float total_days
+  datetime write_date
+  int write_uid
+}
+entity ppm_kpi_snapshot {
+  datetime as_of
+  datetime create_date
+  int create_uid
+  int id
+  varchar kpi_category
+  varchar kpi_key
+  varchar kpi_label
+  varchar name
+  int portfolio_id
+  int program_id
+  int project_id
+  varchar scope
+  varchar source
+  varchar source_ref
+  varchar status
+  float target_value
+  float threshold_green
+  float threshold_yellow
+  varchar unit
+  float value
+  varchar value_text
+  datetime write_date
+  int write_uid
+}
+entity ppm_monthly_close {
+  date approval_due_date
+  date close_month
+  datetime create_date
+  int create_uid
+  boolean created_by_cron
+  int id
+  date month_end_date
+  varchar name
+  text notes
+  date prep_start_date
+  float progress_percentage
+  date review_due_date
+  varchar state
+  int task_completed
+  int task_count
+  datetime write_date
+  int write_uid
+}
+entity ppm_portfolio {
+  boolean active
+  float budget_variance_pct
+  varchar code
+  datetime create_date
+  int create_uid
+  int currency_id
+  date date_end
+  date date_start
+  varchar description
+  int health_score
+  varchar health_status
+  int id
+  varchar name
+  text objective
+  int owner_id
+  int program_count
+  int sequence
+  int sponsor_id
+  decimal total_actual
+  decimal total_budget
+  datetime write_date
+  int write_uid
+}
+entity ppm_program {
+  boolean active
+  decimal actual_cost
+  decimal budget
+  varchar code
+  datetime create_date
+  int create_uid
+  int currency_id
+  date date_end
+  date date_start
+  varchar description
+  text health_notes
+  int health_score
+  varchar health_status
+  int id
+  varchar name
+  text objectives
+  int open_high_risks
+  int portfolio_id
+  int program_manager_id
+  int project_count
+  int risk_count
+  int sequence
+  int sponsor_id
+  datetime write_date
+  int write_uid
+}
+entity ppm_program_project_rel {
+  int program_id
+  int project_id
+}
+entity ppm_resource_allocation {
+  float allocation_pct
+  datetime create_date
+  int create_uid
+  date date_end
+  date date_start
+  int employee_id
+  int id
+  boolean is_overloaded
+  varchar name
+  text notes
+  float planned_hours
+  int program_id
+  int project_id
+  varchar role
+  varchar status
+  int task_id
+  float total_allocation
+  int user_id
+  datetime write_date
+  int write_uid
+}
+entity ppm_risk {
+  int assigned_to_id
+  varchar category
+  varchar code
+  text contingency_plan
+  datetime create_date
+  int create_uid
+  int currency_id
+  date date_closed
+  date date_identified
+  date date_target
+  text description
+  int id
+  varchar impact
+  text mitigation_plan
+  varchar mitigation_strategy
+  varchar name
+  int owner_id
+  int portfolio_id
+  decimal potential_cost
+  varchar probability
+  int program_id
+  int project_id
+  int risk_score
+  varchar scope
+  varchar severity
+  varchar status
+  datetime write_date
+  int write_uid
+}
+entity product_category {
+  int id
+}
+entity product_product {
+  int id
+}
+entity project_category {
+  int id
+}
+entity project_milestone {
+  int alert_days_before
+  date approval_date
+  boolean approval_required
+  int approver_id
+  date baseline_deadline
+  int completed_task_count
+  text completion_criteria
+  datetime create_date
+  int create_uid
+  text deliverables
+  varchar gate_status
+  int id
+  date last_alert_sent
+  varchar milestone_type
+  varchar risk_level
+  text risk_notes
+  int task_count
+  int variance_days
+  datetime write_date
+  int write_uid
+}
+entity project_project {
+  date actual_finish
+  date actual_start
+  date baseline_finish
+  date baseline_start
+  varchar clarity_id
+  datetime create_date
+  int create_uid
+  int critical_milestone_count
+  varchar health_status
+  int id
+  varchar im_code
+  boolean ipai_finance_enabled
+  varchar ipai_im_code
+  boolean ipai_is_im_project
+  int ipai_root_project_id
+  boolean is_program
+  int milestone_count
+  float overall_progress
+  varchar overall_status
+  int parent_id
+  int phase_count
+  int portfolio_id
+  varchar program_code
+  varchar program_type
+  int variance_finish
+  int variance_start
+  datetime write_date
+  int write_uid
+  varchar x_cycle_code
+}
+entity project_task {
+  varchar activity_type
+  float actual_cost
+  float actual_hours
+  float approval_duration
+  int approver_id
+  boolean auto_sync
+  date bir_approval_due_date
+  date bir_deadline
+  varchar bir_form
+  date bir_payment_due_date
+  varchar bir_period_label
+  date bir_prep_due_date
+  boolean bir_related
+  int bir_schedule_id
+  int child_task_count
+  date closing_due_date
+  varchar cluster
+  float cost_variance
+  datetime create_date
+  int create_uid
+  boolean critical_path
+  float earned_value
+  varchar erp_ref
+  int fd_id
+  varchar finance_category
+  varchar finance_code
+  varchar finance_deadline_type
+  int finance_logframe_id
+  int finance_person_id
+  int finance_supervisor_id
+  int free_float
+  int gate_approver_id
+  varchar gate_decision
+  int gate_milestone_id
+  boolean has_gate
+  int id
+  varchar ipai_compliance_step
+  int ipai_days_to_deadline
+  varchar ipai_owner_code
+  varchar ipai_owner_role
+  varchar ipai_status_bucket
+  varchar ipai_task_category
+  int ipai_template_id
+  boolean is_finance_ppm
+  boolean is_phase
+  int lag_days
+  int lead_days
+  int milestone_count
+  varchar owner_code
+  varchar period_covered
+  date phase_baseline_finish
+  date phase_baseline_start
+  float phase_progress
+  varchar phase_status
+  varchar phase_type
+  int phase_variance_days
+  float planned_hours
+  float planned_value
+  float prep_duration
+  varchar relative_due
+  float remaining_hours
+  float resource_allocation
+  float review_duration
+  int reviewer_id
+  varchar role_code
+  float schedule_variance
+  int sfm_id
+  date target_date
+  int total_float
+  varchar wbs_code
+  datetime write_date
+  int write_uid
+  varchar x_cycle_key
+  varchar x_external_key
+  boolean x_obsolete
+  varchar x_seed_hash
+  varchar x_step_code
+  varchar x_task_template_code
+}
+entity project_task_checklist_item {
+  float actual_hours
+  int assigned_user_id
+  text blocker_description
+  date completed_date
+  datetime create_date
+  int create_uid
+  date due_date
+  float estimated_hours
+  int id
+  text notes
+  varchar priority
+  varchar status
+  datetime write_date
+  int write_uid
+}
+entity purchase_order {
+  datetime create_date
+  int create_uid
+  int id
+  datetime write_date
+  int write_uid
+  boolean x_master_control_submitted
+}
+entity res_company {
+  int id
+}
+entity res_config_settings {
+  datetime create_date
+  int create_uid
+  int id
+  boolean ipai_enable_finance_project_analytics
+  boolean superset_auto_sync
+  int superset_connection_id
+  boolean superset_create_analytics_views
+  boolean superset_enable_rls
+  varchar superset_sync_interval
+  datetime write_date
+  int write_uid
+}
+entity res_currency {
+  int id
+}
+entity res_groups {
+  int id
+}
+entity res_partner {
+  boolean bir_registered
+  date bir_registration_date
+  datetime create_date
+  int create_uid
+  int id
+  float srm_overall_score
+  int srm_supplier_id
+  varchar srm_tier
+  varchar tax_type
+  varchar tin
+  varchar tin_branch_code
+  datetime write_date
+  int write_uid
+}
+entity res_users {
+  datetime create_date
+  int create_uid
+  int id
+  datetime write_date
+  int write_uid
+  varchar x_employee_code
+}
+entity srm_kpi_category {
+  boolean active
+  varchar code
+  varchar compute_source
+  datetime create_date
+  int create_uid
+  text description
+  varchar eval_method
+  int id
+  varchar name
+  int sequence
+  float weight
+  datetime write_date
+  int write_uid
+}
+entity srm_qualification {
+  datetime approval_date
+  int approver_id
+  boolean checklist_complete
+  date completion_date
+  datetime create_date
+  int create_uid
+  date expiry_date
+  int id
+  varchar name
+  text notes
+  varchar qualification_type
+  text rejection_reason
+  int reviewer_id
+  text risk_notes
+  float risk_score
+  date start_date
+  varchar state
+  int supplier_id
+  date target_completion
+  datetime write_date
+  int write_uid
+}
+entity srm_qualification_checklist {
+  int completed_by
+  date completed_date
+  datetime create_date
+  int create_uid
+  text description
+  int id
+  boolean is_complete
+  boolean is_required
+  varchar name
+  text notes
+  int qualification_id
+  int sequence
+  datetime write_date
+  int write_uid
+}
+entity srm_qualification_document_ids_rel {
+  int ir_attachment_id
+  int srm_qualification_id
+}
+entity srm_scorecard {
+  text action_items
+  date as_of
+  text comments
+  datetime create_date
+  int create_uid
+  int evaluator_id
+  varchar grade
+  int id
+  varchar name
+  float overall_score
+  varchar period
+  varchar state
+  int supplier_id
+  datetime write_date
+  int write_uid
+}
+entity srm_scorecard_line {
+  datetime create_date
+  int create_uid
+  text evidence
+  int id
+  int kpi_category_id
+  text notes
+  float score
+  int scorecard_id
+  int sequence
+  float weight
+  float weighted_score
+  datetime write_date
+  int write_uid
+}
+entity srm_supplier {
+  varchar code
+  boolean compliance_docs_complete
+  datetime create_date
+  int create_uid
+  int currency_id
+  int id
+  boolean is_qualified
+  date last_audit_date
+  int latest_scorecard_id
+  varchar name
+  date next_audit_date
+  int open_po_count
+  float overall_score
+  int partner_id
+  int primary_contact_id
+  date qualification_expiry
+  varchar risk_level
+  text risk_notes
+  int sales_contact_id
+  varchar state
+  varchar tier
+  int total_po_count
+  datetime write_date
+  int write_uid
+  decimal ytd_spend
+}
+entity srm_supplier_category_ids_rel {
+  int product_category_id
+  int srm_supplier_id
+}
+entity stock_location {
+  int id
+}
+entity superset_analytics_view {
+  boolean active
+  varchar category
+  datetime create_date
+  int create_uid
+  text description
+  int id
+  boolean is_created
+  datetime last_refresh
+  varchar name
+  varchar required_modules
+  int sequence
+  text sql_definition
+  varchar technical_name
+  datetime write_date
+  int write_uid
+}
+entity superset_bulk_dataset_wizard {
+  int connection_id
+  boolean create_analytics_views
+  datetime create_date
+  int create_uid
+  int id
+  varchar preset
+  datetime write_date
+  int write_uid
+}
+entity superset_connection {
+  varchar access_token
+  boolean active
+  varchar api_key
+  varchar auth_method
+  varchar base_url
+  datetime create_date
+  int create_uid
+  varchar csrf_token
+  int dataset_count
+  int db_connection_id
+  varchar db_connection_name
+  int id
+  text last_error
+  datetime last_sync
+  varchar name
+  varchar password
+  varchar pg_database
+  varchar pg_host
+  varchar pg_password
+  int pg_port
+  varchar pg_schema
+  varchar pg_username
+  varchar refresh_token
+  varchar state
+  datetime token_expiry
+  boolean use_ssl
+  varchar username
+  datetime write_date
+  int write_uid
+}
+entity superset_dataset {
+  boolean active
+  varchar category
+  int column_count
+  int connection_id
+  datetime create_date
+  int create_uid
+  text custom_sql
+  text description
+  boolean enable_rls
+  int id
+  boolean include_all_fields
+  datetime last_sync
+  int model_id
+  varchar model_name
+  varchar name
+  varchar rls_filter_column
+  int sequence
+  varchar source_type
+  int superset_dataset_id
+  text sync_error
+  varchar sync_status
+  varchar technical_name
+  boolean view_created
+  varchar view_name
+  text view_sql
+  datetime write_date
+  int write_uid
+}
+entity superset_dataset_column {
+  varchar aggregation
+  varchar column_type
+  datetime create_date
+  int create_uid
+  varchar data_type
+  int dataset_id
+  text description
+  boolean filterable
+  varchar format_string
+  boolean groupable
+  int id
+  varchar label
+  varchar name
+  int sequence
+  datetime write_date
+  int write_uid
+}
+entity superset_dataset_field_ids_rel {
+  int ir_model_fields_id
+  int superset_dataset_id
+}
+entity superset_dataset_wizard {
+  varchar category
+  int connection_id
+  datetime create_date
+  int create_uid
+  boolean create_view
+  boolean enable_rls
+  int id
+  boolean include_all_fields
+  int model_id
+  varchar name
+  boolean sync_to_superset
+  varchar technical_name
+  datetime write_date
+  int write_uid
+}
+entity superset_dataset_wizard_field_ids_rel {
+  int ir_model_fields_id
+  int superset_dataset_wizard_id
+}
+entity workos_comment_mention_rel {
+  int comment_id
+  int user_id
+}
+entity workspace_member_rel {
+  int user_id
+  int workspace_id
+}
+a1_check }o--|| close_approval_gate_template : close_gate_template_id
+a1_check }o--|| res_company : company_id
+a1_check_result }o--|| a1_check : check_id
+a1_check_result }o--|| res_users : executed_by
+a1_check_result }o--|| a1_task : task_id
+a1_check_result_attachment_ids_rel }o--|| a1_check_result : a1_check_result_id
+a1_check_result_attachment_ids_rel }o--|| ir_attachment : ir_attachment_id
+a1_export_run }o--|| res_company : company_id
+a1_role }o--|| res_company : company_id
+a1_role }o--|| res_users : default_user_id
+a1_role }o--|| res_users : fallback_user_id
+a1_role_group_ids_rel }o--|| a1_role : a1_role_id
+a1_role_group_ids_rel }o--|| res_groups : res_groups_id
+a1_task }o--|| res_users : approval_done_by
+a1_task }o--|| res_users : approver_id
+a1_task }o--|| close_task : close_task_id
+a1_task }o--|| res_company : company_id
+a1_task }o--|| res_users : owner_id
+a1_task }o--|| res_users : prep_done_by
+a1_task }o--|| res_users : review_done_by
+a1_task }o--|| res_users : reviewer_id
+a1_task }o--|| a1_tasklist : tasklist_id
+a1_task }o--|| a1_template : template_id
+a1_task }o--|| a1_workstream : workstream_id
+a1_task_checklist }o--|| res_users : done_by
+a1_task_checklist }o--|| a1_task : task_id
+a1_task_checklist }o--|| a1_template_checklist : template_item_id
+a1_task_checklist }o--|| ir_attachment : value_attachment_id
+a1_tasklist }o--|| close_cycle : close_cycle_id
+a1_tasklist }o--|| res_company : company_id
+a1_template }o--|| close_task_template : close_template_id
+a1_template }o--|| res_company : company_id
+a1_template }o--|| a1_workstream : workstream_id
+a1_template_check_rel }o--|| a1_check : check_id
+a1_template_check_rel }o--|| a1_template : template_id
+a1_template_checklist }o--|| a1_template : template_id
+a1_template_step }o--|| a1_template : template_id
+a1_workstream }o--|| close_task_category : close_category_id
+a1_workstream }o--|| res_company : company_id
+a1_workstream }o--|| a1_role : owner_role_id
+a1_workstream }o--|| res_users : owner_user_id
+advisor_playbook_category_ids_rel }o--|| advisor_category : advisor_category_id
+advisor_playbook_category_ids_rel }o--|| advisor_playbook : advisor_playbook_id
+advisor_recommendation }o--|| advisor_category : category_id
+advisor_recommendation }o--|| res_currency : currency_id
+advisor_recommendation }o--|| res_users : owner_id
+advisor_recommendation }o--|| advisor_playbook : playbook_id
+advisor_recommendation_tag_ids_rel }o--|| advisor_recommendation : advisor_recommendation_id
+advisor_recommendation_tag_ids_rel }o--|| advisor_tag : advisor_tag_id
+advisor_score }o--|| advisor_category : category_id
+bir_alphalist }o--|| res_company : company_id
+bir_alphalist }o--|| res_currency : currency_id
+bir_alphalist_line }o--|| bir_alphalist : alphalist_id
+bir_alphalist_line }o--|| res_currency : currency_id
+bir_alphalist_line }o--|| res_partner : partner_id
+bir_filing_deadline }o--|| res_company : company_id
+bir_filing_deadline }o--|| bir_tax_return : return_id
+bir_return }o--|| res_company : company_id
+bir_return }o--|| res_currency : currency_id
+bir_return }o--|| res_users : filed_by
+bir_return }o--|| finance_task : task_id
+bir_return_line }o--|| account_move : move_id
+bir_return_line }o--|| res_partner : partner_id
+bir_return_line }o--|| bir_return : return_id
+bir_tax_return }o--|| res_company : company_id
+bir_tax_return }o--|| res_currency : currency_id
+bir_tax_return }o--|| res_users : filed_by
+bir_tax_return_line }o--|| res_currency : currency_id
+bir_tax_return_line }o--|| account_move : move_id
+bir_tax_return_line }o--|| res_partner : partner_id
+bir_tax_return_line }o--|| bir_tax_return : return_id
+bir_vat_line }o--|| res_currency : currency_id
+bir_vat_line }o--|| account_move : invoice_id
+bir_vat_line }o--|| res_partner : partner_id
+bir_vat_line }o--|| bir_vat_return : return_id
+bir_withholding_line }o--|| res_currency : currency_id
+bir_withholding_line }o--|| account_move : move_id
+bir_withholding_line }o--|| res_partner : partner_id
+bir_withholding_line }o--|| hr_payslip : payslip_id
+bir_withholding_line }o--|| bir_withholding_return : return_id
+close_approval_gate }o--|| res_users : approved_by
+close_approval_gate }o--|| res_users : approver_id
+close_approval_gate }o--|| res_users : approver_user_id
+close_approval_gate }o--|| res_company : company_id
+close_approval_gate }o--|| close_cycle : cycle_id
+close_approval_gate }o--|| close_approval_gate_template : template_id
+close_approval_gate_blocking_exceptions_rel }o--|| close_approval_gate : close_approval_gate_id
+close_approval_gate_blocking_exceptions_rel }o--|| close_exception : close_exception_id
+close_approval_gate_blocking_tasks_rel }o--|| close_approval_gate : close_approval_gate_id
+close_approval_gate_blocking_tasks_rel }o--|| close_task : close_task_id
+close_approval_gate_template }o--|| a1_check : a1_check_id
+close_approval_gate_template }o--|| res_company : company_id
+close_cycle }o--|| a1_tasklist : a1_tasklist_id
+close_cycle }o--|| closing_period : closing_period_id
+close_cycle }o--|| res_company : company_id
+close_exception }o--|| res_users : assigned_to
+close_exception }o--|| res_company : company_id
+close_exception }o--|| res_currency : currency_id
+close_exception }o--|| close_cycle : cycle_id
+close_exception }o--|| res_users : detected_by
+close_exception }o--|| res_users : escalated_to
+close_exception }o--|| account_account : related_account_id
+close_exception }o--|| account_move : related_move_id
+close_exception }o--|| res_partner : related_partner_id
+close_exception }o--|| res_users : reported_by
+close_exception }o--|| res_users : resolved_by
+close_exception }o--|| close_task : task_id
+close_task }o--|| a1_task : a1_task_id
+close_task }o--|| res_users : approval_done_by
+close_task }o--|| res_users : approve_user_id
+close_task }o--|| res_users : approver_id
+close_task }o--|| close_task_category : category_id
+close_task }o--|| res_company : company_id
+close_task }o--|| close_cycle : cycle_id
+close_task }o--|| res_users : prep_done_by
+close_task }o--|| res_users : prep_user_id
+close_task }o--|| res_users : preparer_id
+close_task }o--|| res_users : review_done_by
+close_task }o--|| res_users : review_user_id
+close_task }o--|| res_users : reviewer_id
+close_task }o--|| close_task_template : template_id
+close_task_attachment_ids_rel }o--|| close_task : close_task_id
+close_task_attachment_ids_rel }o--|| ir_attachment : ir_attachment_id
+close_task_category }o--|| a1_workstream : a1_workstream_id
+close_task_category }o--|| res_company : company_id
+close_task_category_gl_account_ids_rel }o--|| account_account : account_account_id
+close_task_category_gl_account_ids_rel }o--|| close_task_category : close_task_category_id
+close_task_checklist }o--|| ir_attachment : attachment_id
+close_task_checklist }o--|| res_users : done_by
+close_task_checklist }o--|| close_task : task_id
+close_task_gl_entry_ids_rel }o--|| account_move : account_move_id
+close_task_gl_entry_ids_rel }o--|| close_task : close_task_id
+close_task_template }o--|| a1_template : a1_template_id
+close_task_template }o--|| res_users : approver_id
+close_task_template }o--|| close_task_category : category_id
+close_task_template }o--|| res_company : company_id
+close_task_template }o--|| res_users : default_approve_user_id
+close_task_template }o--|| res_users : default_prep_user_id
+close_task_template }o--|| res_users : default_review_user_id
+close_task_template }o--|| res_users : preparer_id
+close_task_template }o--|| res_users : reviewer_id
+close_task_template_checklist }o--|| close_task_template : template_id
+close_task_template_gl_account_ids_rel }o--|| account_account : account_account_id
+close_task_template_gl_account_ids_rel }o--|| close_task_template : close_task_template_id
+closing_period }o--|| res_company : company_id
+compliance_check }o--|| res_users : checked_by
+compliance_check }o--|| closing_period : closing_id
+crm_stage_required_fields_rel }o--|| ir_model_fields : field_id
+crm_stage_required_fields_rel }o--|| crm_stage : stage_id
+finance_bir_deadline }o--|| ipai_finance_person : responsible_approval_id
+finance_bir_deadline }o--|| ipai_finance_person : responsible_prep_id
+finance_bir_deadline }o--|| ipai_finance_person : responsible_review_id
+finance_ppm_logframe }o--|| finance_ppm_logframe : parent_id
+finance_ppm_tdi_audit }o--|| res_users : user_id
+finance_task }o--|| res_users : approve_done_by
+finance_task }o--|| res_users : approve_user_id
+finance_task }o--|| bir_return : bir_return_id
+finance_task }o--|| closing_period : closing_id
+finance_task }o--|| res_users : prep_done_by
+finance_task }o--|| res_users : prep_user_id
+finance_task }o--|| res_users : review_done_by
+finance_task }o--|| res_users : review_user_id
+finance_task }o--|| finance_task_template : template_id
+finance_task_template }o--|| res_users : approve_user_id
+finance_task_template }o--|| res_users : prep_user_id
+finance_task_template }o--|| res_users : review_user_id
+finance_task_template_dependency_rel }o--|| finance_task_template : depends_on_id
+finance_task_template_dependency_rel }o--|| finance_task_template : task_id
+hr_expense }o--|| project_project : project_id
+hr_expense }o--|| ipai_travel_request : travel_request_id
+ipai_asset }o--|| ipai_asset_checkout : active_checkout_id
+ipai_asset }o--|| ipai_asset_category : category_id
+ipai_asset }o--|| res_currency : currency_id
+ipai_asset }o--|| hr_employee : custodian_id
+ipai_asset }o--|| stock_location : location_id
+ipai_asset_checkout }o--|| res_users : approved_by
+ipai_asset_checkout }o--|| ipai_asset : asset_id
+ipai_asset_checkout }o--|| hr_employee : employee_id
+ipai_asset_reservation }o--|| ipai_asset : asset_id
+ipai_asset_reservation }o--|| hr_employee : employee_id
+ipai_audit_log }o--|| res_users : user_id
+ipai_bir_dat_wizard }o--|| res_currency : currency_id
+ipai_bir_form_schedule }o--|| ipai_finance_person : responsible_approval_id
+ipai_bir_form_schedule }o--|| ipai_finance_person : responsible_prep_id
+ipai_bir_form_schedule }o--|| ipai_finance_person : responsible_review_id
+ipai_bir_process_step }o--|| ipai_finance_person : person_id
+ipai_bir_process_step }o--|| ipai_bir_form_schedule : schedule_id
+ipai_bir_schedule_step }o--|| ipai_bir_schedule_item : item_id
+ipai_close_generated_map }o--|| ipai_close_generation_run : generation_run_id
+ipai_close_generated_map }o--|| ipai_close_generation_run : run_id
+ipai_close_generated_map }o--|| project_task : task_id
+ipai_close_generated_map }o--|| ipai_close_task_template : template_id
+ipai_close_generation_run }o--|| project_project : project_id
+ipai_close_generation_run }o--|| res_users : user_id
+ipai_close_task_step }o--|| ipai_close_task_template : template_id
+ipai_close_task_step }o--|| res_users : user_id
+ipai_convert_phases_wizard }o--|| project_project : parent_project_id
+ipai_equipment_asset }o--|| product_category : category_id
+ipai_equipment_asset }o--|| res_company : company_id
+ipai_equipment_asset }o--|| stock_location : location_id
+ipai_equipment_asset }o--|| product_product : product_id
+ipai_equipment_booking }o--|| ipai_equipment_asset : asset_id
+ipai_equipment_booking }o--|| res_users : borrower_id
+ipai_equipment_booking }o--|| project_project : project_id
+ipai_equipment_incident }o--|| ipai_equipment_asset : asset_id
+ipai_equipment_incident }o--|| ipai_equipment_booking : booking_id
+ipai_equipment_incident }o--|| res_users : reported_by
+ipai_finance_bir_schedule }o--|| project_task : approval_task_id
+ipai_finance_bir_schedule }o--|| res_users : approver_id
+ipai_finance_bir_schedule }o--|| ipai_finance_logframe : logframe_id
+ipai_finance_bir_schedule }o--|| project_task : prep_task_id
+ipai_finance_bir_schedule }o--|| project_task : review_task_id
+ipai_finance_bir_schedule }o--|| res_users : reviewer_id
+ipai_finance_bir_schedule }o--|| res_users : supervisor_id
+ipai_finance_directory }o--|| res_users : user_id
+ipai_finance_person }o--|| res_users : user_id
+ipai_finance_ppm_golive_checklist }o--|| res_users : created_by
+ipai_finance_ppm_golive_checklist }o--|| res_users : director_id
+ipai_finance_ppm_golive_checklist }o--|| res_users : senior_supervisor_id
+ipai_finance_ppm_golive_checklist }o--|| res_users : supervisor_id
+ipai_finance_ppm_golive_checklist_section_ids_rel }o--|| ipai_finance_ppm_golive_checklist : ipai_finance_ppm_golive_checklist_id
+ipai_finance_ppm_golive_checklist_section_ids_rel }o--|| ipai_finance_ppm_golive_section : ipai_finance_ppm_golive_section_id
+ipai_finance_ppm_golive_item }o--|| res_users : checked_by
+ipai_finance_ppm_golive_item }o--|| ipai_finance_ppm_golive_section : section_id
+ipai_finance_task_template }o--|| ipai_finance_person : approved_by_id
+ipai_finance_task_template }o--|| finance_bir_deadline : bir_form_id
+ipai_finance_task_template }o--|| ipai_finance_person : employee_code_id
+ipai_finance_task_template }o--|| ipai_finance_person : reviewed_by_id
+ipai_generate_bir_tasks_wizard }o--|| project_project : program_project_id
+ipai_generate_im_projects_wizard }o--|| project_project : project_id
+ipai_generate_month_end_wizard }o--|| project_project : program_project_id
+ipai_grid_column }o--|| ipai_grid_view : grid_view_id
+ipai_grid_filter }o--|| ipai_grid_view : grid_view_id
+ipai_grid_filter }o--|| res_users : user_id
+ipai_grid_filter_condition }o--|| ipai_grid_filter : filter_id
+ipai_grid_view }o--|| ipai_grid_filter : active_filter_id
+ipai_grid_view }o--|| ir_model : model_id
+ipai_grid_view_visible_columns_rel }o--|| ipai_grid_column : column_id
+ipai_grid_view_visible_columns_rel }o--|| ipai_grid_view : grid_view_id
+ipai_localization_overlay }o--|| ipai_workstream : workstream_id
+ipai_month_end_closing }o--|| res_company : company_id
+ipai_month_end_task }o--|| res_users : approve_done_by
+ipai_month_end_task }o--|| res_users : approve_user_id
+ipai_month_end_task }o--|| ipai_month_end_closing : closing_id
+ipai_month_end_task }o--|| res_users : prep_done_by
+ipai_month_end_task }o--|| res_users : prep_user_id
+ipai_month_end_task }o--|| res_users : review_done_by
+ipai_month_end_task }o--|| res_users : review_user_id
+ipai_month_end_task }o--|| ipai_month_end_task_template : template_id
+ipai_month_end_task_template }o--|| res_users : approve_user_id
+ipai_month_end_task_template }o--|| res_users : prep_user_id
+ipai_month_end_task_template }o--|| res_users : review_user_id
+ipai_month_end_template_step }o--|| ipai_month_end_template : template_id
+ipai_permission }o--|| res_groups : group_id
+ipai_permission }o--|| res_users : user_id
+ipai_ppm_task }o--|| ipai_ppm_template : template_id
+ipai_ppm_task_checklist }o--|| ipai_ppm_task : task_id
+ipai_ppm_tasklist }o--|| ipai_ppm_template : template_id
+ipai_ppm_tasklist }o--|| ipai_workstream : workstream_id
+ipai_ppm_taskrun }o--|| res_users : approver_id
+ipai_ppm_taskrun }o--|| res_users : assignee_id
+ipai_ppm_taskrun }o--|| ipai_ppm_task : task_id
+ipai_ppm_taskrun }o--|| ipai_ppm_tasklist : tasklist_id
+ipai_ppm_template }o--|| ipai_workstream : workstream_id
+ipai_share_token }o--|| res_users : created_by
+ipai_stc_check }o--|| ipai_stc_worklist_type : worklist_type_id
+ipai_stc_check }o--|| ipai_workstream : workstream_id
+ipai_stc_scenario }o--|| ipai_workstream : workstream_id
+ipai_stc_scenario_check_ids_rel }o--|| ipai_stc_check : ipai_stc_check_id
+ipai_stc_scenario_check_ids_rel }o--|| ipai_stc_scenario : ipai_stc_scenario_id
+ipai_studio_ai_history }o--|| base_automation : automation_id
+ipai_studio_ai_history }o--|| ir_model_fields : field_id
+ipai_studio_ai_history }o--|| ir_model : model_id
+ipai_studio_ai_history }o--|| res_users : user_id
+ipai_studio_ai_wizard }o--|| ir_model : context_model_id
+ipai_studio_ai_wizard }o--|| ir_model_fields : created_field_id
+ipai_studio_ai_wizard }o--|| ipai_studio_ai_history : history_id
+ipai_studio_ai_wizard }o--|| ir_model : relation_model_id
+ipai_studio_ai_wizard }o--|| ir_model : target_model_id
+ipai_task_template_dependency_rel }o--|| ipai_month_end_task_template : depends_on_id
+ipai_task_template_dependency_rel }o--|| ipai_month_end_task_template : task_id
+ipai_travel_request }o--|| res_company : company_id
+ipai_travel_request }o--|| res_currency : currency_id
+ipai_travel_request }o--|| hr_employee : employee_id
+ipai_travel_request }o--|| project_project : project_id
+ipai_workos_block }o--|| ir_attachment : attachment_id
+ipai_workos_block }o--|| ipai_workos_page : page_id
+ipai_workos_block }o--|| ipai_workos_block : parent_block_id
+ipai_workos_canvas }o--|| ipai_workos_page : page_id
+ipai_workos_comment }o--|| res_users : author_id
+ipai_workos_comment }o--|| ipai_workos_comment : parent_id
+ipai_workos_comment }o--|| res_users : resolved_by
+ipai_workos_database }o--|| ipai_workos_page : page_id
+ipai_workos_database }o--|| ipai_workos_space : space_id
+ipai_workos_page }o--|| res_users : last_edited_by
+ipai_workos_page }o--|| ipai_workos_page : parent_id
+ipai_workos_page }o--|| ipai_workos_space : space_id
+ipai_workos_page }o--|| ipai_workos_template : template_id
+ipai_workos_page }o--|| ipai_workos_workspace : workspace_id
+ipai_workos_property }o--|| ipai_workos_database : database_id
+ipai_workos_property }o--|| ipai_workos_database : related_database_id
+ipai_workos_row }o--|| ipai_workos_database : database_id
+ipai_workos_search_history }o--|| res_users : user_id
+ipai_workos_space }o--|| ipai_workos_workspace : workspace_id
+ipai_workos_template_tag_ids_rel }o--|| ipai_workos_template : ipai_workos_template_id
+ipai_workos_template_tag_ids_rel }o--|| ipai_workos_template_tag : ipai_workos_template_tag_id
+ipai_workos_view }o--|| ipai_workos_database : database_id
+ipai_workos_view }o--|| ipai_workos_property : date_property_id
+ipai_workos_view }o--|| ipai_workos_property : group_by_property_id
+ipai_workos_view }o--|| res_users : user_id
+ipai_workos_view_visible_property_ids_rel }o--|| ipai_workos_property : ipai_workos_property_id
+ipai_workos_view_visible_property_ids_rel }o--|| ipai_workos_view : ipai_workos_view_id
+ipai_workos_workspace }o--|| res_users : owner_id
+ipai_workspace }o--|| res_users : account_manager_id
+ipai_workspace }o--|| res_partner : client_id
+ipai_workspace }o--|| res_company : company_id
+ipai_workspace }o--|| ipai_workspace : parent_id
+ipai_workspace_link }o--|| ipai_workspace : workspace_id
+ph_holiday }o--|| res_company : company_id
+ppm_close_task }o--|| ppm_monthly_close : monthly_close_id
+ppm_close_task }o--|| ppm_close_template : template_id
+ppm_kpi_snapshot }o--|| ppm_portfolio : portfolio_id
+ppm_kpi_snapshot }o--|| ppm_program : program_id
+ppm_kpi_snapshot }o--|| project_project : project_id
+ppm_portfolio }o--|| res_currency : currency_id
+ppm_portfolio }o--|| res_users : owner_id
+ppm_portfolio }o--|| res_users : sponsor_id
+ppm_program }o--|| res_currency : currency_id
+ppm_program }o--|| ppm_portfolio : portfolio_id
+ppm_program }o--|| res_users : program_manager_id
+ppm_program }o--|| res_users : sponsor_id
+ppm_program_project_rel }o--|| ppm_program : program_id
+ppm_program_project_rel }o--|| ppm_program : program_id
+ppm_program_project_rel }o--|| project_project : project_id
+ppm_program_project_rel }o--|| project_project : project_id
+ppm_resource_allocation }o--|| hr_employee : employee_id
+ppm_resource_allocation }o--|| ppm_program : program_id
+ppm_resource_allocation }o--|| project_project : project_id
+ppm_resource_allocation }o--|| project_task : task_id
+ppm_risk }o--|| res_users : assigned_to_id
+ppm_risk }o--|| res_currency : currency_id
+ppm_risk }o--|| res_users : owner_id
+ppm_risk }o--|| ppm_portfolio : portfolio_id
+ppm_risk }o--|| ppm_program : program_id
+ppm_risk }o--|| project_project : project_id
+project_milestone }o--|| res_users : approver_id
+project_project }o--|| project_project : ipai_root_project_id
+project_project }o--|| project_project : parent_id
+project_project }o--|| project_category : portfolio_id
+project_task }o--|| res_users : approver_id
+project_task }o--|| ipai_finance_bir_schedule : bir_schedule_id
+project_task }o--|| res_users : fd_id
+project_task }o--|| ipai_finance_logframe : finance_logframe_id
+project_task }o--|| ipai_finance_person : finance_person_id
+project_task }o--|| res_users : finance_supervisor_id
+project_task }o--|| res_users : gate_approver_id
+project_task }o--|| project_milestone : gate_milestone_id
+project_task }o--|| ipai_finance_task_template : ipai_template_id
+project_task }o--|| res_users : reviewer_id
+project_task }o--|| res_users : sfm_id
+project_task_checklist_item }o--|| res_users : assigned_user_id
+res_config_settings }o--|| superset_connection : superset_connection_id
+res_partner }o--|| srm_supplier : srm_supplier_id
+srm_qualification }o--|| res_users : approver_id
+srm_qualification }o--|| res_users : reviewer_id
+srm_qualification }o--|| srm_supplier : supplier_id
+srm_qualification_checklist }o--|| res_users : completed_by
+srm_qualification_checklist }o--|| srm_qualification : qualification_id
+srm_qualification_document_ids_rel }o--|| ir_attachment : ir_attachment_id
+srm_qualification_document_ids_rel }o--|| srm_qualification : srm_qualification_id
+srm_scorecard }o--|| res_users : evaluator_id
+srm_scorecard }o--|| srm_supplier : supplier_id
+srm_scorecard_line }o--|| srm_kpi_category : kpi_category_id
+srm_scorecard_line }o--|| srm_scorecard : scorecard_id
+srm_supplier }o--|| res_currency : currency_id
+srm_supplier }o--|| srm_scorecard : latest_scorecard_id
+srm_supplier }o--|| res_partner : partner_id
+srm_supplier }o--|| res_partner : primary_contact_id
+srm_supplier }o--|| res_partner : sales_contact_id
+srm_supplier_category_ids_rel }o--|| product_category : product_category_id
+srm_supplier_category_ids_rel }o--|| srm_supplier : srm_supplier_id
+superset_bulk_dataset_wizard }o--|| superset_connection : connection_id
+superset_dataset }o--|| superset_connection : connection_id
+superset_dataset }o--|| ir_model : model_id
+superset_dataset_column }o--|| superset_dataset : dataset_id
+superset_dataset_field_ids_rel }o--|| ir_model_fields : ir_model_fields_id
+superset_dataset_field_ids_rel }o--|| superset_dataset : superset_dataset_id
+superset_dataset_wizard }o--|| superset_connection : connection_id
+superset_dataset_wizard }o--|| ir_model : model_id
+superset_dataset_wizard_field_ids_rel }o--|| ir_model_fields : ir_model_fields_id
+superset_dataset_wizard_field_ids_rel }o--|| superset_dataset_wizard : superset_dataset_wizard_id
+workos_comment_mention_rel }o--|| ipai_workos_comment : comment_id
+workos_comment_mention_rel }o--|| res_users : user_id
+workspace_member_rel }o--|| res_users : user_id
+workspace_member_rel }o--|| ipai_workos_workspace : workspace_id
+@enduml

--- a/docs/data-model/ODOO_MODEL_INDEX.json
+++ b/docs/data-model/ODOO_MODEL_INDEX.json
@@ -1,0 +1,24690 @@
+{
+  "models": [
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "check_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "close_gate_template_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.approval.gate.template",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "fail_action",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "pass_criteria",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "severity",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "a1.template",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "a1.check",
+      "python_constraints": [],
+      "relations": [
+        "a1.template",
+        "close.approval.gate.template",
+        "res.company"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Check code must be unique per company.",
+          "name": "code_uniq",
+          "sql": "unique(code, company_id)"
+        },
+        {
+          "message": "Check code must be unique per company.",
+          "name": "code_uniq",
+          "sql": "unique(code, company_id)"
+        }
+      ],
+      "table": "a1_check"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "attachment_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ir.attachment",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "check_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "a1.check",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "evidence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "executed_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "executed_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "result",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "result_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "task_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "a1.task",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "a1.check.result",
+      "python_constraints": [],
+      "relations": [
+        "a1.check",
+        "a1.task",
+        "ir.attachment",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "a1_check_result"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "created_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "error_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "log",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "run_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "seed_hash",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "seed_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "unchanged_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "updated_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "webhook_url",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "a1.export.run",
+      "python_constraints": [],
+      "relations": [
+        "res.company"
+      ],
+      "sql_constraints": [],
+      "table": "a1_export_run"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "default_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "fallback_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "group_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.groups",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "a1.role",
+      "python_constraints": [],
+      "relations": [
+        "res.company",
+        "res.groups",
+        "res.users"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Role code must be unique per company.",
+          "name": "code_uniq",
+          "sql": "unique(code, company_id)"
+        },
+        {
+          "message": "Role code must be unique per company.",
+          "name": "code_uniq",
+          "sql": "unique(code, company_id)"
+        }
+      ],
+      "table": "a1_role"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_done_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_done_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "checklist_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "a1.task.checklist",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": "_compute_checklist_progress",
+          "index": false,
+          "name": "checklist_progress",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "close_task_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.task",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": "tasklist_id.company_id",
+          "relation": "res.company",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "external_key",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "owner_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "owner_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_done_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_done_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_done_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_done_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "reviewer_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "reviewer_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "tasklist_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "a1.tasklist",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "a1.template",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "workstream_id",
+          "ondelete": null,
+          "related": "template_id.workstream_id",
+          "relation": "a1.workstream",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "a1.task",
+      "python_constraints": [],
+      "relations": [
+        "a1.task.checklist",
+        "a1.tasklist",
+        "a1.template",
+        "a1.workstream",
+        "close.task",
+        "res.company",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "a1_task"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "done_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "done_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_done",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_required",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "item_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "task_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "a1.task",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_item_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "a1.template.checklist",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "value_attachment_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ir.attachment",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "value_text",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "a1.task.checklist",
+      "python_constraints": [],
+      "relations": [
+        "a1.task",
+        "a1.template.checklist",
+        "ir.attachment",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "a1_task_checklist"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "close_cycle_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.cycle",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_end",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_period_label",
+          "index": false,
+          "name": "period_label",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_start",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "progress",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "task_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "task_done_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "a1.task",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "webhook_url",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "a1.tasklist",
+      "python_constraints": [],
+      "relations": [
+        "a1.task",
+        "close.cycle",
+        "res.company"
+      ],
+      "sql_constraints": [
+        {
+          "message": "A tasklist for this period already exists.",
+          "name": "period_uniq",
+          "sql": "unique(period_start, period_end, company_id)"
+        },
+        {
+          "message": "A tasklist for this period already exists.",
+          "name": "period_uniq",
+          "sql": "unique(period_start, period_end, company_id)"
+        }
+      ],
+      "table": "a1_tasklist"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "checklist_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "a1.template.checklist",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "close_template_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.task.template",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "owner_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "phase_code",
+          "ondelete": null,
+          "related": "workstream_id.phase_code",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "reviewer_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "step_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "a1.template.step",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": "_compute_total_days",
+          "index": false,
+          "name": "total_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "workstream_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "a1.workstream",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "a1.template",
+      "python_constraints": [],
+      "relations": [
+        "a1.template.checklist",
+        "a1.template.step",
+        "a1.workstream",
+        "close.task.template",
+        "res.company"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Template code must be unique per company.",
+          "name": "code_uniq",
+          "sql": "unique(code, company_id)"
+        },
+        {
+          "message": "Template code must be unique per company.",
+          "name": "code_uniq",
+          "sql": "unique(code, company_id)"
+        }
+      ],
+      "table": "a1_template"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "instructions",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_required",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "item_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "template_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "a1.template",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "a1.template.checklist",
+      "python_constraints": [],
+      "relations": [
+        "a1.template"
+      ],
+      "sql_constraints": [],
+      "table": "a1_template_checklist"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "assignee_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "deadline_offset_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "effort_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "template_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "a1.template",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "a1.template.step",
+      "python_constraints": [],
+      "relations": [
+        "a1.template"
+      ],
+      "sql_constraints": [],
+      "table": "a1_template_step"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "close_category_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.task.category",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "owner_role_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "a1.role",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_owner_user",
+          "index": false,
+          "name": "owner_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "phase_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_template_count",
+          "index": false,
+          "name": "template_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "a1.template",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "a1.workstream",
+      "python_constraints": [],
+      "relations": [
+        "a1.role",
+        "a1.template",
+        "close.task.category",
+        "res.company",
+        "res.users"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Workstream code must be unique per company.",
+          "name": "code_uniq",
+          "sql": "unique(code, company_id)"
+        },
+        {
+          "message": "Workstream code must be unique per company.",
+          "name": "code_uniq",
+          "sql": "unique(code, company_id)"
+        }
+      ],
+      "table": "a1_workstream"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_2307_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_2307_generated",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": "_compute_ewt_amount",
+          "index": false,
+          "name": "ewt_amount",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        }
+      ],
+      "inherits": [
+        "account.move"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "account.move",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "account_move"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "color",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": "_compute_recommendation_count",
+          "index": false,
+          "name": "high_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "icon",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_latest_score",
+          "index": false,
+          "name": "latest_score",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_recommendation_count",
+          "index": false,
+          "name": "open_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_recommendation_count",
+          "index": false,
+          "name": "recommendation_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "recommendation_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "advisor.recommendation",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "advisor.category",
+      "python_constraints": [],
+      "relations": [
+        "advisor.recommendation"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Category code must be unique!",
+          "name": "code_unique",
+          "sql": "UNIQUE(code)"
+        },
+        {
+          "message": "Category code must be unique!",
+          "name": "code_unique",
+          "sql": "UNIQUE(code)"
+        }
+      ],
+      "table": "advisor_category"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "automation_kind",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "automation_params",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "automation_ref",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "category_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "advisor.category",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_recommendation_count",
+          "index": false,
+          "name": "recommendation_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "recommendation_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "advisor.recommendation",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "steps_md",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "advisor.playbook",
+      "python_constraints": [],
+      "relations": [
+        "advisor.category",
+        "advisor.recommendation"
+      ],
+      "sql_constraints": [],
+      "table": "advisor_playbook"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "category_code",
+          "ondelete": null,
+          "related": "category_id.code",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "category_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "advisor.category",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "confidence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_due",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_resolved",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "estimated_savings",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "evidence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "external_link",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "impact_score",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "owner_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "playbook_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "advisor.playbook",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "remediation_steps",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "resource_ref",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "resource_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "severity",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_severity_order",
+          "index": false,
+          "name": "severity_order",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "snooze_until",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "source",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tag_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "advisor.tag",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "advisor.recommendation",
+      "python_constraints": [],
+      "relations": [
+        "advisor.category",
+        "advisor.playbook",
+        "advisor.tag",
+        "res.currency",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "advisor_recommendation"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": true,
+          "name": "as_of",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "category_code",
+          "ondelete": null,
+          "related": "category_id.code",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "category_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "advisor.category",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "critical_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "high_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "inputs_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "open_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "resolved_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "score",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "advisor.score",
+      "python_constraints": [],
+      "relations": [
+        "advisor.category"
+      ],
+      "sql_constraints": [],
+      "table": "advisor_score"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "color",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "advisor.tag",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [
+        {
+          "message": "Tag name must be unique!",
+          "name": "name_unique",
+          "sql": "UNIQUE(name)"
+        },
+        {
+          "message": "Tag name must be unique!",
+          "name": "name_unique",
+          "sql": "UNIQUE(name)"
+        }
+      ],
+      "table": "advisor_tag"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "fiscal_year",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "form_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "line_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "bir.alphalist.line",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_totals",
+          "index": false,
+          "name": "total_gross",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": "_compute_totals",
+          "index": false,
+          "name": "total_wht",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        }
+      ],
+      "inherits": [
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_bir_tax_compliance",
+      "name": "bir.alphalist",
+      "python_constraints": [],
+      "relations": [
+        "bir.alphalist.line",
+        "res.company",
+        "res.currency"
+      ],
+      "sql_constraints": [],
+      "table": "bir_alphalist"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "alphalist_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "bir.alphalist",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": "alphalist_id.currency_id",
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "gross_income",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "income_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "partner_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.partner",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tin",
+          "ondelete": null,
+          "related": "partner_id.tin",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "wht_amount",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_bir_tax_compliance",
+      "name": "bir.alphalist.line",
+      "python_constraints": [],
+      "relations": [
+        "bir.alphalist",
+        "res.currency",
+        "res.partner"
+      ],
+      "sql_constraints": [],
+      "table": "bir_alphalist_line"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "deadline_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "form_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_month",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_year",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_reminder_date",
+          "index": false,
+          "name": "reminder_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "return_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "bir.tax.return",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_state",
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_bir_tax_compliance",
+      "name": "bir.filing.deadline",
+      "python_constraints": [],
+      "relations": [
+        "bir.tax.return",
+        "res.company"
+      ],
+      "sql_constraints": [],
+      "table": "bir_filing_deadline"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_reference",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "exempt_sales",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "filed_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "filed_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "form_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "input_vat",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "interest",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "line_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "bir.return.line",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": "_compute_name",
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "output_vat",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "payment_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "payment_reference",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "penalty",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_end",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_start",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "finance.task",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tax_base",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tax_credits",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tax_due",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": "_compute_tax_payable",
+          "index": false,
+          "name": "tax_payable",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": "_compute_total_due",
+          "index": false,
+          "name": "total_due",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "total_payments",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "total_wht",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "vatable_sales",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "zero_rated_sales",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_tbwa_finance",
+      "name": "bir.return",
+      "python_constraints": [],
+      "relations": [
+        "bir.return.line",
+        "finance.task",
+        "res.company",
+        "res.currency",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "bir_return"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "amount",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": "return_id.currency_id",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "move_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "account.move",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "partner_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.partner",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "return_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "bir.return",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tax_amount",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tin",
+          "ondelete": null,
+          "related": "partner_id.tin",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_tbwa_finance",
+      "name": "bir.return.line",
+      "python_constraints": [],
+      "relations": [
+        "account.move",
+        "bir.return",
+        "res.partner"
+      ],
+      "sql_constraints": [],
+      "table": "bir_return_line"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_reference",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_days_until_due",
+          "index": false,
+          "name": "days_until_due",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_due_date",
+          "index": false,
+          "name": "due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "filed_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "filed_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "form_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_frequency",
+          "index": false,
+          "name": "frequency",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "interest",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": "_compute_days_until_due",
+          "index": false,
+          "name": "is_overdue",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "line_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "bir.tax.return.line",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "payment_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "payment_reference",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "penalty",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_end",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_start",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tax_base",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": "_compute_tax_category",
+          "index": false,
+          "name": "tax_category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tax_credits",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tax_due",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": "_compute_tax_payable",
+          "index": false,
+          "name": "tax_payable",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": "_compute_total_amount_due",
+          "index": false,
+          "name": "total_amount_due",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_bir_tax_compliance",
+      "name": "bir.tax.return",
+      "python_constraints": [],
+      "relations": [
+        "bir.tax.return.line",
+        "res.company",
+        "res.currency",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "bir_tax_return"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": "return_id.currency_id",
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "move_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "account.move",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "partner_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.partner",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "return_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "bir.tax.return",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tax_amount",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tax_base",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tax_rate",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tin",
+          "ondelete": null,
+          "related": "partner_id.tin",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_bir_tax_compliance",
+      "name": "bir.tax.return.line",
+      "python_constraints": [],
+      "relations": [
+        "account.move",
+        "bir.tax.return",
+        "res.currency",
+        "res.partner"
+      ],
+      "sql_constraints": [],
+      "table": "bir_tax_return_line"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "amount_untaxed",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": "return_id.currency_id",
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "invoice_date",
+          "ondelete": null,
+          "related": "invoice_id.invoice_date",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "invoice_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "account.move",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "line_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "partner_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.partner",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "return_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "bir.vat.return",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tin",
+          "ondelete": null,
+          "related": "partner_id.tin",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "vat_amount",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "vat_category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_bir_tax_compliance",
+      "name": "bir.vat.line",
+      "python_constraints": [],
+      "relations": [
+        "account.move",
+        "bir.vat.return",
+        "res.currency",
+        "res.partner"
+      ],
+      "sql_constraints": [],
+      "table": "bir_vat_line"
+    },
+    {
+      "fields": [
+        {
+          "compute": "_compute_net_vat",
+          "index": false,
+          "name": "excess_input_vat",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "excess_input_vat_previous",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "exempt_sales",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "importations",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": "_compute_net_vat",
+          "index": false,
+          "name": "net_vat_payable",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": "_compute_output_vat",
+          "index": false,
+          "name": "output_vat",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "purchase_of_services",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": "_compute_total_input_vat",
+          "index": false,
+          "name": "total_input_vat",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": "_compute_total_sales",
+          "index": false,
+          "name": "total_sales",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "vatable_purchases",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "vatable_sales",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "zero_rated_sales",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        }
+      ],
+      "inherits": [
+        "bir.tax.return"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_bir_tax_compliance",
+      "name": "bir.vat.return",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "bir_vat_return"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": "return_id.currency_id",
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "gross_income",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "income_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "move_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "account.move",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "partner_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.partner",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "payslip_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "hr.payslip",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "return_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "bir.withholding.return",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tin",
+          "ondelete": null,
+          "related": "partner_id.tin",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "wht_amount",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "wht_rate",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_bir_tax_compliance",
+      "name": "bir.withholding.line",
+      "python_constraints": [],
+      "relations": [
+        "account.move",
+        "bir.withholding.return",
+        "hr.payslip",
+        "res.currency",
+        "res.partner"
+      ],
+      "sql_constraints": [],
+      "table": "bir_withholding_line"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "compensation_tax_withheld",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "employee_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "expanded_wht_amount",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "final_wht_amount",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "line_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "bir.withholding.line",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "taxable_compensation",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "total_compensation",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "total_payments",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "withholding_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [
+        "bir.tax.return"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_bir_tax_compliance",
+      "name": "bir.withholding.return",
+      "python_constraints": [],
+      "relations": [
+        "bir.withholding.line"
+      ],
+      "sql_constraints": [],
+      "table": "bir_withholding_return"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "actual_value",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approved_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approved_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "block_on_exceptions",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "block_reason",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "blocking_exceptions",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.exception",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "blocking_reason",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "blocking_tasks",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.task",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": "cycle_id.company_id",
+          "relation": "res.company",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "cycle_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "close.cycle",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "gate_level",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "gate_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "min_completion_pct",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "required_approvals",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "required_task_states",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.approval.gate.template",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "threshold_value",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "close.approval.gate",
+      "python_constraints": [],
+      "relations": [
+        "close.approval.gate.template",
+        "close.cycle",
+        "close.exception",
+        "close.task",
+        "res.company",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "close_approval_gate"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "a1_check_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "a1.check",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "gate_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "pass_criteria",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "close.approval.gate.template",
+      "python_constraints": [],
+      "relations": [
+        "a1.check",
+        "res.company"
+      ],
+      "sql_constraints": [],
+      "table": "close_approval_gate_template"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "a1_tasklist_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "a1.tasklist",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "close_actual_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "close_start_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "close_target_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "closing_period_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "closing.period",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_cycle_time",
+          "index": false,
+          "name": "cycle_time_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_exception_count",
+          "index": false,
+          "name": "exception_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "exception_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.exception",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "gate_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.approval.gate",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": "_compute_gates_ready",
+          "index": false,
+          "name": "gates_ready",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": "_compute_exception_count",
+          "index": false,
+          "name": "open_exception_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_end",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_period_label",
+          "index": false,
+          "name": "period_label",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_start",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "progress",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "task_completion_pct",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "task_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "task_done_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.task",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "webhook_url",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "close.cycle",
+      "python_constraints": [],
+      "relations": [
+        "a1.tasklist",
+        "close.approval.gate",
+        "close.exception",
+        "close.task",
+        "closing.period",
+        "res.company"
+      ],
+      "sql_constraints": [
+        {
+          "message": "A cycle for this period already exists.",
+          "name": "period_uniq",
+          "sql": "unique(period_start, period_end, company_id)"
+        },
+        {
+          "message": "A cycle for this period already exists.",
+          "name": "period_uniq",
+          "sql": "unique(period_start, period_end, company_id)"
+        }
+      ],
+      "table": "close_cycle"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "amount",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "assigned_to",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": "cycle_id.company_id",
+          "relation": "res.company",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "cycle_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "close.cycle",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "detected_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "detected_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "escalated_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "escalated_to",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "escalation_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "escalation_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "escalation_level",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "exception_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "last_escalated",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "related_account_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "account.account",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "related_move_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "account.move",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "related_partner_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.partner",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "reported_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "resolution",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "resolution_action",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "resolved_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "resolved_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "root_cause",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "severity",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "task_id",
+          "ondelete": "set null",
+          "related": null,
+          "relation": "close.task",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "variance_pct",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "close.exception",
+      "python_constraints": [],
+      "relations": [
+        "account.account",
+        "account.move",
+        "close.cycle",
+        "close.task",
+        "res.company",
+        "res.currency",
+        "res.partner",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "close_exception"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "a1_task_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "a1.task",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_done_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_done_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_done_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "attachment_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ir.attachment",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "category_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.task.category",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_checklist_pct",
+          "index": false,
+          "name": "checklist_done_pct",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "checklist_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.task.checklist",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": "_compute_checklist_progress",
+          "index": false,
+          "name": "checklist_progress",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": "cycle_id.company_id",
+          "relation": "res.company",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "cycle_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "close.cycle",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_is_overdue",
+          "index": false,
+          "name": "days_overdue",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "exception_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.exception",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "external_key",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_gl_entry_count",
+          "index": false,
+          "name": "gl_entry_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "gl_entry_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "account.move",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": "_compute_has_exceptions",
+          "index": false,
+          "name": "has_exceptions",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": "_compute_has_open_exceptions",
+          "index": false,
+          "name": "has_open_exceptions",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": "_compute_is_overdue",
+          "index": false,
+          "name": "is_overdue",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_done_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_done_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "preparer_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_done_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_done_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_result",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "reviewer_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.task.template",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "close.task",
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "close.task",
+      "python_constraints": [],
+      "relations": [
+        "a1.task",
+        "account.move",
+        "close.cycle",
+        "close.exception",
+        "close.task.category",
+        "close.task.checklist",
+        "close.task.template",
+        "ir.attachment",
+        "res.company",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "close_task"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "a1_workstream_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "a1.workstream",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "color",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "default_approve_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "default_approve_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "default_prep_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "default_prep_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "default_review_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "default_review_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "gl_account_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "account.account",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.task.template",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "close.task.category",
+      "python_constraints": [],
+      "relations": [
+        "a1.workstream",
+        "account.account",
+        "close.task.template",
+        "res.company"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Category code must be unique",
+          "name": "category_code_unique",
+          "sql": "unique(code)"
+        },
+        {
+          "message": "Category code must be unique per company.",
+          "name": "code_uniq",
+          "sql": "unique(code, company_id)"
+        },
+        {
+          "message": "Category code must be unique per company.",
+          "name": "code_uniq",
+          "sql": "unique(code, company_id)"
+        }
+      ],
+      "table": "close_task_category"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "attachment_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ir.attachment",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "done_at",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "done_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "done_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "evidence_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "instructions",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_done",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_required",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "required",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "close.task",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "close.task.checklist",
+      "python_constraints": [],
+      "relations": [
+        "close.task",
+        "ir.attachment",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "close_task_checklist"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "a1_template_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "a1.template",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_day_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "category_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.task.category",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "checklist_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "close.task.template.checklist",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "creates_gl_entry",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "default_approve_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "default_prep_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "default_review_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "gl_account_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "account.account",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_day_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "preparer_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "preparer_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_day_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "reviewer_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "reviewer_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "close.task.template",
+      "python_constraints": [],
+      "relations": [
+        "a1.template",
+        "account.account",
+        "close.task.category",
+        "close.task.template.checklist",
+        "res.company",
+        "res.users"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Template code must be unique per company.",
+          "name": "code_uniq",
+          "sql": "unique(code, company_id)"
+        },
+        {
+          "message": "Template code must be unique per company.",
+          "name": "code_uniq",
+          "sql": "unique(code, company_id)"
+        },
+        {
+          "message": "Template code must be unique",
+          "name": "template_code_unique",
+          "sql": "unique(code)"
+        }
+      ],
+      "table": "close_task_template"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "evidence_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "instructions",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_required",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "required",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "close.task.template",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "close.task.template.checklist",
+      "python_constraints": [],
+      "relations": [
+        "close.task.template"
+      ],
+      "sql_constraints": [],
+      "table": "close_task_template_checklist"
+    },
+    {
+      "fields": [
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "bir_tasks",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "completed_tasks",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_last_workday",
+          "index": false,
+          "name": "last_workday",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "month_end_tasks",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_name",
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "overdue_tasks",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_period_parts",
+          "index": false,
+          "name": "period_month",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_period_parts",
+          "index": false,
+          "name": "period_year",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "progress",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "finance.task",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "total_tasks",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_tbwa_finance",
+      "name": "closing.period",
+      "python_constraints": [],
+      "relations": [
+        "finance.task",
+        "res.company"
+      ],
+      "sql_constraints": [],
+      "table": "closing_period"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "actual_value",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "check_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "checked_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "checked_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "closing_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "closing.period",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "expected_value",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "result_text",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tolerance",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": "_compute_variance",
+          "index": false,
+          "name": "variance",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_tbwa_finance",
+      "name": "compliance.check",
+      "python_constraints": [],
+      "relations": [
+        "closing.period",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "compliance_check"
+    },
+    {
+      "fields": [
+        {
+          "compute": "_compute_days_in_stage",
+          "index": false,
+          "name": "days_in_stage",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "last_call_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "last_meeting_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "stage_entry_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": "_compute_stage_rule_validated",
+          "index": false,
+          "name": "stage_missing_fields",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_stage_rule_validated",
+          "index": false,
+          "name": "stage_rule_validated",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        }
+      ],
+      "inherits": [
+        "crm.lead"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_crm_pipeline",
+      "name": "crm.lead",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "crm_lead"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "ipai_automation_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "ipai_enforce_rules",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "ipai_required_field_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ir.model.fields",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "ipai_sla_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "ipai_stage_color",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "ipai_stage_icon",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [
+        "crm.stage"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_crm_pipeline",
+      "name": "crm.stage",
+      "python_constraints": [],
+      "relations": [
+        "ir.model.fields"
+      ],
+      "sql_constraints": [],
+      "table": "crm_stage"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_ai_channel",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        }
+      ],
+      "inherits": [
+        "discuss.channel"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_ask_ai",
+      "name": "discuss.channel",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "discuss_channel"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "deadline_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": "_compute_display_name",
+          "index": false,
+          "name": "display_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "form_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_covered",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "responsible_approval_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.person",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "responsible_prep_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.person",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "responsible_review_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.person",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_targets",
+          "index": false,
+          "name": "target_payment_approval_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_targets",
+          "index": false,
+          "name": "target_prep_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_targets",
+          "index": false,
+          "name": "target_report_approval_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "finance.bir.deadline",
+      "python_constraints": [],
+      "relations": [
+        "ipai.finance.person"
+      ],
+      "sql_constraints": [],
+      "table": "finance_bir_deadline"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "filing_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "form_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "form_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "responsible_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "finance.ppm.bir.calendar",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [
+        {
+          "message": "BIR form and period combination must be unique!",
+          "name": "unique_form_period",
+          "sql": "UNIQUE(form_code, period)"
+        },
+        {
+          "message": "BIR form and period combination must be unique!",
+          "name": "unique_form_period",
+          "sql": "UNIQUE(form_code, period)"
+        }
+      ],
+      "table": "finance_ppm_bir_calendar"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "failures_24h",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "last_message",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "last_run_at",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "last_status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "next_scheduled_at",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_status_color",
+          "index": false,
+          "name": "status_color",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "total_runs",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "workflow_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "finance.ppm.dashboard",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "finance_ppm_dashboard"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "error_log",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "file_data",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Binary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "file_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_file_type",
+          "index": false,
+          "name": "file_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "import_summary",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "import_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "records_created",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "records_failed",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "records_skipped",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "records_updated",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "skip_header",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "update_existing",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "finance.ppm.import.wizard",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "finance_ppm_import_wizard"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "child_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "finance.ppm.logframe",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "kpi_baseline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "kpi_measure",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "kpi_target",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "level",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "measurement_frequency",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "parent_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "finance.ppm.logframe",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "parent_path",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "responsible_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "finance.ppm.logframe",
+      "python_constraints": [
+        "_check_parent_hierarchy"
+      ],
+      "relations": [
+        "finance.ppm.logframe"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Logframe code must be unique!",
+          "name": "unique_code",
+          "sql": "UNIQUE(code)"
+        },
+        {
+          "message": "Logframe code must be unique!",
+          "name": "unique_code",
+          "sql": "UNIQUE(code)"
+        }
+      ],
+      "table": "finance_ppm_logframe"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "holiday_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_nationwide",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "finance.ppm.ph.holiday",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [
+        {
+          "message": "Holiday date and name combination must be unique!",
+          "name": "unique_date_name",
+          "sql": "UNIQUE(date, name)"
+        },
+        {
+          "message": "Holiday date and name combination must be unique!",
+          "name": "unique_date_name",
+          "sql": "UNIQUE(date, name)"
+        }
+      ],
+      "table": "finance_ppm_ph_holiday"
+    },
+    {
+      "fields": [
+        {
+          "compute": "_compute_display_name",
+          "index": false,
+          "name": "display_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "error_log",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "file_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_has_errors",
+          "index": false,
+          "name": "has_errors",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "import_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "import_summary",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "import_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "records_created",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "records_failed",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "records_skipped",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "records_updated",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_success_rate",
+          "index": false,
+          "name": "success_rate",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": "_compute_total_records",
+          "index": false,
+          "name": "total_records",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "user_id",
+          "ondelete": "restrict",
+          "related": null,
+          "relation": "res.users",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "finance.ppm.tdi.audit",
+      "python_constraints": [],
+      "relations": [
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "finance_ppm_tdi_audit"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_done",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_done_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_done_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_form_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_reference",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_return_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "bir.return",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "closing_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "closing.period",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": "closing_id.company_id",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_overdue",
+          "index": false,
+          "name": "days_overdue",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "filed_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "filing_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_overdue",
+          "index": false,
+          "name": "is_overdue",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "phase",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_done",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_done_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_done_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_done",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_done_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_done_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_state",
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "finance.task.template",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_tbwa_finance",
+      "name": "finance.task",
+      "python_constraints": [],
+      "relations": [
+        "bir.return",
+        "closing.period",
+        "finance.task.template",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "finance_task"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_day_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_form_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "depends_on_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "finance.task.template",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "filing_day_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "frequency",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "oca_module",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "odoo_model",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "phase",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_day_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_day_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_task_count",
+          "index": false,
+          "name": "task_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_tbwa_finance",
+      "name": "finance.task.template",
+      "python_constraints": [],
+      "relations": [
+        "finance.task.template",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "finance_task_template"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "x_master_control_offboarded",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "x_master_control_onboarded",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        }
+      ],
+      "inherits": [
+        "hr.employee",
+        "master.control.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "hr.employee",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "hr_employee"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "project_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.project",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_requires_project",
+          "index": false,
+          "name": "requires_project",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "travel_request_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.travel.request",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "x_master_control_submitted",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        }
+      ],
+      "inherits": [
+        "hr.expense",
+        "master.control.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "hr.expense",
+      "python_constraints": [
+        "_check_project_required",
+        "_check_travel_request_consistency"
+      ],
+      "relations": [
+        "ipai.travel.request",
+        "project.project"
+      ],
+      "sql_constraints": [],
+      "table": "hr_expense"
+    },
+    {
+      "fields": [],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.ai.studio.mixin",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ipai_ai_studio_mixin"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_requested",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_requested_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_requested_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": "_compute_current_approver",
+          "index": false,
+          "name": "current_approver_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_platform_approvals",
+      "name": "ipai.approval.mixin",
+      "python_constraints": [],
+      "relations": [
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_approval_mixin"
+    },
+    {
+      "fields": [],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_ask_ai",
+      "name": "ipai.ask.ai.service",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ipai_ask_ai_service"
+    },
+    {
+      "fields": [
+        {
+          "compute": "_compute_active_checkout",
+          "index": false,
+          "name": "active_checkout_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.asset.checkout",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "barcode",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "category_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.asset.category",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "checkout_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.asset.checkout",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_current_value",
+          "index": false,
+          "name": "current_value",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "custodian_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "hr.employee",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "image",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Image"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "location_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "stock.location",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "purchase_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "purchase_value",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "reservation_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.asset.reservation",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.asset",
+      "python_constraints": [],
+      "relations": [
+        "hr.employee",
+        "ipai.asset.category",
+        "ipai.asset.checkout",
+        "ipai.asset.reservation",
+        "res.currency",
+        "stock.location"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_asset"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "allow_reservations",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": "_compute_asset_count",
+          "index": false,
+          "name": "asset_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "asset_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.asset",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "max_checkout_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "requires_approval",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.asset.category",
+      "python_constraints": [],
+      "relations": [
+        "ipai.asset"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_asset_category"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "actual_return_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approved_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "asset_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.asset",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "checkout_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "checkout_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "condition_on_return",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "employee_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "hr.employee",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "expected_return_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_name",
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "return_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.asset.checkout",
+      "python_constraints": [
+        "_check_asset_available"
+      ],
+      "relations": [
+        "hr.employee",
+        "ipai.asset",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_asset_checkout"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "asset_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.asset",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "employee_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "hr.employee",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "end_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_name",
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "start_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.asset.reservation",
+      "python_constraints": [
+        "_check_dates",
+        "_check_overlap"
+      ],
+      "relations": [
+        "hr.employee",
+        "ipai.asset"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_asset_reservation"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "action",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_display_name",
+          "index": false,
+          "name": "display_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "field_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "new_value",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "old_value",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "res_id",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "res_model",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "res_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_platform_audit",
+      "name": "ipai.audit.log",
+      "python_constraints": [],
+      "relations": [
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_audit_log"
+    },
+    {
+      "fields": [
+        {
+          "compute": "_compute_audit_log_count",
+          "index": false,
+          "name": "audit_log_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "audit_log_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.audit.log",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_platform_audit",
+      "name": "ipai.audit.mixin",
+      "python_constraints": [],
+      "relations": [
+        "ipai.audit.log"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_audit_mixin"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_end",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_start",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "file_data",
+          "ondelete": null,
+          "related": null,
+          "relation": "DAT File",
+          "required": false,
+          "store": true,
+          "type": "Binary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "file_name",
+          "ondelete": null,
+          "related": null,
+          "relation": "File Name",
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "record_count",
+          "ondelete": null,
+          "related": null,
+          "relation": "Records Processed",
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "report_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "total_amount",
+          "ondelete": null,
+          "related": null,
+          "relation": "Total Income",
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "total_tax",
+          "ondelete": null,
+          "related": null,
+          "relation": "Total Tax Withheld",
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.bir.dat.wizard",
+      "python_constraints": [],
+      "relations": [
+        "DAT File",
+        "File Name",
+        "Records Processed",
+        "Total Income",
+        "Total Tax Withheld",
+        "res.currency"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_bir_dat_wizard"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "form_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "responsible_approval_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.person",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "responsible_prep_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.person",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "responsible_review_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.person",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "step_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.bir.process.step",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.bir.form.schedule",
+      "python_constraints": [],
+      "relations": [
+        "ipai.bir.process.step",
+        "ipai.finance.person"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_bir_form_schedule"
+    },
+    {
+      "fields": [],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.bir.generator",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ipai_bir_generator"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "detail",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "person_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.person",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "schedule_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.bir.form.schedule",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "step_no",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "target_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "title",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.bir.process.step",
+      "python_constraints": [],
+      "relations": [
+        "ipai.bir.form.schedule",
+        "ipai.finance.person"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_bir_process_step"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "bir_form",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "im_xml_id",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "period_covered",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "step_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.bir.schedule.step",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.bir.schedule.item",
+      "python_constraints": [],
+      "relations": [
+        "ipai.bir.schedule.step"
+      ],
+      "sql_constraints": [
+        {
+          "message": "BIR schedule item must be unique per form/period/deadline!",
+          "name": "bir_schedule_unique",
+          "sql": "unique(bir_form, period_covered, deadline)"
+        },
+        {
+          "message": "BIR schedule item must be unique per form/period/deadline!",
+          "name": "bir_schedule_unique",
+          "sql": "unique(bir_form, period_covered, deadline)"
+        }
+      ],
+      "table": "ipai_bir_schedule_item"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_by_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "bir_form",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "deadline_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_label",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_by_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_by_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.bir.schedule.line",
+      "python_constraints": [
+        "_check_dates"
+      ],
+      "relations": [],
+      "sql_constraints": [
+        {
+          "message": "BIR form+period must be unique.",
+          "name": "bir_sched_unique",
+          "sql": "unique(bir_form, period_label)"
+        },
+        {
+          "message": "BIR form+period must be unique.",
+          "name": "bir_sched_unique",
+          "sql": "unique(bir_form, period_label)"
+        }
+      ],
+      "table": "ipai_bir_schedule_line"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "activity_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "business_days_before",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "item_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.bir.schedule.item",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "on_or_before_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "role_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.bir.schedule.step",
+      "python_constraints": [],
+      "relations": [
+        "ipai.bir.schedule.item"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_bir_schedule_step"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": true,
+          "name": "external_key",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "generation_run_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.close.generation.run",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "operation",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "run_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.close.generation.run",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "seed_hash",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "seed_hash_at_generation",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "task_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "project.task",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_id",
+          "ondelete": "set null",
+          "related": null,
+          "relation": "ipai.close.task.template",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.close.generated.map",
+      "python_constraints": [],
+      "relations": [
+        "ipai.close.generation.run",
+        "ipai.close.task.template",
+        "project.task"
+      ],
+      "sql_constraints": [
+        {
+          "message": "External key must be unique (prevents duplicate task creation)",
+          "name": "external_key_uniq",
+          "sql": "UNIQUE(external_key)"
+        },
+        {
+          "message": "External key must be unique (prevents duplicate task creation)",
+          "name": "external_key_uniq",
+          "sql": "UNIQUE(external_key)"
+        },
+        {
+          "message": "External key must be unique.",
+          "name": "external_key_uniq",
+          "sql": "unique(external_key)"
+        },
+        {
+          "message": "External key must be unique.",
+          "name": "external_key_uniq",
+          "sql": "unique(external_key)"
+        }
+      ],
+      "table": "ipai_close_generated_map"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "created_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "cycle_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "cycle_key",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_cycle_type",
+          "index": false,
+          "name": "cycle_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "dry_run",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": "_compute_duration",
+          "index": false,
+          "name": "duration_seconds",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "end_time",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": "_compute_counts",
+          "index": false,
+          "name": "error_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "generated_map_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.close.generated.map",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "generated_task_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.close.generated.map",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": "_compute_name",
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "obsolete_marked_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_end",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_start",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "project_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.project",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "report_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Json"
+        },
+        {
+          "compute": "_compute_report_status",
+          "index": false,
+          "name": "report_status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "seed_id",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "seed_version",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "start_time",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_count_created",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_count_obsolete",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_count_skipped",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_count_updated",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "unchanged_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "unresolved_assignee_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "updated_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_counts",
+          "index": false,
+          "name": "warning_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.close.generation.run",
+      "python_constraints": [],
+      "relations": [
+        "ipai.close.generated.map",
+        "project.project",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_close_generation_run"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.close.generator",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ipai_close_generator"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "default_employee_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "step_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "step_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "template_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.close.task.template",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_user",
+          "index": false,
+          "name": "user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "x_legacy_template_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.close.task.step",
+      "python_constraints": [],
+      "relations": [
+        "ipai.close.task.template",
+        "res.users"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Each template can only have one instance of each step code (PREP, REVIEW, APPROVAL, FILE_PAY)",
+          "name": "unique_template_step",
+          "sql": "UNIQUE(template_id, step_code)"
+        },
+        {
+          "message": "Each template can only have one instance of each step code (PREP, REVIEW, APPROVAL, FILE_PAY)",
+          "name": "unique_template_step",
+          "sql": "UNIQUE(template_id, step_code)"
+        }
+      ],
+      "table": "ipai_close_task_step"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": true,
+          "name": "category_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "category_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "category_seq",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "critical_path",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "cycle_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "duration_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "employee_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "is_active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "offset_from_period_end",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "phase_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "phase_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "phase_seq",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "phase_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "recurrence_rule",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "responsible_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_seed_hash",
+          "index": true,
+          "name": "seed_hash",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "step_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "step_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.close.task.step",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "step_seq",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_name_template",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "template_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_seq",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_version",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "wbs_code_template",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "workstream_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "workstream_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "workstream_seq",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "x_legacy_migration",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.close.task.template",
+      "python_constraints": [],
+      "relations": [
+        "ipai.close.task.step"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Template code + version must be unique",
+          "name": "template_code_uniq",
+          "sql": "UNIQUE(template_code, template_version)"
+        },
+        {
+          "message": "Template code + version must be unique",
+          "name": "template_code_uniq",
+          "sql": "UNIQUE(template_code, template_version)"
+        }
+      ],
+      "table": "ipai_close_task_template"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "im1_keywords",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "im1_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "im2_keywords",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "im2_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "move_tasks_by_keyword",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "parent_project_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.project",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.convert.phases.wizard",
+      "python_constraints": [],
+      "relations": [
+        "project.project"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_convert_phases_wizard"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "email",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_user_id",
+          "index": false,
+          "name": "user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": false,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.directory.person",
+      "python_constraints": [],
+      "relations": [
+        "res.users"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Directory code must be unique!",
+          "name": "code_unique",
+          "sql": "unique(code)"
+        },
+        {
+          "message": "Directory code must be unique!",
+          "name": "code_unique",
+          "sql": "unique(code)"
+        }
+      ],
+      "table": "ipai_directory_person"
+    },
+    {
+      "fields": [
+        {
+          "compute": "_compute_booking_count",
+          "index": false,
+          "name": "booking_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "category_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "product.category",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "condition",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "image_1920",
+          "ondelete": null,
+          "related": null,
+          "relation": "Image",
+          "required": false,
+          "store": true,
+          "type": "Image"
+        },
+        {
+          "compute": "_compute_incident_count",
+          "index": false,
+          "name": "incident_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "location_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "stock.location",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "product_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "product.product",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "serial_number",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.equipment.asset",
+      "python_constraints": [],
+      "relations": [
+        "Image",
+        "product.category",
+        "product.product",
+        "res.company",
+        "stock.location"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_equipment_asset"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "asset_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.equipment.asset",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "borrower_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "end_datetime",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": "_compute_is_overdue",
+          "index": false,
+          "name": "is_overdue",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "project_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.project",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "start_datetime",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.equipment.booking",
+      "python_constraints": [
+        "_check_booking_conflict"
+      ],
+      "relations": [
+        "ipai.equipment.asset",
+        "project.project",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_equipment_booking"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "asset_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.equipment.asset",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "booking_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.equipment.booking",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "reported_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "severity",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.equipment.incident",
+      "python_constraints": [],
+      "relations": [
+        "ipai.equipment.asset",
+        "ipai.equipment.booking",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_equipment_incident"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "export_path",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "webhook_url",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_ppm_a1",
+      "name": "ipai.export.seed.wizard",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ipai_export_seed_wizard"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_task_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.task",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "completion_pct",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "filing_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "logframe_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.logframe",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_covered",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_task_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.task",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_task_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.task",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "reviewer_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "supervisor_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.finance.bir_schedule",
+      "python_constraints": [],
+      "relations": [
+        "ipai.finance.logframe",
+        "project.task",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_finance_bir_schedule"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "email",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.finance.directory",
+      "python_constraints": [
+        "_check_email"
+      ],
+      "relations": [
+        "res.users"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Directory code must be unique.",
+          "name": "code_uniq",
+          "sql": "unique(code)"
+        },
+        {
+          "message": "Directory code must be unique.",
+          "name": "code_uniq",
+          "sql": "unique(code)"
+        }
+      ],
+      "table": "ipai_finance_directory"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "assumptions",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_schedule_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.bir_schedule",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "indicators",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "level",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "means_of_verification",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_task_count",
+          "index": false,
+          "name": "task_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.task",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.finance.logframe",
+      "python_constraints": [],
+      "relations": [
+        "ipai.finance.bir_schedule",
+        "project.task"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_finance_logframe"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "email",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.finance.person",
+      "python_constraints": [],
+      "relations": [
+        "res.users"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Personnel code must be unique!",
+          "name": "code_unique",
+          "sql": "unique(code)"
+        },
+        {
+          "message": "Personnel code must be unique!",
+          "name": "code_unique",
+          "sql": "unique(code)"
+        }
+      ],
+      "table": "ipai_finance_person"
+    },
+    {
+      "fields": [
+        {
+          "compute": "_compute_progress",
+          "index": false,
+          "name": "completed_items",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_progress",
+          "index": false,
+          "name": "completion_pct",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "create_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "created_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "director_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "director_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "director_review_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "director_signoff_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "section_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.ppm.golive.section",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "senior_supervisor_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "senior_supervisor_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "senior_supervisor_review_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "supervisor_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "supervisor_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "supervisor_review_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": "_compute_progress",
+          "index": false,
+          "name": "total_items",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "version",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "write_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_finance_ppm_golive",
+      "name": "ipai.finance.ppm.golive.checklist",
+      "python_constraints": [],
+      "relations": [
+        "ipai.finance.ppm.golive.section",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_finance_ppm_golive_checklist"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "checked_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "checked_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "evidence_url",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_checked",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_critical",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "section_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.finance.ppm.golive.section",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_finance_ppm_golive",
+      "name": "ipai.finance.ppm.golive.item",
+      "python_constraints": [],
+      "relations": [
+        "ipai.finance.ppm.golive.section",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_finance_ppm_golive_item"
+    },
+    {
+      "fields": [
+        {
+          "compute": "_compute_progress",
+          "index": false,
+          "name": "completed_items",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_progress",
+          "index": false,
+          "name": "completion_pct",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "item_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.ppm.golive.item",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "section_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_progress",
+          "index": false,
+          "name": "total_items",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_finance_ppm_golive",
+      "name": "ipai.finance.ppm.golive.section",
+      "python_constraints": [],
+      "relations": [
+        "ipai.finance.ppm.golive.item"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_finance_ppm_golive_section"
+    },
+    {
+      "fields": [],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.finance.seed.service",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ipai_finance_seed_service"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "strict",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.finance.seed.wizard",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ipai_finance_seed_wizard"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "anchor",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_duration",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_by_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approved_by_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.person",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_form_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "finance.bir.deadline",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "day_of_month",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "default_duration_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "employee_code_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.person",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "offset_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_by_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_duration",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_by_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_duration",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "reviewed_by_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.person",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "task_category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "trigger_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.finance.task.template",
+      "python_constraints": [],
+      "relations": [
+        "finance.bir.deadline",
+        "ipai.finance.person"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Template name must be unique per category.",
+          "name": "tmpl_name_unique",
+          "sql": "unique(name, category)"
+        },
+        {
+          "message": "Template name must be unique per category.",
+          "name": "tmpl_name_unique",
+          "sql": "unique(name, category)"
+        }
+      ],
+      "table": "ipai_finance_task_template"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_from",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_to",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "dry_run",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "program_project_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.project",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.generate.bir.tasks.wizard",
+      "python_constraints": [],
+      "relations": [
+        "project.project"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_generate_bir_tasks_wizard"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "create_bir_tasks",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "create_children",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "create_month_end_tasks",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "project_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.project",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.generate.im.projects.wizard",
+      "python_constraints": [],
+      "relations": [
+        "project.project"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_generate_im_projects_wizard"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "anchor_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "dry_run",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "program_project_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.project",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.generate.month.end.wizard",
+      "python_constraints": [],
+      "relations": [
+        "project.project"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_generate_month_end_wizard"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "alignment",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "cell_css_class",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "clickable",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "column_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "css_class",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_field",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_format",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "decimal_places",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_display_name",
+          "index": false,
+          "name": "display_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "editable",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "field_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "field_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "filterable",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "format_string",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "grid_view_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.grid.view",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "header_css_class",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_action_column",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_avatar_column",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_primary",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_selection_column",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "label",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "max_width",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "min_width",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "resizable",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "searchable",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sortable",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "visible",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "widget_options",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "width",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_grid_view",
+      "name": "ipai.grid.column",
+      "python_constraints": [],
+      "relations": [
+        "ipai.grid.view"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_grid_column"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "color",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_condition_count",
+          "index": false,
+          "name": "condition_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "domain",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "filter_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "grid_view_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.grid.view",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "icon",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_default",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_global",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_grid_view",
+      "name": "ipai.grid.filter",
+      "python_constraints": [],
+      "relations": [
+        "ipai.grid.view",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_grid_filter"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "field_label",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "field_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "field_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "filter_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.grid.filter",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "operator",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "value_boolean",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "value_char",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "value_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "value_datetime",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "value_float",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "value_integer",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "value_many2one",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "value_selection",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_grid_view",
+      "name": "ipai.grid.filter.condition",
+      "python_constraints": [],
+      "relations": [
+        "ipai.grid.filter"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_grid_filter_condition"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "active_filter_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.grid.filter",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_column_count",
+          "index": false,
+          "name": "column_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "column_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.grid.column",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "config_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "enable_column_reorder",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "enable_column_resize",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "enable_export",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "enable_quick_search",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "enable_row_selection",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "filter_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.grid.filter",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "model_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ir.model",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "model_name",
+          "ondelete": null,
+          "related": "model_id.model",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "page_size",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "page_size_options",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "show_checkboxes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "show_row_numbers",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sort_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "view_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "visible_column_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.grid.column",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_grid_view",
+      "name": "ipai.grid.view",
+      "python_constraints": [],
+      "relations": [
+        "ipai.grid.column",
+        "ipai.grid.filter",
+        "ir.model"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_grid_view"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "mode",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "seed_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Text"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_ppm_a1",
+      "name": "ipai.import.seed.wizard",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ipai_import_seed_wizard"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "applies_to_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "country",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "patch_payload",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "patch_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "workstream_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workstream",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_ppm_a1",
+      "name": "ipai.localization.overlay",
+      "python_constraints": [],
+      "relations": [
+        "ipai.workstream"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_localization_overlay"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_progress",
+          "index": false,
+          "name": "completed_tasks",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_last_workday",
+          "index": false,
+          "name": "last_workday",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_overdue",
+          "index": false,
+          "name": "overdue_tasks",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_progress",
+          "index": false,
+          "name": "progress",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.month.end.task",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": "_compute_progress",
+          "index": false,
+          "name": "total_tasks",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_month_end",
+      "name": "ipai.month.end.closing",
+      "python_constraints": [],
+      "relations": [
+        "ipai.month.end.task",
+        "res.company"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_month_end_closing"
+    },
+    {
+      "fields": [],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.month.end.generator",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ipai_month_end_generator"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_done",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_done_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_done_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "closing_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.month.end.closing",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_days_overdue",
+          "index": false,
+          "name": "days_overdue",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_days_overdue",
+          "index": false,
+          "name": "is_overdue",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": "Notes",
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "phase",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_done",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_done_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_done_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_done",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_done_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_done_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_state",
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_id",
+          "ondelete": "set null",
+          "related": null,
+          "relation": "ipai.month.end.task.template",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_month_end",
+      "name": "ipai.month.end.task",
+      "python_constraints": [],
+      "relations": [
+        "Notes",
+        "ipai.month.end.closing",
+        "ipai.month.end.task.template",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_month_end_task"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_day_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approve_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "depends_on_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.month.end.task.template",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": "Description",
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "oca_module",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "odoo_model",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "phase",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_day_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_day_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_task_count",
+          "index": false,
+          "name": "task_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_month_end",
+      "name": "ipai.month.end.task.template",
+      "python_constraints": [],
+      "relations": [
+        "Description",
+        "ipai.month.end.task.template",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_month_end_task_template"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "default_im_xml_id",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "step_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.month.end.template.step",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "task_base_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.month.end.template",
+      "python_constraints": [],
+      "relations": [
+        "ipai.month.end.template.step"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Task base name must be unique!",
+          "name": "task_base_name_unique",
+          "sql": "unique(task_base_name)"
+        },
+        {
+          "message": "Task base name must be unique!",
+          "name": "task_base_name_unique",
+          "sql": "unique(task_base_name)"
+        }
+      ],
+      "table": "ipai_month_end_template"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "activity_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "business_days_before",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "offset_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "role_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.month.end.template",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.month.end.template.step",
+      "python_constraints": [],
+      "relations": [
+        "ipai.month.end.template"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_month_end_template_step"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "group_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "res.groups",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "permission_level",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "scope_ref",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Reference"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "scope_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "user_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_platform_permissions",
+      "name": "ipai.permission",
+      "python_constraints": [],
+      "relations": [
+        "res.groups",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_permission"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": true,
+          "name": "date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "holiday_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_year",
+          "index": false,
+          "name": "year",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_month_end",
+      "name": "ipai.ph.holiday",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [
+        {
+          "message": "Holiday already exists for this date!",
+          "name": "date_unique",
+          "sql": "UNIQUE(date)"
+        }
+      ],
+      "table": "ipai_ph_holiday"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "checklist_line_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.ppm.task.checklist",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "due_offset_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "evidence_required",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "owner_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "phase",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "requires_approval",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sap_reference",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "template_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.ppm.template",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_ppm_a1",
+      "name": "ipai.ppm.task",
+      "python_constraints": [],
+      "relations": [
+        "ipai.ppm.task.checklist",
+        "ipai.ppm.template"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Task code must be unique per template.",
+          "name": "task_code_unique",
+          "sql": "unique(code, template_id)"
+        }
+      ],
+      "table": "ipai_ppm_task"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "evidence_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "label",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "required",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "task_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.ppm.task",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_ppm_a1",
+      "name": "ipai.ppm.task.checklist",
+      "python_constraints": [],
+      "relations": [
+        "ipai.ppm.task"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_ppm_task_checklist"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_end",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_start",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "taskrun_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.ppm.taskrun",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "template_id",
+          "ondelete": "restrict",
+          "related": null,
+          "relation": "ipai.ppm.template",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "workstream_id",
+          "ondelete": "restrict",
+          "related": null,
+          "relation": "ipai.workstream",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_ppm_a1",
+      "name": "ipai.ppm.tasklist",
+      "python_constraints": [],
+      "relations": [
+        "ipai.ppm.taskrun",
+        "ipai.ppm.template",
+        "ipai.workstream"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_ppm_tasklist"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_id",
+          "ondelete": "set null",
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "assignee_id",
+          "ondelete": "set null",
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "done_at",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "started_at",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "task_id",
+          "ondelete": "restrict",
+          "related": null,
+          "relation": "ipai.ppm.task",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "tasklist_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.ppm.tasklist",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_ppm_a1",
+      "name": "ipai.ppm.taskrun",
+      "python_constraints": [],
+      "relations": [
+        "ipai.ppm.task",
+        "ipai.ppm.tasklist",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_ppm_taskrun"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.ppm.task",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "version",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "workstream_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workstream",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_ppm_a1",
+      "name": "ipai.ppm.template",
+      "python_constraints": [],
+      "relations": [
+        "ipai.ppm.task",
+        "ipai.workstream"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Template code must be unique per workstream.",
+          "name": "template_code_unique",
+          "sql": "unique(code, workstream_id)"
+        }
+      ],
+      "table": "ipai_ppm_template"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "export_path",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "exported_at",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "payload_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "webhook_status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "webhook_url",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_ppm_a1",
+      "name": "ipai.repo.export_run",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ipai_repo_export_run"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "created_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "expires_at",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_public",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "permission_level",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "scope_ref",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Reference"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "scope_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_platform_permissions",
+      "name": "ipai.share.token",
+      "python_constraints": [],
+      "relations": [
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_share_token"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "auto_run",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "rule_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sap_reference",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "severity",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "worklist_type_id",
+          "ondelete": "set null",
+          "related": null,
+          "relation": "ipai.stc.worklist_type",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "workstream_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workstream",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_ppm_a1",
+      "name": "ipai.stc.check",
+      "python_constraints": [],
+      "relations": [
+        "ipai.stc.worklist_type",
+        "ipai.workstream"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Check code must be unique.",
+          "name": "stc_check_code_unique",
+          "sql": "unique(code)"
+        }
+      ],
+      "table": "ipai_stc_check"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_forms",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "check_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.stc.check",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "frequency",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "run_day_offset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sap_reference",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "workstream_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workstream",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_ppm_a1",
+      "name": "ipai.stc.scenario",
+      "python_constraints": [],
+      "relations": [
+        "ipai.stc.check",
+        "ipai.workstream"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Scenario code must be unique.",
+          "name": "stc_scenario_code_unique",
+          "sql": "unique(code)"
+        }
+      ],
+      "table": "ipai_stc_scenario"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_ppm_a1",
+      "name": "ipai.stc.worklist_type",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [
+        {
+          "message": "Worklist type code must be unique.",
+          "name": "stc_worklist_code_unique",
+          "sql": "unique(code)"
+        }
+      ],
+      "table": "ipai_stc_worklist_type"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "analysis",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "automation_id",
+          "ondelete": "set null",
+          "related": null,
+          "relation": "base.automation",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "command",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "command_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "confidence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "feedback_comment",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "feedback_score",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "field_id",
+          "ondelete": "set null",
+          "related": null,
+          "relation": "ir.model.fields",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "model_id",
+          "ondelete": "set null",
+          "related": null,
+          "relation": "ir.model",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "model_name",
+          "ondelete": null,
+          "related": "model_id.model",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "result",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "result_message",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.studio.ai.history",
+      "python_constraints": [],
+      "relations": [
+        "base.automation",
+        "ir.model",
+        "ir.model.fields",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_studio_ai_history"
+    },
+    {
+      "fields": [],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.studio.ai.service",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ipai_studio_ai_service"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "avg_confidence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "command_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "executed_commands",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "failed_commands",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "total_commands",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.studio.ai.stats",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": null
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "analysis_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "command",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "command_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "confidence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "context_model_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ir.model",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "created_field_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ir.model.fields",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "field_label",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "field_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "field_required",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "field_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "history_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.studio.ai.history",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_ready",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "message",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "relation_model_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ir.model",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "result_message",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "selection_options",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "target_model_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ir.model",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.studio.ai.wizard",
+      "python_constraints": [],
+      "relations": [
+        "ipai.studio.ai.history",
+        "ir.model",
+        "ir.model.fields"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_studio_ai_wizard"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "destination",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "employee_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "hr.employee",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "end_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "estimated_budget",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "project_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.project",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "purpose",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "start_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.travel.request",
+      "python_constraints": [],
+      "relations": [
+        "hr.employee",
+        "project.project",
+        "res.company",
+        "res.currency"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_travel_request"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": true,
+          "name": "workflow_state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "workflow_state_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "workflow_state_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_platform_workflow",
+      "name": "ipai.workflow.mixin",
+      "python_constraints": [],
+      "relations": [
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_workflow_mixin"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "attachment_id",
+          "ondelete": "set null",
+          "related": null,
+          "relation": "ir.attachment",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "block_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "callout_color",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "callout_icon",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "child_block_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.workos.block",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": "_compute_content_html",
+          "index": false,
+          "name": "content_html",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "content_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": "_compute_content_text",
+          "index": false,
+          "name": "content_text",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_checked",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_collapsed",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": "_compute_name",
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "page_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workos.page",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "parent_block_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workos.block",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_workos_blocks",
+      "name": "ipai.workos.block",
+      "python_constraints": [
+        "_check_content_json"
+      ],
+      "relations": [
+        "ipai.workos.block",
+        "ipai.workos.page",
+        "ir.attachment"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_workos_block"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "nodes_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "page_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workos.page",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "viewport_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_workos_canvas",
+      "name": "ipai.workos.canvas",
+      "python_constraints": [],
+      "relations": [
+        "ipai.workos.page"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_workos_canvas"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "anchor_block_id",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "author_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "child_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.workos.comment",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "content",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": "_compute_content_text",
+          "index": false,
+          "name": "content_text",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_resolved",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "mentioned_user_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "parent_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workos.comment",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_reply_count",
+          "index": false,
+          "name": "reply_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "resolved_at",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "resolved_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "target_id",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "target_model",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_target_name",
+          "index": false,
+          "name": "target_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_workos_collab",
+      "name": "ipai.workos.comment",
+      "python_constraints": [],
+      "relations": [
+        "ipai.workos.comment",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_workos_comment"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "icon",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "page_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workos.page",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "property_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.workos.property",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": "_compute_row_count",
+          "index": false,
+          "name": "row_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "row_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.workos.row",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "space_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workos.space",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_workos_db",
+      "name": "ipai.workos.database",
+      "python_constraints": [],
+      "relations": [
+        "ipai.workos.page",
+        "ipai.workos.property",
+        "ipai.workos.row",
+        "ipai.workos.space"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_workos_database"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": "_compute_child_count",
+          "index": false,
+          "name": "child_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "child_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.workos.page",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": "_compute_content_preview",
+          "index": false,
+          "name": "content_preview",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "cover_image",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Binary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "icon",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_archived",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": "_compute_last_edited",
+          "index": false,
+          "name": "last_edited_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "parent_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workos.page",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "parent_path",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_space_id",
+          "index": false,
+          "name": "space_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workos.space",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.workos.template",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "workspace_id",
+          "ondelete": null,
+          "related": "space_id.workspace_id",
+          "relation": "ipai.workos.workspace",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_workos_core",
+      "name": "ipai.workos.page",
+      "python_constraints": [],
+      "relations": [
+        "ipai.workos.page",
+        "ipai.workos.space",
+        "ipai.workos.template",
+        "ipai.workos.workspace",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_workos_page"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "database_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workos.database",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_title",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_visible",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "options_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "property_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "related_database_id",
+          "ondelete": "set null",
+          "related": null,
+          "relation": "ipai.workos.database",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "width",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_workos_db",
+      "name": "ipai.workos.property",
+      "python_constraints": [],
+      "relations": [
+        "ipai.workos.database"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_workos_property"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "database_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workos.database",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_name",
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "values_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_workos_db",
+      "name": "ipai.workos.row",
+      "python_constraints": [],
+      "relations": [
+        "ipai.workos.database"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_workos_row"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "block_results",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "database_results",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "page_results",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "query",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "scope",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "scope_id",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_workos_search",
+      "name": "ipai.workos.search",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ipai_workos_search"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "query",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "result_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_workos_search",
+      "name": "ipai.workos.search.history",
+      "python_constraints": [],
+      "relations": [
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_workos_search_history"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "color",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "icon",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_page_count",
+          "index": false,
+          "name": "page_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "page_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.workos.page",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "visibility",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "workspace_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workos.workspace",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_workos_core",
+      "name": "ipai.workos.space",
+      "python_constraints": [],
+      "relations": [
+        "ipai.workos.page",
+        "ipai.workos.workspace"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_workos_space"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "blocks_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "icon",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_published",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_system",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "properties_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tag_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.workos.template.tag",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "views_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_workos_templates",
+      "name": "ipai.workos.template",
+      "python_constraints": [],
+      "relations": [
+        "ipai.workos.template.tag"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_workos_template"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "color",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_workos_templates",
+      "name": "ipai.workos.template.tag",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ipai_workos_template_tag"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "config_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "database_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workos.database",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_property_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.workos.property",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "filter_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "group_by_property_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.workos.property",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_default",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_shared",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sort_json",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "view_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "visible_property_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.workos.property",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_workos_views",
+      "name": "ipai.workos.view",
+      "python_constraints": [],
+      "relations": [
+        "ipai.workos.database",
+        "ipai.workos.property",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_workos_view"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "color",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "icon",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "member_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "owner_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_space_count",
+          "index": false,
+          "name": "space_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "space_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.workos.space",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_workos_core",
+      "name": "ipai.workos.workspace",
+      "python_constraints": [],
+      "relations": [
+        "ipai.workos.space",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ipai_workos_workspace"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "account_manager_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "brand_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "campaign_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "channel_mix",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "child_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.workspace",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "client_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.partner",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "closing_stage",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "color",
+          "ondelete": null,
+          "related": null,
+          "relation": "Color Index",
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_end",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_start",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": "_compute_counters",
+          "index": false,
+          "name": "engagement_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "entity_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "fiscal_period",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "industry",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_counters",
+          "index": false,
+          "name": "invoice_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_critical",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "link_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.workspace.link",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "parent_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workspace",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "planned_hours",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "progress",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": "_compute_counters",
+          "index": false,
+          "name": "project_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "remaining_hours",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "stage",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "workspace_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [
+        "ipai.workspace",
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.workspace",
+      "python_constraints": [],
+      "relations": [
+        "Color Index",
+        "ipai.workspace",
+        "ipai.workspace.link",
+        "res.company",
+        "res.partner",
+        "res.users"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Workspace name must be unique per company.",
+          "name": "name_company_uniq",
+          "sql": "unique(name, company_id)"
+        },
+        {
+          "message": "Workspace name must be unique per company.",
+          "name": "name_company_uniq",
+          "sql": "unique(name, company_id)"
+        }
+      ],
+      "table": "ipai_workspace"
+    },
+    {
+      "fields": [
+        {
+          "compute": "_compute_display_name",
+          "index": false,
+          "name": "display_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "link_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "res_id",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "res_model",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "workspace_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ipai.workspace",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ipai.workspace.link",
+      "python_constraints": [],
+      "relations": [
+        "ipai.workspace"
+      ],
+      "sql_constraints": [
+        {
+          "message": "This record is already linked to the workspace.",
+          "name": "workspace_res_uniq",
+          "sql": "unique(workspace_id, res_model, res_id)"
+        },
+        {
+          "message": "This record is already linked to the workspace.",
+          "name": "workspace_res_uniq",
+          "sql": "unique(workspace_id, res_model, res_id)"
+        }
+      ],
+      "table": "ipai_workspace_link"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "check_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.stc.check",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "odoo_anchor",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "overlay_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.localization.overlay",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sap_anchor",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "scenario_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.stc.scenario",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tasklist_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.ppm.tasklist",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.ppm.template",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_ppm_a1",
+      "name": "ipai.workstream",
+      "python_constraints": [],
+      "relations": [
+        "ipai.localization.overlay",
+        "ipai.ppm.tasklist",
+        "ipai.ppm.template",
+        "ipai.stc.check",
+        "ipai.stc.scenario"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Workstream code must be unique.",
+          "name": "workstream_code_unique",
+          "sql": "unique(code)"
+        }
+      ],
+      "table": "ipai_workstream"
+    },
+    {
+      "fields": [],
+      "inherits": [
+        "ir.http"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ir.http",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ir_http"
+    },
+    {
+      "fields": [],
+      "inherits": [
+        "ir.qweb"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ir.qweb",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ir_qweb"
+    },
+    {
+      "fields": [],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "master.control.mixin",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "master_control_mixin"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "company_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.company",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "holiday_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_year",
+          "index": true,
+          "name": "year",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_tbwa_finance",
+      "name": "ph.holiday",
+      "python_constraints": [],
+      "relations": [
+        "res.company"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Holiday date must be unique per company",
+          "name": "date_unique",
+          "sql": "unique(date, company_id)"
+        }
+      ],
+      "table": "ph_holiday"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "agency_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_completed_by",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_completed_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_due",
+          "ondelete": null,
+          "related": "monthly_close_id.approval_due_date",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "completion_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "detailed_task",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "monthly_close_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "ppm.monthly.close",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "owner_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_completed_by",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_completed_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_start",
+          "ondelete": null,
+          "related": "monthly_close_id.prep_start_date",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_completed_by",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_completed_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_due",
+          "ondelete": null,
+          "related": "monthly_close_id.review_due_date",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "reviewer_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "template_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ppm.close.template",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_total_days",
+          "index": false,
+          "name": "total_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ppm.close.task",
+      "python_constraints": [],
+      "relations": [
+        "ppm.close.template",
+        "ppm.monthly.close"
+      ],
+      "sql_constraints": [],
+      "table": "ppm_close_task"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "agency_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "detailed_task",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": "_compute_name",
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "owner_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "reviewer_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_total_days",
+          "index": false,
+          "name": "total_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ppm.close.template",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "ppm_close_template"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": true,
+          "name": "as_of",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "kpi_category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "kpi_key",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "kpi_label",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_name",
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "portfolio_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ppm.portfolio",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "program_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ppm.program",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "project_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.project",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "scope",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "source",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "source_ref",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_status",
+          "index": false,
+          "name": "status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "target_value",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "threshold_green",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "threshold_yellow",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "unit",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "value",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "value_text",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ppm.kpi.snapshot",
+      "python_constraints": [],
+      "relations": [
+        "ppm.portfolio",
+        "ppm.program",
+        "project.project"
+      ],
+      "sql_constraints": [],
+      "table": "ppm_kpi_snapshot"
+    },
+    {
+      "fields": [
+        {
+          "compute": "_compute_schedule_dates",
+          "index": false,
+          "name": "approval_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "close_month",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "created_by_cron",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": "_compute_schedule_dates",
+          "index": false,
+          "name": "month_end_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_name",
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": "_compute_schedule_dates",
+          "index": false,
+          "name": "prep_start_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "progress_percentage",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": "_compute_schedule_dates",
+          "index": false,
+          "name": "review_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "task_completed",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_task_stats",
+          "index": false,
+          "name": "task_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ppm.close.task",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ppm.monthly.close",
+      "python_constraints": [],
+      "relations": [
+        "ppm.close.task"
+      ],
+      "sql_constraints": [],
+      "table": "ppm_monthly_close"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": "_compute_budget_rollup",
+          "index": false,
+          "name": "budget_variance_pct",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_end",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_start",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": "_compute_health_status",
+          "index": false,
+          "name": "health_score",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_health_status",
+          "index": false,
+          "name": "health_status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "kpi_snapshot_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ppm.kpi.snapshot",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "objective",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "owner_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_program_count",
+          "index": false,
+          "name": "program_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "program_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ppm.program",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sponsor_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_budget_rollup",
+          "index": false,
+          "name": "total_actual",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": "_compute_budget_rollup",
+          "index": false,
+          "name": "total_budget",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ppm.portfolio",
+      "python_constraints": [],
+      "relations": [
+        "ppm.kpi.snapshot",
+        "ppm.program",
+        "res.currency",
+        "res.users"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Portfolio code must be unique!",
+          "name": "code_unique",
+          "sql": "UNIQUE(code)"
+        },
+        {
+          "message": "Portfolio code must be unique!",
+          "name": "code_unique",
+          "sql": "UNIQUE(code)"
+        }
+      ],
+      "table": "ppm_portfolio"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": "_compute_actual_cost",
+          "index": false,
+          "name": "actual_cost",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "allocation_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ppm.resource.allocation",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "budget",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_end",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_start",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Html"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "health_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "health_score",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "health_status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "kpi_snapshot_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ppm.kpi.snapshot",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "objectives",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": "_compute_risk_count",
+          "index": false,
+          "name": "open_high_risks",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "portfolio_id",
+          "ondelete": "restrict",
+          "related": null,
+          "relation": "ppm.portfolio",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "program_manager_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_project_count",
+          "index": false,
+          "name": "project_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "project_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.project",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": "_compute_risk_count",
+          "index": false,
+          "name": "risk_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "risk_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ppm.risk",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sponsor_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ppm.program",
+      "python_constraints": [],
+      "relations": [
+        "ppm.kpi.snapshot",
+        "ppm.portfolio",
+        "ppm.resource.allocation",
+        "ppm.risk",
+        "project.project",
+        "res.currency",
+        "res.users"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Program code must be unique!",
+          "name": "code_unique",
+          "sql": "UNIQUE(code)"
+        },
+        {
+          "message": "Program code must be unique!",
+          "name": "code_unique",
+          "sql": "UNIQUE(code)"
+        }
+      ],
+      "table": "ppm_program"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "allocation_pct",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_end",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_start",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "employee_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "hr.employee",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_overload",
+          "index": false,
+          "name": "is_overloaded",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": "_compute_name",
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "planned_hours",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "program_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ppm.program",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "project_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.project",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.task",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_overload",
+          "index": false,
+          "name": "total_allocation",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "user_id",
+          "ondelete": null,
+          "related": "employee_id.user_id",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ppm.resource.allocation",
+      "python_constraints": [
+        "_check_allocation",
+        "_check_dates"
+      ],
+      "relations": [
+        "hr.employee",
+        "ppm.program",
+        "project.project",
+        "project.task"
+      ],
+      "sql_constraints": [],
+      "table": "ppm_resource_allocation"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "assigned_to_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "contingency_plan",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_closed",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_identified",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "date_target",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "impact",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "mitigation_plan",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "mitigation_strategy",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "owner_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "portfolio_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ppm.portfolio",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "potential_cost",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "probability",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "program_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ppm.program",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "project_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.project",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_risk_score",
+          "index": false,
+          "name": "risk_score",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "scope",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_risk_score",
+          "index": false,
+          "name": "severity",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "ppm.risk",
+      "python_constraints": [],
+      "relations": [
+        "ppm.portfolio",
+        "ppm.program",
+        "project.project",
+        "res.currency",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "ppm_risk"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "alert_days_before",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_required",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "baseline_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_task_count",
+          "index": false,
+          "name": "completed_task_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "completion_criteria",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "deliverables",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "gate_status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "last_alert_sent",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "milestone_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "risk_level",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "risk_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": "_compute_task_count",
+          "index": false,
+          "name": "task_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "task_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.task",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": "_compute_variance",
+          "index": false,
+          "name": "variance_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [
+        "project.milestone"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "project.milestone",
+      "python_constraints": [
+        "_check_deadlines"
+      ],
+      "relations": [
+        "project.task",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "project_milestone"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "actual_finish",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "actual_start",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "baseline_finish",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "baseline_start",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "child_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.project",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "clarity_id",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_milestone_stats",
+          "index": false,
+          "name": "critical_milestone_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "health_status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "im_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_im_rollups",
+          "index": false,
+          "name": "im_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": false,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_im_rollups",
+          "index": false,
+          "name": "im_task_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": false,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "ipai_finance_enabled",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "ipai_im_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "ipai_is_im_project",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "ipai_root_project_id",
+          "ondelete": "set null",
+          "related": null,
+          "relation": "project.project",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "is_program",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": "_compute_milestone_stats",
+          "index": false,
+          "name": "milestone_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_overall_progress",
+          "index": false,
+          "name": "overall_progress",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": "_compute_overall_status",
+          "index": false,
+          "name": "overall_status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "parent_id",
+          "ondelete": "restrict",
+          "related": null,
+          "relation": "project.project",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_phase_stats",
+          "index": false,
+          "name": "phase_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "portfolio_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.category",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "ppm_program_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ppm.program",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "program_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "program_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_variances",
+          "index": false,
+          "name": "variance_finish",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_variances",
+          "index": false,
+          "name": "variance_start",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "x_cycle_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [
+        "project.project"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "project.project",
+      "python_constraints": [],
+      "relations": [
+        "ppm.program",
+        "project.category",
+        "project.project"
+      ],
+      "sql_constraints": [],
+      "table": "project_project"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": true,
+          "name": "activity_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "actual_cost",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": "_compute_actual_hours",
+          "index": false,
+          "name": "actual_hours",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_duration",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "auto_sync",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_approval_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "bir_form",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_payment_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_period_label",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_prep_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_related",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_schedule_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.bir_schedule",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_child_task_count",
+          "index": false,
+          "name": "child_task_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "closing_due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "cluster",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_variances",
+          "index": false,
+          "name": "cost_variance",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": "_compute_critical_path",
+          "index": true,
+          "name": "critical_path",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": "_compute_earned_value",
+          "index": false,
+          "name": "earned_value",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "erp_ref",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "fd_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "finance_category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "finance_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "finance_deadline_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "finance_logframe_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.logframe",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "finance_person_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ipai.finance.person",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "finance_supervisor_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_float",
+          "index": false,
+          "name": "free_float",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "gate_approver_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "gate_decision",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "gate_milestone_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "project.milestone",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "has_gate",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "ipai_compliance_step",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_ipai_deadline_metrics",
+          "index": false,
+          "name": "ipai_days_to_deadline",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "ipai_owner_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "ipai_owner_role",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_ipai_deadline_metrics",
+          "index": true,
+          "name": "ipai_status_bucket",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "ipai_task_category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "ipai_template_id",
+          "ondelete": "set null",
+          "related": null,
+          "relation": "ipai.finance.task.template",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_is_finance_ppm",
+          "index": false,
+          "name": "is_finance_ppm",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "is_phase",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "lag_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "lead_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_milestone_count",
+          "index": false,
+          "name": "milestone_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "owner_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "period_covered",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "phase_baseline_finish",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "phase_baseline_start",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_phase_progress",
+          "index": false,
+          "name": "phase_progress",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "phase_status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "phase_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_phase_variance",
+          "index": false,
+          "name": "phase_variance_days",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "planned_hours",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "planned_value",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "prep_duration",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "relative_due",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "remaining_hours",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "resource_allocation",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "review_duration",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "reviewer_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "role_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_variances",
+          "index": false,
+          "name": "schedule_variance",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sfm_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "target_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_float",
+          "index": false,
+          "name": "total_float",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_wbs_code",
+          "index": false,
+          "name": "wbs_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "x_cycle_key",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "x_external_key",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "x_obsolete",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "x_seed_hash",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "x_step_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "x_task_template_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [
+        "project.task"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "project.task",
+      "python_constraints": [
+        "_check_phase_hierarchy"
+      ],
+      "relations": [
+        "ipai.finance.bir_schedule",
+        "ipai.finance.logframe",
+        "ipai.finance.person",
+        "ipai.finance.task.template",
+        "project.milestone",
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "project_task"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "actual_hours",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "assigned_user_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "blocker_description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "completed_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "due_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "estimated_hours",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "priority",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_status",
+          "index": false,
+          "name": "status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [
+        "project.task.checklist.item"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "project.task.checklist.item",
+      "python_constraints": [],
+      "relations": [
+        "res.users"
+      ],
+      "sql_constraints": [],
+      "table": "project_task_checklist_item"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "x_master_control_submitted",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        }
+      ],
+      "inherits": [
+        "master.control.mixin",
+        "purchase.order"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "purchase.order",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "purchase_order"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "ipai_enable_finance_project_analytics",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "superset_auto_sync",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "superset_connection_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "superset.connection",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "superset_create_analytics_views",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "superset_enable_rls",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "superset_sync_interval",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [
+        "res.config.settings"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "res.config.settings",
+      "python_constraints": [],
+      "relations": [
+        "superset.connection"
+      ],
+      "sql_constraints": [],
+      "table": "res_config_settings"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_registered",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "bir_registration_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "srm_overall_score",
+          "ondelete": null,
+          "related": "srm_supplier_id.overall_score",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "srm_supplier_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "srm.supplier",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "srm_tier",
+          "ondelete": null,
+          "related": "srm_supplier_id.tier",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tax_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": true,
+          "name": "tin",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tin_branch_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [
+        "res.partner"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "res.partner",
+      "python_constraints": [
+        "_check_tin_format"
+      ],
+      "relations": [
+        "srm.supplier"
+      ],
+      "sql_constraints": [],
+      "table": "res_partner"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": true,
+          "name": "x_employee_code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [
+        "res.users"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "res.users",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [
+        {
+          "message": "Employee code must be unique",
+          "name": "x_employee_code_uniq",
+          "sql": "UNIQUE(x_employee_code)"
+        },
+        {
+          "message": "Employee code must be unique",
+          "name": "x_employee_code_uniq",
+          "sql": "UNIQUE(x_employee_code)"
+        },
+        {
+          "message": "Employee code must be unique when set!",
+          "name": "x_employee_code_unique",
+          "sql": "unique(x_employee_code)"
+        },
+        {
+          "message": "Employee code must be unique when set!",
+          "name": "x_employee_code_unique",
+          "sql": "unique(x_employee_code)"
+        }
+      ],
+      "table": "res_users"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "compute_source",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "eval_method",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "weight",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "srm.kpi.category",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "srm_kpi_category"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "approval_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "approver_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_checklist_complete",
+          "index": false,
+          "name": "checklist_complete",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "checklist_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "srm.qualification.checklist",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "completion_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "document_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ir.attachment",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "expiry_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_name",
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "qualification_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "rejection_reason",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "reviewer_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "risk_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "risk_score",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "start_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "supplier_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "srm.supplier",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "target_completion",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "srm.qualification",
+      "python_constraints": [],
+      "relations": [
+        "ir.attachment",
+        "res.users",
+        "srm.qualification.checklist",
+        "srm.supplier"
+      ],
+      "sql_constraints": [],
+      "table": "srm_qualification"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "completed_by",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "completed_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_complete",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_required",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "qualification_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "srm.qualification",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "srm.qualification.checklist",
+      "python_constraints": [],
+      "relations": [
+        "res.users",
+        "srm.qualification"
+      ],
+      "sql_constraints": [],
+      "table": "srm_qualification_checklist"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "action_items",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "as_of",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "comments",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "evaluator_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.users",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_grade",
+          "index": false,
+          "name": "grade",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "line_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "srm.scorecard.line",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": "_compute_name",
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_overall_score",
+          "index": false,
+          "name": "overall_score",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "period",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "supplier_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "srm.supplier",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        }
+      ],
+      "inherits": [
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "srm.scorecard",
+      "python_constraints": [],
+      "relations": [
+        "res.users",
+        "srm.scorecard.line",
+        "srm.supplier"
+      ],
+      "sql_constraints": [],
+      "table": "srm_scorecard"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "evidence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "kpi_category_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "srm.kpi.category",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "score",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "scorecard_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "srm.scorecard",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": "kpi_category_id.sequence",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "weight",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": "_compute_weighted_score",
+          "index": false,
+          "name": "weighted_score",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "srm.scorecard.line",
+      "python_constraints": [],
+      "relations": [
+        "srm.kpi.category",
+        "srm.scorecard"
+      ],
+      "sql_constraints": [],
+      "table": "srm_scorecard_line"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "category_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "product.category",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "code",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "compliance_docs_complete",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "currency_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.currency",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": "_compute_is_qualified",
+          "index": false,
+          "name": "is_qualified",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "last_audit_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_latest_scorecard",
+          "index": false,
+          "name": "latest_scorecard_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "srm.scorecard",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "next_audit_date",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": "_compute_po_stats",
+          "index": false,
+          "name": "open_po_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_overall_score",
+          "index": false,
+          "name": "overall_score",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Float"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "partner_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.partner",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "primary_contact_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.partner",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "qualification_expiry",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Date"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "qualification_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "srm.qualification",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "risk_level",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "risk_notes",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sales_contact_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "res.partner",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "scorecard_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "srm.scorecard",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "tier",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_po_stats",
+          "index": false,
+          "name": "total_po_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": "_compute_ytd_spend",
+          "index": false,
+          "name": "ytd_spend",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Monetary"
+        }
+      ],
+      "inherits": [
+        "mail.activity.mixin",
+        "mail.thread"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai",
+      "name": "srm.supplier",
+      "python_constraints": [],
+      "relations": [
+        "product.category",
+        "res.currency",
+        "res.partner",
+        "srm.qualification",
+        "srm.scorecard"
+      ],
+      "sql_constraints": [],
+      "table": "srm_supplier"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "is_created",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "last_refresh",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "required_modules",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sql_definition",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "technical_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_superset_connector",
+      "name": "superset.analytics.view",
+      "python_constraints": [],
+      "relations": [],
+      "sql_constraints": [],
+      "table": "superset_analytics_view"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "connection_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "superset.connection",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "create_analytics_views",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "preset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_superset_connector",
+      "name": "superset.bulk.dataset.wizard",
+      "python_constraints": [],
+      "relations": [
+        "superset.connection"
+      ],
+      "sql_constraints": [],
+      "table": "superset_bulk_dataset_wizard"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "access_token",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "api_key",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "auth_method",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "base_url",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "csrf_token",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": "_compute_dataset_count",
+          "index": false,
+          "name": "dataset_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "dataset_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "superset.dataset",
+          "required": false,
+          "store": true,
+          "type": "One2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "db_connection_id",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "db_connection_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "last_error",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "last_sync",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "password",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "pg_database",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "pg_host",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "pg_password",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "pg_port",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "pg_schema",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "pg_username",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "refresh_token",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "state",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "token_expiry",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "use_ssl",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "username",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_superset_connector",
+      "name": "superset.connection",
+      "python_constraints": [],
+      "relations": [
+        "superset.dataset"
+      ],
+      "sql_constraints": [],
+      "table": "superset_connection"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "active",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": "_compute_column_count",
+          "index": false,
+          "name": "column_count",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "connection_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "superset.connection",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "custom_sql",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "enable_rls",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "field_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ir.model.fields",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "include_all_fields",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "last_sync",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Datetime"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "model_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ir.model",
+          "required": false,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "model_name",
+          "ondelete": null,
+          "related": "model_id.model",
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "rls_filter_column",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "source_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "superset_dataset_id",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sync_error",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sync_status",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "technical_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "view_created",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": "_compute_view_name",
+          "index": false,
+          "name": "view_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "view_sql",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        }
+      ],
+      "inherits": [
+        "mail.thread",
+        "mail.activity.mixin"
+      ],
+      "inherits_delegated": {},
+      "module": "ipai_superset_connector",
+      "name": "superset.dataset",
+      "python_constraints": [],
+      "relations": [
+        "ir.model",
+        "ir.model.fields",
+        "superset.connection"
+      ],
+      "sql_constraints": [
+        {
+          "message": "Technical name must be unique!",
+          "name": "technical_name_uniq",
+          "sql": "unique(technical_name)"
+        }
+      ],
+      "table": "superset_dataset"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "aggregation",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "column_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "data_type",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "dataset_id",
+          "ondelete": "cascade",
+          "related": null,
+          "relation": "superset.dataset",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "description",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Text"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "filterable",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "format_string",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "groupable",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "label",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": true,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sequence",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Integer"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_superset_connector",
+      "name": "superset.dataset.column",
+      "python_constraints": [],
+      "relations": [
+        "superset.dataset"
+      ],
+      "sql_constraints": [],
+      "table": "superset_dataset_column"
+    },
+    {
+      "fields": [
+        {
+          "compute": null,
+          "index": false,
+          "name": "category",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Selection"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "connection_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "superset.connection",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "create_view",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "enable_rls",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "field_ids",
+          "ondelete": null,
+          "related": null,
+          "relation": "ir.model.fields",
+          "required": false,
+          "store": true,
+          "type": "Many2many"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "include_all_fields",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "model_id",
+          "ondelete": null,
+          "related": null,
+          "relation": "ir.model",
+          "required": true,
+          "store": true,
+          "type": "Many2one"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "sync_to_superset",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Boolean"
+        },
+        {
+          "compute": null,
+          "index": false,
+          "name": "technical_name",
+          "ondelete": null,
+          "related": null,
+          "relation": null,
+          "required": false,
+          "store": true,
+          "type": "Char"
+        }
+      ],
+      "inherits": [],
+      "inherits_delegated": {},
+      "module": "ipai_superset_connector",
+      "name": "superset.dataset.wizard",
+      "python_constraints": [],
+      "relations": [
+        "ir.model",
+        "ir.model.fields",
+        "superset.connection"
+      ],
+      "sql_constraints": [],
+      "table": "superset_dataset_wizard"
+    }
+  ]
+}

--- a/docs/data-model/ODOO_MODULE_DELTAS.md
+++ b/docs/data-model/ODOO_MODULE_DELTAS.md
@@ -1,0 +1,307 @@
+# Odoo Module Deltas
+
+## ipai
+
+- New tables:
+  - `a1_check`
+  - `a1_check_result`
+  - `a1_export_run`
+  - `a1_role`
+  - `a1_task`
+  - `a1_task_checklist`
+  - `a1_tasklist`
+  - `a1_template`
+  - `a1_template_checklist`
+  - `a1_template_step`
+  - `a1_workstream`
+  - `account_move`
+  - `advisor_category`
+  - `advisor_playbook`
+  - `advisor_recommendation`
+  - `advisor_score`
+  - `advisor_tag`
+  - `close_approval_gate`
+  - `close_approval_gate_template`
+  - `close_cycle`
+  - `close_exception`
+  - `close_task`
+  - `close_task_category`
+  - `close_task_checklist`
+  - `close_task_template`
+  - `close_task_template_checklist`
+  - `finance_bir_deadline`
+  - `finance_ppm_bir_calendar`
+  - `finance_ppm_dashboard`
+  - `finance_ppm_import_wizard`
+  - `finance_ppm_logframe`
+  - `finance_ppm_ph_holiday`
+  - `finance_ppm_tdi_audit`
+  - `hr_employee`
+  - `hr_expense`
+  - `ipai_asset`
+  - `ipai_asset_category`
+  - `ipai_asset_checkout`
+  - `ipai_asset_reservation`
+  - `ipai_bir_dat_wizard`
+  - `ipai_bir_form_schedule`
+  - `ipai_bir_process_step`
+  - `ipai_bir_schedule_item`
+  - `ipai_bir_schedule_line`
+  - `ipai_bir_schedule_step`
+  - `ipai_close_generated_map`
+  - `ipai_close_generation_run`
+  - `ipai_close_generator`
+  - `ipai_close_task_step`
+  - `ipai_close_task_template`
+  - `ipai_convert_phases_wizard`
+  - `ipai_directory_person`
+  - `ipai_equipment_asset`
+  - `ipai_equipment_booking`
+  - `ipai_equipment_incident`
+  - `ipai_finance_bir_schedule`
+  - `ipai_finance_directory`
+  - `ipai_finance_logframe`
+  - `ipai_finance_person`
+  - `ipai_finance_seed_service`
+  - `ipai_finance_seed_wizard`
+  - `ipai_finance_task_template`
+  - `ipai_generate_bir_tasks_wizard`
+  - `ipai_generate_im_projects_wizard`
+  - `ipai_generate_month_end_wizard`
+  - `ipai_month_end_template`
+  - `ipai_month_end_template_step`
+  - `ipai_studio_ai_history`
+  - `ipai_studio_ai_wizard`
+  - `ipai_travel_request`
+  - `ipai_workspace`
+  - `ipai_workspace_link`
+  - `ppm_close_task`
+  - `ppm_close_template`
+  - `ppm_kpi_snapshot`
+  - `ppm_monthly_close`
+  - `ppm_portfolio`
+  - `ppm_program`
+  - `ppm_resource_allocation`
+  - `ppm_risk`
+  - `project_milestone`
+  - `project_project`
+  - `project_task`
+  - `project_task_checklist_item`
+  - `purchase_order`
+  - `res_config_settings`
+  - `res_partner`
+  - `res_users`
+  - `srm_kpi_category`
+  - `srm_qualification`
+  - `srm_qualification_checklist`
+  - `srm_scorecard`
+  - `srm_scorecard_line`
+  - `srm_supplier`
+- Extended tables:
+  - `account_move`: bir_2307_date, bir_2307_generated, ewt_amount
+  - `close_task`: a1_task_id, approval_deadline, approval_done_by, approval_done_date, approve_done_date, approve_due_date, approve_notes, approve_user_id, approver_id, attachment_ids, category_id, checklist_done_pct, checklist_ids, checklist_progress, company_id, cycle_id, days_overdue, description, exception_ids, external_key, gl_entry_count, gl_entry_ids, has_exceptions, has_open_exceptions, is_overdue, name, notes, prep_deadline, prep_done_by, prep_done_date, prep_due_date, prep_notes, prep_user_id, preparer_id, review_deadline, review_done_by, review_done_date, review_due_date, review_notes, review_result, review_user_id, reviewer_id, sequence, state, template_id
+  - `hr_employee`: x_master_control_offboarded, x_master_control_onboarded
+  - `hr_expense`: project_id, requires_project, travel_request_id, x_master_control_submitted
+  - `ipai_workspace`: account_manager_id, active, brand_name, campaign_type, channel_mix, child_ids, client_id, closing_stage, code, color, company_id, date_end, date_start, engagement_count, entity_code, fiscal_period, industry, invoice_count, is_critical, link_ids, name, parent_id, planned_hours, progress, project_count, remaining_hours, sequence, stage, workspace_type
+  - `project_milestone`: alert_days_before, approval_date, approval_required, approver_id, baseline_deadline, completed_task_count, completion_criteria, deliverables, gate_status, last_alert_sent, milestone_type, risk_level, risk_notes, task_count, task_ids, variance_days
+  - `project_project`: actual_finish, actual_start, baseline_finish, baseline_start, child_ids, clarity_id, critical_milestone_count, health_status, im_code, im_count, im_task_count, ipai_finance_enabled, ipai_im_code, ipai_is_im_project, ipai_root_project_id, is_program, milestone_count, overall_progress, overall_status, parent_id, phase_count, portfolio_id, ppm_program_ids, program_code, program_type, variance_finish, variance_start, x_cycle_code
+  - `project_task`: activity_type, actual_cost, actual_hours, approval_duration, approver_id, auto_sync, bir_approval_due_date, bir_deadline, bir_form, bir_payment_due_date, bir_period_label, bir_prep_due_date, bir_related, bir_schedule_id, child_task_count, closing_due_date, cluster, cost_variance, critical_path, earned_value, erp_ref, fd_id, finance_category, finance_code, finance_deadline_type, finance_logframe_id, finance_person_id, finance_supervisor_id, free_float, gate_approver_id, gate_decision, gate_milestone_id, has_gate, ipai_compliance_step, ipai_days_to_deadline, ipai_owner_code, ipai_owner_role, ipai_status_bucket, ipai_task_category, ipai_template_id, is_finance_ppm, is_phase, lag_days, lead_days, milestone_count, owner_code, period_covered, phase_baseline_finish, phase_baseline_start, phase_progress, phase_status, phase_type, phase_variance_days, planned_hours, planned_value, prep_duration, relative_due, remaining_hours, resource_allocation, review_duration, reviewer_id, role_code, schedule_variance, sfm_id, target_date, total_float, wbs_code, x_cycle_key, x_external_key, x_obsolete, x_seed_hash, x_step_code, x_task_template_code
+  - `project_task_checklist_item`: actual_hours, assigned_user_id, blocker_description, completed_date, due_date, estimated_hours, notes, priority, status
+  - `purchase_order`: x_master_control_submitted
+  - `res_config_settings`: ipai_enable_finance_project_analytics, superset_auto_sync, superset_connection_id, superset_create_analytics_views, superset_enable_rls, superset_sync_interval
+  - `res_partner`: bir_registered, bir_registration_date, srm_overall_score, srm_supplier_id, srm_tier, tax_type, tin, tin_branch_code
+  - `res_users`: x_employee_code
+- Relation tables:
+  - `a1_check_result_attachment_ids_rel`
+  - `a1_role_group_ids_rel`
+  - `a1_template_check_rel`
+  - `advisor_playbook_category_ids_rel`
+  - `advisor_recommendation_tag_ids_rel`
+  - `close_approval_gate_blocking_exceptions_rel`
+  - `close_approval_gate_blocking_tasks_rel`
+  - `close_task_attachment_ids_rel`
+  - `close_task_category_gl_account_ids_rel`
+  - `close_task_gl_entry_ids_rel`
+  - `close_task_template_gl_account_ids_rel`
+  - `ppm_program_project_rel`
+  - `srm_qualification_document_ids_rel`
+  - `srm_supplier_category_ids_rel`
+
+## ipai_ask_ai
+
+- New tables:
+  - `discuss_channel`
+  - `ipai_ask_ai_service`
+- Extended tables:
+  - `discuss_channel`: is_ai_channel
+
+## ipai_bir_tax_compliance
+
+- New tables:
+  - `bir_alphalist`
+  - `bir_alphalist_line`
+  - `bir_filing_deadline`
+  - `bir_tax_return`
+  - `bir_tax_return_line`
+  - `bir_vat_line`
+  - `bir_vat_return`
+  - `bir_withholding_line`
+  - `bir_withholding_return`
+
+## ipai_crm_pipeline
+
+- New tables:
+  - `crm_lead`
+  - `crm_stage`
+- Extended tables:
+  - `crm_lead`: days_in_stage, last_call_date, last_meeting_date, stage_entry_date, stage_missing_fields, stage_rule_validated
+  - `crm_stage`: ipai_automation_notes, ipai_enforce_rules, ipai_required_field_ids, ipai_sla_days, ipai_stage_color, ipai_stage_icon
+- Relation tables:
+  - `crm_stage_required_fields_rel`
+
+## ipai_finance_ppm_golive
+
+- New tables:
+  - `ipai_finance_ppm_golive_checklist`
+  - `ipai_finance_ppm_golive_item`
+  - `ipai_finance_ppm_golive_section`
+- Relation tables:
+  - `ipai_finance_ppm_golive_checklist_section_ids_rel`
+
+## ipai_grid_view
+
+- New tables:
+  - `ipai_grid_column`
+  - `ipai_grid_filter`
+  - `ipai_grid_filter_condition`
+  - `ipai_grid_view`
+- Relation tables:
+  - `ipai_grid_view_visible_columns_rel`
+
+## ipai_month_end
+
+- New tables:
+  - `ipai_month_end_closing`
+  - `ipai_month_end_task`
+  - `ipai_month_end_task_template`
+  - `ipai_ph_holiday`
+- Relation tables:
+  - `ipai_task_template_dependency_rel`
+
+## ipai_platform_approvals
+
+- _No model changes detected._
+
+## ipai_platform_audit
+
+- New tables:
+  - `ipai_audit_log`
+
+## ipai_platform_permissions
+
+- New tables:
+  - `ipai_permission`
+  - `ipai_share_token`
+
+## ipai_platform_workflow
+
+- _No model changes detected._
+
+## ipai_ppm_a1
+
+- New tables:
+  - `ipai_export_seed_wizard`
+  - `ipai_import_seed_wizard`
+  - `ipai_localization_overlay`
+  - `ipai_ppm_task`
+  - `ipai_ppm_task_checklist`
+  - `ipai_ppm_tasklist`
+  - `ipai_ppm_taskrun`
+  - `ipai_ppm_template`
+  - `ipai_repo_export_run`
+  - `ipai_stc_check`
+  - `ipai_stc_scenario`
+  - `ipai_stc_worklist_type`
+  - `ipai_workstream`
+- Relation tables:
+  - `ipai_stc_scenario_check_ids_rel`
+
+## ipai_superset_connector
+
+- New tables:
+  - `superset_analytics_view`
+  - `superset_bulk_dataset_wizard`
+  - `superset_connection`
+  - `superset_dataset`
+  - `superset_dataset_column`
+  - `superset_dataset_wizard`
+- Relation tables:
+  - `superset_dataset_field_ids_rel`
+  - `superset_dataset_wizard_field_ids_rel`
+
+## ipai_tbwa_finance
+
+- New tables:
+  - `bir_return`
+  - `bir_return_line`
+  - `closing_period`
+  - `compliance_check`
+  - `finance_task`
+  - `finance_task_template`
+  - `ph_holiday`
+- Relation tables:
+  - `finance_task_template_dependency_rel`
+
+## ipai_workos_blocks
+
+- New tables:
+  - `ipai_workos_block`
+
+## ipai_workos_canvas
+
+- New tables:
+  - `ipai_workos_canvas`
+
+## ipai_workos_collab
+
+- New tables:
+  - `ipai_workos_comment`
+- Relation tables:
+  - `workos_comment_mention_rel`
+
+## ipai_workos_core
+
+- New tables:
+  - `ipai_workos_page`
+  - `ipai_workos_space`
+  - `ipai_workos_workspace`
+- Relation tables:
+  - `workspace_member_rel`
+
+## ipai_workos_db
+
+- New tables:
+  - `ipai_workos_database`
+  - `ipai_workos_property`
+  - `ipai_workos_row`
+
+## ipai_workos_search
+
+- New tables:
+  - `ipai_workos_search`
+  - `ipai_workos_search_history`
+
+## ipai_workos_templates
+
+- New tables:
+  - `ipai_workos_template`
+  - `ipai_workos_template_tag`
+- Relation tables:
+  - `ipai_workos_template_tag_ids_rel`
+
+## ipai_workos_views
+
+- New tables:
+  - `ipai_workos_view`
+- Relation tables:
+  - `ipai_workos_view_visible_property_ids_rel`

--- a/docs/data-model/ODOO_ORM_MAP.md
+++ b/docs/data-model/ODOO_ORM_MAP.md
@@ -1,0 +1,4004 @@
+# Odoo ORM Map
+
+## a1.check
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `a1_check`
+- SQL constraints:
+  - `code_uniq`: `unique(code, company_id)` (Check code must be unique per company.)
+  - `code_uniq`: `unique(code, company_id)` (Check code must be unique per company.)
+
+### Persisted fields
+- `active`: `Boolean`
+- `check_type`: `Selection` (required)
+- `close_gate_template_id`: `Many2one` (relation=close.approval.gate.template)
+- `code`: `Char` (required, index)
+- `company_id`: `Many2one` (relation=res.company, required)
+- `description`: `Html`
+- `fail_action`: `Text`
+- `name`: `Char` (required)
+- `pass_criteria`: `Text`
+- `sequence`: `Integer`
+- `severity`: `Selection` (required)
+- `template_ids`: `Many2many` (relation=a1.template)
+
+### Non-persisted fields
+- _none_
+
+## a1.check.result
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `a1_check_result`
+
+### Persisted fields
+- `attachment_ids`: `Many2many` (relation=ir.attachment)
+- `check_id`: `Many2one` (relation=a1.check, required, ondelete=cascade)
+- `evidence`: `Html`
+- `executed_by`: `Many2one` (relation=res.users)
+- `executed_date`: `Datetime`
+- `result`: `Selection` (required)
+- `result_notes`: `Text`
+- `task_id`: `Many2one` (relation=a1.task, required, index, ondelete=cascade)
+
+### Non-persisted fields
+- _none_
+
+## a1.export.run
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `a1_export_run`
+
+### Persisted fields
+- `company_id`: `Many2one` (relation=res.company, required)
+- `created_count`: `Integer`
+- `error_count`: `Integer`
+- `log`: `Text`
+- `run_type`: `Selection` (required)
+- `seed_hash`: `Char` (index)
+- `seed_json`: `Text`
+- `status`: `Selection` (required)
+- `unchanged_count`: `Integer`
+- `updated_count`: `Integer`
+- `webhook_url`: `Char`
+
+### Non-persisted fields
+- _none_
+
+## a1.role
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `a1_role`
+- SQL constraints:
+  - `code_uniq`: `unique(code, company_id)` (Role code must be unique per company.)
+  - `code_uniq`: `unique(code, company_id)` (Role code must be unique per company.)
+
+### Persisted fields
+- `active`: `Boolean`
+- `code`: `Char` (required, index)
+- `company_id`: `Many2one` (relation=res.company, required)
+- `default_user_id`: `Many2one` (relation=res.users)
+- `description`: `Text`
+- `fallback_user_id`: `Many2one` (relation=res.users)
+- `group_ids`: `Many2many` (relation=res.groups)
+- `name`: `Char` (required)
+- `sequence`: `Integer`
+
+### Non-persisted fields
+- _none_
+
+## a1.task
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `a1_task`
+- _inherit: `mail.activity.mixin, mail.thread`
+
+### Persisted fields
+- `approval_deadline`: `Date`
+- `approval_done_by`: `Many2one` (relation=res.users)
+- `approval_done_date`: `Datetime`
+- `approver_id`: `Many2one` (relation=res.users)
+- `approver_role`: `Char`
+- `checklist_progress`: `Float` (compute=_compute_checklist_progress)
+- `close_task_id`: `Many2one` (relation=close.task)
+- `company_id`: `Many2one` (relation=res.company, related=tasklist_id.company_id)
+- `external_key`: `Char` (index)
+- `name`: `Char` (required)
+- `notes`: `Html`
+- `owner_id`: `Many2one` (relation=res.users)
+- `owner_role`: `Char`
+- `prep_deadline`: `Date`
+- `prep_done_by`: `Many2one` (relation=res.users)
+- `prep_done_date`: `Datetime`
+- `review_deadline`: `Date`
+- `review_done_by`: `Many2one` (relation=res.users)
+- `review_done_date`: `Datetime`
+- `reviewer_id`: `Many2one` (relation=res.users)
+- `reviewer_role`: `Char`
+- `sequence`: `Integer`
+- `state`: `Selection` (required)
+- `tasklist_id`: `Many2one` (relation=a1.tasklist, required, index, ondelete=cascade)
+- `template_id`: `Many2one` (relation=a1.template)
+- `workstream_id`: `Many2one` (relation=a1.workstream, related=template_id.workstream_id)
+
+### Non-persisted fields
+- `checklist_ids`: `One2many` (relation=a1.task.checklist)
+
+## a1.task.checklist
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `a1_task_checklist`
+
+### Persisted fields
+- `code`: `Char` (required)
+- `done_by`: `Many2one` (relation=res.users)
+- `done_date`: `Datetime`
+- `is_done`: `Boolean`
+- `is_required`: `Boolean`
+- `item_type`: `Selection` (required)
+- `name`: `Char` (required)
+- `sequence`: `Integer`
+- `task_id`: `Many2one` (relation=a1.task, required, index, ondelete=cascade)
+- `template_item_id`: `Many2one` (relation=a1.template.checklist)
+- `value_attachment_id`: `Many2one` (relation=ir.attachment)
+- `value_text`: `Text`
+
+### Non-persisted fields
+- _none_
+
+## a1.tasklist
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `a1_tasklist`
+- _inherit: `mail.activity.mixin, mail.thread`
+- SQL constraints:
+  - `period_uniq`: `unique(period_start, period_end, company_id)` (A tasklist for this period already exists.)
+  - `period_uniq`: `unique(period_start, period_end, company_id)` (A tasklist for this period already exists.)
+
+### Persisted fields
+- `close_cycle_id`: `Many2one` (relation=close.cycle)
+- `company_id`: `Many2one` (relation=res.company, required)
+- `name`: `Char` (required)
+- `notes`: `Html`
+- `period_end`: `Date` (required)
+- `period_label`: `Char` (compute=_compute_period_label)
+- `period_start`: `Date` (required)
+- `progress`: `Float` (compute=_compute_task_stats)
+- `state`: `Selection` (required)
+- `task_count`: `Integer` (compute=_compute_task_stats)
+- `task_done_count`: `Integer` (compute=_compute_task_stats)
+- `webhook_url`: `Char`
+
+### Non-persisted fields
+- `task_ids`: `One2many` (relation=a1.task)
+
+## a1.template
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `a1_template`
+- _inherit: `mail.activity.mixin, mail.thread`
+- SQL constraints:
+  - `code_uniq`: `unique(code, company_id)` (Template code must be unique per company.)
+  - `code_uniq`: `unique(code, company_id)` (Template code must be unique per company.)
+
+### Persisted fields
+- `active`: `Boolean`
+- `approval_days`: `Float`
+- `approver_role`: `Char`
+- `close_template_id`: `Many2one` (relation=close.task.template)
+- `code`: `Char` (required, index)
+- `company_id`: `Many2one` (relation=res.company, required)
+- `description`: `Html`
+- `name`: `Char` (required)
+- `owner_role`: `Char` (required)
+- `phase_code`: `Char` (related=workstream_id.phase_code)
+- `prep_days`: `Float`
+- `review_days`: `Float`
+- `reviewer_role`: `Char`
+- `sequence`: `Integer`
+- `total_days`: `Float` (compute=_compute_total_days)
+- `workstream_id`: `Many2one` (relation=a1.workstream, required, index, ondelete=cascade)
+
+### Non-persisted fields
+- `checklist_ids`: `One2many` (relation=a1.template.checklist)
+- `step_ids`: `One2many` (relation=a1.template.step)
+
+## a1.template.checklist
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `a1_template_checklist`
+
+### Persisted fields
+- `code`: `Char` (required)
+- `instructions`: `Text`
+- `is_required`: `Boolean`
+- `item_type`: `Selection` (required)
+- `name`: `Char` (required)
+- `sequence`: `Integer`
+- `template_id`: `Many2one` (relation=a1.template, required, index, ondelete=cascade)
+
+### Non-persisted fields
+- _none_
+
+## a1.template.step
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `a1_template_step`
+
+### Persisted fields
+- `assignee_role`: `Char`
+- `code`: `Char` (required)
+- `deadline_offset_days`: `Integer`
+- `effort_days`: `Float`
+- `name`: `Char` (required)
+- `sequence`: `Integer`
+- `template_id`: `Many2one` (relation=a1.template, required, index, ondelete=cascade)
+
+### Non-persisted fields
+- _none_
+
+## a1.workstream
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `a1_workstream`
+- _inherit: `mail.activity.mixin, mail.thread`
+- SQL constraints:
+  - `code_uniq`: `unique(code, company_id)` (Workstream code must be unique per company.)
+  - `code_uniq`: `unique(code, company_id)` (Workstream code must be unique per company.)
+
+### Persisted fields
+- `active`: `Boolean`
+- `close_category_id`: `Many2one` (relation=close.task.category)
+- `code`: `Char` (required, index)
+- `company_id`: `Many2one` (relation=res.company, required)
+- `description`: `Html`
+- `name`: `Char` (required)
+- `owner_role_id`: `Many2one` (relation=a1.role)
+- `owner_user_id`: `Many2one` (relation=res.users, compute=_compute_owner_user)
+- `phase_code`: `Char`
+- `sequence`: `Integer`
+- `template_count`: `Integer` (compute=_compute_template_count)
+
+### Non-persisted fields
+- `template_ids`: `One2many` (relation=a1.template)
+
+## account.move
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `account_move`
+- _inherit: `account.move`
+
+### Persisted fields
+- `bir_2307_date`: `Date`
+- `bir_2307_generated`: `Boolean`
+- `ewt_amount`: `Monetary` (compute=_compute_ewt_amount)
+
+### Non-persisted fields
+- _none_
+
+## advisor.category
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `advisor_category`
+- SQL constraints:
+  - `code_unique`: `UNIQUE(code)` (Category code must be unique!)
+  - `code_unique`: `UNIQUE(code)` (Category code must be unique!)
+
+### Persisted fields
+- `active`: `Boolean`
+- `code`: `Char` (required)
+- `color`: `Integer`
+- `description`: `Text`
+- `high_count`: `Integer` (compute=_compute_recommendation_count)
+- `icon`: `Char`
+- `latest_score`: `Integer` (compute=_compute_latest_score)
+- `name`: `Char` (required)
+- `open_count`: `Integer` (compute=_compute_recommendation_count)
+- `recommendation_count`: `Integer` (compute=_compute_recommendation_count)
+- `sequence`: `Integer`
+
+### Non-persisted fields
+- `recommendation_ids`: `One2many` (relation=advisor.recommendation)
+
+## advisor.playbook
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `advisor_playbook`
+
+### Persisted fields
+- `active`: `Boolean`
+- `automation_kind`: `Selection`
+- `automation_params`: `Text`
+- `automation_ref`: `Char`
+- `category_ids`: `Many2many` (relation=advisor.category)
+- `code`: `Char`
+- `description`: `Text`
+- `name`: `Char` (required)
+- `recommendation_count`: `Integer` (compute=_compute_recommendation_count)
+- `steps_md`: `Text`
+
+### Non-persisted fields
+- `recommendation_ids`: `One2many` (relation=advisor.recommendation)
+
+## advisor.recommendation
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `advisor_recommendation`
+- _inherit: `mail.activity.mixin, mail.thread`
+
+### Persisted fields
+- `category_code`: `Char` (related=category_id.code)
+- `category_id`: `Many2one` (relation=advisor.category, required, index)
+- `confidence`: `Float`
+- `currency_id`: `Many2one` (relation=res.currency)
+- `date_due`: `Date`
+- `date_resolved`: `Date`
+- `description`: `Text`
+- `estimated_savings`: `Monetary`
+- `evidence`: `Text`
+- `external_link`: `Char`
+- `impact_score`: `Integer`
+- `name`: `Char` (required)
+- `owner_id`: `Many2one` (relation=res.users)
+- `playbook_id`: `Many2one` (relation=advisor.playbook)
+- `remediation_steps`: `Text`
+- `resource_ref`: `Char`
+- `resource_type`: `Char`
+- `severity`: `Selection` (required)
+- `severity_order`: `Integer` (compute=_compute_severity_order)
+- `snooze_until`: `Date`
+- `source`: `Selection`
+- `status`: `Selection`
+- `tag_ids`: `Many2many` (relation=advisor.tag)
+
+### Non-persisted fields
+- _none_
+
+## advisor.score
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `advisor_score`
+
+### Persisted fields
+- `as_of`: `Datetime` (required, index)
+- `category_code`: `Char` (related=category_id.code)
+- `category_id`: `Many2one` (relation=advisor.category, required, index, ondelete=cascade)
+- `critical_count`: `Integer`
+- `high_count`: `Integer`
+- `inputs_json`: `Text`
+- `open_count`: `Integer`
+- `resolved_count`: `Integer`
+- `score`: `Integer` (required)
+
+### Non-persisted fields
+- _none_
+
+## advisor.tag
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `advisor_tag`
+- SQL constraints:
+  - `name_unique`: `UNIQUE(name)` (Tag name must be unique!)
+  - `name_unique`: `UNIQUE(name)` (Tag name must be unique!)
+
+### Persisted fields
+- `color`: `Integer`
+- `name`: `Char` (required)
+
+### Non-persisted fields
+- _none_
+
+## bir.alphalist
+
+- Module: `ipai_bir_tax_compliance`
+- Model type: `Model`
+- Table: `bir_alphalist`
+- _inherit: `mail.thread`
+
+### Persisted fields
+- `company_id`: `Many2one` (relation=res.company, required)
+- `currency_id`: `Many2one` (relation=res.currency)
+- `fiscal_year`: `Integer` (required)
+- `form_type`: `Selection` (required)
+- `name`: `Char` (required)
+- `state`: `Selection`
+- `total_gross`: `Monetary` (compute=_compute_totals)
+- `total_wht`: `Monetary` (compute=_compute_totals)
+
+### Non-persisted fields
+- `line_ids`: `One2many` (relation=bir.alphalist.line)
+
+## bir.alphalist.line
+
+- Module: `ipai_bir_tax_compliance`
+- Model type: `Model`
+- Table: `bir_alphalist_line`
+
+### Persisted fields
+- `alphalist_id`: `Many2one` (relation=bir.alphalist, required, ondelete=cascade)
+- `currency_id`: `Many2one` (relation=res.currency, related=alphalist_id.currency_id)
+- `gross_income`: `Monetary`
+- `income_type`: `Selection`
+- `partner_id`: `Many2one` (relation=res.partner, required)
+- `tin`: `Char` (related=partner_id.tin)
+- `wht_amount`: `Monetary`
+
+### Non-persisted fields
+- _none_
+
+## bir.filing.deadline
+
+- Module: `ipai_bir_tax_compliance`
+- Model type: `Model`
+- Table: `bir_filing_deadline`
+
+### Persisted fields
+- `company_id`: `Many2one` (relation=res.company, required)
+- `deadline_date`: `Date` (required)
+- `form_type`: `Selection` (required)
+- `name`: `Char` (required)
+- `period_month`: `Integer`
+- `period_year`: `Integer`
+- `reminder_date`: `Date` (compute=_compute_reminder_date)
+- `return_id`: `Many2one` (relation=bir.tax.return)
+- `state`: `Selection` (compute=_compute_state)
+
+### Non-persisted fields
+- _none_
+
+## bir.return
+
+- Module: `ipai_tbwa_finance`
+- Model type: `Model`
+- Table: `bir_return`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `bir_reference`: `Char`
+- `company_id`: `Many2one` (relation=res.company, required)
+- `currency_id`: `Many2one` (relation=res.currency)
+- `exempt_sales`: `Monetary`
+- `filed_by`: `Many2one` (relation=res.users)
+- `filed_date`: `Datetime`
+- `form_type`: `Selection` (required)
+- `input_vat`: `Monetary`
+- `interest`: `Monetary`
+- `name`: `Char` (compute=_compute_name)
+- `notes`: `Text`
+- `output_vat`: `Monetary`
+- `payment_date`: `Date`
+- `payment_reference`: `Char`
+- `penalty`: `Monetary`
+- `period_end`: `Date` (required)
+- `period_start`: `Date` (required)
+- `state`: `Selection`
+- `task_id`: `Many2one` (relation=finance.task)
+- `tax_base`: `Monetary`
+- `tax_credits`: `Monetary`
+- `tax_due`: `Monetary`
+- `tax_payable`: `Monetary` (compute=_compute_tax_payable)
+- `total_due`: `Monetary` (compute=_compute_total_due)
+- `total_payments`: `Monetary`
+- `total_wht`: `Monetary`
+- `vatable_sales`: `Monetary`
+- `zero_rated_sales`: `Monetary`
+
+### Non-persisted fields
+- `line_ids`: `One2many` (relation=bir.return.line)
+
+## bir.return.line
+
+- Module: `ipai_tbwa_finance`
+- Model type: `Model`
+- Table: `bir_return_line`
+
+### Persisted fields
+- `amount`: `Monetary`
+- `currency_id`: `Many2one` (related=return_id.currency_id)
+- `description`: `Char`
+- `move_id`: `Many2one` (relation=account.move)
+- `partner_id`: `Many2one` (relation=res.partner)
+- `return_id`: `Many2one` (relation=bir.return, required, ondelete=cascade)
+- `sequence`: `Integer`
+- `tax_amount`: `Monetary`
+- `tin`: `Char` (related=partner_id.tin)
+
+### Non-persisted fields
+- _none_
+
+## bir.tax.return
+
+- Module: `ipai_bir_tax_compliance`
+- Model type: `Model`
+- Table: `bir_tax_return`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `bir_reference`: `Char`
+- `company_id`: `Many2one` (relation=res.company, required)
+- `currency_id`: `Many2one` (relation=res.currency)
+- `days_until_due`: `Integer` (compute=_compute_days_until_due)
+- `due_date`: `Date` (compute=_compute_due_date)
+- `filed_by`: `Many2one` (relation=res.users)
+- `filed_date`: `Datetime`
+- `form_type`: `Selection` (required)
+- `frequency`: `Selection` (compute=_compute_frequency)
+- `interest`: `Monetary`
+- `is_overdue`: `Boolean` (compute=_compute_days_until_due)
+- `name`: `Char` (required)
+- `notes`: `Text`
+- `payment_date`: `Date`
+- `payment_reference`: `Char`
+- `penalty`: `Monetary`
+- `period_end`: `Date` (required)
+- `period_start`: `Date` (required)
+- `state`: `Selection`
+- `tax_base`: `Monetary`
+- `tax_category`: `Selection` (compute=_compute_tax_category)
+- `tax_credits`: `Monetary`
+- `tax_due`: `Monetary`
+- `tax_payable`: `Monetary` (compute=_compute_tax_payable)
+- `total_amount_due`: `Monetary` (compute=_compute_total_amount_due)
+
+### Non-persisted fields
+- `line_ids`: `One2many` (relation=bir.tax.return.line)
+
+## bir.tax.return.line
+
+- Module: `ipai_bir_tax_compliance`
+- Model type: `Model`
+- Table: `bir_tax_return_line`
+
+### Persisted fields
+- `currency_id`: `Many2one` (relation=res.currency, related=return_id.currency_id)
+- `description`: `Char` (required)
+- `move_id`: `Many2one` (relation=account.move)
+- `partner_id`: `Many2one` (relation=res.partner)
+- `return_id`: `Many2one` (relation=bir.tax.return, required, ondelete=cascade)
+- `sequence`: `Integer`
+- `tax_amount`: `Monetary`
+- `tax_base`: `Monetary`
+- `tax_rate`: `Float`
+- `tin`: `Char` (related=partner_id.tin)
+
+### Non-persisted fields
+- _none_
+
+## bir.vat.line
+
+- Module: `ipai_bir_tax_compliance`
+- Model type: `Model`
+- Table: `bir_vat_line`
+
+### Persisted fields
+- `amount_untaxed`: `Monetary`
+- `currency_id`: `Many2one` (relation=res.currency, related=return_id.currency_id)
+- `invoice_date`: `Date` (related=invoice_id.invoice_date)
+- `invoice_id`: `Many2one` (relation=account.move)
+- `line_type`: `Selection` (required)
+- `partner_id`: `Many2one` (relation=res.partner)
+- `return_id`: `Many2one` (relation=bir.vat.return, required, ondelete=cascade)
+- `tin`: `Char` (related=partner_id.tin)
+- `vat_amount`: `Monetary`
+- `vat_category`: `Selection`
+
+### Non-persisted fields
+- _none_
+
+## bir.vat.return
+
+- Module: `ipai_bir_tax_compliance`
+- Model type: `Model`
+- Table: `bir_vat_return`
+- _inherit: `bir.tax.return`
+
+### Persisted fields
+- `excess_input_vat`: `Monetary` (compute=_compute_net_vat)
+- `excess_input_vat_previous`: `Monetary`
+- `exempt_sales`: `Monetary`
+- `importations`: `Monetary`
+- `net_vat_payable`: `Monetary` (compute=_compute_net_vat)
+- `output_vat`: `Monetary` (compute=_compute_output_vat)
+- `purchase_of_services`: `Monetary`
+- `total_input_vat`: `Monetary` (compute=_compute_total_input_vat)
+- `total_sales`: `Monetary` (compute=_compute_total_sales)
+- `vatable_purchases`: `Monetary`
+- `vatable_sales`: `Monetary`
+- `zero_rated_sales`: `Monetary`
+
+### Non-persisted fields
+- _none_
+
+## bir.withholding.line
+
+- Module: `ipai_bir_tax_compliance`
+- Model type: `Model`
+- Table: `bir_withholding_line`
+
+### Persisted fields
+- `currency_id`: `Many2one` (relation=res.currency, related=return_id.currency_id)
+- `gross_income`: `Monetary`
+- `income_type`: `Selection`
+- `move_id`: `Many2one` (relation=account.move)
+- `partner_id`: `Many2one` (relation=res.partner)
+- `payslip_id`: `Many2one` (relation=hr.payslip)
+- `return_id`: `Many2one` (relation=bir.withholding.return, required, ondelete=cascade)
+- `tin`: `Char` (related=partner_id.tin)
+- `wht_amount`: `Monetary`
+- `wht_rate`: `Float`
+
+### Non-persisted fields
+- _none_
+
+## bir.withholding.return
+
+- Module: `ipai_bir_tax_compliance`
+- Model type: `Model`
+- Table: `bir_withholding_return`
+- _inherit: `bir.tax.return`
+
+### Persisted fields
+- `compensation_tax_withheld`: `Monetary`
+- `employee_count`: `Integer`
+- `expanded_wht_amount`: `Monetary`
+- `final_wht_amount`: `Monetary`
+- `taxable_compensation`: `Monetary`
+- `total_compensation`: `Monetary`
+- `total_payments`: `Monetary`
+- `withholding_type`: `Selection` (required)
+
+### Non-persisted fields
+- `line_ids`: `One2many` (relation=bir.withholding.line)
+
+## close.approval.gate
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `close_approval_gate`
+- _inherit: `mail.activity.mixin, mail.thread`
+
+### Persisted fields
+- `actual_value`: `Float`
+- `approval_notes`: `Text`
+- `approved_by`: `Many2one` (relation=res.users)
+- `approved_date`: `Datetime`
+- `approver_id`: `Many2one` (relation=res.users)
+- `approver_role`: `Selection` (required)
+- `approver_user_id`: `Many2one` (relation=res.users)
+- `block_on_exceptions`: `Boolean`
+- `block_reason`: `Text`
+- `blocking_exceptions`: `Many2many` (relation=close.exception)
+- `blocking_reason`: `Text`
+- `blocking_tasks`: `Many2many` (relation=close.task)
+- `company_id`: `Many2one` (relation=res.company, related=cycle_id.company_id)
+- `cycle_id`: `Many2one` (relation=close.cycle, required, index, ondelete=cascade)
+- `gate_level`: `Integer` (required)
+- `gate_type`: `Selection` (required)
+- `min_completion_pct`: `Float`
+- `name`: `Char` (required)
+- `notes`: `Html`
+- `required_approvals`: `Integer`
+- `required_task_states`: `Char`
+- `sequence`: `Integer`
+- `state`: `Selection`
+- `template_id`: `Many2one` (relation=close.approval.gate.template)
+- `threshold_value`: `Float`
+
+### Non-persisted fields
+- _none_
+
+## close.approval.gate.template
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `close_approval_gate_template`
+
+### Persisted fields
+- `a1_check_id`: `Many2one` (relation=a1.check)
+- `active`: `Boolean`
+- `code`: `Char` (required, index)
+- `company_id`: `Many2one` (relation=res.company, required)
+- `description`: `Html`
+- `gate_type`: `Selection` (required)
+- `name`: `Char` (required)
+- `pass_criteria`: `Text`
+- `sequence`: `Integer`
+
+### Non-persisted fields
+- _none_
+
+## close.cycle
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `close_cycle`
+- _inherit: `mail.activity.mixin, mail.thread`
+- SQL constraints:
+  - `period_uniq`: `unique(period_start, period_end, company_id)` (A cycle for this period already exists.)
+  - `period_uniq`: `unique(period_start, period_end, company_id)` (A cycle for this period already exists.)
+
+### Persisted fields
+- `a1_tasklist_id`: `Many2one` (relation=a1.tasklist)
+- `close_actual_date`: `Date`
+- `close_start_date`: `Date`
+- `close_target_date`: `Date`
+- `closing_period_id`: `Many2one` (relation=closing.period)
+- `company_id`: `Many2one` (relation=res.company, required)
+- `cycle_time_days`: `Integer` (compute=_compute_cycle_time)
+- `exception_count`: `Integer` (compute=_compute_exception_count)
+- `gates_ready`: `Boolean` (compute=_compute_gates_ready)
+- `name`: `Char` (required)
+- `notes`: `Html`
+- `open_exception_count`: `Integer` (compute=_compute_exception_count)
+- `period_end`: `Date` (required)
+- `period_label`: `Char` (compute=_compute_period_label)
+- `period_start`: `Date` (required)
+- `period_type`: `Selection` (required)
+- `progress`: `Float` (compute=_compute_task_stats)
+- `state`: `Selection`
+- `task_completion_pct`: `Float` (compute=_compute_task_stats)
+- `task_count`: `Integer` (compute=_compute_task_stats)
+- `task_done_count`: `Integer` (compute=_compute_task_stats)
+- `webhook_url`: `Char`
+
+### Non-persisted fields
+- `exception_ids`: `One2many` (relation=close.exception)
+- `gate_ids`: `One2many` (relation=close.approval.gate)
+- `task_ids`: `One2many` (relation=close.task)
+
+## close.exception
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `close_exception`
+- _inherit: `mail.activity.mixin, mail.thread`
+
+### Persisted fields
+- `amount`: `Monetary`
+- `assigned_to`: `Many2one` (relation=res.users)
+- `company_id`: `Many2one` (relation=res.company, related=cycle_id.company_id)
+- `currency_id`: `Many2one` (relation=res.currency)
+- `cycle_id`: `Many2one` (relation=close.cycle, required, index, ondelete=cascade)
+- `description`: `Text`
+- `detected_by`: `Many2one` (relation=res.users)
+- `detected_date`: `Datetime`
+- `escalated_date`: `Datetime`
+- `escalated_to`: `Many2one` (relation=res.users)
+- `escalation_count`: `Integer`
+- `escalation_deadline`: `Datetime`
+- `escalation_level`: `Integer`
+- `exception_type`: `Selection` (required)
+- `last_escalated`: `Datetime`
+- `name`: `Char` (required)
+- `related_account_id`: `Many2one` (relation=account.account)
+- `related_move_id`: `Many2one` (relation=account.move)
+- `related_partner_id`: `Many2one` (relation=res.partner)
+- `reported_by`: `Many2one` (relation=res.users)
+- `resolution`: `Html`
+- `resolution_action`: `Text`
+- `resolved_by`: `Many2one` (relation=res.users)
+- `resolved_date`: `Datetime`
+- `root_cause`: `Text`
+- `severity`: `Selection` (required)
+- `state`: `Selection`
+- `task_id`: `Many2one` (relation=close.task, index, ondelete=set null)
+- `variance_pct`: `Float`
+
+### Non-persisted fields
+- _none_
+
+## close.task
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `close_task`
+- _inherit: `close.task, mail.activity.mixin, mail.thread`
+
+### Persisted fields
+- `a1_task_id`: `Many2one` (relation=a1.task)
+- `approval_deadline`: `Date`
+- `approval_done_by`: `Many2one` (relation=res.users)
+- `approval_done_date`: `Datetime`
+- `approve_done_date`: `Datetime`
+- `approve_due_date`: `Date`
+- `approve_notes`: `Text`
+- `approve_user_id`: `Many2one` (relation=res.users)
+- `approver_id`: `Many2one` (relation=res.users)
+- `attachment_ids`: `Many2many` (relation=ir.attachment)
+- `category_id`: `Many2one` (relation=close.task.category)
+- `checklist_done_pct`: `Float` (compute=_compute_checklist_pct)
+- `checklist_progress`: `Float` (compute=_compute_checklist_progress)
+- `company_id`: `Many2one` (relation=res.company, related=cycle_id.company_id)
+- `cycle_id`: `Many2one` (relation=close.cycle, required, index, ondelete=cascade)
+- `days_overdue`: `Integer` (compute=_compute_is_overdue)
+- `description`: `Text`
+- `external_key`: `Char` (index)
+- `gl_entry_count`: `Integer` (compute=_compute_gl_entry_count)
+- `gl_entry_ids`: `Many2many` (relation=account.move)
+- `has_exceptions`: `Boolean` (compute=_compute_has_exceptions)
+- `has_open_exceptions`: `Boolean` (compute=_compute_has_open_exceptions)
+- `is_overdue`: `Boolean` (compute=_compute_is_overdue)
+- `name`: `Char` (required)
+- `notes`: `Html`
+- `prep_deadline`: `Date`
+- `prep_done_by`: `Many2one` (relation=res.users)
+- `prep_done_date`: `Datetime`
+- `prep_due_date`: `Date`
+- `prep_notes`: `Text`
+- `prep_user_id`: `Many2one` (relation=res.users)
+- `preparer_id`: `Many2one` (relation=res.users)
+- `review_deadline`: `Date`
+- `review_done_by`: `Many2one` (relation=res.users)
+- `review_done_date`: `Datetime`
+- `review_due_date`: `Date`
+- `review_notes`: `Text`
+- `review_result`: `Selection`
+- `review_user_id`: `Many2one` (relation=res.users)
+- `reviewer_id`: `Many2one` (relation=res.users)
+- `sequence`: `Integer`
+- `state`: `Selection`
+- `template_id`: `Many2one` (relation=close.task.template)
+
+### Non-persisted fields
+- `checklist_ids`: `One2many` (relation=close.task.checklist)
+- `exception_ids`: `One2many` (relation=close.exception)
+
+## close.task.category
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `close_task_category`
+- SQL constraints:
+  - `category_code_unique`: `unique(code)` (Category code must be unique)
+  - `code_uniq`: `unique(code, company_id)` (Category code must be unique per company.)
+  - `code_uniq`: `unique(code, company_id)` (Category code must be unique per company.)
+
+### Persisted fields
+- `a1_workstream_id`: `Many2one` (relation=a1.workstream)
+- `active`: `Boolean`
+- `code`: `Char` (required)
+- `color`: `Integer`
+- `company_id`: `Many2one` (relation=res.company, required)
+- `default_approve_days`: `Integer`
+- `default_approve_role`: `Selection`
+- `default_prep_days`: `Integer`
+- `default_prep_role`: `Selection`
+- `default_review_days`: `Integer`
+- `default_review_role`: `Selection`
+- `description`: `Text`
+- `gl_account_ids`: `Many2many` (relation=account.account)
+- `name`: `Char` (required)
+- `sequence`: `Integer`
+
+### Non-persisted fields
+- `template_ids`: `One2many` (relation=close.task.template)
+
+## close.task.checklist
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `close_task_checklist`
+
+### Persisted fields
+- `attachment_id`: `Many2one` (relation=ir.attachment)
+- `code`: `Char` (required)
+- `done_at`: `Datetime`
+- `done_by`: `Many2one` (relation=res.users)
+- `done_date`: `Datetime`
+- `evidence_type`: `Selection`
+- `instructions`: `Text`
+- `is_done`: `Boolean`
+- `is_required`: `Boolean`
+- `name`: `Char` (required)
+- `notes`: `Text`
+- `required`: `Boolean`
+- `sequence`: `Integer`
+- `task_id`: `Many2one` (relation=close.task, required, ondelete=cascade)
+
+### Non-persisted fields
+- _none_
+
+## close.task.template
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `close_task_template`
+- SQL constraints:
+  - `code_uniq`: `unique(code, company_id)` (Template code must be unique per company.)
+  - `code_uniq`: `unique(code, company_id)` (Template code must be unique per company.)
+  - `template_code_unique`: `unique(code)` (Template code must be unique)
+
+### Persisted fields
+- `a1_template_id`: `Many2one` (relation=a1.template)
+- `active`: `Boolean`
+- `approval_days`: `Float`
+- `approval_offset`: `Integer`
+- `approve_day_offset`: `Integer`
+- `approver_id`: `Many2one` (relation=res.users)
+- `approver_role`: `Selection`
+- `category_id`: `Many2one` (relation=close.task.category, required)
+- `code`: `Char` (required)
+- `company_id`: `Many2one` (relation=res.company, required)
+- `creates_gl_entry`: `Boolean`
+- `default_approve_user_id`: `Many2one` (relation=res.users)
+- `default_prep_user_id`: `Many2one` (relation=res.users)
+- `default_review_user_id`: `Many2one` (relation=res.users)
+- `description`: `Text`
+- `gl_account_ids`: `Many2many` (relation=account.account)
+- `name`: `Char` (required)
+- `period_type`: `Selection`
+- `prep_day_offset`: `Integer`
+- `prep_days`: `Float`
+- `prep_offset`: `Integer`
+- `preparer_id`: `Many2one` (relation=res.users)
+- `preparer_role`: `Selection`
+- `review_day_offset`: `Integer`
+- `review_days`: `Float`
+- `review_offset`: `Integer`
+- `reviewer_id`: `Many2one` (relation=res.users)
+- `reviewer_role`: `Selection`
+- `sequence`: `Integer`
+
+### Non-persisted fields
+- `checklist_ids`: `One2many` (relation=close.task.template.checklist)
+
+## close.task.template.checklist
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `close_task_template_checklist`
+
+### Persisted fields
+- `code`: `Char` (required)
+- `evidence_type`: `Selection`
+- `instructions`: `Text`
+- `is_required`: `Boolean`
+- `name`: `Char` (required)
+- `required`: `Boolean`
+- `sequence`: `Integer`
+- `template_id`: `Many2one` (relation=close.task.template, required, ondelete=cascade)
+
+### Non-persisted fields
+- _none_
+
+## closing.period
+
+- Module: `ipai_tbwa_finance`
+- Model type: `Model`
+- Table: `closing_period`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `bir_tasks`: `Integer` (compute=_compute_task_stats)
+- `company_id`: `Many2one` (relation=res.company, required)
+- `completed_tasks`: `Integer` (compute=_compute_task_stats)
+- `last_workday`: `Date` (compute=_compute_last_workday)
+- `month_end_tasks`: `Integer` (compute=_compute_task_stats)
+- `name`: `Char` (compute=_compute_name)
+- `notes`: `Text`
+- `overdue_tasks`: `Integer` (compute=_compute_task_stats)
+- `period_date`: `Date` (required)
+- `period_month`: `Integer` (compute=_compute_period_parts)
+- `period_year`: `Integer` (compute=_compute_period_parts)
+- `progress`: `Float` (compute=_compute_task_stats)
+- `state`: `Selection`
+- `total_tasks`: `Integer` (compute=_compute_task_stats)
+
+### Non-persisted fields
+- `task_ids`: `One2many` (relation=finance.task)
+
+## compliance.check
+
+- Module: `ipai_tbwa_finance`
+- Model type: `Model`
+- Table: `compliance_check`
+
+### Persisted fields
+- `actual_value`: `Float`
+- `check_type`: `Selection` (required)
+- `checked_by`: `Many2one` (relation=res.users)
+- `checked_date`: `Datetime`
+- `closing_id`: `Many2one` (relation=closing.period, required, ondelete=cascade)
+- `expected_value`: `Float`
+- `name`: `Char` (required)
+- `result_text`: `Text`
+- `sequence`: `Integer`
+- `status`: `Selection`
+- `tolerance`: `Float`
+- `variance`: `Float` (compute=_compute_variance)
+
+### Non-persisted fields
+- _none_
+
+## crm.lead
+
+- Module: `ipai_crm_pipeline`
+- Model type: `Model`
+- Table: `crm_lead`
+- _inherit: `crm.lead`
+
+### Persisted fields
+- `days_in_stage`: `Integer` (compute=_compute_days_in_stage)
+- `last_call_date`: `Datetime`
+- `last_meeting_date`: `Datetime`
+- `stage_entry_date`: `Datetime`
+- `stage_missing_fields`: `Char` (compute=_compute_stage_rule_validated)
+- `stage_rule_validated`: `Boolean` (compute=_compute_stage_rule_validated)
+
+### Non-persisted fields
+- _none_
+
+## crm.stage
+
+- Module: `ipai_crm_pipeline`
+- Model type: `Model`
+- Table: `crm_stage`
+- _inherit: `crm.stage`
+
+### Persisted fields
+- `ipai_automation_notes`: `Text`
+- `ipai_enforce_rules`: `Boolean`
+- `ipai_required_field_ids`: `Many2many` (relation=ir.model.fields)
+- `ipai_sla_days`: `Integer`
+- `ipai_stage_color`: `Char`
+- `ipai_stage_icon`: `Char`
+
+### Non-persisted fields
+- _none_
+
+## discuss.channel
+
+- Module: `ipai_ask_ai`
+- Model type: `Model`
+- Table: `discuss_channel`
+- _inherit: `discuss.channel`
+
+### Persisted fields
+- `is_ai_channel`: `Boolean`
+
+### Non-persisted fields
+- _none_
+
+## finance.bir.deadline
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `finance_bir_deadline`
+- _inherit: `mail.activity.mixin, mail.thread`
+
+### Persisted fields
+- `active`: `Boolean`
+- `deadline_date`: `Date` (required)
+- `description`: `Text`
+- `display_name`: `Char` (compute=_compute_display_name)
+- `form_type`: `Selection`
+- `name`: `Char` (required)
+- `period_covered`: `Char`
+- `responsible_approval_id`: `Many2one` (relation=ipai.finance.person)
+- `responsible_prep_id`: `Many2one` (relation=ipai.finance.person)
+- `responsible_review_id`: `Many2one` (relation=ipai.finance.person)
+- `state`: `Selection`
+- `target_payment_approval_date`: `Date` (compute=_compute_targets)
+- `target_prep_date`: `Date` (compute=_compute_targets)
+- `target_report_approval_date`: `Date` (compute=_compute_targets)
+
+### Non-persisted fields
+- _none_
+
+## finance.ppm.bir.calendar
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `finance_ppm_bir_calendar`
+- SQL constraints:
+  - `unique_form_period`: `UNIQUE(form_code, period)` (BIR form and period combination must be unique!)
+  - `unique_form_period`: `UNIQUE(form_code, period)` (BIR form and period combination must be unique!)
+
+### Persisted fields
+- `description`: `Text`
+- `filing_deadline`: `Date` (required)
+- `form_code`: `Char` (required)
+- `form_name`: `Char` (required)
+- `period`: `Char` (required)
+- `responsible_role`: `Char` (required)
+
+### Non-persisted fields
+- _none_
+
+## finance.ppm.dashboard
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `finance_ppm_dashboard`
+
+### Persisted fields
+- `failures_24h`: `Integer`
+- `last_message`: `Text`
+- `last_run_at`: `Datetime`
+- `last_status`: `Selection`
+- `name`: `Char` (required)
+- `next_scheduled_at`: `Datetime`
+- `sequence`: `Integer`
+- `status_color`: `Selection` (compute=_compute_status_color)
+- `total_runs`: `Integer`
+- `workflow_code`: `Selection` (required, index)
+
+### Non-persisted fields
+- _none_
+
+## finance.ppm.import.wizard
+
+- Module: `ipai`
+- Model type: `TransientModel`
+- Table: `finance_ppm_import_wizard`
+
+### Persisted fields
+- `error_log`: `Text`
+- `file_data`: `Binary` (required)
+- `file_name`: `Char`
+- `file_type`: `Selection` (compute=_compute_file_type)
+- `import_summary`: `Text`
+- `import_type`: `Selection` (required)
+- `records_created`: `Integer`
+- `records_failed`: `Integer`
+- `records_skipped`: `Integer`
+- `records_updated`: `Integer`
+- `skip_header`: `Boolean`
+- `state`: `Selection`
+- `update_existing`: `Boolean`
+
+### Non-persisted fields
+- _none_
+
+## finance.ppm.logframe
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `finance_ppm_logframe`
+- SQL constraints:
+  - `unique_code`: `UNIQUE(code)` (Logframe code must be unique!)
+  - `unique_code`: `UNIQUE(code)` (Logframe code must be unique!)
+- Python constraints:
+  - `_check_parent_hierarchy`
+
+### Persisted fields
+- `code`: `Char` (required)
+- `description`: `Text`
+- `kpi_baseline`: `Char`
+- `kpi_measure`: `Char`
+- `kpi_target`: `Char`
+- `level`: `Selection` (required)
+- `measurement_frequency`: `Selection`
+- `name`: `Char` (required)
+- `parent_id`: `Many2one` (relation=finance.ppm.logframe, ondelete=cascade)
+- `parent_path`: `Char` (index)
+- `responsible_role`: `Char`
+
+### Non-persisted fields
+- `child_ids`: `One2many` (relation=finance.ppm.logframe)
+
+## finance.ppm.ph.holiday
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `finance_ppm_ph_holiday`
+- SQL constraints:
+  - `unique_date_name`: `UNIQUE(date, name)` (Holiday date and name combination must be unique!)
+  - `unique_date_name`: `UNIQUE(date, name)` (Holiday date and name combination must be unique!)
+
+### Persisted fields
+- `date`: `Date` (required)
+- `description`: `Text`
+- `holiday_type`: `Selection` (required)
+- `is_nationwide`: `Boolean`
+- `name`: `Char` (required)
+
+### Non-persisted fields
+- _none_
+
+## finance.ppm.tdi.audit
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `finance_ppm_tdi_audit`
+
+### Persisted fields
+- `display_name`: `Char` (compute=_compute_display_name)
+- `error_log`: `Text`
+- `file_name`: `Char` (required)
+- `has_errors`: `Boolean` (compute=_compute_has_errors)
+- `import_date`: `Datetime` (required, index)
+- `import_summary`: `Text`
+- `import_type`: `Selection` (required, index)
+- `records_created`: `Integer`
+- `records_failed`: `Integer`
+- `records_skipped`: `Integer`
+- `records_updated`: `Integer`
+- `state`: `Selection` (required, index)
+- `success_rate`: `Float` (compute=_compute_success_rate)
+- `total_records`: `Integer` (compute=_compute_total_records)
+- `user_id`: `Many2one` (relation=res.users, required, ondelete=restrict)
+
+### Non-persisted fields
+- _none_
+
+## finance.task
+
+- Module: `ipai_tbwa_finance`
+- Model type: `Model`
+- Table: `finance_task`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `approve_done`: `Boolean`
+- `approve_done_by`: `Many2one` (relation=res.users)
+- `approve_done_date`: `Datetime`
+- `approve_due_date`: `Date`
+- `approve_user_id`: `Many2one` (relation=res.users)
+- `bir_form_type`: `Selection`
+- `bir_reference`: `Char`
+- `bir_return_id`: `Many2one` (relation=bir.return)
+- `closing_id`: `Many2one` (relation=closing.period, required, ondelete=cascade)
+- `company_id`: `Many2one` (related=closing_id.company_id)
+- `days_overdue`: `Integer` (compute=_compute_overdue)
+- `filed_date`: `Datetime`
+- `filing_due_date`: `Date`
+- `is_overdue`: `Boolean` (compute=_compute_overdue)
+- `name`: `Char` (required)
+- `notes`: `Text`
+- `phase`: `Selection`
+- `prep_done`: `Boolean`
+- `prep_done_by`: `Many2one` (relation=res.users)
+- `prep_done_date`: `Datetime`
+- `prep_due_date`: `Date`
+- `prep_user_id`: `Many2one` (relation=res.users)
+- `review_done`: `Boolean`
+- `review_done_by`: `Many2one` (relation=res.users)
+- `review_done_date`: `Datetime`
+- `review_due_date`: `Date`
+- `review_user_id`: `Many2one` (relation=res.users)
+- `sequence`: `Integer`
+- `state`: `Selection` (compute=_compute_state)
+- `task_type`: `Selection` (required)
+- `template_id`: `Many2one` (relation=finance.task.template)
+
+### Non-persisted fields
+- _none_
+
+## finance.task.template
+
+- Module: `ipai_tbwa_finance`
+- Model type: `Model`
+- Table: `finance_task_template`
+
+### Persisted fields
+- `active`: `Boolean`
+- `approve_day_offset`: `Integer`
+- `approve_user_id`: `Many2one` (relation=res.users)
+- `bir_form_type`: `Selection`
+- `depends_on_ids`: `Many2many` (relation=finance.task.template)
+- `description`: `Html`
+- `filing_day_offset`: `Integer`
+- `frequency`: `Selection`
+- `name`: `Char` (required)
+- `oca_module`: `Char`
+- `odoo_model`: `Char`
+- `phase`: `Selection`
+- `prep_day_offset`: `Integer`
+- `prep_user_id`: `Many2one` (relation=res.users)
+- `review_day_offset`: `Integer`
+- `review_user_id`: `Many2one` (relation=res.users)
+- `sequence`: `Integer`
+- `task_count`: `Integer` (compute=_compute_task_count)
+- `task_type`: `Selection` (required)
+
+### Non-persisted fields
+- _none_
+
+## hr.employee
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `hr_employee`
+- _inherit: `hr.employee, master.control.mixin`
+
+### Persisted fields
+- `x_master_control_offboarded`: `Boolean`
+- `x_master_control_onboarded`: `Boolean`
+
+### Non-persisted fields
+- _none_
+
+## hr.expense
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `hr_expense`
+- _inherit: `hr.expense, master.control.mixin`
+- Python constraints:
+  - `_check_project_required`
+  - `_check_travel_request_consistency`
+
+### Persisted fields
+- `project_id`: `Many2one` (relation=project.project)
+- `requires_project`: `Boolean` (compute=_compute_requires_project)
+- `travel_request_id`: `Many2one` (relation=ipai.travel.request)
+- `x_master_control_submitted`: `Boolean`
+
+### Non-persisted fields
+- _none_
+
+## ipai.ai.studio.mixin
+
+- Module: `ipai`
+- Model type: `AbstractModel`
+- Table: `ipai_ai_studio_mixin`
+
+### Persisted fields
+
+### Non-persisted fields
+- _none_
+
+## ipai.approval.mixin
+
+- Module: `ipai_platform_approvals`
+- Model type: `AbstractModel`
+- Table: `ipai_approval_mixin`
+
+### Persisted fields
+- `approval_notes`: `Text`
+- `approval_requested`: `Boolean`
+- `approval_requested_by`: `Many2one` (relation=res.users)
+- `approval_requested_date`: `Datetime`
+- `current_approver_id`: `Many2one` (relation=res.users, compute=_compute_current_approver)
+
+### Non-persisted fields
+- _none_
+
+## ipai.ask.ai.service
+
+- Module: `ipai_ask_ai`
+- Model type: `TransientModel`
+- Table: `ipai_ask_ai_service`
+
+### Persisted fields
+
+### Non-persisted fields
+- _none_
+
+## ipai.asset
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_asset`
+- _inherit: `mail.activity.mixin, mail.thread`
+
+### Persisted fields
+- `active_checkout_id`: `Many2one` (relation=ipai.asset.checkout, compute=_compute_active_checkout)
+- `barcode`: `Char`
+- `category_id`: `Many2one` (relation=ipai.asset.category, required)
+- `code`: `Char`
+- `currency_id`: `Many2one` (relation=res.currency)
+- `current_value`: `Monetary` (compute=_compute_current_value)
+- `custodian_id`: `Many2one` (relation=hr.employee)
+- `description`: `Text`
+- `image`: `Image`
+- `location_id`: `Many2one` (relation=stock.location)
+- `name`: `Char` (required)
+- `purchase_date`: `Date`
+- `purchase_value`: `Monetary`
+- `state`: `Selection`
+
+### Non-persisted fields
+- `checkout_ids`: `One2many` (relation=ipai.asset.checkout)
+- `reservation_ids`: `One2many` (relation=ipai.asset.reservation)
+
+## ipai.asset.category
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_asset_category`
+
+### Persisted fields
+- `allow_reservations`: `Boolean`
+- `asset_count`: `Integer` (compute=_compute_asset_count)
+- `code`: `Char` (required)
+- `description`: `Text`
+- `max_checkout_days`: `Integer`
+- `name`: `Char` (required)
+- `requires_approval`: `Boolean`
+- `sequence`: `Integer`
+
+### Non-persisted fields
+- `asset_ids`: `One2many` (relation=ipai.asset)
+
+## ipai.asset.checkout
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_asset_checkout`
+- _inherit: `mail.activity.mixin, mail.thread`
+- Python constraints:
+  - `_check_asset_available`
+
+### Persisted fields
+- `actual_return_date`: `Datetime`
+- `approval_date`: `Datetime`
+- `approved_by`: `Many2one` (relation=res.users)
+- `asset_id`: `Many2one` (relation=ipai.asset, required)
+- `checkout_date`: `Datetime` (required)
+- `checkout_notes`: `Text`
+- `condition_on_return`: `Selection`
+- `employee_id`: `Many2one` (relation=hr.employee, required)
+- `expected_return_date`: `Date`
+- `name`: `Char` (compute=_compute_name)
+- `return_notes`: `Text`
+- `state`: `Selection`
+
+### Non-persisted fields
+- _none_
+
+## ipai.asset.reservation
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_asset_reservation`
+- _inherit: `mail.thread`
+- Python constraints:
+  - `_check_dates`
+  - `_check_overlap`
+
+### Persisted fields
+- `asset_id`: `Many2one` (relation=ipai.asset, required)
+- `employee_id`: `Many2one` (relation=hr.employee, required)
+- `end_date`: `Date` (required)
+- `name`: `Char` (compute=_compute_name)
+- `notes`: `Text`
+- `start_date`: `Date` (required)
+- `state`: `Selection`
+
+### Non-persisted fields
+- _none_
+
+## ipai.audit.log
+
+- Module: `ipai_platform_audit`
+- Model type: `Model`
+- Table: `ipai_audit_log`
+
+### Persisted fields
+- `action`: `Selection` (required)
+- `display_name`: `Char` (compute=_compute_display_name)
+- `field_name`: `Char`
+- `new_value`: `Text`
+- `old_value`: `Text`
+- `res_id`: `Integer` (required, index)
+- `res_model`: `Char` (required, index)
+- `res_name`: `Char`
+- `user_id`: `Many2one` (relation=res.users, required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.audit.mixin
+
+- Module: `ipai_platform_audit`
+- Model type: `AbstractModel`
+- Table: `ipai_audit_mixin`
+
+### Persisted fields
+- `audit_log_count`: `Integer` (compute=_compute_audit_log_count)
+
+### Non-persisted fields
+- `audit_log_ids`: `One2many` (relation=ipai.audit.log)
+
+## ipai.bir.dat.wizard
+
+- Module: `ipai`
+- Model type: `TransientModel`
+- Table: `ipai_bir_dat_wizard`
+
+### Persisted fields
+- `currency_id`: `Many2one` (relation=res.currency)
+- `date_end`: `Date` (required)
+- `date_start`: `Date` (required)
+- `file_data`: `Binary` (relation=DAT File)
+- `file_name`: `Char` (relation=File Name)
+- `record_count`: `Integer` (relation=Records Processed)
+- `report_type`: `Selection` (required)
+- `state`: `Selection`
+- `total_amount`: `Monetary` (relation=Total Income)
+- `total_tax`: `Monetary` (relation=Total Tax Withheld)
+
+### Non-persisted fields
+- _none_
+
+## ipai.bir.form.schedule
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_bir_form_schedule`
+- _inherit: `mail.activity.mixin, mail.thread`
+
+### Persisted fields
+- `approval_date`: `Date`
+- `bir_deadline`: `Date` (required)
+- `form_code`: `Char` (required)
+- `period`: `Char` (required)
+- `prep_date`: `Date`
+- `responsible_approval_id`: `Many2one` (relation=ipai.finance.person)
+- `responsible_prep_id`: `Many2one` (relation=ipai.finance.person)
+- `responsible_review_id`: `Many2one` (relation=ipai.finance.person)
+- `review_date`: `Date`
+
+### Non-persisted fields
+- `step_ids`: `One2many` (relation=ipai.bir.process.step)
+
+## ipai.bir.generator
+
+- Module: `ipai`
+- Model type: `AbstractModel`
+- Table: `ipai_bir_generator`
+
+### Persisted fields
+
+### Non-persisted fields
+- _none_
+
+## ipai.bir.process.step
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_bir_process_step`
+
+### Persisted fields
+- `detail`: `Text`
+- `person_id`: `Many2one` (relation=ipai.finance.person)
+- `role`: `Char`
+- `schedule_id`: `Many2one` (relation=ipai.bir.form.schedule, ondelete=cascade)
+- `step_no`: `Integer` (required)
+- `target_offset`: `Integer`
+- `title`: `Char` (required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.bir.schedule.item
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_bir_schedule_item`
+- SQL constraints:
+  - `bir_schedule_unique`: `unique(bir_form, period_covered, deadline)` (BIR schedule item must be unique per form/period/deadline!)
+  - `bir_schedule_unique`: `unique(bir_form, period_covered, deadline)` (BIR schedule item must be unique per form/period/deadline!)
+
+### Persisted fields
+- `active`: `Boolean`
+- `bir_form`: `Char` (required, index)
+- `deadline`: `Date` (required, index)
+- `im_xml_id`: `Char` (required)
+- `period_covered`: `Char` (required, index)
+
+### Non-persisted fields
+- `step_ids`: `One2many` (relation=ipai.bir.schedule.step)
+
+## ipai.bir.schedule.line
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_bir_schedule_line`
+- SQL constraints:
+  - `bir_sched_unique`: `unique(bir_form, period_label)` (BIR form+period must be unique.)
+  - `bir_sched_unique`: `unique(bir_form, period_label)` (BIR form+period must be unique.)
+- Python constraints:
+  - `_check_dates`
+
+### Persisted fields
+- `approve_by_code`: `Char`
+- `approve_due_date`: `Date`
+- `bir_form`: `Char` (required, index)
+- `deadline_date`: `Date` (required, index)
+- `notes`: `Char`
+- `period_label`: `Char` (required)
+- `prep_by_code`: `Char`
+- `prep_due_date`: `Date`
+- `review_by_code`: `Char`
+- `review_due_date`: `Date`
+
+### Non-persisted fields
+- _none_
+
+## ipai.bir.schedule.step
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_bir_schedule_step`
+
+### Persisted fields
+- `activity_type`: `Selection` (required)
+- `business_days_before`: `Integer`
+- `item_id`: `Many2one` (relation=ipai.bir.schedule.item, required, ondelete=cascade)
+- `on_or_before_deadline`: `Boolean`
+- `role_code`: `Char`
+- `sequence`: `Integer`
+
+### Non-persisted fields
+- _none_
+
+## ipai.close.generated.map
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_close_generated_map`
+- SQL constraints:
+  - `external_key_uniq`: `UNIQUE(external_key)` (External key must be unique (prevents duplicate task creation))
+  - `external_key_uniq`: `UNIQUE(external_key)` (External key must be unique (prevents duplicate task creation))
+  - `external_key_uniq`: `unique(external_key)` (External key must be unique.)
+  - `external_key_uniq`: `unique(external_key)` (External key must be unique.)
+
+### Persisted fields
+- `external_key`: `Char` (required, index)
+- `generation_run_id`: `Many2one` (relation=ipai.close.generation.run, required, index, ondelete=cascade)
+- `operation`: `Selection` (required)
+- `run_id`: `Many2one` (relation=ipai.close.generation.run, required, index, ondelete=cascade)
+- `seed_hash`: `Char` (index)
+- `seed_hash_at_generation`: `Char`
+- `task_id`: `Many2one` (relation=project.task, required, index, ondelete=cascade)
+- `template_id`: `Many2one` (relation=ipai.close.task.template, ondelete=set null)
+
+### Non-persisted fields
+- _none_
+
+## ipai.close.generation.run
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_close_generation_run`
+
+### Persisted fields
+- `created_count`: `Integer`
+- `cycle_code`: `Char` (required, index)
+- `cycle_key`: `Char` (index)
+- `cycle_type`: `Selection` (compute=_compute_cycle_type)
+- `dry_run`: `Boolean`
+- `duration_seconds`: `Integer` (compute=_compute_duration)
+- `end_time`: `Datetime`
+- `error_count`: `Integer` (compute=_compute_counts)
+- `name`: `Char` (compute=_compute_name)
+- `obsolete_marked_count`: `Integer`
+- `period_end`: `Date` (required)
+- `period_start`: `Date` (required)
+- `project_id`: `Many2one` (relation=project.project)
+- `report_json`: `Json`
+- `report_status`: `Selection` (compute=_compute_report_status)
+- `seed_id`: `Char` (required, index)
+- `seed_version`: `Char`
+- `start_time`: `Datetime`
+- `status`: `Selection` (required)
+- `task_count_created`: `Integer`
+- `task_count_obsolete`: `Integer`
+- `task_count_skipped`: `Integer`
+- `task_count_updated`: `Integer`
+- `unchanged_count`: `Integer`
+- `unresolved_assignee_count`: `Integer`
+- `updated_count`: `Integer`
+- `user_id`: `Many2one` (relation=res.users)
+- `warning_count`: `Integer` (compute=_compute_counts)
+
+### Non-persisted fields
+- `generated_map_ids`: `One2many` (relation=ipai.close.generated.map)
+- `generated_task_ids`: `One2many` (relation=ipai.close.generated.map)
+
+## ipai.close.generator
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_close_generator`
+
+### Persisted fields
+- `name`: `Char`
+
+### Non-persisted fields
+- _none_
+
+## ipai.close.task.step
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_close_task_step`
+- SQL constraints:
+  - `unique_template_step`: `UNIQUE(template_id, step_code)` (Each template can only have one instance of each step code (PREP, REVIEW, APPROVAL, FILE_PAY))
+  - `unique_template_step`: `UNIQUE(template_id, step_code)` (Each template can only have one instance of each step code (PREP, REVIEW, APPROVAL, FILE_PAY))
+
+### Persisted fields
+- `default_employee_code`: `Char`
+- `sequence`: `Integer`
+- `step_code`: `Selection` (required, index)
+- `step_name`: `Char` (required)
+- `template_id`: `Many2one` (relation=ipai.close.task.template, required, index, ondelete=cascade)
+- `user_id`: `Many2one` (relation=res.users, compute=_compute_user)
+- `x_legacy_template_code`: `Char`
+
+### Non-persisted fields
+- _none_
+
+## ipai.close.task.template
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_close_task_template`
+- SQL constraints:
+  - `template_code_uniq`: `UNIQUE(template_code, template_version)` (Template code + version must be unique)
+  - `template_code_uniq`: `UNIQUE(template_code, template_version)` (Template code + version must be unique)
+
+### Persisted fields
+- `category_code`: `Char` (index)
+- `category_name`: `Char`
+- `category_seq`: `Integer`
+- `critical_path`: `Boolean`
+- `cycle_code`: `Selection` (required, index)
+- `duration_days`: `Integer`
+- `employee_code`: `Char`
+- `is_active`: `Boolean` (index)
+- `offset_from_period_end`: `Integer`
+- `phase_code`: `Char` (required, index)
+- `phase_name`: `Char` (required)
+- `phase_seq`: `Integer`
+- `phase_type`: `Selection`
+- `recurrence_rule`: `Char`
+- `responsible_role`: `Char`
+- `seed_hash`: `Char` (compute=_compute_seed_hash, index)
+- `step_code`: `Selection` (index)
+- `step_seq`: `Integer`
+- `task_description`: `Text`
+- `task_name_template`: `Char` (required)
+- `template_code`: `Char` (required, index)
+- `template_seq`: `Integer`
+- `template_version`: `Char`
+- `wbs_code_template`: `Char`
+- `workstream_code`: `Char` (index)
+- `workstream_name`: `Char`
+- `workstream_seq`: `Integer`
+- `x_legacy_migration`: `Boolean`
+
+### Non-persisted fields
+- `step_ids`: `One2many` (relation=ipai.close.task.step)
+
+## ipai.convert.phases.wizard
+
+- Module: `ipai`
+- Model type: `TransientModel`
+- Table: `ipai_convert_phases_wizard`
+
+### Persisted fields
+- `im1_keywords`: `Char`
+- `im1_name`: `Char` (required)
+- `im2_keywords`: `Char`
+- `im2_name`: `Char` (required)
+- `move_tasks_by_keyword`: `Boolean`
+- `parent_project_id`: `Many2one` (relation=project.project, required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.directory.person
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_directory_person`
+- SQL constraints:
+  - `code_unique`: `unique(code)` (Directory code must be unique!)
+  - `code_unique`: `unique(code)` (Directory code must be unique!)
+
+### Persisted fields
+- `active`: `Boolean`
+- `code`: `Char` (required, index)
+- `email`: `Char`
+- `name`: `Char` (required)
+- `role`: `Char`
+
+### Non-persisted fields
+- `user_id`: `Many2one` (relation=res.users, compute=_compute_user_id)
+
+## ipai.equipment.asset
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_equipment_asset`
+
+### Persisted fields
+- `booking_count`: `Integer` (compute=_compute_booking_count)
+- `category_id`: `Many2one` (relation=product.category)
+- `company_id`: `Many2one` (relation=res.company)
+- `condition`: `Selection` (required)
+- `image_1920`: `Image` (relation=Image)
+- `incident_count`: `Integer` (compute=_compute_incident_count)
+- `location_id`: `Many2one` (relation=stock.location)
+- `name`: `Char` (required)
+- `product_id`: `Many2one` (relation=product.product)
+- `serial_number`: `Char`
+- `status`: `Selection` (required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.equipment.booking
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_equipment_booking`
+- Python constraints:
+  - `_check_booking_conflict`
+
+### Persisted fields
+- `asset_id`: `Many2one` (relation=ipai.equipment.asset, required)
+- `borrower_id`: `Many2one` (relation=res.users, required)
+- `end_datetime`: `Datetime` (required)
+- `is_overdue`: `Boolean` (compute=_compute_is_overdue)
+- `name`: `Char` (required)
+- `project_id`: `Many2one` (relation=project.project)
+- `start_datetime`: `Datetime` (required)
+- `state`: `Selection` (required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.equipment.incident
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_equipment_incident`
+
+### Persisted fields
+- `asset_id`: `Many2one` (relation=ipai.equipment.asset, required)
+- `booking_id`: `Many2one` (relation=ipai.equipment.booking)
+- `description`: `Text`
+- `name`: `Char` (required)
+- `reported_by`: `Many2one` (relation=res.users, required)
+- `severity`: `Selection` (required)
+- `status`: `Selection` (required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.export.seed.wizard
+
+- Module: `ipai_ppm_a1`
+- Model type: `TransientModel`
+- Table: `ipai_export_seed_wizard`
+
+### Persisted fields
+- `export_path`: `Char`
+- `webhook_url`: `Char`
+
+### Non-persisted fields
+- _none_
+
+## ipai.finance.bir_schedule
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_finance_bir_schedule`
+
+### Persisted fields
+- `approval_deadline`: `Date`
+- `approval_task_id`: `Many2one` (relation=project.task)
+- `approver_id`: `Many2one` (relation=res.users)
+- `completion_pct`: `Float`
+- `filing_deadline`: `Date` (required)
+- `logframe_id`: `Many2one` (relation=ipai.finance.logframe)
+- `name`: `Char` (required)
+- `period_covered`: `Char`
+- `prep_deadline`: `Date`
+- `prep_task_id`: `Many2one` (relation=project.task)
+- `review_deadline`: `Date`
+- `review_task_id`: `Many2one` (relation=project.task)
+- `reviewer_id`: `Many2one` (relation=res.users)
+- `status`: `Selection` (required)
+- `supervisor_id`: `Many2one` (relation=res.users)
+
+### Non-persisted fields
+- _none_
+
+## ipai.finance.directory
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_finance_directory`
+- SQL constraints:
+  - `code_uniq`: `unique(code)` (Directory code must be unique.)
+  - `code_uniq`: `unique(code)` (Directory code must be unique.)
+- Python constraints:
+  - `_check_email`
+
+### Persisted fields
+- `active`: `Boolean`
+- `code`: `Char` (required, index)
+- `email`: `Char` (index)
+- `name`: `Char` (required)
+- `user_id`: `Many2one` (relation=res.users)
+
+### Non-persisted fields
+- _none_
+
+## ipai.finance.logframe
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_finance_logframe`
+
+### Persisted fields
+- `assumptions`: `Text`
+- `code`: `Char`
+- `indicators`: `Text`
+- `level`: `Selection` (required)
+- `means_of_verification`: `Text`
+- `name`: `Char` (required)
+- `sequence`: `Integer`
+- `task_count`: `Integer` (compute=_compute_task_count)
+
+### Non-persisted fields
+- `bir_schedule_ids`: `One2many` (relation=ipai.finance.bir_schedule)
+- `task_ids`: `One2many` (relation=project.task)
+
+## ipai.finance.person
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_finance_person`
+- _inherit: `mail.activity.mixin, mail.thread`
+- SQL constraints:
+  - `code_unique`: `unique(code)` (Personnel code must be unique!)
+  - `code_unique`: `unique(code)` (Personnel code must be unique!)
+
+### Persisted fields
+- `code`: `Char` (required)
+- `email`: `Char`
+- `name`: `Char` (required)
+- `role`: `Selection`
+- `user_id`: `Many2one` (relation=res.users)
+
+### Non-persisted fields
+- _none_
+
+## ipai.finance.ppm.golive.checklist
+
+- Module: `ipai_finance_ppm_golive`
+- Model type: `Model`
+- Table: `ipai_finance_ppm_golive_checklist`
+
+### Persisted fields
+- `completed_items`: `Integer` (compute=_compute_progress)
+- `completion_pct`: `Float` (compute=_compute_progress)
+- `create_date`: `Datetime`
+- `created_by`: `Many2one` (relation=res.users)
+- `director_id`: `Many2one` (relation=res.users)
+- `director_notes`: `Text`
+- `director_review_date`: `Datetime`
+- `director_signoff_date`: `Datetime`
+- `name`: `Char` (required)
+- `section_ids`: `Many2many` (relation=ipai.finance.ppm.golive.section)
+- `senior_supervisor_id`: `Many2one` (relation=res.users)
+- `senior_supervisor_notes`: `Text`
+- `senior_supervisor_review_date`: `Datetime`
+- `state`: `Selection`
+- `supervisor_id`: `Many2one` (relation=res.users)
+- `supervisor_notes`: `Text`
+- `supervisor_review_date`: `Datetime`
+- `total_items`: `Integer` (compute=_compute_progress)
+- `version`: `Char`
+- `write_date`: `Datetime`
+
+### Non-persisted fields
+- _none_
+
+## ipai.finance.ppm.golive.item
+
+- Module: `ipai_finance_ppm_golive`
+- Model type: `Model`
+- Table: `ipai_finance_ppm_golive_item`
+
+### Persisted fields
+- `checked_by`: `Many2one` (relation=res.users)
+- `checked_date`: `Datetime`
+- `description`: `Text`
+- `evidence_url`: `Char`
+- `is_checked`: `Boolean`
+- `is_critical`: `Boolean`
+- `name`: `Char` (required)
+- `notes`: `Text`
+- `section_id`: `Many2one` (relation=ipai.finance.ppm.golive.section, required, ondelete=cascade)
+- `sequence`: `Integer`
+
+### Non-persisted fields
+- _none_
+
+## ipai.finance.ppm.golive.section
+
+- Module: `ipai_finance_ppm_golive`
+- Model type: `Model`
+- Table: `ipai_finance_ppm_golive_section`
+
+### Persisted fields
+- `completed_items`: `Integer` (compute=_compute_progress)
+- `completion_pct`: `Float` (compute=_compute_progress)
+- `description`: `Text`
+- `name`: `Char` (required)
+- `section_type`: `Selection` (required)
+- `sequence`: `Integer`
+- `total_items`: `Integer` (compute=_compute_progress)
+
+### Non-persisted fields
+- `item_ids`: `One2many` (relation=ipai.finance.ppm.golive.item)
+
+## ipai.finance.seed.service
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_finance_seed_service`
+
+### Persisted fields
+
+### Non-persisted fields
+- _none_
+
+## ipai.finance.seed.wizard
+
+- Module: `ipai`
+- Model type: `TransientModel`
+- Table: `ipai_finance_seed_wizard`
+
+### Persisted fields
+- `strict`: `Boolean`
+
+### Non-persisted fields
+- _none_
+
+## ipai.finance.task.template
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_finance_task_template`
+- _inherit: `mail.activity.mixin, mail.thread`
+- SQL constraints:
+  - `tmpl_name_unique`: `unique(name, category)` (Template name must be unique per category.)
+  - `tmpl_name_unique`: `unique(name, category)` (Template name must be unique per category.)
+
+### Persisted fields
+- `active`: `Boolean`
+- `anchor`: `Selection` (required)
+- `approval_duration`: `Float`
+- `approve_by_code`: `Char`
+- `approved_by_id`: `Many2one` (relation=ipai.finance.person)
+- `bir_form_id`: `Many2one` (relation=finance.bir.deadline)
+- `category`: `Selection` (required, index)
+- `day_of_month`: `Integer`
+- `default_duration_days`: `Integer`
+- `description`: `Text`
+- `employee_code_id`: `Many2one` (relation=ipai.finance.person)
+- `name`: `Char` (required)
+- `offset_days`: `Integer`
+- `prep_by_code`: `Char`
+- `prep_duration`: `Float`
+- `review_by_code`: `Char`
+- `review_duration`: `Float`
+- `reviewed_by_id`: `Many2one` (relation=ipai.finance.person)
+- `sequence`: `Integer`
+- `task_category`: `Selection` (index)
+- `trigger_type`: `Selection` (required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.generate.bir.tasks.wizard
+
+- Module: `ipai`
+- Model type: `TransientModel`
+- Table: `ipai_generate_bir_tasks_wizard`
+
+### Persisted fields
+- `date_from`: `Date`
+- `date_to`: `Date`
+- `dry_run`: `Boolean`
+- `program_project_id`: `Many2one` (relation=project.project, required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.generate.im.projects.wizard
+
+- Module: `ipai`
+- Model type: `TransientModel`
+- Table: `ipai_generate_im_projects_wizard`
+
+### Persisted fields
+- `create_bir_tasks`: `Boolean`
+- `create_children`: `Boolean`
+- `create_month_end_tasks`: `Boolean`
+- `project_id`: `Many2one` (relation=project.project, required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.generate.month.end.wizard
+
+- Module: `ipai`
+- Model type: `TransientModel`
+- Table: `ipai_generate_month_end_wizard`
+
+### Persisted fields
+- `anchor_date`: `Date` (required)
+- `dry_run`: `Boolean`
+- `program_project_id`: `Many2one` (relation=project.project, required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.grid.column
+
+- Module: `ipai_grid_view`
+- Model type: `Model`
+- Table: `ipai_grid_column`
+
+### Persisted fields
+- `alignment`: `Selection`
+- `cell_css_class`: `Char`
+- `clickable`: `Boolean`
+- `column_type`: `Selection`
+- `css_class`: `Char`
+- `currency_field`: `Char`
+- `date_format`: `Char`
+- `decimal_places`: `Integer`
+- `display_name`: `Char` (compute=_compute_display_name)
+- `editable`: `Boolean`
+- `field_name`: `Char` (required)
+- `field_type`: `Selection`
+- `filterable`: `Boolean`
+- `format_string`: `Char`
+- `grid_view_id`: `Many2one` (relation=ipai.grid.view, required, ondelete=cascade)
+- `header_css_class`: `Char`
+- `is_action_column`: `Boolean`
+- `is_avatar_column`: `Boolean`
+- `is_primary`: `Boolean`
+- `is_selection_column`: `Boolean`
+- `label`: `Char`
+- `max_width`: `Integer`
+- `min_width`: `Integer`
+- `resizable`: `Boolean`
+- `searchable`: `Boolean`
+- `sequence`: `Integer`
+- `sortable`: `Boolean`
+- `visible`: `Boolean`
+- `widget_options`: `Text`
+- `width`: `Integer`
+
+### Non-persisted fields
+- _none_
+
+## ipai.grid.filter
+
+- Module: `ipai_grid_view`
+- Model type: `Model`
+- Table: `ipai_grid_filter`
+
+### Persisted fields
+- `active`: `Boolean`
+- `color`: `Selection`
+- `condition_count`: `Integer` (compute=_compute_condition_count)
+- `domain`: `Char`
+- `filter_json`: `Text`
+- `grid_view_id`: `Many2one` (relation=ipai.grid.view, ondelete=cascade)
+- `icon`: `Char`
+- `is_default`: `Boolean`
+- `is_global`: `Boolean`
+- `name`: `Char` (required)
+- `sequence`: `Integer`
+- `user_id`: `Many2one` (relation=res.users)
+
+### Non-persisted fields
+- _none_
+
+## ipai.grid.filter.condition
+
+- Module: `ipai_grid_view`
+- Model type: `TransientModel`
+- Table: `ipai_grid_filter_condition`
+
+### Persisted fields
+- `field_label`: `Char`
+- `field_name`: `Char` (required)
+- `field_type`: `Selection`
+- `filter_id`: `Many2one` (relation=ipai.grid.filter)
+- `operator`: `Selection` (required)
+- `value_boolean`: `Boolean`
+- `value_char`: `Char`
+- `value_date`: `Date`
+- `value_datetime`: `Datetime`
+- `value_float`: `Float`
+- `value_integer`: `Integer`
+- `value_many2one`: `Integer`
+- `value_selection`: `Char`
+
+### Non-persisted fields
+- _none_
+
+## ipai.grid.view
+
+- Module: `ipai_grid_view`
+- Model type: `Model`
+- Table: `ipai_grid_view`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `active`: `Boolean`
+- `active_filter_id`: `Many2one` (relation=ipai.grid.filter)
+- `column_count`: `Integer` (compute=_compute_column_count)
+- `config_json`: `Text`
+- `enable_column_reorder`: `Boolean`
+- `enable_column_resize`: `Boolean`
+- `enable_export`: `Boolean`
+- `enable_quick_search`: `Boolean`
+- `enable_row_selection`: `Boolean`
+- `model_id`: `Many2one` (relation=ir.model, required, ondelete=cascade)
+- `model_name`: `Char` (related=model_id.model)
+- `name`: `Char` (required)
+- `page_size`: `Integer`
+- `page_size_options`: `Char`
+- `sequence`: `Integer`
+- `show_checkboxes`: `Boolean`
+- `show_row_numbers`: `Boolean`
+- `sort_json`: `Text`
+- `view_type`: `Selection` (required)
+- `visible_column_ids`: `Many2many` (relation=ipai.grid.column)
+
+### Non-persisted fields
+- `column_ids`: `One2many` (relation=ipai.grid.column)
+- `filter_ids`: `One2many` (relation=ipai.grid.filter)
+
+## ipai.import.seed.wizard
+
+- Module: `ipai_ppm_a1`
+- Model type: `TransientModel`
+- Table: `ipai_import_seed_wizard`
+
+### Persisted fields
+- `mode`: `Selection` (required)
+- `seed_json`: `Text` (required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.localization.overlay
+
+- Module: `ipai_ppm_a1`
+- Model type: `Model`
+- Table: `ipai_localization_overlay`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `active`: `Boolean`
+- `applies_to_code`: `Char` (required)
+- `country`: `Selection` (required)
+- `patch_payload`: `Text` (required)
+- `patch_type`: `Selection` (required)
+- `sequence`: `Integer`
+- `workstream_id`: `Many2one` (relation=ipai.workstream, required, index, ondelete=cascade)
+
+### Non-persisted fields
+- _none_
+
+## ipai.month.end.closing
+
+- Module: `ipai_month_end`
+- Model type: `Model`
+- Table: `ipai_month_end_closing`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `company_id`: `Many2one` (relation=res.company, required)
+- `completed_tasks`: `Integer` (compute=_compute_progress)
+- `last_workday`: `Date` (compute=_compute_last_workday)
+- `name`: `Char` (required)
+- `overdue_tasks`: `Integer` (compute=_compute_overdue)
+- `period_date`: `Date` (required)
+- `progress`: `Float` (compute=_compute_progress)
+- `state`: `Selection`
+- `total_tasks`: `Integer` (compute=_compute_progress)
+
+### Non-persisted fields
+- `task_ids`: `One2many` (relation=ipai.month.end.task)
+
+## ipai.month.end.generator
+
+- Module: `ipai`
+- Model type: `AbstractModel`
+- Table: `ipai_month_end_generator`
+
+### Persisted fields
+
+### Non-persisted fields
+- _none_
+
+## ipai.month.end.task
+
+- Module: `ipai_month_end`
+- Model type: `Model`
+- Table: `ipai_month_end_task`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `approve_done`: `Boolean`
+- `approve_done_by`: `Many2one` (relation=res.users)
+- `approve_done_date`: `Datetime`
+- `approve_due_date`: `Date`
+- `approve_user_id`: `Many2one` (relation=res.users)
+- `closing_id`: `Many2one` (relation=ipai.month.end.closing, required, ondelete=cascade)
+- `days_overdue`: `Integer` (compute=_compute_days_overdue)
+- `is_overdue`: `Boolean` (compute=_compute_days_overdue)
+- `name`: `Char` (required)
+- `notes`: `Html` (relation=Notes)
+- `phase`: `Selection` (required)
+- `prep_done`: `Boolean`
+- `prep_done_by`: `Many2one` (relation=res.users)
+- `prep_done_date`: `Datetime`
+- `prep_due_date`: `Date`
+- `prep_user_id`: `Many2one` (relation=res.users)
+- `review_done`: `Boolean`
+- `review_done_by`: `Many2one` (relation=res.users)
+- `review_done_date`: `Datetime`
+- `review_due_date`: `Date`
+- `review_user_id`: `Many2one` (relation=res.users)
+- `sequence`: `Integer`
+- `state`: `Selection` (compute=_compute_state)
+- `template_id`: `Many2one` (relation=ipai.month.end.task.template, ondelete=set null)
+
+### Non-persisted fields
+- _none_
+
+## ipai.month.end.task.template
+
+- Module: `ipai_month_end`
+- Model type: `Model`
+- Table: `ipai_month_end_task_template`
+
+### Persisted fields
+- `active`: `Boolean`
+- `approve_day_offset`: `Integer`
+- `approve_user_id`: `Many2one` (relation=res.users)
+- `depends_on_ids`: `Many2many` (relation=ipai.month.end.task.template)
+- `description`: `Html` (relation=Description)
+- `name`: `Char` (required)
+- `oca_module`: `Char`
+- `odoo_model`: `Char`
+- `phase`: `Selection` (required)
+- `prep_day_offset`: `Integer`
+- `prep_user_id`: `Many2one` (relation=res.users)
+- `review_day_offset`: `Integer`
+- `review_user_id`: `Many2one` (relation=res.users)
+- `sequence`: `Integer`
+- `task_count`: `Integer` (compute=_compute_task_count)
+
+### Non-persisted fields
+- _none_
+
+## ipai.month.end.template
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_month_end_template`
+- SQL constraints:
+  - `task_base_name_unique`: `unique(task_base_name)` (Task base name must be unique!)
+  - `task_base_name_unique`: `unique(task_base_name)` (Task base name must be unique!)
+
+### Persisted fields
+- `active`: `Boolean`
+- `category`: `Char`
+- `default_im_xml_id`: `Char`
+- `task_base_name`: `Char` (required, index)
+
+### Non-persisted fields
+- `step_ids`: `One2many` (relation=ipai.month.end.template.step)
+
+## ipai.month.end.template.step
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_month_end_template_step`
+
+### Persisted fields
+- `activity_type`: `Selection` (required)
+- `business_days_before`: `Integer`
+- `offset_days`: `Integer`
+- `role_code`: `Char`
+- `sequence`: `Integer`
+- `template_id`: `Many2one` (relation=ipai.month.end.template, required, ondelete=cascade)
+
+### Non-persisted fields
+- _none_
+
+## ipai.permission
+
+- Module: `ipai_platform_permissions`
+- Model type: `Model`
+- Table: `ipai_permission`
+
+### Persisted fields
+- `active`: `Boolean`
+- `group_id`: `Many2one` (relation=res.groups, ondelete=cascade)
+- `name`: `Char` (required)
+- `permission_level`: `Selection` (required)
+- `role`: `Selection` (required)
+- `scope_ref`: `Reference`
+- `scope_type`: `Selection` (required)
+- `user_id`: `Many2one` (relation=res.users, ondelete=cascade)
+
+### Non-persisted fields
+- _none_
+
+## ipai.ph.holiday
+
+- Module: `ipai_month_end`
+- Model type: `Model`
+- Table: `ipai_ph_holiday`
+- SQL constraints:
+  - `date_unique`: `UNIQUE(date)` (Holiday already exists for this date!)
+
+### Persisted fields
+- `date`: `Date` (required, index)
+- `holiday_type`: `Selection` (required)
+- `name`: `Char` (required)
+- `year`: `Integer` (compute=_compute_year)
+
+### Non-persisted fields
+- _none_
+
+## ipai.ppm.task
+
+- Module: `ipai_ppm_a1`
+- Model type: `Model`
+- Table: `ipai_ppm_task`
+- _inherit: `mail.thread, mail.activity.mixin`
+- SQL constraints:
+  - `task_code_unique`: `unique(code, template_id)` (Task code must be unique per template.)
+
+### Persisted fields
+- `category`: `Char`
+- `code`: `Char` (required)
+- `due_offset_days`: `Integer`
+- `evidence_required`: `Boolean`
+- `name`: `Char` (required)
+- `owner_role`: `Char`
+- `phase`: `Selection`
+- `prep_offset`: `Integer`
+- `requires_approval`: `Boolean`
+- `review_offset`: `Integer`
+- `sap_reference`: `Char`
+- `sequence`: `Integer`
+- `template_id`: `Many2one` (relation=ipai.ppm.template, required, index, ondelete=cascade)
+
+### Non-persisted fields
+- `checklist_line_ids`: `One2many` (relation=ipai.ppm.task.checklist)
+
+## ipai.ppm.task.checklist
+
+- Module: `ipai_ppm_a1`
+- Model type: `Model`
+- Table: `ipai_ppm_task_checklist`
+
+### Persisted fields
+- `evidence_type`: `Selection` (required)
+- `label`: `Char` (required)
+- `notes`: `Char`
+- `required`: `Boolean`
+- `sequence`: `Integer`
+- `task_id`: `Many2one` (relation=ipai.ppm.task, required, index, ondelete=cascade)
+
+### Non-persisted fields
+- _none_
+
+## ipai.ppm.tasklist
+
+- Module: `ipai_ppm_a1`
+- Model type: `Model`
+- Table: `ipai_ppm_tasklist`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `name`: `Char` (required)
+- `period_end`: `Date` (required)
+- `period_start`: `Date` (required)
+- `status`: `Selection`
+- `template_id`: `Many2one` (relation=ipai.ppm.template, required, index, ondelete=restrict)
+- `workstream_id`: `Many2one` (relation=ipai.workstream, required, index, ondelete=restrict)
+
+### Non-persisted fields
+- `taskrun_ids`: `One2many` (relation=ipai.ppm.taskrun)
+
+## ipai.ppm.taskrun
+
+- Module: `ipai_ppm_a1`
+- Model type: `Model`
+- Table: `ipai_ppm_taskrun`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `approver_id`: `Many2one` (relation=res.users, ondelete=set null)
+- `assignee_id`: `Many2one` (relation=res.users, ondelete=set null)
+- `done_at`: `Datetime`
+- `name`: `Char` (required)
+- `started_at`: `Datetime`
+- `status`: `Selection`
+- `task_id`: `Many2one` (relation=ipai.ppm.task, required, index, ondelete=restrict)
+- `tasklist_id`: `Many2one` (relation=ipai.ppm.tasklist, required, index, ondelete=cascade)
+
+### Non-persisted fields
+- _none_
+
+## ipai.ppm.template
+
+- Module: `ipai_ppm_a1`
+- Model type: `Model`
+- Table: `ipai_ppm_template`
+- _inherit: `mail.thread, mail.activity.mixin`
+- SQL constraints:
+  - `template_code_unique`: `unique(code, workstream_id)` (Template code must be unique per workstream.)
+
+### Persisted fields
+- `code`: `Char` (required)
+- `is_active`: `Boolean`
+- `name`: `Char` (required)
+- `period_type`: `Selection` (required)
+- `sequence`: `Integer`
+- `version`: `Char`
+- `workstream_id`: `Many2one` (relation=ipai.workstream, required, index, ondelete=cascade)
+
+### Non-persisted fields
+- `task_ids`: `One2many` (relation=ipai.ppm.task)
+
+## ipai.repo.export_run
+
+- Module: `ipai_ppm_a1`
+- Model type: `Model`
+- Table: `ipai_repo_export_run`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `export_path`: `Char`
+- `exported_at`: `Datetime`
+- `name`: `Char` (required)
+- `payload_json`: `Text`
+- `state`: `Selection`
+- `webhook_status`: `Char`
+- `webhook_url`: `Char`
+
+### Non-persisted fields
+- _none_
+
+## ipai.share.token
+
+- Module: `ipai_platform_permissions`
+- Model type: `Model`
+- Table: `ipai_share_token`
+
+### Persisted fields
+- `active`: `Boolean`
+- `created_by`: `Many2one` (relation=res.users)
+- `expires_at`: `Datetime`
+- `is_public`: `Boolean`
+- `name`: `Char` (required)
+- `permission_level`: `Selection` (required)
+- `scope_ref`: `Reference`
+- `scope_type`: `Selection` (required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.stc.check
+
+- Module: `ipai_ppm_a1`
+- Model type: `Model`
+- Table: `ipai_stc_check`
+- _inherit: `mail.thread, mail.activity.mixin`
+- SQL constraints:
+  - `stc_check_code_unique`: `unique(code)` (Check code must be unique.)
+
+### Persisted fields
+- `auto_run`: `Boolean`
+- `category`: `Char`
+- `code`: `Char` (required)
+- `description`: `Text`
+- `is_active`: `Boolean`
+- `name`: `Char` (required)
+- `rule_json`: `Text`
+- `sap_reference`: `Char`
+- `sequence`: `Integer`
+- `severity`: `Selection`
+- `worklist_type_id`: `Many2one` (relation=ipai.stc.worklist_type, ondelete=set null)
+- `workstream_id`: `Many2one` (relation=ipai.workstream, required, index, ondelete=cascade)
+
+### Non-persisted fields
+- _none_
+
+## ipai.stc.scenario
+
+- Module: `ipai_ppm_a1`
+- Model type: `Model`
+- Table: `ipai_stc_scenario`
+- _inherit: `mail.thread, mail.activity.mixin`
+- SQL constraints:
+  - `stc_scenario_code_unique`: `unique(code)` (Scenario code must be unique.)
+
+### Persisted fields
+- `bir_forms`: `Char`
+- `check_ids`: `Many2many` (relation=ipai.stc.check)
+- `code`: `Char` (required)
+- `frequency`: `Selection`
+- `name`: `Char` (required)
+- `notes`: `Text`
+- `run_day_offset`: `Integer`
+- `sap_reference`: `Char`
+- `sequence`: `Integer`
+- `workstream_id`: `Many2one` (relation=ipai.workstream, required, index, ondelete=cascade)
+
+### Non-persisted fields
+- _none_
+
+## ipai.stc.worklist_type
+
+- Module: `ipai_ppm_a1`
+- Model type: `Model`
+- Table: `ipai_stc_worklist_type`
+- SQL constraints:
+  - `stc_worklist_code_unique`: `unique(code)` (Worklist type code must be unique.)
+
+### Persisted fields
+- `code`: `Char` (required)
+- `description`: `Text`
+- `name`: `Char` (required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.studio.ai.history
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_studio_ai_history`
+
+### Persisted fields
+- `analysis`: `Text`
+- `automation_id`: `Many2one` (relation=base.automation, ondelete=set null)
+- `command`: `Text` (required)
+- `command_type`: `Selection`
+- `confidence`: `Float`
+- `feedback_comment`: `Text`
+- `feedback_score`: `Selection`
+- `field_id`: `Many2one` (relation=ir.model.fields, ondelete=set null)
+- `model_id`: `Many2one` (relation=ir.model, ondelete=set null)
+- `model_name`: `Char` (related=model_id.model)
+- `result`: `Selection`
+- `result_message`: `Text`
+- `user_id`: `Many2one` (relation=res.users, required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.studio.ai.service
+
+- Module: `ipai`
+- Model type: `AbstractModel`
+- Table: `ipai_studio_ai_service`
+
+### Persisted fields
+
+### Non-persisted fields
+- _none_
+
+## ipai.studio.ai.stats
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `N/A`
+
+### Persisted fields
+- `avg_confidence`: `Float`
+- `command_type`: `Selection`
+- `date`: `Date`
+- `executed_commands`: `Integer`
+- `failed_commands`: `Integer`
+- `total_commands`: `Integer`
+
+### Non-persisted fields
+- _none_
+
+## ipai.studio.ai.wizard
+
+- Module: `ipai`
+- Model type: `TransientModel`
+- Table: `ipai_studio_ai_wizard`
+
+### Persisted fields
+- `analysis_json`: `Text`
+- `command`: `Text` (required)
+- `command_type`: `Selection`
+- `confidence`: `Float`
+- `context_model_id`: `Many2one` (relation=ir.model)
+- `created_field_id`: `Many2one` (relation=ir.model.fields)
+- `field_label`: `Char`
+- `field_name`: `Char`
+- `field_required`: `Boolean`
+- `field_type`: `Selection`
+- `history_id`: `Many2one` (relation=ipai.studio.ai.history)
+- `is_ready`: `Boolean`
+- `message`: `Html`
+- `relation_model_id`: `Many2one` (relation=ir.model)
+- `result_message`: `Html`
+- `selection_options`: `Text`
+- `state`: `Selection`
+- `target_model_id`: `Many2one` (relation=ir.model)
+
+### Non-persisted fields
+- _none_
+
+## ipai.travel.request
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_travel_request`
+
+### Persisted fields
+- `company_id`: `Many2one` (relation=res.company)
+- `currency_id`: `Many2one` (relation=res.currency)
+- `destination`: `Char` (required)
+- `employee_id`: `Many2one` (relation=hr.employee, required)
+- `end_date`: `Date` (required)
+- `estimated_budget`: `Monetary`
+- `name`: `Char` (required)
+- `project_id`: `Many2one` (relation=project.project)
+- `purpose`: `Text`
+- `start_date`: `Date` (required)
+- `state`: `Selection` (required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.workflow.mixin
+
+- Module: `ipai_platform_workflow`
+- Model type: `AbstractModel`
+- Table: `ipai_workflow_mixin`
+
+### Persisted fields
+- `workflow_state`: `Selection` (index)
+- `workflow_state_date`: `Datetime`
+- `workflow_state_user_id`: `Many2one` (relation=res.users)
+
+### Non-persisted fields
+- _none_
+
+## ipai.workos.block
+
+- Module: `ipai_workos_blocks`
+- Model type: `Model`
+- Table: `ipai_workos_block`
+- Python constraints:
+  - `_check_content_json`
+
+### Persisted fields
+- `attachment_id`: `Many2one` (relation=ir.attachment, ondelete=set null)
+- `block_type`: `Selection` (required)
+- `callout_color`: `Char`
+- `callout_icon`: `Char`
+- `content_html`: `Html` (compute=_compute_content_html)
+- `content_json`: `Text`
+- `content_text`: `Text` (compute=_compute_content_text)
+- `is_checked`: `Boolean`
+- `is_collapsed`: `Boolean`
+- `name`: `Char` (compute=_compute_name)
+- `page_id`: `Many2one` (relation=ipai.workos.page, required, index, ondelete=cascade)
+- `parent_block_id`: `Many2one` (relation=ipai.workos.block, ondelete=cascade)
+- `sequence`: `Integer`
+
+### Non-persisted fields
+- `child_block_ids`: `One2many` (relation=ipai.workos.block)
+
+## ipai.workos.canvas
+
+- Module: `ipai_workos_canvas`
+- Model type: `Model`
+- Table: `ipai_workos_canvas`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `active`: `Boolean`
+- `name`: `Char` (required)
+- `nodes_json`: `Text`
+- `page_id`: `Many2one` (relation=ipai.workos.page, index, ondelete=cascade)
+- `viewport_json`: `Text`
+
+### Non-persisted fields
+- _none_
+
+## ipai.workos.comment
+
+- Module: `ipai_workos_collab`
+- Model type: `Model`
+- Table: `ipai_workos_comment`
+- _inherit: `mail.thread`
+
+### Persisted fields
+- `anchor_block_id`: `Integer`
+- `author_id`: `Many2one` (relation=res.users, required)
+- `content`: `Html` (required)
+- `content_text`: `Text` (compute=_compute_content_text)
+- `is_resolved`: `Boolean`
+- `mentioned_user_ids`: `Many2many` (relation=res.users)
+- `parent_id`: `Many2one` (relation=ipai.workos.comment, ondelete=cascade)
+- `reply_count`: `Integer` (compute=_compute_reply_count)
+- `resolved_at`: `Datetime`
+- `resolved_by`: `Many2one` (relation=res.users)
+- `target_id`: `Integer` (required, index)
+- `target_model`: `Char` (required, index)
+- `target_name`: `Char` (compute=_compute_target_name)
+
+### Non-persisted fields
+- `child_ids`: `One2many` (relation=ipai.workos.comment)
+
+## ipai.workos.database
+
+- Module: `ipai_workos_db`
+- Model type: `Model`
+- Table: `ipai_workos_database`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `active`: `Boolean`
+- `description`: `Text`
+- `icon`: `Char`
+- `name`: `Char` (required)
+- `page_id`: `Many2one` (relation=ipai.workos.page, ondelete=cascade)
+- `row_count`: `Integer` (compute=_compute_row_count)
+- `space_id`: `Many2one` (relation=ipai.workos.space, ondelete=cascade)
+
+### Non-persisted fields
+- `property_ids`: `One2many` (relation=ipai.workos.property)
+- `row_ids`: `One2many` (relation=ipai.workos.row)
+
+## ipai.workos.page
+
+- Module: `ipai_workos_core`
+- Model type: `Model`
+- Table: `ipai_workos_page`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `active`: `Boolean`
+- `child_count`: `Integer` (compute=_compute_child_count)
+- `content_preview`: `Text` (compute=_compute_content_preview)
+- `cover_image`: `Binary`
+- `icon`: `Char`
+- `is_archived`: `Boolean`
+- `last_edited_by`: `Many2one` (relation=res.users, compute=_compute_last_edited)
+- `name`: `Char` (required)
+- `parent_id`: `Many2one` (relation=ipai.workos.page, index, ondelete=cascade)
+- `parent_path`: `Char` (index)
+- `sequence`: `Integer`
+- `space_id`: `Many2one` (relation=ipai.workos.space, compute=_compute_space_id, ondelete=cascade)
+- `template_id`: `Many2one` (relation=ipai.workos.template)
+- `workspace_id`: `Many2one` (relation=ipai.workos.workspace, related=space_id.workspace_id)
+
+### Non-persisted fields
+- `child_ids`: `One2many` (relation=ipai.workos.page)
+
+## ipai.workos.property
+
+- Module: `ipai_workos_db`
+- Model type: `Model`
+- Table: `ipai_workos_property`
+
+### Persisted fields
+- `database_id`: `Many2one` (relation=ipai.workos.database, required, ondelete=cascade)
+- `is_title`: `Boolean`
+- `is_visible`: `Boolean`
+- `name`: `Char` (required)
+- `options_json`: `Text`
+- `property_type`: `Selection` (required)
+- `related_database_id`: `Many2one` (relation=ipai.workos.database, ondelete=set null)
+- `sequence`: `Integer`
+- `width`: `Integer`
+
+### Non-persisted fields
+- _none_
+
+## ipai.workos.row
+
+- Module: `ipai_workos_db`
+- Model type: `Model`
+- Table: `ipai_workos_row`
+
+### Persisted fields
+- `active`: `Boolean`
+- `database_id`: `Many2one` (relation=ipai.workos.database, required, index, ondelete=cascade)
+- `name`: `Char` (compute=_compute_name)
+- `sequence`: `Integer`
+- `values_json`: `Text`
+
+### Non-persisted fields
+- _none_
+
+## ipai.workos.search
+
+- Module: `ipai_workos_search`
+- Model type: `TransientModel`
+- Table: `ipai_workos_search`
+
+### Persisted fields
+- `block_results`: `Text`
+- `database_results`: `Text`
+- `page_results`: `Text`
+- `query`: `Char`
+- `scope`: `Selection`
+- `scope_id`: `Integer`
+
+### Non-persisted fields
+- _none_
+
+## ipai.workos.search.history
+
+- Module: `ipai_workos_search`
+- Model type: `Model`
+- Table: `ipai_workos_search_history`
+
+### Persisted fields
+- `query`: `Char` (required)
+- `result_count`: `Integer`
+- `user_id`: `Many2one` (relation=res.users, required, index)
+
+### Non-persisted fields
+- _none_
+
+## ipai.workos.space
+
+- Module: `ipai_workos_core`
+- Model type: `Model`
+- Table: `ipai_workos_space`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `active`: `Boolean`
+- `color`: `Integer`
+- `description`: `Text`
+- `icon`: `Char`
+- `name`: `Char` (required)
+- `page_count`: `Integer` (compute=_compute_page_count)
+- `sequence`: `Integer`
+- `visibility`: `Selection` (required)
+- `workspace_id`: `Many2one` (relation=ipai.workos.workspace, required, ondelete=cascade)
+
+### Non-persisted fields
+- `page_ids`: `One2many` (relation=ipai.workos.page)
+
+## ipai.workos.template
+
+- Module: `ipai_workos_templates`
+- Model type: `Model`
+- Table: `ipai_workos_template`
+
+### Persisted fields
+- `blocks_json`: `Text`
+- `category`: `Selection` (required)
+- `description`: `Text`
+- `icon`: `Char`
+- `is_published`: `Boolean`
+- `is_system`: `Boolean`
+- `name`: `Char` (required)
+- `properties_json`: `Text`
+- `sequence`: `Integer`
+- `tag_ids`: `Many2many` (relation=ipai.workos.template.tag)
+- `views_json`: `Text`
+
+### Non-persisted fields
+- _none_
+
+## ipai.workos.template.tag
+
+- Module: `ipai_workos_templates`
+- Model type: `Model`
+- Table: `ipai_workos_template_tag`
+
+### Persisted fields
+- `color`: `Integer`
+- `name`: `Char` (required)
+
+### Non-persisted fields
+- _none_
+
+## ipai.workos.view
+
+- Module: `ipai_workos_views`
+- Model type: `Model`
+- Table: `ipai_workos_view`
+
+### Persisted fields
+- `config_json`: `Text`
+- `database_id`: `Many2one` (relation=ipai.workos.database, required, index, ondelete=cascade)
+- `date_property_id`: `Many2one` (relation=ipai.workos.property)
+- `filter_json`: `Text`
+- `group_by_property_id`: `Many2one` (relation=ipai.workos.property)
+- `is_default`: `Boolean`
+- `is_shared`: `Boolean`
+- `name`: `Char` (required)
+- `sequence`: `Integer`
+- `sort_json`: `Text`
+- `user_id`: `Many2one` (relation=res.users)
+- `view_type`: `Selection` (required)
+- `visible_property_ids`: `Many2many` (relation=ipai.workos.property)
+
+### Non-persisted fields
+- _none_
+
+## ipai.workos.workspace
+
+- Module: `ipai_workos_core`
+- Model type: `Model`
+- Table: `ipai_workos_workspace`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `active`: `Boolean`
+- `color`: `Integer`
+- `description`: `Text`
+- `icon`: `Char`
+- `member_ids`: `Many2many` (relation=res.users)
+- `name`: `Char` (required)
+- `owner_id`: `Many2one` (relation=res.users, required)
+- `space_count`: `Integer` (compute=_compute_space_count)
+
+### Non-persisted fields
+- `space_ids`: `One2many` (relation=ipai.workos.space)
+
+## ipai.workspace
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_workspace`
+- _inherit: `ipai.workspace, mail.activity.mixin, mail.thread`
+- SQL constraints:
+  - `name_company_uniq`: `unique(name, company_id)` (Workspace name must be unique per company.)
+  - `name_company_uniq`: `unique(name, company_id)` (Workspace name must be unique per company.)
+
+### Persisted fields
+- `account_manager_id`: `Many2one` (relation=res.users)
+- `active`: `Boolean`
+- `brand_name`: `Char`
+- `campaign_type`: `Selection`
+- `channel_mix`: `Char`
+- `client_id`: `Many2one` (relation=res.partner, index)
+- `closing_stage`: `Selection`
+- `code`: `Char` (index)
+- `color`: `Integer` (relation=Color Index)
+- `company_id`: `Many2one` (relation=res.company, index)
+- `date_end`: `Datetime`
+- `date_start`: `Datetime`
+- `engagement_count`: `Integer` (compute=_compute_counters)
+- `entity_code`: `Char`
+- `fiscal_period`: `Char`
+- `industry`: `Selection` (required)
+- `invoice_count`: `Integer` (compute=_compute_counters)
+- `is_critical`: `Boolean`
+- `name`: `Char` (required)
+- `parent_id`: `Many2one` (relation=ipai.workspace, index, ondelete=cascade)
+- `planned_hours`: `Float`
+- `progress`: `Float`
+- `project_count`: `Integer` (compute=_compute_counters)
+- `remaining_hours`: `Float`
+- `sequence`: `Integer`
+- `stage`: `Selection`
+- `workspace_type`: `Selection` (required)
+
+### Non-persisted fields
+- `child_ids`: `One2many` (relation=ipai.workspace)
+- `link_ids`: `One2many` (relation=ipai.workspace.link)
+
+## ipai.workspace.link
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ipai_workspace_link`
+- SQL constraints:
+  - `workspace_res_uniq`: `unique(workspace_id, res_model, res_id)` (This record is already linked to the workspace.)
+  - `workspace_res_uniq`: `unique(workspace_id, res_model, res_id)` (This record is already linked to the workspace.)
+
+### Persisted fields
+- `display_name`: `Char` (compute=_compute_display_name)
+- `link_type`: `Selection`
+- `res_id`: `Integer` (required)
+- `res_model`: `Char` (required)
+- `workspace_id`: `Many2one` (relation=ipai.workspace, required, index, ondelete=cascade)
+
+### Non-persisted fields
+- _none_
+
+## ipai.workstream
+
+- Module: `ipai_ppm_a1`
+- Model type: `Model`
+- Table: `ipai_workstream`
+- _inherit: `mail.thread, mail.activity.mixin`
+- SQL constraints:
+  - `workstream_code_unique`: `unique(code)` (Workstream code must be unique.)
+
+### Persisted fields
+- `active`: `Boolean`
+- `code`: `Selection` (required)
+- `description`: `Text`
+- `name`: `Char` (required)
+- `odoo_anchor`: `Char`
+- `sap_anchor`: `Char`
+
+### Non-persisted fields
+- `check_ids`: `One2many` (relation=ipai.stc.check)
+- `overlay_ids`: `One2many` (relation=ipai.localization.overlay)
+- `scenario_ids`: `One2many` (relation=ipai.stc.scenario)
+- `tasklist_ids`: `One2many` (relation=ipai.ppm.tasklist)
+- `template_ids`: `One2many` (relation=ipai.ppm.template)
+
+## ir.http
+
+- Module: `ipai`
+- Model type: `AbstractModel`
+- Table: `ir_http`
+- _inherit: `ir.http`
+
+### Persisted fields
+
+### Non-persisted fields
+- _none_
+
+## ir.qweb
+
+- Module: `ipai`
+- Model type: `AbstractModel`
+- Table: `ir_qweb`
+- _inherit: `ir.qweb`
+
+### Persisted fields
+
+### Non-persisted fields
+- _none_
+
+## master.control.mixin
+
+- Module: `ipai`
+- Model type: `AbstractModel`
+- Table: `master_control_mixin`
+
+### Persisted fields
+
+### Non-persisted fields
+- _none_
+
+## ph.holiday
+
+- Module: `ipai_tbwa_finance`
+- Model type: `Model`
+- Table: `ph_holiday`
+- SQL constraints:
+  - `date_unique`: `unique(date, company_id)` (Holiday date must be unique per company)
+
+### Persisted fields
+- `company_id`: `Many2one` (relation=res.company)
+- `date`: `Date` (required, index)
+- `holiday_type`: `Selection` (required)
+- `name`: `Char` (required)
+- `year`: `Integer` (compute=_compute_year, index)
+
+### Non-persisted fields
+- _none_
+
+## ppm.close.task
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ppm_close_task`
+- _inherit: `mail.activity.mixin, mail.thread`
+
+### Persisted fields
+- `agency_code`: `Selection` (required)
+- `approval_completed_by`: `Char`
+- `approval_completed_date`: `Date`
+- `approval_days`: `Float`
+- `approval_due`: `Date` (related=monthly_close_id.approval_due_date)
+- `approver_code`: `Char`
+- `completion_notes`: `Text`
+- `detailed_task`: `Text` (required)
+- `monthly_close_id`: `Many2one` (relation=ppm.monthly.close, required, index, ondelete=cascade)
+- `name`: `Char` (required)
+- `notes`: `Text`
+- `owner_code`: `Char` (required)
+- `prep_completed_by`: `Char`
+- `prep_completed_date`: `Date`
+- `prep_days`: `Float`
+- `prep_start`: `Date` (related=monthly_close_id.prep_start_date)
+- `review_completed_by`: `Char`
+- `review_completed_date`: `Date`
+- `review_days`: `Float`
+- `review_due`: `Date` (related=monthly_close_id.review_due_date)
+- `reviewer_code`: `Char`
+- `sequence`: `Integer`
+- `state`: `Selection` (required)
+- `template_id`: `Many2one` (relation=ppm.close.template)
+- `total_days`: `Float` (compute=_compute_total_days)
+
+### Non-persisted fields
+- _none_
+
+## ppm.close.template
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ppm_close_template`
+
+### Persisted fields
+- `active`: `Boolean`
+- `agency_code`: `Selection` (required)
+- `approval_days`: `Float`
+- `approver_code`: `Char`
+- `detailed_task`: `Text` (required)
+- `name`: `Char` (compute=_compute_name)
+- `notes`: `Text`
+- `owner_code`: `Char` (required)
+- `prep_days`: `Float`
+- `review_days`: `Float`
+- `reviewer_code`: `Char`
+- `sequence`: `Integer`
+- `task_category`: `Char` (required)
+- `total_days`: `Float` (compute=_compute_total_days)
+
+### Non-persisted fields
+- _none_
+
+## ppm.kpi.snapshot
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ppm_kpi_snapshot`
+
+### Persisted fields
+- `as_of`: `Datetime` (required, index)
+- `kpi_category`: `Selection`
+- `kpi_key`: `Char` (required, index)
+- `kpi_label`: `Char`
+- `name`: `Char` (compute=_compute_name)
+- `portfolio_id`: `Many2one` (relation=ppm.portfolio, index)
+- `program_id`: `Many2one` (relation=ppm.program, index)
+- `project_id`: `Many2one` (relation=project.project, index)
+- `scope`: `Selection` (required)
+- `source`: `Selection`
+- `source_ref`: `Char`
+- `status`: `Selection` (compute=_compute_status)
+- `target_value`: `Float`
+- `threshold_green`: `Float`
+- `threshold_yellow`: `Float`
+- `unit`: `Char`
+- `value`: `Float` (required)
+- `value_text`: `Char`
+
+### Non-persisted fields
+- _none_
+
+## ppm.monthly.close
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ppm_monthly_close`
+- _inherit: `mail.activity.mixin, mail.thread`
+
+### Persisted fields
+- `approval_due_date`: `Date` (compute=_compute_schedule_dates)
+- `close_month`: `Date` (required)
+- `created_by_cron`: `Boolean`
+- `month_end_date`: `Date` (compute=_compute_schedule_dates)
+- `name`: `Char` (compute=_compute_name)
+- `notes`: `Text`
+- `prep_start_date`: `Date` (compute=_compute_schedule_dates)
+- `progress_percentage`: `Float` (compute=_compute_task_stats)
+- `review_due_date`: `Date` (compute=_compute_schedule_dates)
+- `state`: `Selection`
+- `task_completed`: `Integer` (compute=_compute_task_stats)
+- `task_count`: `Integer` (compute=_compute_task_stats)
+
+### Non-persisted fields
+- `task_ids`: `One2many` (relation=ppm.close.task)
+
+## ppm.portfolio
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ppm_portfolio`
+- _inherit: `mail.activity.mixin, mail.thread`
+- SQL constraints:
+  - `code_unique`: `UNIQUE(code)` (Portfolio code must be unique!)
+  - `code_unique`: `UNIQUE(code)` (Portfolio code must be unique!)
+
+### Persisted fields
+- `active`: `Boolean`
+- `budget_variance_pct`: `Float` (compute=_compute_budget_rollup)
+- `code`: `Char` (required)
+- `currency_id`: `Many2one` (relation=res.currency)
+- `date_end`: `Date`
+- `date_start`: `Date`
+- `description`: `Html`
+- `health_score`: `Integer` (compute=_compute_health_status)
+- `health_status`: `Selection` (compute=_compute_health_status)
+- `name`: `Char` (required)
+- `objective`: `Text`
+- `owner_id`: `Many2one` (relation=res.users)
+- `program_count`: `Integer` (compute=_compute_program_count)
+- `sequence`: `Integer`
+- `sponsor_id`: `Many2one` (relation=res.users)
+- `total_actual`: `Monetary` (compute=_compute_budget_rollup)
+- `total_budget`: `Monetary` (compute=_compute_budget_rollup)
+
+### Non-persisted fields
+- `kpi_snapshot_ids`: `One2many` (relation=ppm.kpi.snapshot)
+- `program_ids`: `One2many` (relation=ppm.program)
+
+## ppm.program
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ppm_program`
+- _inherit: `mail.activity.mixin, mail.thread`
+- SQL constraints:
+  - `code_unique`: `UNIQUE(code)` (Program code must be unique!)
+  - `code_unique`: `UNIQUE(code)` (Program code must be unique!)
+
+### Persisted fields
+- `active`: `Boolean`
+- `actual_cost`: `Monetary` (compute=_compute_actual_cost)
+- `budget`: `Monetary`
+- `code`: `Char` (required)
+- `currency_id`: `Many2one` (relation=res.currency)
+- `date_end`: `Date`
+- `date_start`: `Date`
+- `description`: `Html`
+- `health_notes`: `Text`
+- `health_score`: `Integer`
+- `health_status`: `Selection`
+- `name`: `Char` (required)
+- `objectives`: `Text`
+- `open_high_risks`: `Integer` (compute=_compute_risk_count)
+- `portfolio_id`: `Many2one` (relation=ppm.portfolio, ondelete=restrict)
+- `program_manager_id`: `Many2one` (relation=res.users)
+- `project_count`: `Integer` (compute=_compute_project_count)
+- `project_ids`: `Many2many` (relation=project.project)
+- `risk_count`: `Integer` (compute=_compute_risk_count)
+- `sequence`: `Integer`
+- `sponsor_id`: `Many2one` (relation=res.users)
+
+### Non-persisted fields
+- `allocation_ids`: `One2many` (relation=ppm.resource.allocation)
+- `kpi_snapshot_ids`: `One2many` (relation=ppm.kpi.snapshot)
+- `risk_ids`: `One2many` (relation=ppm.risk)
+
+## ppm.resource.allocation
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ppm_resource_allocation`
+- Python constraints:
+  - `_check_allocation`
+  - `_check_dates`
+
+### Persisted fields
+- `allocation_pct`: `Float`
+- `date_end`: `Date` (required)
+- `date_start`: `Date` (required)
+- `employee_id`: `Many2one` (relation=hr.employee, required, index)
+- `is_overloaded`: `Boolean` (compute=_compute_overload)
+- `name`: `Char` (compute=_compute_name)
+- `notes`: `Text`
+- `planned_hours`: `Float`
+- `program_id`: `Many2one` (relation=ppm.program, index)
+- `project_id`: `Many2one` (relation=project.project, index)
+- `role`: `Selection`
+- `status`: `Selection`
+- `task_id`: `Many2one` (relation=project.task)
+- `total_allocation`: `Float` (compute=_compute_overload)
+- `user_id`: `Many2one` (related=employee_id.user_id)
+
+### Non-persisted fields
+- _none_
+
+## ppm.risk
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `ppm_risk`
+- _inherit: `mail.activity.mixin, mail.thread`
+
+### Persisted fields
+- `assigned_to_id`: `Many2one` (relation=res.users)
+- `category`: `Selection` (required)
+- `code`: `Char`
+- `contingency_plan`: `Text`
+- `currency_id`: `Many2one` (relation=res.currency)
+- `date_closed`: `Date`
+- `date_identified`: `Date`
+- `date_target`: `Date`
+- `description`: `Text`
+- `impact`: `Selection` (required)
+- `mitigation_plan`: `Text`
+- `mitigation_strategy`: `Selection`
+- `name`: `Char` (required)
+- `owner_id`: `Many2one` (relation=res.users)
+- `portfolio_id`: `Many2one` (relation=ppm.portfolio)
+- `potential_cost`: `Monetary`
+- `probability`: `Selection` (required)
+- `program_id`: `Many2one` (relation=ppm.program)
+- `project_id`: `Many2one` (relation=project.project)
+- `risk_score`: `Integer` (compute=_compute_risk_score)
+- `scope`: `Selection` (required)
+- `severity`: `Selection` (compute=_compute_risk_score)
+- `status`: `Selection`
+
+### Non-persisted fields
+- _none_
+
+## project.milestone
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `project_milestone`
+- _inherit: `project.milestone`
+- Python constraints:
+  - `_check_deadlines`
+
+### Persisted fields
+- `alert_days_before`: `Integer`
+- `approval_date`: `Date`
+- `approval_required`: `Boolean`
+- `approver_id`: `Many2one` (relation=res.users)
+- `baseline_deadline`: `Date`
+- `completed_task_count`: `Integer` (compute=_compute_task_count)
+- `completion_criteria`: `Text`
+- `deliverables`: `Text`
+- `gate_status`: `Selection`
+- `last_alert_sent`: `Date`
+- `milestone_type`: `Selection` (required)
+- `risk_level`: `Selection`
+- `risk_notes`: `Text`
+- `task_count`: `Integer` (compute=_compute_task_count)
+- `variance_days`: `Integer` (compute=_compute_variance)
+
+### Non-persisted fields
+- `task_ids`: `One2many` (relation=project.task)
+
+## project.project
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `project_project`
+- _inherit: `project.project`
+
+### Persisted fields
+- `actual_finish`: `Date`
+- `actual_start`: `Date`
+- `baseline_finish`: `Date`
+- `baseline_start`: `Date`
+- `clarity_id`: `Char` (required, index)
+- `critical_milestone_count`: `Integer` (compute=_compute_milestone_stats)
+- `health_status`: `Selection` (required)
+- `im_code`: `Char` (index)
+- `ipai_finance_enabled`: `Boolean`
+- `ipai_im_code`: `Selection` (index)
+- `ipai_is_im_project`: `Boolean` (index)
+- `ipai_root_project_id`: `Many2one` (relation=project.project, index, ondelete=set null)
+- `is_program`: `Boolean` (index)
+- `milestone_count`: `Integer` (compute=_compute_milestone_stats)
+- `overall_progress`: `Float` (compute=_compute_overall_progress)
+- `overall_status`: `Selection` (compute=_compute_overall_status)
+- `parent_id`: `Many2one` (relation=project.project, index, ondelete=restrict)
+- `phase_count`: `Integer` (compute=_compute_phase_stats)
+- `portfolio_id`: `Many2one` (relation=project.category)
+- `ppm_program_ids`: `Many2many` (relation=ppm.program)
+- `program_code`: `Char` (index)
+- `program_type`: `Selection` (index)
+- `variance_finish`: `Integer` (compute=_compute_variances)
+- `variance_start`: `Integer` (compute=_compute_variances)
+- `x_cycle_code`: `Char` (index)
+
+### Non-persisted fields
+- `child_ids`: `One2many` (relation=project.project)
+- `im_count`: `Integer` (compute=_compute_im_rollups)
+- `im_task_count`: `Integer` (compute=_compute_im_rollups)
+
+## project.task
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `project_task`
+- _inherit: `project.task`
+- Python constraints:
+  - `_check_phase_hierarchy`
+
+### Persisted fields
+- `activity_type`: `Selection` (index)
+- `actual_cost`: `Float`
+- `actual_hours`: `Float` (compute=_compute_actual_hours)
+- `approval_duration`: `Float`
+- `approver_id`: `Many2one` (relation=res.users)
+- `auto_sync`: `Boolean`
+- `bir_approval_due_date`: `Date`
+- `bir_deadline`: `Date`
+- `bir_form`: `Char` (index)
+- `bir_payment_due_date`: `Date`
+- `bir_period_label`: `Char`
+- `bir_prep_due_date`: `Date`
+- `bir_related`: `Boolean`
+- `bir_schedule_id`: `Many2one` (relation=ipai.finance.bir_schedule)
+- `child_task_count`: `Integer` (compute=_compute_child_task_count)
+- `closing_due_date`: `Date`
+- `cluster`: `Selection`
+- `cost_variance`: `Float` (compute=_compute_variances)
+- `critical_path`: `Boolean` (compute=_compute_critical_path, index)
+- `earned_value`: `Float` (compute=_compute_earned_value)
+- `erp_ref`: `Char`
+- `fd_id`: `Many2one` (relation=res.users)
+- `finance_category`: `Selection`
+- `finance_code`: `Char`
+- `finance_deadline_type`: `Selection`
+- `finance_logframe_id`: `Many2one` (relation=ipai.finance.logframe)
+- `finance_person_id`: `Many2one` (relation=ipai.finance.person)
+- `finance_supervisor_id`: `Many2one` (relation=res.users)
+- `free_float`: `Integer` (compute=_compute_float)
+- `gate_approver_id`: `Many2one` (relation=res.users)
+- `gate_decision`: `Selection`
+- `gate_milestone_id`: `Many2one` (relation=project.milestone)
+- `has_gate`: `Boolean`
+- `ipai_compliance_step`: `Selection` (index)
+- `ipai_days_to_deadline`: `Integer` (compute=_compute_ipai_deadline_metrics)
+- `ipai_owner_code`: `Char` (index)
+- `ipai_owner_role`: `Selection` (index)
+- `ipai_status_bucket`: `Selection` (compute=_compute_ipai_deadline_metrics, index)
+- `ipai_task_category`: `Selection` (index)
+- `ipai_template_id`: `Many2one` (relation=ipai.finance.task.template, index, ondelete=set null)
+- `is_finance_ppm`: `Boolean` (compute=_compute_is_finance_ppm)
+- `is_phase`: `Boolean` (index)
+- `lag_days`: `Integer`
+- `lead_days`: `Integer`
+- `milestone_count`: `Integer` (compute=_compute_milestone_count)
+- `owner_code`: `Char`
+- `period_covered`: `Char` (index)
+- `phase_baseline_finish`: `Date`
+- `phase_baseline_start`: `Date`
+- `phase_progress`: `Float` (compute=_compute_phase_progress)
+- `phase_status`: `Selection`
+- `phase_type`: `Selection`
+- `phase_variance_days`: `Integer` (compute=_compute_phase_variance)
+- `planned_hours`: `Float`
+- `planned_value`: `Float`
+- `prep_duration`: `Float`
+- `relative_due`: `Char`
+- `remaining_hours`: `Float`
+- `resource_allocation`: `Float`
+- `review_duration`: `Float`
+- `reviewer_id`: `Many2one` (relation=res.users)
+- `role_code`: `Char` (index)
+- `schedule_variance`: `Float` (compute=_compute_variances)
+- `sfm_id`: `Many2one` (relation=res.users)
+- `target_date`: `Date` (index)
+- `total_float`: `Integer` (compute=_compute_float)
+- `wbs_code`: `Char` (compute=_compute_wbs_code)
+- `x_cycle_key`: `Char` (index)
+- `x_external_key`: `Char` (index)
+- `x_obsolete`: `Boolean` (index)
+- `x_seed_hash`: `Char` (index)
+- `x_step_code`: `Char` (index)
+- `x_task_template_code`: `Char` (index)
+
+### Non-persisted fields
+- _none_
+
+## project.task.checklist.item
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `project_task_checklist_item`
+- _inherit: `project.task.checklist.item`
+
+### Persisted fields
+- `actual_hours`: `Float`
+- `assigned_user_id`: `Many2one` (relation=res.users)
+- `blocker_description`: `Text`
+- `completed_date`: `Date`
+- `due_date`: `Date`
+- `estimated_hours`: `Float`
+- `notes`: `Text`
+- `priority`: `Selection`
+- `status`: `Selection` (compute=_compute_status)
+
+### Non-persisted fields
+- _none_
+
+## purchase.order
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `purchase_order`
+- _inherit: `master.control.mixin, purchase.order`
+
+### Persisted fields
+- `x_master_control_submitted`: `Boolean`
+
+### Non-persisted fields
+- _none_
+
+## res.config.settings
+
+- Module: `ipai`
+- Model type: `TransientModel`
+- Table: `res_config_settings`
+- _inherit: `res.config.settings`
+
+### Persisted fields
+- `ipai_enable_finance_project_analytics`: `Boolean`
+- `superset_auto_sync`: `Boolean`
+- `superset_connection_id`: `Many2one` (relation=superset.connection)
+- `superset_create_analytics_views`: `Boolean`
+- `superset_enable_rls`: `Boolean`
+- `superset_sync_interval`: `Selection`
+
+### Non-persisted fields
+- _none_
+
+## res.partner
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `res_partner`
+- _inherit: `res.partner`
+- Python constraints:
+  - `_check_tin_format`
+
+### Persisted fields
+- `bir_registered`: `Boolean`
+- `bir_registration_date`: `Date`
+- `srm_overall_score`: `Float` (related=srm_supplier_id.overall_score)
+- `srm_supplier_id`: `Many2one` (relation=srm.supplier)
+- `srm_tier`: `Selection` (related=srm_supplier_id.tier)
+- `tax_type`: `Selection`
+- `tin`: `Char` (index)
+- `tin_branch_code`: `Char`
+
+### Non-persisted fields
+- _none_
+
+## res.users
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `res_users`
+- _inherit: `res.users`
+- SQL constraints:
+  - `x_employee_code_uniq`: `UNIQUE(x_employee_code)` (Employee code must be unique)
+  - `x_employee_code_uniq`: `UNIQUE(x_employee_code)` (Employee code must be unique)
+  - `x_employee_code_unique`: `unique(x_employee_code)` (Employee code must be unique when set!)
+  - `x_employee_code_unique`: `unique(x_employee_code)` (Employee code must be unique when set!)
+
+### Persisted fields
+- `x_employee_code`: `Char` (index)
+
+### Non-persisted fields
+- _none_
+
+## srm.kpi.category
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `srm_kpi_category`
+
+### Persisted fields
+- `active`: `Boolean`
+- `code`: `Char` (required)
+- `compute_source`: `Selection`
+- `description`: `Text`
+- `eval_method`: `Selection`
+- `name`: `Char` (required)
+- `sequence`: `Integer`
+- `weight`: `Float`
+
+### Non-persisted fields
+- _none_
+
+## srm.qualification
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `srm_qualification`
+- _inherit: `mail.activity.mixin, mail.thread`
+
+### Persisted fields
+- `approval_date`: `Datetime`
+- `approver_id`: `Many2one` (relation=res.users)
+- `checklist_complete`: `Boolean` (compute=_compute_checklist_complete)
+- `completion_date`: `Date`
+- `document_ids`: `Many2many` (relation=ir.attachment)
+- `expiry_date`: `Date`
+- `name`: `Char` (compute=_compute_name)
+- `notes`: `Text`
+- `qualification_type`: `Selection` (required)
+- `rejection_reason`: `Text`
+- `reviewer_id`: `Many2one` (relation=res.users)
+- `risk_notes`: `Text`
+- `risk_score`: `Float`
+- `start_date`: `Date`
+- `state`: `Selection`
+- `supplier_id`: `Many2one` (relation=srm.supplier, required)
+- `target_completion`: `Date`
+
+### Non-persisted fields
+- `checklist_ids`: `One2many` (relation=srm.qualification.checklist)
+
+## srm.qualification.checklist
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `srm_qualification_checklist`
+
+### Persisted fields
+- `completed_by`: `Many2one` (relation=res.users)
+- `completed_date`: `Date`
+- `description`: `Text`
+- `is_complete`: `Boolean`
+- `is_required`: `Boolean`
+- `name`: `Char` (required)
+- `notes`: `Text`
+- `qualification_id`: `Many2one` (relation=srm.qualification, required, ondelete=cascade)
+- `sequence`: `Integer`
+
+### Non-persisted fields
+- _none_
+
+## srm.scorecard
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `srm_scorecard`
+- _inherit: `mail.thread`
+
+### Persisted fields
+- `action_items`: `Text`
+- `as_of`: `Date` (required)
+- `comments`: `Text`
+- `evaluator_id`: `Many2one` (relation=res.users)
+- `grade`: `Selection` (compute=_compute_grade)
+- `name`: `Char` (compute=_compute_name)
+- `overall_score`: `Float` (compute=_compute_overall_score)
+- `period`: `Selection`
+- `state`: `Selection`
+- `supplier_id`: `Many2one` (relation=srm.supplier, required)
+
+### Non-persisted fields
+- `line_ids`: `One2many` (relation=srm.scorecard.line)
+
+## srm.scorecard.line
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `srm_scorecard_line`
+
+### Persisted fields
+- `evidence`: `Text`
+- `kpi_category_id`: `Many2one` (relation=srm.kpi.category, required)
+- `notes`: `Text`
+- `score`: `Float`
+- `scorecard_id`: `Many2one` (relation=srm.scorecard, required, ondelete=cascade)
+- `sequence`: `Integer` (related=kpi_category_id.sequence)
+- `weight`: `Float`
+- `weighted_score`: `Float` (compute=_compute_weighted_score)
+
+### Non-persisted fields
+- _none_
+
+## srm.supplier
+
+- Module: `ipai`
+- Model type: `Model`
+- Table: `srm_supplier`
+- _inherit: `mail.activity.mixin, mail.thread`
+
+### Persisted fields
+- `category_ids`: `Many2many` (relation=product.category)
+- `code`: `Char`
+- `compliance_docs_complete`: `Boolean`
+- `currency_id`: `Many2one` (relation=res.currency)
+- `is_qualified`: `Boolean` (compute=_compute_is_qualified)
+- `last_audit_date`: `Date`
+- `latest_scorecard_id`: `Many2one` (relation=srm.scorecard, compute=_compute_latest_scorecard)
+- `name`: `Char` (required)
+- `next_audit_date`: `Date`
+- `open_po_count`: `Integer` (compute=_compute_po_stats)
+- `overall_score`: `Float` (compute=_compute_overall_score)
+- `partner_id`: `Many2one` (relation=res.partner, required)
+- `primary_contact_id`: `Many2one` (relation=res.partner)
+- `qualification_expiry`: `Date`
+- `risk_level`: `Selection`
+- `risk_notes`: `Text`
+- `sales_contact_id`: `Many2one` (relation=res.partner)
+- `state`: `Selection`
+- `tier`: `Selection`
+- `total_po_count`: `Integer` (compute=_compute_po_stats)
+- `ytd_spend`: `Monetary` (compute=_compute_ytd_spend)
+
+### Non-persisted fields
+- `qualification_ids`: `One2many` (relation=srm.qualification)
+- `scorecard_ids`: `One2many` (relation=srm.scorecard)
+
+## superset.analytics.view
+
+- Module: `ipai_superset_connector`
+- Model type: `Model`
+- Table: `superset_analytics_view`
+
+### Persisted fields
+- `active`: `Boolean`
+- `category`: `Selection` (required)
+- `description`: `Text`
+- `is_created`: `Boolean`
+- `last_refresh`: `Datetime`
+- `name`: `Char` (required)
+- `required_modules`: `Char`
+- `sequence`: `Integer`
+- `sql_definition`: `Text` (required)
+- `technical_name`: `Char` (required)
+
+### Non-persisted fields
+- _none_
+
+## superset.bulk.dataset.wizard
+
+- Module: `ipai_superset_connector`
+- Model type: `TransientModel`
+- Table: `superset_bulk_dataset_wizard`
+
+### Persisted fields
+- `connection_id`: `Many2one` (relation=superset.connection, required)
+- `create_analytics_views`: `Boolean`
+- `preset`: `Selection`
+
+### Non-persisted fields
+- _none_
+
+## superset.connection
+
+- Module: `ipai_superset_connector`
+- Model type: `Model`
+- Table: `superset_connection`
+- _inherit: `mail.thread, mail.activity.mixin`
+
+### Persisted fields
+- `access_token`: `Char`
+- `active`: `Boolean`
+- `api_key`: `Char`
+- `auth_method`: `Selection` (required)
+- `base_url`: `Char` (required)
+- `csrf_token`: `Char`
+- `dataset_count`: `Integer` (compute=_compute_dataset_count)
+- `db_connection_id`: `Integer`
+- `db_connection_name`: `Char`
+- `last_error`: `Text`
+- `last_sync`: `Datetime`
+- `name`: `Char` (required)
+- `password`: `Char`
+- `pg_database`: `Char`
+- `pg_host`: `Char`
+- `pg_password`: `Char`
+- `pg_port`: `Integer`
+- `pg_schema`: `Char`
+- `pg_username`: `Char`
+- `refresh_token`: `Char`
+- `state`: `Selection`
+- `token_expiry`: `Datetime`
+- `use_ssl`: `Boolean`
+- `username`: `Char`
+
+### Non-persisted fields
+- `dataset_ids`: `One2many` (relation=superset.dataset)
+
+## superset.dataset
+
+- Module: `ipai_superset_connector`
+- Model type: `Model`
+- Table: `superset_dataset`
+- _inherit: `mail.thread, mail.activity.mixin`
+- SQL constraints:
+  - `technical_name_uniq`: `unique(technical_name)` (Technical name must be unique!)
+
+### Persisted fields
+- `active`: `Boolean`
+- `category`: `Selection`
+- `column_count`: `Integer` (compute=_compute_column_count)
+- `connection_id`: `Many2one` (relation=superset.connection, required, ondelete=cascade)
+- `custom_sql`: `Text`
+- `description`: `Text`
+- `enable_rls`: `Boolean`
+- `field_ids`: `Many2many` (relation=ir.model.fields)
+- `include_all_fields`: `Boolean`
+- `last_sync`: `Datetime`
+- `model_id`: `Many2one` (relation=ir.model)
+- `model_name`: `Char` (related=model_id.model)
+- `name`: `Char` (required)
+- `rls_filter_column`: `Char`
+- `sequence`: `Integer`
+- `source_type`: `Selection` (required)
+- `superset_dataset_id`: `Integer`
+- `sync_error`: `Text`
+- `sync_status`: `Selection`
+- `technical_name`: `Char` (required)
+- `view_created`: `Boolean`
+- `view_name`: `Char` (compute=_compute_view_name)
+- `view_sql`: `Text`
+
+### Non-persisted fields
+- _none_
+
+## superset.dataset.column
+
+- Module: `ipai_superset_connector`
+- Model type: `Model`
+- Table: `superset_dataset_column`
+
+### Persisted fields
+- `aggregation`: `Selection`
+- `column_type`: `Selection`
+- `data_type`: `Selection`
+- `dataset_id`: `Many2one` (relation=superset.dataset, required, ondelete=cascade)
+- `description`: `Text`
+- `filterable`: `Boolean`
+- `format_string`: `Char`
+- `groupable`: `Boolean`
+- `label`: `Char`
+- `name`: `Char` (required)
+- `sequence`: `Integer`
+
+### Non-persisted fields
+- _none_
+
+## superset.dataset.wizard
+
+- Module: `ipai_superset_connector`
+- Model type: `TransientModel`
+- Table: `superset_dataset_wizard`
+
+### Persisted fields
+- `category`: `Selection`
+- `connection_id`: `Many2one` (relation=superset.connection, required)
+- `create_view`: `Boolean`
+- `enable_rls`: `Boolean`
+- `field_ids`: `Many2many` (relation=ir.model.fields)
+- `include_all_fields`: `Boolean`
+- `model_id`: `Many2one` (relation=ir.model, required)
+- `name`: `Char`
+- `sync_to_superset`: `Boolean`
+- `technical_name`: `Char`
+
+### Non-persisted fields
+- _none_

--- a/docs/data-model/README.md
+++ b/docs/data-model/README.md
@@ -1,0 +1,26 @@
+# Odoo Data Model Artifacts
+
+This folder contains canonical, generated representations of the Odoo CE data model as defined by this repository’s addons.
+
+## Contents
+
+- `ODOO_CANONICAL_SCHEMA.dbml`: Canonical DBML schema suitable for dbdiagram.io.
+- `ODOO_ERD.mmd`: Mermaid ER diagram export.
+- `ODOO_ERD.puml`: PlantUML ER diagram export.
+- `ODOO_ORM_MAP.md`: ORM map linking Odoo models, tables, and fields.
+- `ODOO_MODULE_DELTAS.md`: Per-module deltas highlighting new and extended tables.
+- `ODOO_MODEL_INDEX.json`: Machine-readable index of models, fields, and relations.
+
+## Regenerate locally
+
+Run the generator from the repo root:
+
+```bash
+python scripts/generate_odoo_dbml.py
+```
+
+## Viewing ERDs
+
+- DBML: import into https://dbdiagram.io
+- Mermaid: use a Mermaid-compatible renderer or GitHub preview.
+- PlantUML: render with PlantUML tooling.

--- a/scripts/generate_odoo_dbml.py
+++ b/scripts/generate_odoo_dbml.py
@@ -1,0 +1,629 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import ast
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+ROOT = Path(__file__).resolve().parents[1]
+
+SCAN_DIRS = ["addons", "oca", "vendor", "external-src"]
+MANIFEST_FILES = {"__manifest__.py", "__openerp__.py"}
+
+FIELD_TYPE_MAP = {
+    "Char": "varchar",
+    "Text": "text",
+    "Boolean": "boolean",
+    "Integer": "int",
+    "Float": "float",
+    "Monetary": "decimal",
+    "Binary": "binary",
+    "Date": "date",
+    "Datetime": "datetime",
+    "Selection": "varchar",
+    "Many2one": "int",
+    "Many2many": "int",
+}
+
+
+@dataclass
+class FieldDef:
+    name: str
+    field_type: str
+    store: bool = True
+    required: bool = False
+    index: bool = False
+    relation: Optional[str] = None
+    inverse: Optional[str] = None
+    relation_table: Optional[str] = None
+    column1: Optional[str] = None
+    column2: Optional[str] = None
+    ondelete: Optional[str] = None
+    related: Optional[str] = None
+    compute: Optional[str] = None
+
+
+@dataclass
+class ModelDef:
+    name: str
+    module: str
+    table: Optional[str]
+    model_type: str
+    inherits: List[str] = field(default_factory=list)
+    inherits_delegated: Dict[str, str] = field(default_factory=dict)
+    fields: Dict[str, FieldDef] = field(default_factory=dict)
+    sql_constraints: List[Tuple[str, str, str]] = field(default_factory=list)
+    python_constraints: List[str] = field(default_factory=list)
+    file_paths: Set[str] = field(default_factory=set)
+
+
+@dataclass
+class TableDef:
+    name: str
+    fields: Dict[str, str] = field(default_factory=dict)
+    notes: List[str] = field(default_factory=list)
+
+
+def iter_module_roots() -> Dict[Path, str]:
+    module_roots: Dict[Path, str] = {}
+    for dir_name in SCAN_DIRS:
+        root_dir = ROOT / dir_name
+        if not root_dir.exists():
+            continue
+        for manifest in root_dir.rglob("__manifest__.py"):
+            module_roots[manifest.parent] = manifest.parent.name
+        for manifest in root_dir.rglob("__openerp__.py"):
+            module_roots[manifest.parent] = manifest.parent.name
+    return module_roots
+
+
+def find_module_root(path: Path, module_roots: Dict[Path, str]) -> Optional[Path]:
+    for parent in [path] + list(path.parents):
+        if parent in module_roots:
+            return parent
+    return None
+
+
+def literal_eval(node: ast.AST) -> Any:
+    try:
+        return ast.literal_eval(node)
+    except Exception:
+        return None
+
+
+def get_base_name(node: ast.AST) -> Optional[str]:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = get_base_name(node.value)
+        if base:
+            return f"{base}.{node.attr}"
+        return node.attr
+    return None
+
+
+def is_odoo_model_base(node: ast.AST) -> Optional[str]:
+    name = get_base_name(node)
+    if not name:
+        return None
+    if name.endswith("models.Model"):
+        return "Model"
+    if name.endswith("models.TransientModel"):
+        return "TransientModel"
+    if name.endswith("models.AbstractModel"):
+        return "AbstractModel"
+    return None
+
+
+def parse_field_call(node: ast.Call) -> Optional[FieldDef]:
+    if not isinstance(node.func, ast.Attribute):
+        return None
+    if not isinstance(node.func.value, ast.Name):
+        return None
+    if node.func.value.id != "fields":
+        return None
+    field_type = node.func.attr
+    field = FieldDef(name="", field_type=field_type)
+    if node.args:
+        first_arg = literal_eval(node.args[0])
+        if isinstance(first_arg, str):
+            field.relation = first_arg
+    if field_type == "One2many" and len(node.args) >= 2:
+        field.inverse = literal_eval(node.args[1])
+    if field_type == "Many2many":
+        if len(node.args) >= 2:
+            field.relation_table = literal_eval(node.args[1])
+        if len(node.args) >= 3:
+            field.column1 = literal_eval(node.args[2])
+        if len(node.args) >= 4:
+            field.column2 = literal_eval(node.args[3])
+    for keyword in node.keywords:
+        if keyword.arg == "store":
+            store_val = literal_eval(keyword.value)
+            if isinstance(store_val, bool):
+                field.store = store_val
+        if keyword.arg == "required":
+            required_val = literal_eval(keyword.value)
+            if isinstance(required_val, bool):
+                field.required = required_val
+        if keyword.arg == "index":
+            index_val = literal_eval(keyword.value)
+            if isinstance(index_val, bool):
+                field.index = index_val
+        if keyword.arg == "ondelete":
+            ondelete_val = literal_eval(keyword.value)
+            if isinstance(ondelete_val, str):
+                field.ondelete = ondelete_val
+        if keyword.arg == "related":
+            related_val = literal_eval(keyword.value)
+            if isinstance(related_val, str):
+                field.related = related_val
+        if keyword.arg == "compute":
+            compute_val = literal_eval(keyword.value)
+            if isinstance(compute_val, str):
+                field.compute = compute_val
+    return field
+
+
+def parse_model(file_path: Path, module: str) -> List[ModelDef]:
+    source = file_path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    models: List[ModelDef] = []
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        model_type = None
+        for base in node.bases:
+            model_type = is_odoo_model_base(base)
+            if model_type:
+                break
+        if not model_type:
+            continue
+        attrs: Dict[str, Any] = {}
+        fields: Dict[str, FieldDef] = {}
+        sql_constraints: List[Tuple[str, str, str]] = []
+        python_constraints: List[str] = []
+        for item in node.body:
+            if isinstance(item, ast.Assign):
+                if len(item.targets) != 1:
+                    continue
+                target = item.targets[0]
+                if isinstance(target, ast.Name):
+                    name = target.id
+                    if name in {"_name", "_inherit", "_table", "_auto", "_inherits"}:
+                        attrs[name] = literal_eval(item.value)
+                        continue
+                    if isinstance(item.value, ast.Call):
+                        field_def = parse_field_call(item.value)
+                        if field_def:
+                            field_def.name = name
+                            fields[name] = field_def
+            if isinstance(item, ast.Assign):
+                for target in item.targets:
+                    if isinstance(target, ast.Name) and target.id == "_sql_constraints":
+                        constraints_val = literal_eval(item.value)
+                        if isinstance(constraints_val, list):
+                            for entry in constraints_val:
+                                if (
+                                    isinstance(entry, (list, tuple))
+                                    and len(entry) >= 3
+                                    and all(isinstance(v, str) for v in entry[:3])
+                                ):
+                                    sql_constraints.append((entry[0], entry[1], entry[2]))
+            if isinstance(item, ast.FunctionDef):
+                for decorator in item.decorator_list:
+                    if isinstance(decorator, ast.Call):
+                        deco_name = get_base_name(decorator.func)
+                        if deco_name == "api.constrains":
+                            python_constraints.append(item.name)
+        model_name = attrs.get("_name")
+        inherit_val = attrs.get("_inherit")
+        inherit_list: List[str] = []
+        if isinstance(inherit_val, str):
+            inherit_list = [inherit_val]
+        elif isinstance(inherit_val, (list, tuple)):
+            inherit_list = [v for v in inherit_val if isinstance(v, str)]
+        if not model_name and isinstance(inherit_val, str):
+            model_name = inherit_val
+        if not model_name:
+            continue
+        auto_val = attrs.get("_auto")
+        if auto_val is False:
+            table_name = None
+        else:
+            table_name = attrs.get("_table")
+            if not table_name:
+                table_name = model_name.replace(".", "_")
+        inherits_delegated = {}
+        inherits_val = attrs.get("_inherits")
+        if isinstance(inherits_val, dict):
+            inherits_delegated = {
+                k: v for k, v in inherits_val.items() if isinstance(k, str) and isinstance(v, str)
+            }
+        model_def = ModelDef(
+            name=model_name,
+            module=module,
+            table=table_name,
+            model_type=model_type,
+            inherits=inherit_list,
+            inherits_delegated=inherits_delegated,
+            fields=fields,
+            sql_constraints=sql_constraints,
+            python_constraints=python_constraints,
+        )
+        model_def.file_paths.add(str(file_path.relative_to(ROOT)))
+        models.append(model_def)
+    return models
+
+
+def collect_models() -> Dict[str, ModelDef]:
+    module_roots = iter_module_roots()
+    models: Dict[str, ModelDef] = {}
+    for module_root, module_name in sorted(module_roots.items(), key=lambda x: x[1]):
+        for file_path in module_root.rglob("*.py"):
+            if any(part.startswith(".") for part in file_path.parts):
+                continue
+            if file_path.name in MANIFEST_FILES:
+                continue
+            file_models = parse_model(file_path, module_name)
+            for model_def in file_models:
+                existing = models.get(model_def.name)
+                if existing:
+                    existing.fields.update(model_def.fields)
+                    existing.sql_constraints.extend(model_def.sql_constraints)
+                    existing.python_constraints.extend(model_def.python_constraints)
+                    existing.file_paths.update(model_def.file_paths)
+                    if model_def.table and not existing.table:
+                        existing.table = model_def.table
+                    if model_def.inherits:
+                        existing.inherits = sorted(set(existing.inherits + model_def.inherits))
+                    existing.inherits_delegated.update(model_def.inherits_delegated)
+                else:
+                    models[model_def.name] = model_def
+    return models
+
+
+def ensure_meta_fields(model: ModelDef, table: TableDef) -> None:
+    for meta, field_type in [
+        ("id", "int"),
+        ("create_uid", "int"),
+        ("create_date", "datetime"),
+        ("write_uid", "int"),
+        ("write_date", "datetime"),
+    ]:
+        if meta not in table.fields:
+            table.fields[meta] = field_type
+    if "active" in model.fields and "active" not in table.fields:
+        table.fields["active"] = FIELD_TYPE_MAP.get("Boolean", "boolean")
+    if "company_id" in model.fields and "company_id" not in table.fields:
+        table.fields["company_id"] = FIELD_TYPE_MAP.get("Many2one", "int")
+
+
+def derive_many2many_table(model: ModelDef, field: FieldDef, model_table: str, models: Dict[str, ModelDef]) -> Tuple[str, str, str]:
+    relation_table = field.relation_table
+    comodel_table = None
+    if field.relation:
+        comodel = models.get(field.relation)
+        comodel_table = comodel.table if comodel else field.relation.replace(".", "_")
+    if not relation_table:
+        relation_table = f"{model_table}_{field.name}_rel"
+    col1 = field.column1 or f"{model_table}_id"
+    col2 = field.column2 or f"{comodel_table or 'id'}_id"
+    return relation_table, col1, col2
+
+
+def build_tables(models: Dict[str, ModelDef]) -> Tuple[Dict[str, TableDef], List[Tuple[str, str]]]:
+    tables: Dict[str, TableDef] = {}
+    refs: List[Tuple[str, str]] = []
+    for model in models.values():
+        if not model.table:
+            continue
+        if model.model_type == "AbstractModel":
+            continue
+        table = tables.setdefault(model.table, TableDef(name=model.table))
+        for field in model.fields.values():
+            if field.field_type == "One2many":
+                continue
+            if field.field_type in {"Many2one", "Many2many"}:
+                if not field.store:
+                    continue
+            if field.compute and not field.store:
+                continue
+            if field.related and not field.store:
+                continue
+            if field.field_type == "Many2many":
+                continue
+            field_type = FIELD_TYPE_MAP.get(field.field_type, "varchar")
+            table.fields.setdefault(field.name, field_type)
+            if field.field_type == "Many2one" and field.relation:
+                refs.append((f"{model.table}.{field.name}", field.relation))
+        ensure_meta_fields(model, table)
+        if model.sql_constraints:
+            for name, sql, msg in model.sql_constraints:
+                table.notes.append(f"{name}: {sql} ({msg})")
+    # many2many tables
+    for model in models.values():
+        if not model.table:
+            continue
+        if model.model_type == "AbstractModel":
+            continue
+        for field in model.fields.values():
+            if field.field_type != "Many2many":
+                continue
+            if field.compute and not field.store:
+                continue
+            if field.related and not field.store:
+                continue
+            model_table = model.table
+            relation_table, col1, col2 = derive_many2many_table(model, field, model_table, models)
+            if relation_table not in tables:
+                tables[relation_table] = TableDef(name=relation_table)
+            tables[relation_table].fields.setdefault(col1, "int")
+            tables[relation_table].fields.setdefault(col2, "int")
+            if field.relation:
+                refs.append((f"{relation_table}.{col2}", field.relation))
+            refs.append((f"{relation_table}.{col1}", model.name))
+    return tables, refs
+
+
+def collect_stub_tables(tables: Dict[str, TableDef], refs: List[Tuple[str, str]], models: Dict[str, ModelDef]) -> None:
+    model_by_name = models
+    for _, target_model in refs:
+        if target_model in model_by_name and model_by_name[target_model].table:
+            continue
+        table_name = target_model.replace(".", "_")
+        if table_name not in tables:
+            tables[table_name] = TableDef(name=table_name, fields={"id": "int"}, notes=["stub for core model"]) 
+
+
+def generate_dbml(tables: Dict[str, TableDef], refs: List[Tuple[str, str]], models: Dict[str, ModelDef]) -> str:
+    lines: List[str] = []
+    for table_name in sorted(tables.keys()):
+        table = tables[table_name]
+        lines.append(f"Table {table.name} {{")
+        for field_name in sorted(table.fields.keys()):
+            field_type = table.fields[field_name]
+            pk = " [pk]" if field_name == "id" else ""
+            lines.append(f"  {field_name} {field_type}{pk}")
+        if table.notes:
+            note = "\\n".join(sorted(set(table.notes)))
+            lines.append(f"  Note: '{note}'")
+        lines.append("}")
+        lines.append("")
+    # refs
+    for source, target_model in sorted(refs):
+        target_table = target_model.replace(".", "_")
+        if target_model in models and models[target_model].table:
+            target_table = models[target_model].table
+        lines.append(f"Ref: {source} > {target_table}.id")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def generate_mermaid(tables: Dict[str, TableDef], refs: List[Tuple[str, str]], models: Dict[str, ModelDef]) -> str:
+    lines = ["erDiagram"]
+    for table_name in sorted(tables.keys()):
+        table = tables[table_name]
+        lines.append(f"  {table.name} {{")
+        for field_name in sorted(table.fields.keys()):
+            field_type = table.fields[field_name]
+            lines.append(f"    {field_type} {field_name}")
+        lines.append("  }")
+    for source, target_model in sorted(refs):
+        source_table, source_field = source.split(".")
+        target_table = target_model.replace(".", "_")
+        if target_model in models and models[target_model].table:
+            target_table = models[target_model].table
+        lines.append(f"  {source_table} ||--o{{ {target_table} : \"{source_field}\"")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def generate_plantuml(tables: Dict[str, TableDef], refs: List[Tuple[str, str]], models: Dict[str, ModelDef]) -> str:
+    lines = ["@startuml", "hide circle", "skinparam linetype ortho"]
+    for table_name in sorted(tables.keys()):
+        table = tables[table_name]
+        lines.append(f"entity {table.name} {{")
+        for field_name in sorted(table.fields.keys()):
+            field_type = table.fields[field_name]
+            lines.append(f"  {field_type} {field_name}")
+        lines.append("}")
+    for source, target_model in sorted(refs):
+        source_table, source_field = source.split(".")
+        target_table = target_model.replace(".", "_")
+        if target_model in models and models[target_model].table:
+            target_table = models[target_model].table
+        lines.append(f"{source_table} }}o--|| {target_table} : {source_field}")
+    lines.append("@enduml")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def generate_orm_map(models: Dict[str, ModelDef]) -> str:
+    lines: List[str] = ["# Odoo ORM Map", ""]
+    for model_name in sorted(models.keys()):
+        model = models[model_name]
+        lines.append(f"## {model.name}")
+        lines.append("")
+        lines.append(f"- Module: `{model.module}`")
+        lines.append(f"- Model type: `{model.model_type}`")
+        lines.append(f"- Table: `{model.table or 'N/A'}`")
+        if model.inherits:
+            lines.append(f"- _inherit: `{', '.join(model.inherits)}`")
+        if model.inherits_delegated:
+            inherits_fmt = ", ".join(f"{k} via {v}" for k, v in model.inherits_delegated.items())
+            lines.append(f"- _inherits: `{inherits_fmt}`")
+        if model.sql_constraints:
+            lines.append("- SQL constraints:")
+            for name, sql, msg in sorted(model.sql_constraints):
+                lines.append(f"  - `{name}`: `{sql}` ({msg})")
+        if model.python_constraints:
+            lines.append("- Python constraints:")
+            for name in sorted(set(model.python_constraints)):
+                lines.append(f"  - `{name}`")
+        lines.append("")
+        persisted = []
+        non_persisted = []
+        for field in sorted(model.fields.values(), key=lambda f: f.name):
+            is_persisted = True
+            if field.field_type == "One2many":
+                is_persisted = False
+            if field.compute and not field.store:
+                is_persisted = False
+            if field.related and not field.store:
+                is_persisted = False
+            if field.field_type == "Many2many":
+                is_persisted = True
+            if is_persisted:
+                persisted.append(field)
+            else:
+                non_persisted.append(field)
+        lines.append("### Persisted fields")
+        for field in persisted:
+            details = []
+            if field.relation:
+                details.append(f"relation={field.relation}")
+            if field.related:
+                details.append(f"related={field.related}")
+            if field.compute:
+                details.append(f"compute={field.compute}")
+            if field.required:
+                details.append("required")
+            if field.index:
+                details.append("index")
+            if field.ondelete:
+                details.append(f"ondelete={field.ondelete}")
+            detail_str = f" ({', '.join(details)})" if details else ""
+            lines.append(f"- `{field.name}`: `{field.field_type}`{detail_str}")
+        lines.append("")
+        lines.append("### Non-persisted fields")
+        if non_persisted:
+            for field in non_persisted:
+                details = []
+                if field.relation:
+                    details.append(f"relation={field.relation}")
+                if field.related:
+                    details.append(f"related={field.related}")
+                if field.compute:
+                    details.append(f"compute={field.compute}")
+                detail_str = f" ({', '.join(details)})" if details else ""
+                lines.append(f"- `{field.name}`: `{field.field_type}`{detail_str}")
+        else:
+            lines.append("- _none_")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def generate_module_deltas(models: Dict[str, ModelDef]) -> str:
+    lines = ["# Odoo Module Deltas", ""]
+    ipai_modules = sorted({m.module for m in models.values() if m.module.startswith("ipai")})
+    for module in ipai_modules:
+        lines.append(f"## {module}")
+        lines.append("")
+        new_tables = []
+        extended_tables: Dict[str, List[str]] = {}
+        relation_tables: Set[str] = set()
+        for model in models.values():
+            if model.module != module:
+                continue
+            if model.model_type == "AbstractModel":
+                continue
+            if model.table and model.name.replace(".", "_") == model.table:
+                if model.name not in model.inherits or model.name in model.inherits and model.name != model.table:
+                    new_tables.append(model.table)
+            if model.inherits and model.name in model.inherits and model.table:
+                fields_added = sorted(model.fields.keys())
+                if fields_added:
+                    extended_tables.setdefault(model.table, []).extend(fields_added)
+            for field in model.fields.values():
+                if field.field_type == "Many2many" and model.table:
+                    relation_table, _, _ = derive_many2many_table(model, field, model.table, models)
+                    relation_tables.add(relation_table)
+        if new_tables:
+            lines.append("- New tables:")
+            for table in sorted(set(new_tables)):
+                lines.append(f"  - `{table}`")
+        if extended_tables:
+            lines.append("- Extended tables:")
+            for table in sorted(extended_tables.keys()):
+                fields_list = ", ".join(sorted(set(extended_tables[table])))
+                lines.append(f"  - `{table}`: {fields_list}")
+        if relation_tables:
+            lines.append("- Relation tables:")
+            for table in sorted(relation_tables):
+                lines.append(f"  - `{table}`")
+        if not any([new_tables, extended_tables, relation_tables]):
+            lines.append("- _No model changes detected._")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def generate_model_index(models: Dict[str, ModelDef]) -> Dict[str, Any]:
+    model_entries = []
+    for model_name in sorted(models.keys()):
+        model = models[model_name]
+        field_entries = []
+        for field in sorted(model.fields.values(), key=lambda f: f.name):
+            field_entries.append(
+                {
+                    "name": field.name,
+                    "type": field.field_type,
+                    "store": field.store,
+                    "relation": field.relation,
+                    "required": field.required,
+                    "index": field.index,
+                    "ondelete": field.ondelete,
+                    "related": field.related,
+                    "compute": field.compute,
+                }
+            )
+        model_entries.append(
+            {
+                "name": model.name,
+                "table": model.table,
+                "module": model.module,
+                "inherits": model.inherits,
+                "inherits_delegated": model.inherits_delegated,
+                "fields": field_entries,
+                "sql_constraints": [
+                    {"name": name, "sql": sql, "message": msg}
+                    for name, sql, msg in sorted(model.sql_constraints)
+                ],
+                "python_constraints": sorted(set(model.python_constraints)),
+                "relations": sorted({f.relation for f in model.fields.values() if f.relation}),
+            }
+        )
+    return {"models": model_entries}
+
+
+def write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def main() -> None:
+    models = collect_models()
+    tables, refs = build_tables(models)
+    collect_stub_tables(tables, refs, models)
+
+    dbml = generate_dbml(tables, refs, models)
+    mermaid = generate_mermaid(tables, refs, models)
+    plantuml = generate_plantuml(tables, refs, models)
+    orm_map = generate_orm_map(models)
+    module_deltas = generate_module_deltas(models)
+    model_index = generate_model_index(models)
+
+    output_dir = ROOT / "docs" / "data-model"
+    write_file(output_dir / "ODOO_CANONICAL_SCHEMA.dbml", dbml)
+    write_file(output_dir / "ODOO_ERD.mmd", mermaid)
+    write_file(output_dir / "ODOO_ERD.puml", plantuml)
+    write_file(output_dir / "ODOO_ORM_MAP.md", orm_map)
+    write_file(output_dir / "ODOO_MODULE_DELTAS.md", module_deltas)
+    write_file(output_dir / "ODOO_MODEL_INDEX.json", json.dumps(model_index, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a canonical, machine-readable representation of the repository's Odoo CE data model (DBML, Mermaid, PlantUML, ORM map and JSON index).
- Keep the artifacts deterministic and versioned in-repo so teams can review schema deltas and documentation alongside code.
- Prevent drift between code and canonical docs by adding an automated CI guardrail that regenerates and verifies artifacts.
- Make regeneration reproducible for contributors via a lightweight generator script and README instructions.

### Description
- Add a deterministic generator script `scripts/generate_odoo_dbml.py` that parses addons and emits the six canonical artifacts under `docs/data-model/`.
- Add generated artifacts: `docs/data-model/ODOO_CANONICAL_SCHEMA.dbml`, `ODOO_ERD.mmd`, `ODOO_ERD.puml`, `ODOO_ORM_MAP.md`, `ODOO_MODULE_DELTAS.md`, `ODOO_MODEL_INDEX.json`, and `docs/data-model/README.md` describing usage.
- Wire a CI job `data-model-drift` into `.github/workflows/ci-odoo-ce.yml` that runs `python scripts/generate_odoo_dbml.py` and fails if `git diff --exit-code docs/data-model/` reports changes.
- Update `SITEMAP.md` and `TREE.md` to include the new `docs/data-model/` files and commit all changes.

### Testing
- Ran the generator locally with `python scripts/generate_odoo_dbml.py` and it completed successfully (no errors).
- Verified there is no unintended output by running `git diff --exit-code docs/data-model/`, which returned exit code 0 (no diffs).
- Confirmed the generator file was created executable (`chmod +x`) and the docs files were created under `docs/data-model/`.
- The CI workflow was updated to run the generator and the new `data-model-drift` job will enforce artifact drift in CI (change committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695859f000f483229274ba98083ec1dd)