### PR TITLE
fix(data-model): regenerate canonical artifacts to reflect ORM metadata changes

### DIFF
--- a/docs/data-model/ODOO_CANONICAL_SCHEMA.dbml
+++ b/docs/data-model/ODOO_CANONICAL_SCHEMA.dbml
@@ -681,7 +681,7 @@ Table close_exception {
   create_uid int
   currency_id int
   cycle_id int
-  description text
+  description varchar
   detected_by int
   detected_date datetime
   escalated_date datetime
@@ -836,7 +836,7 @@ Table close_task_template {
   default_approve_user_id int
   default_prep_user_id int
   default_review_user_id int
-  description text
+  description varchar
   id int [pk]
   name varchar
   period_type varchar

--- a/docs/data-model/ODOO_ERD.mmd
+++ b/docs/data-model/ODOO_ERD.mmd
@@ -632,7 +632,7 @@ erDiagram
     int create_uid
     int currency_id
     int cycle_id
-    text description
+    varchar description
     int detected_by
     datetime detected_date
     datetime escalated_date
@@ -779,7 +779,7 @@ erDiagram
     int default_approve_user_id
     int default_prep_user_id
     int default_review_user_id
-    text description
+    varchar description
     int id
     varchar name
     varchar period_type

--- a/docs/data-model/ODOO_ERD.puml
+++ b/docs/data-model/ODOO_ERD.puml
@@ -634,7 +634,7 @@ entity close_exception {
   int create_uid
   int currency_id
   int cycle_id
-  text description
+  varchar description
   int detected_by
   datetime detected_date
   datetime escalated_date
@@ -781,7 +781,7 @@ entity close_task_template {
   int default_approve_user_id
   int default_prep_user_id
   int default_review_user_id
-  text description
+  varchar description
   int id
   varchar name
   varchar period_type

--- a/docs/data-model/ODOO_MODEL_INDEX.json
+++ b/docs/data-model/ODOO_MODEL_INDEX.json
@@ -4494,7 +4494,7 @@
           "ondelete": null,
           "related": null,
           "relation": null,
-          "required": false,
+          "required": true,
           "store": true,
           "type": "Selection"
         },
@@ -4872,7 +4872,7 @@
           "ondelete": null,
           "related": null,
           "relation": null,
-          "required": false,
+          "required": true,
           "store": true,
           "type": "Selection"
         },
@@ -5028,7 +5028,7 @@
           "relation": null,
           "required": false,
           "store": true,
-          "type": "Text"
+          "type": "Html"
         },
         {
           "compute": null,
@@ -5257,7 +5257,7 @@
           "ondelete": null,
           "related": null,
           "relation": null,
-          "required": false,
+          "required": true,
           "store": true,
           "type": "Selection"
         },
@@ -5787,7 +5787,7 @@
           "ondelete": null,
           "related": null,
           "relation": null,
-          "required": false,
+          "required": true,
           "store": true,
           "type": "Selection"
         },
@@ -5853,7 +5853,7 @@
         },
         {
           "compute": null,
-          "index": false,
+          "index": true,
           "name": "code",
           "ondelete": null,
           "related": null,
@@ -6183,7 +6183,7 @@
         },
         {
           "compute": null,
-          "index": false,
+          "index": true,
           "name": "task_id",
           "ondelete": "cascade",
           "related": null,
@@ -6287,12 +6287,12 @@
         },
         {
           "compute": null,
-          "index": false,
+          "index": true,
           "name": "category_id",
-          "ondelete": null,
+          "ondelete": "cascade",
           "related": null,
           "relation": "close.task.category",
-          "required": true,
+          "required": false,
           "store": true,
           "type": "Many2one"
         },
@@ -6309,7 +6309,7 @@
         },
         {
           "compute": null,
-          "index": false,
+          "index": true,
           "name": "code",
           "ondelete": null,
           "related": null,
@@ -6382,7 +6382,7 @@
           "relation": null,
           "required": false,
           "store": true,
-          "type": "Text"
+          "type": "Html"
         },
         {
           "compute": null,

--- a/docs/data-model/ODOO_ORM_MAP.md
+++ b/docs/data-model/ODOO_ORM_MAP.md
@@ -696,7 +696,7 @@
 - `required_approvals`: `Integer`
 - `required_task_states`: `Char`
 - `sequence`: `Integer`
-- `state`: `Selection`
+- `state`: `Selection` (required)
 - `template_id`: `Many2one` (relation=close.approval.gate.template)
 - `threshold_value`: `Float`
 
@@ -751,7 +751,7 @@
 - `period_start`: `Date` (required)
 - `period_type`: `Selection` (required)
 - `progress`: `Float` (compute=_compute_task_stats)
-- `state`: `Selection`
+- `state`: `Selection` (required)
 - `task_completion_pct`: `Float` (compute=_compute_task_stats)
 - `task_count`: `Integer` (compute=_compute_task_stats)
 - `task_done_count`: `Integer` (compute=_compute_task_stats)
@@ -775,7 +775,7 @@
 - `company_id`: `Many2one` (relation=res.company, related=cycle_id.company_id)
 - `currency_id`: `Many2one` (relation=res.currency)
 - `cycle_id`: `Many2one` (relation=close.cycle, required, index, ondelete=cascade)
-- `description`: `Text`
+- `description`: `Html`
 - `detected_by`: `Many2one` (relation=res.users)
 - `detected_date`: `Datetime`
 - `escalated_date`: `Datetime`
@@ -796,7 +796,7 @@
 - `resolved_date`: `Datetime`
 - `root_cause`: `Text`
 - `severity`: `Selection` (required)
-- `state`: `Selection`
+- `state`: `Selection` (required)
 - `task_id`: `Many2one` (relation=close.task, index, ondelete=set null)
 - `variance_pct`: `Float`
 
@@ -852,7 +852,7 @@
 - `review_user_id`: `Many2one` (relation=res.users)
 - `reviewer_id`: `Many2one` (relation=res.users)
 - `sequence`: `Integer`
-- `state`: `Selection`
+- `state`: `Selection` (required)
 - `template_id`: `Many2one` (relation=close.task.template)
 
 ### Non-persisted fields
@@ -872,7 +872,7 @@
 ### Persisted fields
 - `a1_workstream_id`: `Many2one` (relation=a1.workstream)
 - `active`: `Boolean`
-- `code`: `Char` (required)
+- `code`: `Char` (required, index)
 - `color`: `Integer`
 - `company_id`: `Many2one` (relation=res.company, required)
 - `default_approve_days`: `Integer`
@@ -909,7 +909,7 @@
 - `notes`: `Text`
 - `required`: `Boolean`
 - `sequence`: `Integer`
-- `task_id`: `Many2one` (relation=close.task, required, ondelete=cascade)
+- `task_id`: `Many2one` (relation=close.task, required, index, ondelete=cascade)
 
 ### Non-persisted fields
 - _none_
@@ -932,14 +932,14 @@
 - `approve_day_offset`: `Integer`
 - `approver_id`: `Many2one` (relation=res.users)
 - `approver_role`: `Selection`
-- `category_id`: `Many2one` (relation=close.task.category, required)
-- `code`: `Char` (required)
+- `category_id`: `Many2one` (relation=close.task.category, index, ondelete=cascade)
+- `code`: `Char` (required, index)
 - `company_id`: `Many2one` (relation=res.company, required)
 - `creates_gl_entry`: `Boolean`
 - `default_approve_user_id`: `Many2one` (relation=res.users)
 - `default_prep_user_id`: `Many2one` (relation=res.users)
 - `default_review_user_id`: `Many2one` (relation=res.users)
-- `description`: `Text`
+- `description`: `Html`
 - `gl_account_ids`: `Many2many` (relation=account.account)
 - `name`: `Char` (required)
 - `period_type`: `Selection`


### PR DESCRIPTION
### Motivation
- Keep the repository's canonical, generator-derived data model artifacts in sync with the current ORM so CI's `data-model-drift` gate is stable.
- Capture recent metadata changes such as field types, `required` flags, `index` flags, and `ondelete` attributes in the documented schema.

### Description
- Regenerated the canonical artifacts using the DBML generator, updating `docs/data-model/ODOO_CANONICAL_SCHEMA.dbml`, `ODOO_ERD.mmd`, `ODOO_ERD.puml`, `ODOO_MODEL_INDEX.json`, and `ODOO_ORM_MAP.md`.
- Applied metadata updates including type changes (`Text` -> `Html` / `varchar`), toggled `required` flags on selection fields, added/changed `index` flags, and adjusted `ondelete` attributes and relation indexing.
- The changes are deterministic output from `scripts/generate_odoo_dbml.py` and only affect documentation/derived-data-model artifacts.

### Testing
- Ran the generator locally with `python scripts/generate_odoo_dbml.py` and verified output diffs via `git status --porcelain` and `git diff --stat`.
- Committed the regenerated artifacts with `git commit -m "fix(data-model): regenerate canonical artifacts"` to ensure the repository matches the generator output.
- No unit or CI test suite was executed as part of this change, since this is a generator-only artifact update.
- Local generator run completed successfully and produced the committed changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69586b7dc28c83228dabf013d35640a0)