### PR TITLE
fix(ci): repair infra-validate YAML + align to DigitalOcean

### DIFF
--- a/.github/workflows/infra-validate.yml
+++ b/.github/workflows/infra-validate.yml
@@ -1,89 +1,100 @@
-name: Infrastructure Validation
+name: Infrastructure Validation (DigitalOcean)
 
-# DISABLED: Project uses DigitalOcean, not Azure (per CLAUDE.md)
-# Azure services are prohibited for this project
 on:
-  workflow_dispatch:
   pull_request:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: infra-validate-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  validate-bicep:
-    name: Validate Bicep Templates
+  validate-docker:
+    name: Validate Docker / Compose
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Azure CLI
+      - name: Show versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker --version
+          docker compose version
+
+      - name: Validate compose files (if present)
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(docker-compose.yml docker-compose.yaml docker-compose.*.yml docker-compose.*.yaml)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No docker-compose files found; skipping."
+            exit 0
+          fi
+          for f in "${files[@]}"; do
+            echo "==> docker compose config: $f"
+            docker compose -f "$f" config >/dev/null
+          done
+
+      - name: Validate ops files (non-blocking)
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f CLAUDE.md || echo "::warning::Missing CLAUDE.md"
+          test -d .github/workflows || echo "::warning::Missing .github/workflows"
+
+  azure-lint-optional:
+    name: (Optional) Azure Bicep Lint (manual only)
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    env:
+      AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Skip if no AZURE_CREDENTIALS
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${AZURE_CREDENTIALS:-}" ]; then
+            echo "AZURE_CREDENTIALS not set; skipping Azure lint."
+            exit 0
+          fi
+
+      - name: Azure login
         uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-        continue-on-error: true
 
       - name: Install Bicep CLI
+        shell: bash
         run: |
+          set -euo pipefail
           curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
 
-      - name: Lint Bicep files
+      - name: Lint Bicep files (soft)
+        shell: bash
         run: |
+          set -euo pipefail
+          if [ ! -d infra/azure ]; then
+            echo "infra/azure not present; skipping."
+            exit 0
+          fi
           cd infra/azure
           for file in $(find . -name "*.bicep"); do
             echo "Linting $file"
             bicep lint "$file" || true
           done
-
-      - name: Build Bicep templates
-        run: |
-          cd infra/azure
-          bicep build main.bicep --outfile main.json
-
-      - name: Validate ARM template (dev)
-        if: always()
-        env:
-          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
-        run: |
-          if [ -z "$AZURE_CREDENTIALS" ]; then
-            echo "Skipping validation (AZURE_CREDENTIALS not set)"
-            exit 0
-          fi
-          az deployment group validate \
-            --resource-group rg-notion-ppm-dev \
-            --template-file infra/azure/main.json \
-            --parameters infra/azure/parameters/dev.parameters.json
-        continue-on-error: true
-
-      - name: Upload ARM template
-        uses: actions/upload-artifact@v4
-        with:
-          name: arm-template
-          path: infra/azure/main.json
-          retention-days: 7
-
-  security-scan:
-    name: Security Scan
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Run Checkov
-        uses: bridgecrewio/checkov-action@master
-        with:
-          directory: infra/azure
-          framework: bicep
-          soft_fail: true
-          output_format: sarif
-          output_file_path: checkov-results.sarif
-
-      - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@v3
-        if: always()
-        with:
-          sarif_file: checkov-results.sarif
-        continue-on-error: true

--- a/.github/workflows/spec-kit-enforce.yml
+++ b/.github/workflows/spec-kit-enforce.yml
@@ -98,13 +98,7 @@ jobs:
             echo "Validating YAML files in spec bundles..."
             while IFS= read -r f; do
               [ -z "$f" ] && continue
-              python3 - <<PY
-import yaml, sys
-p = r"""$f"""
-with open(p, "r", encoding="utf-8") as fh:
-    yaml.safe_load(fh)
-print("OK:", p)
-PY
+              python3 -c "import yaml; yaml.safe_load(open(r'''$f''', encoding='utf-8')); print('OK:', r'''$f''')"
             done <<< "$yaml_files"
           else
             echo "No YAML files found under spec/."

--- a/.github/workflows/workflow-yaml-validate.yml
+++ b/.github/workflows/workflow-yaml-validate.yml
@@ -1,0 +1,71 @@
+name: Workflow YAML Validation
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: yaml-validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-yaml:
+    name: Validate Workflow YAML Syntax
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PyYAML
+        shell: bash
+        run: |
+          set -euo pipefail
+          pip install --quiet pyyaml
+
+      - name: Validate all workflow YAML files
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Validating .github/workflows/*.yml files..."
+
+          exit_code=0
+          for file in .github/workflows/*.yml; do
+            if [ ! -f "$file" ]; then
+              echo "No workflow files found."
+              exit 0
+            fi
+            echo -n "Checking $file ... "
+            if python -c "import yaml; yaml.safe_load(open('$file'))" 2>&1; then
+              echo "OK"
+            else
+              echo "FAILED"
+              exit_code=1
+            fi
+          done
+
+          if [ $exit_code -eq 0 ]; then
+            echo ""
+            echo "All workflow YAML files are valid."
+          else
+            echo ""
+            echo "::error::Some workflow YAML files have syntax errors."
+          fi
+
+          exit $exit_code


### PR DESCRIPTION
- Replace infra-validate.yml with DigitalOcean/Docker-first workflow
  - Validate docker-compose files (Docker Compose config check)
  - Azure Bicep lint is now optional (manual workflow_dispatch only)
  - Gracefully skip if Azure credentials or infra/azure not present
- Fix spec-kit-enforce.yml YAML parsing error (heredoc causing issue)
  - Convert Python heredoc to inline one-liner
- Add workflow-yaml-validate.yml to validate all workflow YAML syntax
  - Runs on PR and push to main when workflow files change
  - Uses PyYAML for YAML syntax validation