### PR TITLE
Fix Google login creating portal users instead of backend users

### DIFF
--- a/addons/ipai/ipai_auth_oauth_internal/__init__.py
+++ b/addons/ipai/ipai_auth_oauth_internal/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/addons/ipai/ipai_auth_oauth_internal/__manifest__.py
+++ b/addons/ipai/ipai_auth_oauth_internal/__manifest__.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "IPAI OAuth Internal User",
+    "version": "18.0.1.0.0",
+    "category": "Technical",
+    "summary": "Makes OAuth users Internal Users instead of Portal users",
+    "description": """
+IPAI OAuth Internal User
+========================
+
+This module modifies the default OAuth authentication behavior to create
+users as Internal Users (with backend access) instead of Portal users
+(limited to portal pages like /my/home).
+
+By default, Odoo's auth_oauth module creates new OAuth users with the
+Portal group (base.group_portal), which only allows access to portal
+pages like invoices, quotes, and account settings.
+
+This module overrides that behavior to:
+
+1. Assign the Internal User group (base.group_user) to new OAuth users
+2. Remove the Portal group if it was assigned
+3. Allow OAuth users full access to the Odoo backend (/web)
+
+Use Case
+--------
+This is useful when you want employees to log in via Google OAuth
+and have access to the full ERP system, not just the portal.
+
+Security Note
+-------------
+Only enable this module if ALL OAuth users should be internal users.
+If you need to distinguish between portal and internal OAuth users,
+consider using a more sophisticated approach based on email domain
+or OAuth provider attributes.
+    """,
+    "author": "InsightPulse AI",
+    "website": "https://github.com/jgtolentino/odoo-ce",
+    "license": "AGPL-3",
+    "depends": [
+        "auth_oauth",
+    ],
+    "data": [],
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+}

--- a/addons/ipai/ipai_auth_oauth_internal/models/__init__.py
+++ b/addons/ipai/ipai_auth_oauth_internal/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import res_users

--- a/addons/ipai/ipai_auth_oauth_internal/models/res_users.py
+++ b/addons/ipai/ipai_auth_oauth_internal/models/res_users.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from odoo import api, models
+
+_logger = logging.getLogger(__name__)
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    @api.model
+    def _auth_oauth_signin(self, provider, validation, params):
+        """
+        Override OAuth signin to make new users Internal Users.
+
+        The standard auth_oauth module creates users with portal group.
+        This override ensures users get the internal user group instead,
+        giving them access to the full Odoo backend.
+        """
+        # Call the original method to create/find the user
+        login = super()._auth_oauth_signin(provider, validation, params)
+
+        # Find the user that was just created/logged in
+        user = self.search([("login", "=", login)], limit=1)
+        if user:
+            self._promote_to_internal_user(user)
+
+        return login
+
+    def _promote_to_internal_user(self, user):
+        """
+        Promote a user to internal user status.
+
+        This method:
+        1. Adds the Internal User group (base.group_user)
+        2. Removes the Portal group (base.group_portal) if present
+
+        Args:
+            user: res.users record to promote
+        """
+        try:
+            internal_group = self.env.ref("base.group_user")
+            portal_group = self.env.ref("base.group_portal")
+
+            # Check if user is already an internal user
+            if internal_group in user.groups_id:
+                _logger.debug(
+                    "OAuth user %s (id=%s) is already an internal user",
+                    user.login,
+                    user.id,
+                )
+                return
+
+            _logger.info(
+                "Promoting OAuth user %s (id=%s) from portal to internal user",
+                user.login,
+                user.id,
+            )
+
+            # Use sudo() to bypass access rights during promotion
+            user_sudo = user.sudo()
+
+            # Build the groups_id update commands
+            groups_update = [
+                (4, internal_group.id),  # Add internal user group
+            ]
+
+            # Remove portal group if present
+            if portal_group in user.groups_id:
+                groups_update.append((3, portal_group.id))
+
+            user_sudo.write({"groups_id": groups_update})
+
+            _logger.info(
+                "Successfully promoted OAuth user %s to internal user. " "Groups: %s",
+                user.login,
+                [g.full_name for g in user_sudo.groups_id],
+            )
+
+        except Exception as e:
+            _logger.error(
+                "Failed to promote OAuth user %s to internal user: %s",
+                user.login if user else "unknown",
+                str(e),
+            )
+            # Don't raise - allow login to proceed even if promotion fails
+            # The user can be manually promoted via UI


### PR DESCRIPTION
When users log in via Google OAuth, Odoo's default auth_oauth module creates them as Portal users (base.group_portal), which only gives access to /my pages (invoices, account settings, etc).

This new module ipai_auth_oauth_internal overrides the OAuth signin behavior to:
1. Add the Internal User group (base.group_user) after OAuth login
2. Remove the Portal group if present
3. Allow OAuth users full access to the Odoo backend (/web)

This fixes the issue where Google login users see "My Account" portal instead of the full ERP backend.