### PR TITLE
Set up email for Odoo on DigitalOcean

### DIFF
--- a/.env.smtp.example
+++ b/.env.smtp.example
@@ -1,11 +1,134 @@
-# Gmail SMTP Configuration
+# =============================================================================
+# SMTP Configuration for Odoo CE 18
+# =============================================================================
 # Copy this file to .env.smtp and fill in your credentials
 # NEVER commit .env.smtp to git
+# =============================================================================
 
+# =============================================================================
+# PROVIDER SELECTION
+# =============================================================================
+# Choose your email provider. Options: sendgrid, mailgun, brevo, gmail, zoho
+# For DigitalOcean deployments, use sendgrid or mailgun (port 2525 works!)
+SMTP_PROVIDER=sendgrid
+
+# =============================================================================
+# OPTION 1: SendGrid (RECOMMENDED for DigitalOcean)
+# =============================================================================
+# SendGrid is a DigitalOcean partner - 100 free emails/day
+# Port 2525 bypasses DigitalOcean's SMTP port blocking
+#
+# Setup:
+# 1. Sign up: https://signup.sendgrid.com/
+# 2. Create API Key: Settings > API Keys > Create API Key
+# 3. Verify sender: Settings > Sender Authentication
+#
+SENDGRID_HOST=smtp.sendgrid.net
+SENDGRID_PORT=2525
+SENDGRID_USER=apikey
+SENDGRID_API_KEY=SG.your-api-key-here
+SENDGRID_ENCRYPTION=starttls
+
+# =============================================================================
+# OPTION 2: Mailgun (RECOMMENDED for DigitalOcean)
+# =============================================================================
+# Mailgun offers 5,000 free emails/month for 3 months
+# Port 2525 bypasses DigitalOcean's SMTP port blocking
+#
+# Setup:
+# 1. Sign up: https://www.mailgun.com/
+# 2. Add domain: Sending > Domains > Add Domain
+# 3. Configure DNS records (SPF, DKIM)
+# 4. Get credentials: Sending > Domain Settings > SMTP credentials
+#
+MAILGUN_HOST=smtp.mailgun.org
+MAILGUN_PORT=2525
+MAILGUN_USER=postmaster@mail.yourdomain.com
+MAILGUN_PASSWORD=your-smtp-password
+MAILGUN_ENCRYPTION=starttls
+
+# =============================================================================
+# OPTION 3: Brevo (formerly Sendinblue)
+# =============================================================================
+# Brevo offers 300 free emails/day
+# Port 2525 bypasses DigitalOcean's SMTP port blocking
+#
+BREVO_HOST=smtp-relay.brevo.com
+BREVO_PORT=2525
+BREVO_USER=your-email@domain.com
+BREVO_PASSWORD=your-smtp-key
+BREVO_ENCRYPTION=starttls
+
+# =============================================================================
+# OPTION 4: Gmail (Requires port unblock on DigitalOcean)
+# =============================================================================
+# Gmail requires ports 465/587 which are BLOCKED by DigitalOcean
+# Request port unblock: docs/DIGITALOCEAN_SMTP_UNBLOCK_REQUEST.md
+#
+# Setup:
+# 1. Enable 2FA: https://myaccount.google.com/security
+# 2. Generate App Password: https://myaccount.google.com/apppasswords
+# 3. App Password is 16 characters (spaces optional)
+#
+GMAIL_HOST=smtp.gmail.com
+GMAIL_PORT=587
 GMAIL_USER=your.email@gmail.com
-GMAIL_APP_PASSWORD=wcxu fssn evbs mzcy
+GMAIL_APP_PASSWORD=xxxx xxxx xxxx xxxx
+GMAIL_ENCRYPTION=starttls
 
-# Notes:
-# 1. App Password should be 16 characters (spaces optional)
-# 2. Generate at: https://myaccount.google.com/apppasswords
-# 3. Requires 2FA enabled on Gmail account
+# =============================================================================
+# OPTION 5: Zoho (Requires port unblock on DigitalOcean)
+# =============================================================================
+# Zoho requires ports 465/587 which are BLOCKED by DigitalOcean
+# Request port unblock: docs/DIGITALOCEAN_SMTP_UNBLOCK_REQUEST.md
+#
+ZOHO_HOST=smtppro.zoho.com
+ZOHO_PORT=465
+ZOHO_USER=your.email@zoho.com
+ZOHO_PASSWORD=your-password
+ZOHO_ENCRYPTION=ssl
+
+# =============================================================================
+# COMMON SETTINGS
+# =============================================================================
+# These apply regardless of provider
+#
+MAIL_CATCHALL_DOMAIN=yourdomain.com
+MAIL_DEFAULT_FROM=notifications
+MAIL_CATCHALL_ALIAS=catchall
+MAIL_BOUNCE_ALIAS=bounce
+MAIL_FORCE_SMTP_FROM=notifications@yourdomain.com
+
+# =============================================================================
+# DNS RECORDS REQUIRED FOR DELIVERABILITY
+# =============================================================================
+# Add these records to your DNS provider:
+#
+# SPF (TXT record):
+#   Host: @
+#   Value: v=spf1 include:sendgrid.net ~all  (or your provider)
+#
+# DKIM (TXT record):
+#   Host: [provided by email provider]
+#   Value: [provided by email provider]
+#
+# DMARC (TXT record):
+#   Host: _dmarc
+#   Value: v=DMARC1; p=none; rua=mailto:dmarc@yourdomain.com
+#
+# =============================================================================
+
+# =============================================================================
+# DIGITALOCEAN SMTP PORT BLOCKING INFO
+# =============================================================================
+# DigitalOcean blocks these ports by default (spam prevention):
+#   - Port 25  (SMTP relay) - BLOCKED
+#   - Port 465 (SMTPS/SSL) - BLOCKED
+#   - Port 587 (Submission/STARTTLS) - BLOCKED
+#
+# These ports work on DigitalOcean:
+#   - Port 2525 (Alternative SMTP) - OPEN
+#   - Port 443  (HTTPS/API) - OPEN
+#
+# For details: docs/DIGITALOCEAN_EMAIL_SETUP.md
+# =============================================================================

--- a/docs/DIGITALOCEAN_EMAIL_SETUP.md
+++ b/docs/DIGITALOCEAN_EMAIL_SETUP.md
@@ -1,0 +1,540 @@
+# DigitalOcean Email Setup for Odoo CE 18
+
+**Version**: 1.0
+**Date**: 2026-01-05
+**Stack**: Odoo 18 CE on DigitalOcean Droplet
+
+---
+
+## The Problem: DigitalOcean SMTP Port Blocking
+
+DigitalOcean **permanently blocks** standard outbound SMTP ports for new accounts to prevent spam:
+- **Port 25** - Blocked (legacy SMTP relay)
+- **Port 465** - Blocked (SMTPS/SSL)
+- **Port 587** - Blocked (SMTP Submission/STARTTLS)
+
+Traditional configurations using these ports will result in:
+- "Connection Test Failed" errors in Odoo
+- Socket connection timeouts
+- Emails stuck in "Outgoing" queue
+
+**Analogy**: Setting up email on DigitalOcean is like trying to mail a letter from a high-security facility. The standard exit gates (ports 25, 465, 587) are locked tight. You need a specialized courier service (port 2525 or API) that has its own authorized side-door.
+
+---
+
+## Solution Options
+
+### Option A: Port 2525 SMTP (Recommended - Fastest Implementation)
+
+Port **2525** is an alternative SMTP submission port that is **NOT blocked** by DigitalOcean. Major providers support it:
+
+| Provider | SMTP Server | Port | Free Tier |
+|----------|-------------|------|-----------|
+| **Mailgun** | smtp.mailgun.org | 2525 | 5,000 emails/month (3 months) |
+| **SendGrid** | smtp.sendgrid.net | 2525 | 100 emails/day |
+| **Brevo** | smtp-relay.brevo.com | 2525 | 300 emails/day |
+
+**Pros**:
+- Works immediately on DigitalOcean
+- No support ticket required
+- Standard SMTP protocol (easy debugging)
+- All major providers support it
+
+**Cons**:
+- Requires third-party provider account
+- Free tiers have volume limits
+
+### Option B: API-Based Sending (Most Reliable)
+
+Use RESTful HTTP APIs instead of SMTP. This uses **port 443 (HTTPS)** which is never blocked.
+
+| Provider | API Endpoint | Free Tier |
+|----------|--------------|-----------|
+| **Mailgun** | api.mailgun.net/v3 | 5,000 emails/month |
+| **SendGrid** | api.sendgrid.com/v3 | 100 emails/day |
+| **Amazon SES** | email.{region}.amazonaws.com | $0.10 per 1,000 |
+
+**Pros**:
+- Never blocked (uses HTTPS port 443)
+- Up to 3x faster than SMTP
+- Better deliverability metrics
+- Webhook support for tracking
+
+**Cons**:
+- Requires custom Odoo module or OCA integration
+- More complex initial setup
+
+### Option C: Request SMTP Port Unblock (Legacy)
+
+Submit a support ticket to DigitalOcean requesting port unblock.
+
+**Process**:
+1. Submit ticket: https://cloud.digitalocean.com/support/tickets
+2. Subject: "Request to unblock outbound SMTP ports"
+3. Explain business use case
+4. Wait 24-48 hours
+
+**Pros**:
+- Can use any SMTP provider
+- Gmail/Zoho work directly
+
+**Cons**:
+- May be denied (especially for new accounts)
+- 24-48 hour wait time
+- DigitalOcean prefers API-based solutions
+
+---
+
+## Quick Start: SendGrid with Port 2525
+
+SendGrid is a DigitalOcean partner and the easiest to set up.
+
+### Step 1: Create SendGrid Account
+
+1. Sign up at: https://signup.sendgrid.com/
+2. Verify your email address
+3. Complete account setup
+
+### Step 2: Create API Key
+
+1. Go to: Settings > API Keys
+2. Click "Create API Key"
+3. Name: "Odoo ERP"
+4. Select "Full Access" (or Restricted with Mail Send)
+5. **Copy the API key** (shown only once!)
+
+### Step 3: Verify Sender Domain
+
+1. Go to: Settings > Sender Authentication
+2. Click "Authenticate Your Domain"
+3. Select your DNS provider
+4. Add the required DNS records (SPF, DKIM)
+5. Verify domain
+
+### Step 4: Configure Odoo
+
+**Option A - Automated Script**:
+```bash
+# SSH into your droplet
+ssh root@your-droplet-ip
+
+# Navigate to project
+cd /root/odoo-ce
+
+# Run configuration script
+docker exec -i odoo-core odoo shell -d odoo_core < scripts/configure_sendgrid_smtp.py
+```
+
+**Option B - Odoo UI**:
+1. Go to Settings > Technical > Outgoing Mail Servers
+2. Click "Create"
+3. Configure:
+   - **Name**: SendGrid SMTP
+   - **SMTP Server**: smtp.sendgrid.net
+   - **SMTP Port**: 2525
+   - **Connection Security**: TLS (STARTTLS)
+   - **Username**: apikey (literal string)
+   - **Password**: [Your SendGrid API Key]
+4. Click "Save"
+5. Click "Test Connection"
+
+### Step 5: Test Email Sending
+
+```bash
+# Test from Odoo shell
+docker exec -i odoo-core odoo shell -d odoo_core <<EOF
+mail = env['mail.mail'].create({
+    'email_to': 'test@example.com',
+    'subject': 'Test from Odoo on DigitalOcean',
+    'body_html': '<p>Port 2525 works!</p>'
+})
+mail.send()
+print(f"Email sent - State: {mail.state}")
+EOF
+```
+
+---
+
+## Quick Start: Mailgun with Port 2525
+
+### Step 1: Create Mailgun Account
+
+1. Sign up at: https://www.mailgun.com/
+2. Verify your email
+3. Add payment method (required for custom domain)
+
+### Step 2: Add Sending Domain
+
+1. Go to: Sending > Domains
+2. Click "Add New Domain"
+3. Enter: mail.yourdomain.com (or mg.yourdomain.com)
+4. Select region (US or EU)
+
+### Step 3: Configure DNS
+
+Add these records to your DNS provider:
+
+**SPF Record**:
+```
+Type: TXT
+Host: mail (or your subdomain)
+Value: v=spf1 include:mailgun.org ~all
+```
+
+**DKIM Records** (from Mailgun dashboard):
+```
+Type: TXT
+Host: k1._domainkey.mail (or as shown)
+Value: [Provided by Mailgun]
+```
+
+**CNAME for Tracking** (optional):
+```
+Type: CNAME
+Host: email.mail
+Value: mailgun.org
+```
+
+### Step 4: Get SMTP Credentials
+
+1. Go to: Sending > Domain Settings
+2. Click on your domain
+3. Navigate to "SMTP credentials"
+4. Note the SMTP login (usually postmaster@mail.yourdomain.com)
+5. Reset password or create new credential
+
+### Step 5: Configure Odoo
+
+```bash
+# Run configuration script
+docker exec -i odoo-core odoo shell -d odoo_core < scripts/configure_mailgun_smtp.py
+```
+
+Or configure manually in Odoo UI:
+- **SMTP Server**: smtp.mailgun.org
+- **SMTP Port**: 2525
+- **Connection Security**: TLS (STARTTLS)
+- **Username**: postmaster@mail.yourdomain.com
+- **Password**: [Your Mailgun SMTP password]
+
+---
+
+## DNS Configuration for Email Deliverability
+
+**Critical**: Without proper DNS records, your emails will be flagged as spam.
+
+### SPF (Sender Policy Framework)
+
+Add a TXT record to authorize your email provider:
+
+```
+# For SendGrid
+v=spf1 include:sendgrid.net ~all
+
+# For Mailgun
+v=spf1 include:mailgun.org ~all
+
+# For multiple providers
+v=spf1 include:sendgrid.net include:mailgun.org ~all
+```
+
+### DKIM (DomainKeys Identified Mail)
+
+Add the DKIM TXT record provided by your email provider. Each provider gives you a unique key.
+
+**Example** (Mailgun):
+```
+Host: k1._domainkey.yourdomain.com
+Type: TXT
+Value: k=rsa; p=MIGfMA0GCSq...
+```
+
+### DMARC (Domain-based Message Authentication)
+
+Add a DMARC policy to tell receivers how to handle failed authentication:
+
+```
+Host: _dmarc.yourdomain.com
+Type: TXT
+Value: v=DMARC1; p=none; rua=mailto:dmarc@yourdomain.com
+```
+
+**Policy options**:
+- `p=none` - Monitor only (recommended to start)
+- `p=quarantine` - Send to spam
+- `p=reject` - Block completely
+
+### Verify DNS Configuration
+
+Use these tools to verify your DNS setup:
+- **MX Toolbox**: https://mxtoolbox.com/
+- **Mail-Tester**: https://www.mail-tester.com/
+- **DKIM Validator**: https://dkimvalidator.com/
+
+---
+
+## Odoo System Parameters
+
+Configure these system parameters for proper email handling:
+
+| Parameter | Value | Purpose |
+|-----------|-------|---------|
+| `mail.catchall.domain` | yourdomain.com | Domain for catchall emails |
+| `mail.default.from` | notifications | Default FROM name |
+| `mail.catchall.alias` | catchall | Catchall alias |
+| `mail.bounce.alias` | bounce | Bounce handling alias |
+| `mail.force.smtp.from` | sender@yourdomain.com | Force all mail from this address |
+
+### Configure via Script
+
+```bash
+docker exec -i odoo-core odoo shell -d odoo_core <<EOF
+ICP = env['ir.config_parameter'].sudo()
+ICP.set_param('mail.catchall.domain', 'insightpulseai.net')
+ICP.set_param('mail.default.from', 'notifications')
+ICP.set_param('mail.force.smtp.from', 'notifications@insightpulseai.net')
+env.cr.commit()
+print("System parameters configured!")
+EOF
+```
+
+### Force FROM Address
+
+To prevent "Sender Mismatch" errors:
+
+```bash
+docker exec -i odoo-core odoo shell -d odoo_core <<EOF
+ICP = env['ir.config_parameter'].sudo()
+ICP.set_param('mail.force.smtp.from', 'notifications@insightpulseai.net')
+env.cr.commit()
+print("mail.force.smtp.from configured!")
+EOF
+```
+
+---
+
+## Testing & Verification
+
+### Test 1: SMTP Port Connectivity
+
+```bash
+# Test from inside Odoo container
+docker exec odoo-core python3 <<EOF
+import socket
+ports = [25, 465, 587, 2525]
+for port in ports:
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(5)
+        result = sock.connect_ex(('smtp.sendgrid.net', port))
+        status = 'OPEN' if result == 0 else 'BLOCKED'
+        sock.close()
+        print(f"Port {port}: {status}")
+    except Exception as e:
+        print(f"Port {port}: ERROR - {e}")
+EOF
+```
+
+**Expected Output**:
+```
+Port 25: BLOCKED
+Port 465: BLOCKED
+Port 587: BLOCKED
+Port 2525: OPEN
+```
+
+### Test 2: SMTP Connection Test
+
+```bash
+# Run the diagnostic script
+./scripts/diagnose_smtp.sh
+```
+
+### Test 3: Odoo Connection Test
+
+1. Go to: Settings > Technical > Outgoing Mail Servers
+2. Click on your configured server
+3. Click "Test Connection"
+4. Expected: "Connection Test Successful!"
+
+### Test 4: Send Test Email
+
+```bash
+docker exec -i odoo-core odoo shell -d odoo_core <<EOF
+mail = env['mail.mail'].create({
+    'email_to': 'your.email@gmail.com',
+    'subject': 'Odoo Test Email - DigitalOcean Port 2525',
+    'body_html': '<p>If you receive this, email is working!</p>'
+})
+mail.send()
+print(f"Email ID: {mail.id}")
+print(f"State: {mail.state}")
+print(f"Failure: {mail.failure_reason or 'None'}")
+EOF
+```
+
+---
+
+## Troubleshooting
+
+### Issue: "Connection Test Failed" with timeout
+
+**Cause**: Port is blocked by DigitalOcean
+**Solution**: Use port 2525 instead of 465/587
+
+### Issue: "Authentication Required" error
+
+**Cause**: Wrong credentials or auth method
+**Solution**:
+- For SendGrid: Username must be literal "apikey"
+- For Mailgun: Use the SMTP password, not your account password
+
+### Issue: Emails marked as spam
+
+**Cause**: Missing or incorrect DNS records
+**Solution**:
+1. Verify SPF record is correct
+2. Verify DKIM record is correct
+3. Add DMARC record
+4. Check sender reputation at https://www.mail-tester.com/
+
+### Issue: "Sender address rejected"
+
+**Cause**: FROM address doesn't match authenticated sender
+**Solution**: Set `mail.force.smtp.from` system parameter
+
+### Issue: Emails stuck in "Outgoing" state
+
+**Cause**: Mail cron not running
+**Solution**:
+```bash
+# Enable mail queue cron
+docker exec -i odoo-core odoo shell -d odoo_core <<EOF
+cron = env['ir.cron'].search([('model', '=', 'mail.mail')])
+for c in cron:
+    c.active = True
+    print(f"Enabled cron: {c.name}")
+env.cr.commit()
+EOF
+```
+
+---
+
+## API-Based Email (Advanced)
+
+For maximum reliability, use API-based sending with an OCA module.
+
+### Available OCA Modules
+
+| Module | Provider | Repository |
+|--------|----------|------------|
+| `mail_tracking_mailgun` | Mailgun | OCA/social |
+| `mail_tracking` | Multiple | OCA/social |
+
+### Installation
+
+1. Add OCA/social to your module sources
+2. Update oca.lock.json:
+```json
+{
+  "social": {
+    "url": "https://github.com/OCA/social",
+    "branch": "18.0",
+    "modules": ["mail_tracking_mailgun"]
+  }
+}
+```
+
+3. Install the module:
+```bash
+docker exec odoo-core odoo -d odoo_core -i mail_tracking_mailgun --stop-after-init
+```
+
+4. Configure in Settings > Technical > Mailgun
+
+---
+
+## Configuration Scripts
+
+The following scripts are available in `/scripts/`:
+
+| Script | Purpose |
+|--------|---------|
+| `configure_sendgrid_smtp.py` | Configure SendGrid with port 2525 |
+| `configure_mailgun_smtp.py` | Configure Mailgun with port 2525 |
+| `configure_gmail_smtp.py` | Configure Gmail (requires port unblock) |
+| `configure_zoho_smtp.py` | Configure Zoho (requires port unblock) |
+| `diagnose_smtp.sh` | Diagnose SMTP connectivity issues |
+| `audit_email_config.py` | Audit current email configuration |
+
+### Usage
+
+```bash
+# Configure SendGrid (recommended for DigitalOcean)
+docker exec -i odoo-core odoo shell -d odoo_core < scripts/configure_sendgrid_smtp.py
+
+# Configure Mailgun
+docker exec -i odoo-core odoo shell -d odoo_core < scripts/configure_mailgun_smtp.py
+
+# Diagnose SMTP issues
+./scripts/diagnose_smtp.sh
+
+# Audit current configuration
+docker exec -i odoo-core odoo shell -d odoo_core < scripts/audit_email_config.py
+```
+
+---
+
+## Environment Variables
+
+Add these to your `.env` file for configuration management:
+
+```bash
+# Email Provider (sendgrid, mailgun, gmail, zoho)
+SMTP_PROVIDER=sendgrid
+
+# SMTP Configuration
+SMTP_HOST=smtp.sendgrid.net
+SMTP_PORT=2525
+SMTP_USER=apikey
+SMTP_PASSWORD=your-api-key-here
+SMTP_ENCRYPTION=starttls
+
+# Email Addresses
+MAIL_CATCHALL_DOMAIN=insightpulseai.net
+MAIL_DEFAULT_FROM=notifications
+MAIL_FORCE_FROM=notifications@insightpulseai.net
+```
+
+---
+
+## Summary: Recommended Approach
+
+For **DigitalOcean deployments**, use this priority order:
+
+1. **SendGrid via Port 2525** (Fastest, DigitalOcean partner)
+   - Sign up: https://signup.sendgrid.com/
+   - Run: `docker exec -i odoo-core odoo shell -d odoo_core < scripts/configure_sendgrid_smtp.py`
+
+2. **Mailgun via Port 2525** (More features, better for high volume)
+   - Sign up: https://www.mailgun.com/
+   - Run: `docker exec -i odoo-core odoo shell -d odoo_core < scripts/configure_mailgun_smtp.py`
+
+3. **Request Port Unblock** (Last resort)
+   - See: `docs/DIGITALOCEAN_SMTP_UNBLOCK_REQUEST.md`
+   - Wait 24-48 hours
+
+**Remember**: Always configure SPF, DKIM, and DMARC DNS records for deliverability!
+
+---
+
+## Related Documentation
+
+- `DIGITALOCEAN_SMTP_UNBLOCK_REQUEST.md` - Port unblock request template
+- `EMAIL_AND_OAUTH_SETUP.md` - Gmail/OAuth configuration
+- `DEPLOYMENT_GUIDE.md` - Full deployment instructions
+
+---
+
+**Last Updated**: 2026-01-05
+**Maintained By**: DevOps Team

--- a/scripts/configure_mailgun_smtp.py
+++ b/scripts/configure_mailgun_smtp.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+configure_mailgun_smtp.py - Configure Mailgun SMTP for Odoo 18 on DigitalOcean
+
+This script configures Mailgun SMTP using PORT 2525, which bypasses DigitalOcean's
+SMTP port blocking (ports 25, 465, 587 are blocked by default).
+
+Run with: docker exec -i odoo-core odoo shell -d odoo_core < scripts/configure_mailgun_smtp.py
+
+For SendGrid, use configure_sendgrid_smtp.py instead.
+"""
+
+# ============================================
+# CONFIGURATION VALUES - UPDATE THESE
+# ============================================
+
+SMTP_CONFIG = {
+    'name': 'Mailgun SMTP - InsightPulse',
+    'smtp_host': 'smtp.mailgun.org',
+    'smtp_port': 2525,  # Port 2525 bypasses DigitalOcean blocking!
+    'smtp_encryption': 'starttls',  # TLS (STARTTLS)
+    'smtp_user': 'postmaster@mail.insightpulseai.net',  # UPDATE: Your Mailgun SMTP user
+    'smtp_pass': '',  # SET VIA ODOO UI or update here
+    'from_filter': '@insightpulseai.net',  # Domain-based FROM filter
+    'sequence': 10,
+    'smtp_authentication': 'login',
+    'smtp_debug': False,
+    'active': True,
+}
+
+SYSTEM_PARAMS = {
+    'mail.catchall.domain': 'insightpulseai.net',
+    'mail.default.from': 'notifications',
+    'mail.catchall.alias': 'catchall',
+    'mail.bounce.alias': 'bounce',
+    # Force all outgoing mail to use authorized sender
+    'mail.force.smtp.from': 'notifications@insightpulseai.net',
+}
+
+# ============================================
+# CONFIGURE MAIL SERVER
+# ============================================
+
+print("=" * 60)
+print("Mailgun SMTP Configuration for Odoo 18 (DigitalOcean)")
+print("=" * 60)
+print("\nUsing PORT 2525 to bypass DigitalOcean SMTP blocking")
+
+MailServer = env['ir.mail_server'].sudo()
+
+# Check for existing Mailgun server
+existing = MailServer.search([('smtp_host', '=', 'smtp.mailgun.org')], limit=1)
+
+if existing:
+    print(f"\nExisting Mailgun server found (ID: {existing.id})")
+    print("   Updating configuration...")
+    existing.write(SMTP_CONFIG)
+    server = existing
+else:
+    print("\nCreating new Mailgun SMTP server...")
+    server = MailServer.create(SMTP_CONFIG)
+
+print(f"\nMail Server configured:")
+print(f"   ID: {server.id}")
+print(f"   Name: {server.name}")
+print(f"   Host: {server.smtp_host}:{server.smtp_port}")
+print(f"   Encryption: {server.smtp_encryption}")
+print(f"   User: {server.smtp_user}")
+print(f"   FROM Filter: {server.from_filter or 'Not set'}")
+
+# ============================================
+# CONFIGURE SYSTEM PARAMETERS
+# ============================================
+
+print("\n" + "=" * 60)
+print("System Parameters Configuration")
+print("=" * 60)
+
+ICP = env['ir.config_parameter'].sudo()
+
+for key, value in SYSTEM_PARAMS.items():
+    ICP.set_param(key, value)
+    print(f"   {key} = {value}")
+
+# ============================================
+# COMMIT CHANGES
+# ============================================
+
+env.cr.commit()
+
+print("\n" + "=" * 60)
+print("Configuration Complete!")
+print("=" * 60)
+print("\nNEXT STEPS:")
+print("1. Go to Settings > Technical > Outgoing Mail Servers")
+print("2. Click on 'Mailgun SMTP - InsightPulse'")
+print("3. Set the Password field (your Mailgun SMTP password)")
+print("4. Save the record")
+print("5. Click 'Test Connection' button")
+print("\nMAILGUN SETUP (if not done):")
+print("1. Sign up at: https://www.mailgun.com/")
+print("2. Add your domain: Sending > Domains > Add Domain")
+print("3. Configure DNS records (SPF, DKIM, MX)")
+print("4. Get SMTP credentials: Sending > Domain Settings > SMTP credentials")
+print("\nPORT 2525 INFO:")
+print("   Port 2525 is an alternative SMTP submission port")
+print("   It works on DigitalOcean without requesting port unblock")
+print("   Mailgun, SendGrid, and Brevo all support port 2525")
+print("\nTo test manually in shell:")
+print("   server = env['ir.mail_server'].sudo().search([('smtp_host', '=', 'smtp.mailgun.org')], limit=1)")
+print("   server.test_smtp_connection()")

--- a/scripts/configure_sendgrid_smtp.py
+++ b/scripts/configure_sendgrid_smtp.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+configure_sendgrid_smtp.py - Configure SendGrid SMTP for Odoo 18 on DigitalOcean
+
+This script configures SendGrid SMTP using PORT 2525, which bypasses DigitalOcean's
+SMTP port blocking (ports 25, 465, 587 are blocked by default).
+
+SendGrid is a DigitalOcean partner and provides 100 free emails/day.
+
+Run with: docker exec -i odoo-core odoo shell -d odoo_core < scripts/configure_sendgrid_smtp.py
+
+For Mailgun, use configure_mailgun_smtp.py instead.
+"""
+
+# ============================================
+# CONFIGURATION VALUES - UPDATE THESE
+# ============================================
+
+SMTP_CONFIG = {
+    'name': 'SendGrid SMTP - InsightPulse',
+    'smtp_host': 'smtp.sendgrid.net',
+    'smtp_port': 2525,  # Port 2525 bypasses DigitalOcean blocking!
+    'smtp_encryption': 'starttls',  # TLS (STARTTLS)
+    'smtp_user': 'apikey',  # SendGrid uses literal "apikey" as username
+    'smtp_pass': '',  # Your SendGrid API key - SET VIA ODOO UI
+    'from_filter': '@insightpulseai.net',  # Domain-based FROM filter
+    'sequence': 10,
+    'smtp_authentication': 'login',
+    'smtp_debug': False,
+    'active': True,
+}
+
+SYSTEM_PARAMS = {
+    'mail.catchall.domain': 'insightpulseai.net',
+    'mail.default.from': 'notifications',
+    'mail.catchall.alias': 'catchall',
+    'mail.bounce.alias': 'bounce',
+    # Force all outgoing mail to use authorized sender
+    'mail.force.smtp.from': 'notifications@insightpulseai.net',
+}
+
+# ============================================
+# CONFIGURE MAIL SERVER
+# ============================================
+
+print("=" * 60)
+print("SendGrid SMTP Configuration for Odoo 18 (DigitalOcean)")
+print("=" * 60)
+print("\nUsing PORT 2525 to bypass DigitalOcean SMTP blocking")
+
+MailServer = env['ir.mail_server'].sudo()
+
+# Check for existing SendGrid server
+existing = MailServer.search([('smtp_host', '=', 'smtp.sendgrid.net')], limit=1)
+
+if existing:
+    print(f"\nExisting SendGrid server found (ID: {existing.id})")
+    print("   Updating configuration...")
+    existing.write(SMTP_CONFIG)
+    server = existing
+else:
+    print("\nCreating new SendGrid SMTP server...")
+    server = MailServer.create(SMTP_CONFIG)
+
+print(f"\nMail Server configured:")
+print(f"   ID: {server.id}")
+print(f"   Name: {server.name}")
+print(f"   Host: {server.smtp_host}:{server.smtp_port}")
+print(f"   Encryption: {server.smtp_encryption}")
+print(f"   User: {server.smtp_user}")
+print(f"   FROM Filter: {server.from_filter or 'Not set'}")
+
+# ============================================
+# CONFIGURE SYSTEM PARAMETERS
+# ============================================
+
+print("\n" + "=" * 60)
+print("System Parameters Configuration")
+print("=" * 60)
+
+ICP = env['ir.config_parameter'].sudo()
+
+for key, value in SYSTEM_PARAMS.items():
+    ICP.set_param(key, value)
+    print(f"   {key} = {value}")
+
+# ============================================
+# COMMIT CHANGES
+# ============================================
+
+env.cr.commit()
+
+print("\n" + "=" * 60)
+print("Configuration Complete!")
+print("=" * 60)
+print("\nNEXT STEPS:")
+print("1. Go to Settings > Technical > Outgoing Mail Servers")
+print("2. Click on 'SendGrid SMTP - InsightPulse'")
+print("3. Set the Password field (your SendGrid API key)")
+print("4. Save the record")
+print("5. Click 'Test Connection' button")
+print("\nSENDGRID SETUP (if not done):")
+print("1. Sign up at: https://signup.sendgrid.com/")
+print("2. Create API key: Settings > API Keys > Create API Key")
+print("3. Select 'Full Access' or 'Restricted Access' with Mail Send permission")
+print("4. Copy the API key (shown only once!)")
+print("5. Verify sender: Settings > Sender Authentication")
+print("\nSENDGRID + DIGITALOCEAN:")
+print("   SendGrid is a DigitalOcean partner")
+print("   Free tier: 100 emails/day")
+print("   Port 2525 is NOT blocked by DigitalOcean")
+print("\nIMPORTANT - USERNAME:")
+print("   SendGrid uses literal 'apikey' as SMTP username")
+print("   Password is your actual SendGrid API key")
+print("\nTo test manually in shell:")
+print("   server = env['ir.mail_server'].sudo().search([('smtp_host', '=', 'smtp.sendgrid.net')], limit=1)")
+print("   server.test_smtp_connection()")


### PR DESCRIPTION
DigitalOcean blocks standard SMTP ports (25, 465, 587) by default. This adds comprehensive documentation and configuration scripts for setting up email using port 2525, which bypasses the blocking.

Added:
- docs/DIGITALOCEAN_EMAIL_SETUP.md - Comprehensive setup guide
- scripts/configure_sendgrid_smtp.py - SendGrid config (port 2525)
- scripts/configure_mailgun_smtp.py - Mailgun config (port 2525)

Updated:
- .env.smtp.example - Added all provider options with port info
- scripts/diagnose_smtp.sh - Added port 2525 testing and recommendations

Recommended approach for DigitalOcean:
1. Use SendGrid or Mailgun with port 2525
2. Configure SPF, DKIM, DMARC DNS records
3. Set mail.force.smtp.from for sender consistency