### PR TITLE
Create Odoo 18 ship checklist with view fixes

### DIFF
--- a/addons/ipai/ipai_v18_compat/__init__.py
+++ b/addons/ipai/ipai_v18_compat/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# IPAI Odoo 18 Compatibility Fixes
+# This module provides post-migration fixes via migrations/18.0.1.0.0/post-migrate.py

--- a/addons/ipai/ipai_v18_compat/__manifest__.py
+++ b/addons/ipai/ipai_v18_compat/__manifest__.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "IPAI Odoo 18 Compatibility Fixes",
+    "summary": "Post-migrate hotfixes for Odoo 18 view_mode rename (tree->list) and kanban card template issues",
+    "description": """
+IPAI Odoo 18 Compatibility Fixes
+================================
+
+This module provides automatic fixes for breaking changes in Odoo 18:
+
+1. **tree -> list View Mode Rename**
+   Odoo 18 renamed the 'tree' view mode to 'list'. This module automatically
+   updates all ir.actions.act_window records that still use 'tree' in their
+   view_mode field.
+
+2. **Kanban Card Template Requirement**
+   Odoo 18 requires kanban views to have a `t-name="card"` template. This module
+   detects kanban views missing this template and optionally deactivates them.
+
+Usage
+-----
+
+**Installation:**
+    odoo -d <database> -i ipai_v18_compat --stop-after-init
+
+**Re-run migration:**
+    odoo -d <database> -u ipai_v18_compat --stop-after-init
+
+**Enable auto-deactivation of broken kanban views:**
+    Set system parameter: ipai_v18_compat.deactivate_broken_kanban = 1
+
+Configuration
+-------------
+
+System Parameters:
+- ipai_v18_compat.deactivate_broken_kanban: Set to "1" to automatically
+  deactivate kanban views missing the card template.
+    """,
+    "version": "18.0.1.0.0",
+    "category": "Technical",
+    "author": "InsightPulse AI",
+    "website": "https://github.com/jgtolentino/odoo-ce",
+    "license": "LGPL-3",
+    "depends": ["base"],
+    "data": [],
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+}

--- a/addons/ipai/ipai_v18_compat/migrations/18.0.1.0.0/post-migrate.py
+++ b/addons/ipai/ipai_v18_compat/migrations/18.0.1.0.0/post-migrate.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+"""
+IPAI Odoo 18 Compatibility Post-Migration Script
+
+This script runs automatically when the ipai_v18_compat module is upgraded.
+It fixes two critical Odoo 18 breaking changes:
+
+1. tree -> list: Updates ir.actions.act_window.view_mode from 'tree' to 'list'
+2. Kanban card template: Detects (and optionally deactivates) kanban views
+   missing the required t-name="card" template.
+
+Usage:
+    # Standard upgrade (runs this migration)
+    odoo -d <database> -u ipai_v18_compat --stop-after-init
+
+    # Enable auto-deactivation of broken kanban views
+    # Set system parameter: ipai_v18_compat.deactivate_broken_kanban = 1
+"""
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def _fix_tree_to_list(env):
+    """
+    Replace 'tree' with 'list' in ir.actions.act_window.view_mode.
+
+    Odoo 18 renamed the 'tree' view type to 'list'. Actions using the old
+    'tree' keyword will fail with:
+        "View types not defined tree found in act_window action ..."
+
+    Returns:
+        int: Number of actions updated
+    """
+    ActWindow = env["ir.actions.act_window"].sudo()
+    actions = ActWindow.search([("view_mode", "ilike", "tree")])
+
+    changed = 0
+    for action in actions:
+        modes = [m.strip() for m in (action.view_mode or "").split(",") if m.strip()]
+        if not modes:
+            continue
+
+        new_modes = ["list" if m == "tree" else m for m in modes]
+
+        if new_modes != modes:
+            old_mode = action.view_mode
+            action.write({"view_mode": ",".join(new_modes)})
+            _logger.info(
+                "ipai_v18_compat: Updated action %s (%s): '%s' -> '%s'",
+                action.id,
+                action.name,
+                old_mode,
+                ",".join(new_modes),
+            )
+            changed += 1
+
+    _logger.warning(
+        "ipai_v18_compat: tree->list migration completed. Updated %s act_window actions.",
+        changed,
+    )
+    return changed
+
+
+def _find_kanban_missing_card(env):
+    """
+    Find active kanban views missing the required t-name="card" template.
+
+    Odoo 18's KanbanArchParser requires a <templates><t t-name="card">...</t></templates>
+    structure. Views missing this will fail with:
+        "Missing 'card' template."
+
+    Returns:
+        recordset: ir.ui.view records with broken kanban templates
+    """
+    View = env["ir.ui.view"].sudo()
+    views = View.search([("type", "=", "kanban"), ("active", "=", True)])
+
+    broken = View.browse()
+    for view in views:
+        arch = view.arch_db or ""
+        # Check for both single and double quote variants
+        if 't-name="card"' not in arch and "t-name='card'" not in arch:
+            broken |= view
+            _logger.info(
+                "ipai_v18_compat: Kanban view missing card template: "
+                "id=%s, xml_id=%s, name=%s, model=%s, module=%s",
+                view.id,
+                view.xml_id or "(no xml_id)",
+                view.name,
+                view.model,
+                view.module or "(unknown)",
+            )
+
+    _logger.warning(
+        "ipai_v18_compat: Found %s active kanban views missing 't-name=\"card\"' template.",
+        len(broken),
+    )
+    return broken
+
+
+def _deactivate_broken_views(env, views):
+    """
+    Deactivate broken kanban views to prevent UI crashes.
+
+    This is the safest approach: it allows the system to boot while you
+    patch the source modules. The views can be re-activated after fixing
+    their templates.
+
+    Args:
+        env: Odoo environment
+        views: recordset of ir.ui.view to deactivate
+
+    Returns:
+        int: Number of views deactivated
+    """
+    if not views:
+        return 0
+
+    deactivated = []
+    for view in views:
+        deactivated.append(
+            {
+                "id": view.id,
+                "xml_id": view.xml_id or "(no xml_id)",
+                "name": view.name,
+                "model": view.model,
+            }
+        )
+
+    views.write({"active": False})
+
+    for info in deactivated:
+        _logger.warning(
+            "ipai_v18_compat: DEACTIVATED kanban view id=%s xml_id=%s name=%s model=%s",
+            info["id"],
+            info["xml_id"],
+            info["name"],
+            info["model"],
+        )
+
+    _logger.warning(
+        "ipai_v18_compat: Deactivated %s broken kanban views. "
+        "Re-activate after fixing their templates.",
+        len(views),
+    )
+    return len(views)
+
+
+def migrate(cr, version):
+    """
+    Post-migration hook for ipai_v18_compat module.
+
+    This function is automatically called by Odoo during module upgrade.
+
+    Args:
+        cr: Database cursor
+        version: Current module version (before migration)
+    """
+    # Import here to avoid issues during module loading
+    from odoo.api import Environment
+    from odoo import SUPERUSER_ID
+
+    _logger.warning(
+        "ipai_v18_compat: Starting post-migration (from version=%s)", version
+    )
+
+    env = Environment(cr, SUPERUSER_ID, {})
+
+    # Fix 1: tree -> list in view_mode
+    tree_count = _fix_tree_to_list(env)
+
+    # Fix 2: Find broken kanban views
+    broken_kanban = _find_kanban_missing_card(env)
+
+    # Optionally deactivate broken views (opt-in via system parameter)
+    # Set in Odoo: Settings -> Technical -> Parameters -> System Parameters
+    # Key: ipai_v18_compat.deactivate_broken_kanban = 1
+    deactivate_param = (
+        env["ir.config_parameter"]
+        .sudo()
+        .get_param("ipai_v18_compat.deactivate_broken_kanban", "0")
+    )
+    should_deactivate = deactivate_param in ("1", "true", "True", "yes", "Yes")
+
+    deactivated_count = 0
+    if should_deactivate and broken_kanban:
+        deactivated_count = _deactivate_broken_views(env, broken_kanban)
+    elif broken_kanban:
+        _logger.warning(
+            "ipai_v18_compat: To auto-deactivate broken kanban views, set system parameter "
+            "'ipai_v18_compat.deactivate_broken_kanban' to '1'"
+        )
+
+    # Clear caches to ensure changes take effect
+    env.registry.clear_cache()
+
+    _logger.warning(
+        "ipai_v18_compat: Post-migration completed. "
+        "tree->list: %s actions updated, "
+        "broken kanban: %s found, %s deactivated.",
+        tree_count,
+        len(broken_kanban),
+        deactivated_count,
+    )

--- a/docs/GO_LIVE_CHECKLIST_ODOO18_IPAI.md
+++ b/docs/GO_LIVE_CHECKLIST_ODOO18_IPAI.md
@@ -1,0 +1,385 @@
+# Odoo 18 CE + OCA + IPAI Go-Live Checklist (InsightPulseAI)
+
+**Version**: 2.0
+**Stack**: Dockerized Odoo 18 CE on DO droplet + nginx reverse proxy + OCA modules + IPAI custom suite
+**Optional**: AI (OpenAI/Gemini) + OCR/Digitalization service
+**Last Updated**: January 2026
+
+---
+
+## 0) Platform / Infra Health (must be green before functional testing)
+
+### 0.1 Domain + TLS
+
+- [ ] Domain + TLS ok: https://erp.insightpulseai.net loads without mixed-content errors
+- [ ] Certificate valid and not expiring within 30 days
+- [ ] HSTS headers configured
+
+### 0.2 Container Health
+
+- [ ] Odoo container healthy:
+  - [ ] `docker ps` shows `odoo-erp-prod` running
+  - [ ] `docker logs -n 200 odoo-erp-prod` shows no repeating tracebacks
+- [ ] Workers restart policy set; no crash loop
+- [ ] Filestore volume mounted & writable
+
+### 0.3 Outbound Connectivity (for AI/OCR)
+
+- [ ] Outbound HTTPS from container works:
+  - [ ] `curl -sS https://api.openai.com` returns a response (no DNS/egress block)
+  - [ ] `curl -sS https://generativelanguage.googleapis.com` returns a response
+
+### 0.4 Database Health
+
+- [ ] PostgreSQL 15 running and healthy
+- [ ] Database backup schedule active
+- [ ] Connection pooling configured
+
+---
+
+## 1) Critical Odoo 18 Compatibility Gate (prevents UI hard-stops)
+
+> **CRITICAL**: Odoo 18 renamed `tree` view mode to `list`. Kanban views now require `t-name="card"` template. These breaking changes will crash the UI if not fixed.
+
+### 1.1 Fix act_window view_mode breaking change (tree -> list)
+
+- [ ] Install `ipai_v18_compat` module:
+  ```bash
+  docker exec -it odoo-erp-prod odoo -d odoo -u ipai_v18_compat --stop-after-init
+  docker restart odoo-erp-prod
+  ```
+- [ ] OR run standalone fix script:
+  ```bash
+  docker exec -it odoo-erp-prod python /mnt/extra-addons/ipai/scripts/fix_odoo18_views.py
+  ```
+- [ ] Verify no `tree` view_mode remains:
+  ```bash
+  docker exec -it odoo-erp-prod odoo shell -d odoo -c /etc/odoo/odoo.conf << 'EOF'
+  actions = env['ir.actions.act_window'].sudo().search([('view_mode', 'ilike', 'tree')])
+  print(f"Actions with tree view_mode: {len(actions)}")
+  for a in actions[:10]:
+      print(f"  - {a.id}: {a.name} ({a.view_mode})")
+  EOF
+  ```
+
+### 1.2 Fix broken kanban views missing `t-name="card"`
+
+- [ ] Detect kanban views missing card template (script will log these)
+- [ ] Option A: Patch the views in source modules
+- [ ] Option B: Enable auto-deactivation via system parameter:
+  ```bash
+  docker exec -it odoo-erp-prod odoo shell -d odoo -c /etc/odoo/odoo.conf << 'EOF'
+  env["ir.config_parameter"].sudo().set_param("ipai_v18_compat.deactivate_broken_kanban", "1")
+  print("Set ipai_v18_compat.deactivate_broken_kanban=1")
+  EOF
+  ```
+
+### 1.3 Verification (Evidence)
+
+- [ ] No client errors in browser console:
+  - [ ] No "View types not defined tree found in act_window action ..."
+  - [ ] No "Missing 'card' template."
+- [ ] Verify logs are clean:
+  ```bash
+  docker logs -n 200 odoo-erp-prod | grep -iE "Missing .card.|View types not defined|Traceback" || echo "Clean!"
+  ```
+
+---
+
+## 2) Email / Invites / Reset Password (Outbound-only baseline)
+
+### 2.1 Outgoing SMTP Configuration
+
+- [ ] Outgoing SMTP configured (Mailgun 2525 / TLS STARTTLS)
+- [ ] Odoo test connection successful
+- [ ] From filtering set (e.g. *@insightpulseai.net)
+
+### 2.2 Email Delivery Tests
+
+- [ ] Send test:
+  - [ ] Invite user email arrives
+  - [ ] Password reset email arrives
+- [ ] No mail queue stuck: Settings -> Technical -> Emails
+- [ ] Check mail.mail model for failed records:
+  ```bash
+  docker exec -it odoo-erp-prod odoo shell -d odoo << 'EOF'
+  failed = env['mail.mail'].sudo().search([('state', '=', 'exception')])
+  print(f"Failed emails: {len(failed)}")
+  EOF
+  ```
+
+---
+
+## 3) AI Provider Configuration (Ask AI feature)
+
+### 3.1 Provider Setup
+
+- [ ] Settings -> AI Provider Configuration
+  - [ ] "Use your own ChatGPT account" enabled + key saved
+  - [ ] "Use your own Google Gemini account" enabled + key saved
+
+### 3.2 Functional Tests
+
+- [ ] Ask AI channel responds (Discuss -> Ask AI)
+- [ ] Test simple prompt: "Say OK" returns response
+
+### 3.3 Verification
+
+- [ ] No provider errors in logs:
+  ```bash
+  docker logs -n 200 odoo-erp-prod | grep -iE "ai|openai|gemini|http.*error|traceback" || echo "Clean!"
+  ```
+- [ ] API key not exposed in logs or UI
+
+---
+
+## 4) Expenses + Document Digitalization (OCR) Readiness
+
+### 4.1 Core Expenses Flow
+
+- [ ] Products exist for expense categories:
+  - [ ] Meals
+  - [ ] Transportation
+  - [ ] Accommodation
+  - [ ] Miscellaneous
+- [ ] Employee Expense Journal configured
+- [ ] Payment modes correct:
+  - [ ] "Employee (to reimburse)"
+  - [ ] "Company"
+
+### 4.2 End-to-End Expense Test
+
+- [ ] Create expense
+- [ ] Create expense report
+- [ ] Submit for approval
+- [ ] Approve expense report
+- [ ] Post journal entry
+- [ ] Verify GL entries created
+
+### 4.3 Incoming Email Expenses (optional)
+
+- [ ] Alias configured (expense@insightpulseai.net)
+- [ ] Email gateway routes to Odoo (inbound)
+- [ ] OR mark as "disabled/out-of-scope"
+
+### 4.4 OCR / Receipt Ingestion
+
+Pick ONE approach:
+
+**Option A: Odoo Built-in OCR (if available)**
+- [ ] OCR provider configured in Settings
+- [ ] IAP account linked (if applicable)
+
+**Option B: Custom OCR Microservice (recommended for CE)**
+- [ ] Define endpoint in System Parameters: `ipai.ocr.endpoint`
+- [ ] Define auth token in System Parameters: `ipai.ocr.api_key`
+- [ ] ipai_ocr_expense module installed
+
+### 4.5 OCR Verification
+
+- [ ] Upload receipt produces structured fields:
+  - [ ] Date extracted
+  - [ ] Merchant extracted
+  - [ ] Amount extracted
+- [ ] At least one receipt processed successfully end-to-end
+
+---
+
+## 5) Accounting Go-Live (Opening Balances)
+
+> Adapted from Odoo community best practices for accrual-basis accounting
+
+### 5.A Opening Entries (Open Invoices/Bills)
+
+#### Create Clearing Accounts
+- [ ] Create AR Clearing account (reconcilable current asset)
+- [ ] Create AP Clearing account (reconcilable current liability)
+- [ ] Validate totals vs open AR/AP balances from prior system
+
+#### Import Open Documents
+- [ ] Import open invoices
+- [ ] Import open credit notes
+- [ ] Import open vendor bills
+- [ ] Import open vendor refunds/credit memos
+
+#### Reconciliation
+- [ ] Reconcile AR Clearing to zero (or expected balance)
+- [ ] Reconcile AP Clearing to zero (or expected balance)
+
+### 5.B Inventory (only if holding stock)
+
+#### Automated Valuation
+- [ ] Product categories configured:
+  - [ ] Costing method set (FIFO/Average/Standard)
+  - [ ] Valuation method set (Automated)
+- [ ] Inventory clearing account configured
+- [ ] Import on-hand quantities
+- [ ] Validate stock valuation vs initial balance
+
+#### Manual Valuation
+- [ ] Ensure no stock valuation expected on balance sheet
+- [ ] Mark as "not applicable" if no inventory
+
+### 5.C Trial Balance Import
+
+#### Bank Account Method Selection
+- [ ] Choose outstanding receipt/payment accounts (if using payment entries)
+- [ ] OR use bank clearing account (if not using payment entries)
+
+#### Trial Balance Entry
+- [ ] Modify TB to account for AR/AP/Inventory clearing approach
+- [ ] Post Trial Balance journal entry as opening entry
+- [ ] Set journal entry date to cutover date
+
+#### Validation
+- [ ] AR Clearing account balance = 0 (or expected)
+- [ ] AP Clearing account balance = 0 (or expected)
+- [ ] Inventory Clearing account balance = 0 (or expected)
+- [ ] Balance sheet balances
+
+---
+
+## 6) Final Smoke Tests (non-negotiable)
+
+### 6.1 UI/UX Validation
+
+- [ ] No blocking JS client errors in normal navigation
+- [ ] Settings pages open without Owl "Oops" modal
+- [ ] All installed app menus accessible
+
+### 6.2 Core Workflows
+
+- [ ] Create a user -> invitation email works
+- [ ] Ask AI answers "Say OK" (if AI enabled)
+- [ ] Create & submit an expense report
+- [ ] Accounting reports load without access errors
+- [ ] PDF reports generate correctly
+
+### 6.3 Module Compatibility
+
+- [ ] All IPAI modules installed without error
+- [ ] All OCA dependencies resolved
+- [ ] Module upgrade completes successfully:
+  ```bash
+  docker exec -it odoo-erp-prod odoo -d odoo -u all --stop-after-init
+  ```
+
+### 6.4 Backup Verification
+
+- [ ] Backup snapshot taken
+- [ ] Backup restoration tested on separate instance
+- [ ] Filestore included in backup
+
+---
+
+## 7) Post-Fix Verification Commands
+
+Run these after any fixes:
+
+```bash
+# Check for tree view_mode remnants
+docker exec -it odoo-erp-prod odoo shell -d odoo << 'EOF'
+tree_actions = env['ir.actions.act_window'].sudo().search([('view_mode', 'ilike', 'tree')])
+print(f"Actions with 'tree': {len(tree_actions)}")
+EOF
+
+# Check for broken kanban views
+docker exec -it odoo-erp-prod odoo shell -d odoo << 'EOF'
+kanban_views = env['ir.ui.view'].sudo().search([('type', '=', 'kanban'), ('active', '=', True)])
+broken = [v for v in kanban_views if 't-name="card"' not in (v.arch_db or '') and "t-name='card'" not in (v.arch_db or '')]
+print(f"Broken kanban views: {len(broken)}")
+for v in broken[:10]:
+    print(f"  - {v.id}: {v.name} ({v.model})")
+EOF
+
+# Check for client errors in logs
+docker logs -n 500 odoo-erp-prod 2>&1 | grep -iE "traceback|error|exception|missing" | head -20
+
+# General health check
+docker exec -it odoo-erp-prod odoo shell -d odoo << 'EOF'
+print("=== Module Status ===")
+for mod in env['ir.module.module'].sudo().search([('name', 'like', 'ipai_%')]):
+    print(f"  {mod.name}: {mod.state}")
+print("\n=== Database Info ===")
+cr = env.cr
+cr.execute("SELECT version();")
+print(f"  PostgreSQL: {cr.fetchone()[0]}")
+EOF
+```
+
+---
+
+## 8) Sign-Off
+
+### Technical Sign-Off
+
+- [ ] All Section 0-1 checks passed (Platform + V18 Compat)
+- [ ] All Section 2-4 checks passed (Email + AI + Expenses)
+- [ ] Section 5 Accounting opening complete
+- [ ] Section 6 smoke tests all green
+
+**Signed By**: _________________________ (DevOps Lead)
+**Date/Time**: _________________________
+
+### Business Sign-Off
+
+- [ ] Core business processes verified
+- [ ] User acceptance testing complete
+- [ ] Training delivered
+- [ ] Go-live approved
+
+**Signed By**: _________________________ (Business Owner)
+**Date/Time**: _________________________
+
+---
+
+## Quick Reference: ipai_v18_compat Module
+
+### Installation
+
+```bash
+# Standard installation (migration runs automatically)
+docker exec -it odoo-erp-prod odoo -d odoo -i ipai_v18_compat --stop-after-init
+docker restart odoo-erp-prod
+```
+
+### Upgrade (re-run migration)
+
+```bash
+docker exec -it odoo-erp-prod odoo -d odoo -u ipai_v18_compat --stop-after-init
+docker restart odoo-erp-prod
+```
+
+### Enable Auto-Deactivation of Broken Kanban
+
+```bash
+docker exec -it odoo-erp-prod odoo shell -d odoo << 'EOF'
+env["ir.config_parameter"].sudo().set_param("ipai_v18_compat.deactivate_broken_kanban", "1")
+env.cr.commit()
+print("Enabled auto-deactivation")
+EOF
+```
+
+---
+
+## Appendix A: Common Odoo 18 Breaking Changes
+
+| Change | Impact | Fix |
+|--------|--------|-----|
+| `tree` -> `list` in view_mode | UI crashes with "View types not defined tree" | Run ipai_v18_compat migration |
+| Kanban requires `t-name="card"` | UI crashes with "Missing 'card' template" | Patch views or deactivate |
+| `arch` -> `arch_db` in views | Code accessing `arch` may fail | Update to use `arch_db` |
+| `search_count` signature change | Existing code may break | Check domain parameter |
+
+---
+
+## Appendix B: Related Documentation
+
+- [CLAUDE.md](../CLAUDE.md) - Project conventions and commands
+- [GO_LIVE_CHECKLIST.md](GO_LIVE_CHECKLIST.md) - Original comprehensive checklist
+- [ODOO_18_EE_TO_CE_OCA_PARITY.md](ODOO_18_EE_TO_CE_OCA_PARITY.md) - Enterprise to CE mapping
+- [TESTING_ODOO_18.md](TESTING_ODOO_18.md) - Testing guide
+
+---
+
+*This checklist extends the original GO_LIVE_CHECKLIST.md with Odoo 18-specific compatibility fixes and AI/OCR readiness sections.*

--- a/scripts/fix_odoo18_views.py
+++ b/scripts/fix_odoo18_views.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Odoo 18 View Compatibility Fix Script
+
+This standalone script fixes two critical Odoo 18 breaking changes:
+
+1. tree -> list: Updates ir.actions.act_window.view_mode from 'tree' to 'list'
+2. Kanban card template: Detects (and optionally deactivates) kanban views
+   missing the required t-name="card" template.
+
+Usage (inside Docker container):
+
+    # Basic run (fix tree->list, report broken kanban)
+    export ODOO_DB=odoo
+    export ODOO_CONF=/etc/odoo/odoo.conf
+    python /mnt/extra-addons/ipai/scripts/fix_odoo18_views.py
+
+    # With auto-deactivation of broken kanban views
+    export ODOO_DB=odoo
+    export ODOO_CONF=/etc/odoo/odoo.conf
+    export DEACTIVATE_BROKEN_KANBAN=1
+    python /mnt/extra-addons/ipai/scripts/fix_odoo18_views.py
+
+    # Full Docker command
+    docker exec -it odoo-erp-prod bash -lc '
+      export ODOO_DB=odoo
+      export ODOO_CONF=/etc/odoo/odoo.conf
+      python /mnt/extra-addons/ipai/scripts/fix_odoo18_views.py
+    '
+
+Environment Variables:
+    ODOO_DB: Database name (default: "odoo")
+    ODOO_CONF: Path to odoo.conf (default: "/etc/odoo/odoo.conf")
+    DEACTIVATE_BROKEN_KANBAN: Set to "1" to auto-deactivate broken kanban views
+"""
+
+import logging
+import os
+import sys
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+_logger = logging.getLogger("fix_odoo18_views")
+
+
+def fix_tree_to_list(env):
+    """
+    Replace 'tree' with 'list' in ir.actions.act_window.view_mode.
+
+    Odoo 18 renamed the 'tree' view type to 'list'. Actions using the old
+    'tree' keyword will fail with:
+        "View types not defined tree found in act_window action ..."
+
+    Args:
+        env: Odoo environment
+
+    Returns:
+        int: Number of actions updated
+    """
+    ActWindow = env["ir.actions.act_window"].sudo()
+    actions = ActWindow.search([("view_mode", "ilike", "tree")])
+
+    _logger.info("Found %s actions with 'tree' in view_mode", len(actions))
+
+    changed = 0
+    for action in actions:
+        modes = [m.strip() for m in (action.view_mode or "").split(",") if m.strip()]
+        if not modes:
+            continue
+
+        new_modes = ["list" if m == "tree" else m for m in modes]
+
+        if new_modes != modes:
+            old_mode = action.view_mode
+            action.write({"view_mode": ",".join(new_modes)})
+            _logger.info(
+                "Updated action %s (%s): '%s' -> '%s'",
+                action.id,
+                action.name,
+                old_mode,
+                ",".join(new_modes),
+            )
+            changed += 1
+
+    _logger.info("tree->list: Updated %s actions", changed)
+    return changed
+
+
+def find_broken_kanban(env):
+    """
+    Find active kanban views missing the required t-name="card" template.
+
+    Odoo 18's KanbanArchParser requires a <templates><t t-name="card">...</t></templates>
+    structure. Views missing this will fail with:
+        "Missing 'card' template."
+
+    Args:
+        env: Odoo environment
+
+    Returns:
+        list: List of broken view records
+    """
+    View = env["ir.ui.view"].sudo()
+    views = View.search([("type", "=", "kanban"), ("active", "=", True)])
+
+    _logger.info("Checking %s active kanban views for card template...", len(views))
+
+    broken = []
+    for view in views:
+        arch = view.arch_db or ""
+        # Check for both single and double quote variants
+        if 't-name="card"' not in arch and "t-name='card'" not in arch:
+            broken.append(view)
+
+    _logger.info("Found %s kanban views missing 't-name=\"card\"' template", len(broken))
+
+    # Log details of broken views (limit to 200 to avoid log spam)
+    for view in broken[:200]:
+        _logger.warning(
+            "BROKEN: id=%s, xml_id=%s, name=%s, model=%s, module=%s",
+            view.id,
+            view.xml_id or "(no xml_id)",
+            view.name,
+            view.model,
+            view.module or "(unknown)",
+        )
+
+    if len(broken) > 200:
+        _logger.warning("... and %s more broken views", len(broken) - 200)
+
+    return broken
+
+
+def deactivate_views(env, views):
+    """
+    Deactivate broken kanban views to prevent UI crashes.
+
+    Args:
+        env: Odoo environment
+        views: List of ir.ui.view records to deactivate
+
+    Returns:
+        int: Number of views deactivated
+    """
+    if not views:
+        return 0
+
+    # Get the recordset from list
+    View = env["ir.ui.view"].sudo()
+    view_ids = [v.id for v in views]
+    recordset = View.browse(view_ids)
+
+    recordset.write({"active": False})
+
+    for view in views:
+        _logger.warning(
+            "DEACTIVATED: id=%s, xml_id=%s, name=%s, model=%s",
+            view.id,
+            view.xml_id or "(no xml_id)",
+            view.name,
+            view.model,
+        )
+
+    _logger.info("Deactivated %s broken kanban views", len(views))
+    return len(views)
+
+
+def main():
+    """
+    Main entry point for the fix script.
+    """
+    # Get configuration from environment
+    db_name = os.environ.get("ODOO_DB", "odoo")
+    conf_path = os.environ.get("ODOO_CONF", "/etc/odoo/odoo.conf")
+    deactivate_broken = os.environ.get("DEACTIVATE_BROKEN_KANBAN", "0") in (
+        "1",
+        "true",
+        "True",
+        "yes",
+        "Yes",
+    )
+
+    _logger.info("=" * 60)
+    _logger.info("Odoo 18 View Compatibility Fix Script")
+    _logger.info("=" * 60)
+    _logger.info("Database: %s", db_name)
+    _logger.info("Config: %s", conf_path)
+    _logger.info("Deactivate broken kanban: %s", deactivate_broken)
+    _logger.info("=" * 60)
+
+    # Initialize Odoo
+    try:
+        import odoo
+        from odoo import api, SUPERUSER_ID
+        from odoo.tools import config
+    except ImportError as e:
+        _logger.error(
+            "Failed to import Odoo. Make sure this script is run "
+            "inside the Odoo container or environment: %s",
+            e,
+        )
+        sys.exit(1)
+
+    # Parse config
+    try:
+        config.parse_config(["-c", conf_path, "-d", db_name])
+    except Exception as e:
+        _logger.error("Failed to parse Odoo config: %s", e)
+        sys.exit(1)
+
+    # Initialize Odoo
+    try:
+        odoo.cli.server.report_configuration()
+        odoo.service.server.load_server_wide_modules()
+    except Exception as e:
+        _logger.warning("Server-wide module load issue (may be okay): %s", e)
+
+    # Get database registry and environment
+    try:
+        registry = odoo.registry(db_name)
+    except Exception as e:
+        _logger.error("Failed to get database registry for '%s': %s", db_name, e)
+        sys.exit(1)
+
+    with registry.cursor() as cr:
+        env = api.Environment(cr, SUPERUSER_ID, {})
+
+        _logger.info("")
+        _logger.info("=== Fix 1: tree -> list in view_mode ===")
+        tree_count = fix_tree_to_list(env)
+
+        _logger.info("")
+        _logger.info("=== Fix 2: Detect broken kanban views ===")
+        broken_kanban = find_broken_kanban(env)
+
+        deactivated_count = 0
+        if deactivate_broken and broken_kanban:
+            _logger.info("")
+            _logger.info("=== Deactivating broken kanban views ===")
+            deactivated_count = deactivate_views(env, broken_kanban)
+        elif broken_kanban:
+            _logger.warning("")
+            _logger.warning(
+                "To auto-deactivate broken kanban views, set DEACTIVATE_BROKEN_KANBAN=1"
+            )
+
+        # Commit changes
+        cr.commit()
+
+        # Clear caches
+        env.registry.clear_cache()
+
+        _logger.info("")
+        _logger.info("=" * 60)
+        _logger.info("Summary:")
+        _logger.info("  - tree->list: %s actions updated", tree_count)
+        _logger.info("  - Broken kanban: %s found", len(broken_kanban))
+        _logger.info("  - Kanban deactivated: %s", deactivated_count)
+        _logger.info("=" * 60)
+
+        if broken_kanban and not deactivated_count:
+            _logger.warning(
+                "You have %s broken kanban views that may cause UI errors!",
+                len(broken_kanban),
+            )
+            _logger.warning("Options:")
+            _logger.warning("  1. Patch the source modules to add t-name=\"card\" templates")
+            _logger.warning("  2. Re-run with DEACTIVATE_BROKEN_KANBAN=1 to auto-deactivate")
+
+    _logger.info("")
+    _logger.info("Done! Restart Odoo to apply changes.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add comprehensive go-live checklist and automatic compatibility fixes for Odoo 18 breaking changes:

1. GO_LIVE_CHECKLIST_ODOO18_IPAI.md - Ship checklist with sections for:
   - Platform/infra health checks
   - Odoo 18 compatibility gate (tree->list, kanban card template)
   - Email/SMTP configuration
   - AI provider configuration (OpenAI/Gemini)
   - Expenses + OCR/Digitalization readiness
   - Accounting opening balances

2. ipai_v18_compat module - Automatic post-migration fixes:
   - Replaces 'tree' with 'list' in ir.actions.act_window.view_mode
   - Detects kanban views missing t-name="card" template
   - Optional auto-deactivation via system parameter

3. fix_odoo18_views.py - Standalone script for manual fixes:
   - Can run without installing the module
   - Same functionality as migration script
   - Environment variable configuration

These fixes address:
- "View types not defined tree found in act_window action" errors
- "Missing 'card' template" kanban errors