### PR TITLE
Compare Odoo Project with workspace tools

### DIFF
--- a/addons/ipai/ipai_ai_audit/__manifest__.py
+++ b/addons/ipai/ipai_ai_audit/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "IPAI AI Audit & Governance",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Productivity/AI",
     "summary": "AI usage logging, redaction, and governance controls",
     "description": """

--- a/addons/ipai/ipai_ai_audit/views/audit_log_views.xml
+++ b/addons/ipai/ipai_ai_audit/views/audit_log_views.xml
@@ -144,7 +144,7 @@
     <record id="action_ipai_ai_audit_log" model="ir.actions.act_window">
         <field name="name">AI Audit Logs</field>
         <field name="res_model">ipai.ai.audit.log</field>
-        <field name="view_mode">tree,form,pivot,graph</field>
+        <field name="view_mode">list,form,pivot,graph</field>
         <field name="search_view_id" ref="view_ipai_ai_audit_log_search"/>
         <field name="context">{'search_default_filter_today': 1}</field>
     </record>

--- a/addons/ipai/ipai_ai_audit/views/governance_views.xml
+++ b/addons/ipai/ipai_ai_audit/views/governance_views.xml
@@ -107,7 +107,7 @@
     <record id="action_ipai_ai_governance_rule" model="ir.actions.act_window">
         <field name="name">AI Governance Rules</field>
         <field name="res_model">ipai.ai.governance.rule</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create your first AI governance rule

--- a/addons/ipai/ipai_ai_core/__manifest__.py
+++ b/addons/ipai/ipai_ai_core/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "IPAI AI Core",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Productivity",
     "summary": "Provider-based AI threads/messages/citations for Odoo CE 18 (works with OCA AI UI).",
     "description": """

--- a/addons/ipai/ipai_ai_core/views/ipai_ai_menus.xml
+++ b/addons/ipai/ipai_ai_core/views/ipai_ai_menus.xml
@@ -10,7 +10,7 @@
     <record id="action_ipai_ai_threads" model="ir.actions.act_window">
         <field name="name">AI Threads</field>
         <field name="res_model">ipai.ai.thread</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
         <field name="context">{'search_default_my_threads': 1}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
@@ -26,7 +26,7 @@
     <record id="action_ipai_ai_providers" model="ir.actions.act_window">
         <field name="name">AI Providers</field>
         <field name="res_model">ipai.ai.provider</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
         <field name="domain">[]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">

--- a/addons/ipai/ipai_ai_prompts/__manifest__.py
+++ b/addons/ipai/ipai_ai_prompts/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "IPAI AI Prompts Library",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Productivity/AI",
     "summary": "Prompt templates and topic library for AI interactions",
     "description": """

--- a/addons/ipai/ipai_ai_prompts/views/prompt_views.xml
+++ b/addons/ipai/ipai_ai_prompts/views/prompt_views.xml
@@ -108,7 +108,7 @@
     <record id="action_ipai_ai_prompt" model="ir.actions.act_window">
         <field name="name">AI Prompts</field>
         <field name="res_model">ipai.ai.prompt</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
         <field name="search_view_id" ref="view_ipai_ai_prompt_search"/>
         <field name="context">{'search_default_filter_active': 1}</field>
         <field name="help" type="html">

--- a/addons/ipai/ipai_ai_prompts/views/topic_views.xml
+++ b/addons/ipai/ipai_ai_prompts/views/topic_views.xml
@@ -87,7 +87,7 @@
                 <field name="icon"/>
                 <field name="prompt_count"/>
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="card">
                         <div class="oe_kanban_card oe_kanban_global_click">
                             <div class="o_kanban_record_top">
                                 <div class="o_kanban_record_headings">
@@ -114,7 +114,7 @@
     <record id="action_ipai_ai_topic" model="ir.actions.act_window">
         <field name="name">AI Topics</field>
         <field name="res_model">ipai.ai.topic</field>
-        <field name="view_mode">kanban,tree,form</field>
+        <field name="view_mode">kanban,list,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create your first AI topic

--- a/addons/ipai/ipai_ai_provider_pulser/__manifest__.py
+++ b/addons/ipai/ipai_ai_provider_pulser/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "IPAI AI Provider - Pulser Gateway",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Productivity/AI",
     "summary": "AI provider adapter for Pulser/self-hosted AI gateway",
     "description": """

--- a/addons/ipai/ipai_ai_provider_pulser/views/provider_views.xml
+++ b/addons/ipai/ipai_ai_provider_pulser/views/provider_views.xml
@@ -97,7 +97,7 @@
     <record id="action_ipai_ai_provider_config" model="ir.actions.act_window">
         <field name="name">AI Providers</field>
         <field name="res_model">ipai.ai.provider.config</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Configure your AI providers

--- a/addons/ipai/ipai_finance_ppm/__manifest__.py
+++ b/addons/ipai/ipai_finance_ppm/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "IPAI Finance PPM",
     "summary": "Finance Project Portfolio Management (Notion Parity).",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Accounting/Finance",
     "author": "InsightPulse AI",
     "website": "https://github.com/jgtolentino/odoo-ce/tree/18.0/addons/ipai/ipai_finance_ppm",

--- a/addons/ipai/ipai_finance_ppm/views/finance_kanban_views.xml
+++ b/addons/ipai/ipai_finance_ppm/views/finance_kanban_views.xml
@@ -20,7 +20,7 @@
                     colors='{"draft": "muted", "active": "warning", "review": "danger", "done": "success"}'/>
 
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="card">
                         <div t-attf-class="oe_kanban_global_click #{record.color.raw_value ? 'oe_kanban_color_' + record.color.raw_value : ''}">
                             <div class="oe_kanban_content">
                                 <!-- Header with badges -->

--- a/addons/ipai/ipai_finance_ppm/views/ppm_dashboard_views.xml
+++ b/addons/ipai/ipai_finance_ppm/views/ppm_dashboard_views.xml
@@ -39,7 +39,7 @@
                 <field name="status_color"/>
 
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="card">
                         <div t-attf-class="oe_kanban_global_click o_kanban_record oe_kanban_color_#{record.status_color.value}">
                             <div class="o_kanban_details">
                                 <strong t-esc="record.name.value"/>

--- a/addons/ipai/ipai_marketing_journey/__manifest__.py
+++ b/addons/ipai/ipai_marketing_journey/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "IPAI Marketing Journey Builder",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Marketing",
     "summary": "Node-based marketing journey builder (Enterprise MA substitute)",
     "description": """

--- a/addons/ipai/ipai_marketing_journey/models/journey.py
+++ b/addons/ipai/ipai_marketing_journey/models/journey.py
@@ -198,7 +198,7 @@ class MarketingJourney(models.Model):
             "type": "ir.actions.act_window",
             "name": "Participants",
             "res_model": "marketing.journey.participant",
-            "view_mode": "tree,form",
+            "view_mode": "list,form",
             "domain": [("journey_id", "=", self.id)],
             "context": {"default_journey_id": self.id},
         }

--- a/addons/ipai/ipai_marketing_journey/views/journey_views.xml
+++ b/addons/ipai/ipai_marketing_journey/views/journey_views.xml
@@ -146,7 +146,7 @@
     <record id="action_marketing_journey" model="ir.actions.act_window">
         <field name="name">Journeys</field>
         <field name="res_model">marketing.journey</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
         <field name="search_view_id" ref="view_marketing_journey_search"/>
         <field name="context">{'search_default_filter_active': 1}</field>
         <field name="help" type="html">

--- a/addons/ipai/ipai_marketing_journey/views/node_views.xml
+++ b/addons/ipai/ipai_marketing_journey/views/node_views.xml
@@ -113,6 +113,6 @@
     <record id="action_marketing_journey_node" model="ir.actions.act_window">
         <field name="name">Journey Nodes</field>
         <field name="res_model">marketing.journey.node</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
     </record>
 </odoo>

--- a/addons/ipai/ipai_marketing_journey/views/participant_views.xml
+++ b/addons/ipai/ipai_marketing_journey/views/participant_views.xml
@@ -121,7 +121,7 @@
     <record id="action_marketing_journey_participant" model="ir.actions.act_window">
         <field name="name">Participants</field>
         <field name="res_model">marketing.journey.participant</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
         <field name="search_view_id" ref="view_marketing_journey_participant_search"/>
     </record>
 
@@ -149,6 +149,6 @@
     <record id="action_marketing_journey_execution_log" model="ir.actions.act_window">
         <field name="name">Execution Logs</field>
         <field name="res_model">marketing.journey.execution.log</field>
-        <field name="view_mode">tree</field>
+        <field name="view_mode">list</field>
     </record>
 </odoo>

--- a/addons/ipai/ipai_project_profitability_bridge/__manifest__.py
+++ b/addons/ipai/ipai_project_profitability_bridge/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "IPAI Project Profitability Bridge",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Project",
     "summary": "Lightweight profitability KPIs per project using analytic lines (CE-safe).",
     "description": """

--- a/addons/ipai/ipai_project_profitability_bridge/views/profitability_views.xml
+++ b/addons/ipai/ipai_project_profitability_bridge/views/profitability_views.xml
@@ -114,7 +114,7 @@
     <record id="action_ipai_project_profitability" model="ir.actions.act_window">
         <field name="name">Profitability (IPAI)</field>
         <field name="res_model">ipai.project.profitability</field>
-        <field name="view_mode">tree,form,pivot,graph</field>
+        <field name="view_mode">list,form,pivot,graph</field>
         <field name="search_view_id" ref="view_ipai_project_profitability_search"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">

--- a/addons/ipai/ipai_workspace_core/__manifest__.py
+++ b/addons/ipai/ipai_workspace_core/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "InsightPulse Workspace Core",
     "summary": "Unified workspace model for marketing agencies and accounting firms.",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "InsightPulse/Core",
     "author": "InsightPulse AI",
     "website": "https://github.com/jgtolentino/odoo-ce/tree/18.0/addons/ipai/ipai_workspace_core",

--- a/addons/ipai/ipai_workspace_core/views/ipai_workspace_views.xml
+++ b/addons/ipai/ipai_workspace_core/views/ipai_workspace_views.xml
@@ -112,7 +112,7 @@
         <field name="is_critical"/>
         <field name="client_id"/>
         <templates>
-          <t t-name="kanban-box">
+          <t t-name="card">
             <div t-attf-class="oe_kanban_color_#{kanban_getcolor(record.color.raw_value)} oe_kanban_global_click">
               <div class="oe_kanban_content">
                 <div class="o_kanban_record_top">


### PR DESCRIPTION
Fix two critical Odoo 18 breaking changes that were causing UI crashes:

1. Kanban views: Renamed t-name="kanban-box" to t-name="card" as required by Odoo 18's KanbanArchParser (fixes "Missing 'card' template" error)

2. Actions view_mode: Replaced 'tree' with 'list' in all ir.actions.act_window view_mode fields (fixes "View types not defined tree found" error)

Affected modules:
- ipai_ai_prompts (topic_views.xml, prompt_views.xml)
- ipai_ai_audit (audit_log_views.xml, governance_views.xml)
- ipai_ai_core (ipai_ai_menus.xml)
- ipai_ai_provider_pulser (provider_views.xml)
- ipai_finance_ppm (finance_kanban_views.xml, ppm_dashboard_views.xml)
- ipai_marketing_journey (journey.py, journey/node/participant_views.xml)
- ipai_project_profitability_bridge (profitability_views.xml)
- ipai_workspace_core (ipai_workspace_views.xml)

Manifest versions bumped to 18.0.1.0.1 to trigger module upgrades.