### PR TITLE
Separate collaboration tools from ERP repository

### DIFF
--- a/addons/ipai/ipai_focalboard_connector/__init__.py
+++ b/addons/ipai/ipai_focalboard_connector/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import models
+from . import services

--- a/addons/ipai/ipai_focalboard_connector/__manifest__.py
+++ b/addons/ipai/ipai_focalboard_connector/__manifest__.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "IPAI Focalboard Connector",
+    "version": "18.0.1.0.0",
+    "category": "Technical/Integrations",
+    "summary": "API client and sync for Focalboard project boards",
+    "description": """
+IPAI Focalboard Connector
+=========================
+
+Connects Odoo to Focalboard for Kanban-style project tracking.
+
+Features:
+---------
+* Focalboard API client
+* Board/card synchronization
+* Bidirectional task sync with Odoo project.task
+* Webhook handlers for real-time updates
+
+Architecture:
+-------------
+This module provides the Focalboard-specific API client and models.
+For the admin UI, see ipai_integrations module.
+
+External Service:
+-----------------
+Focalboard runs in ipai-ops-stack (NOT vendored here):
+* URL: https://boards.insightpulseai.net
+* API: Focalboard REST API
+
+Author: InsightPulse AI
+License: LGPL-3
+    """,
+    "author": "InsightPulse AI",
+    "website": "https://github.com/jgtolentino/odoo-ce",
+    "license": "LGPL-3",
+    "depends": [
+        "base",
+        "project",
+        "ipai_integrations",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "data/connector_data.xml",
+        "views/focalboard_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+}

--- a/addons/ipai/ipai_focalboard_connector/data/connector_data.xml
+++ b/addons/ipai/ipai_focalboard_connector/data/connector_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <!-- Default Focalboard connector (demo/template) -->
+    <record id="connector_focalboard_default" model="ipai.integration.connector">
+        <field name="name">Focalboard (InsightPulse AI)</field>
+        <field name="code">focalboard_ipai</field>
+        <field name="connector_type">focalboard</field>
+        <field name="base_url">https://boards.insightpulseai.net</field>
+        <field name="api_version">v2</field>
+        <field name="auth_type">token</field>
+        <field name="state">draft</field>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_focalboard_connector/models/__init__.py
+++ b/addons/ipai/ipai_focalboard_connector/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+from . import focalboard_board
+from . import focalboard_card
+from . import integration_connector
+from . import project_task

--- a/addons/ipai/ipai_focalboard_connector/models/focalboard_board.py
+++ b/addons/ipai/ipai_focalboard_connector/models/focalboard_board.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class FocalboardBoard(models.Model):
+    """Cached Focalboard board information."""
+
+    _name = "ipai.focalboard.board"
+    _description = "Focalboard Board"
+    _order = "title"
+
+    connector_id = fields.Many2one(
+        "ipai.integration.connector",
+        required=True,
+        ondelete="cascade",
+        domain="[('connector_type', '=', 'focalboard')]"
+    )
+
+    # Focalboard IDs
+    fb_board_id = fields.Char(required=True, index=True)
+    fb_workspace_id = fields.Char(index=True)
+
+    # Board info
+    title = fields.Char(required=True)
+    description = fields.Text()
+    board_type = fields.Selection([
+        ("board", "Board"),
+        ("table", "Table"),
+        ("gallery", "Gallery"),
+        ("calendar", "Calendar"),
+    ], default="board")
+    icon = fields.Char()
+
+    # Linked Odoo project
+    project_id = fields.Many2one(
+        "project.project",
+        string="Linked Project",
+        help="Odoo project to sync cards with"
+    )
+
+    # Sync settings
+    sync_enabled = fields.Boolean(default=False)
+    sync_direction = fields.Selection([
+        ("fb_to_odoo", "Focalboard -> Odoo"),
+        ("odoo_to_fb", "Odoo -> Focalboard"),
+        ("bidirectional", "Bidirectional"),
+    ], default="bidirectional")
+    last_sync = fields.Datetime()
+
+    # Cards
+    card_ids = fields.One2many(
+        "ipai.focalboard.card", "board_id", string="Cards"
+    )
+    card_count = fields.Integer(compute="_compute_card_count")
+
+    active = fields.Boolean(default=True)
+
+    _sql_constraints = [
+        ("board_uniq", "unique(connector_id, fb_board_id)",
+         "Board already exists for this connector!"),
+    ]
+
+    def _compute_card_count(self):
+        for rec in self:
+            rec.card_count = len(rec.card_ids)
+
+    @api.model
+    def sync_boards(self, connector):
+        """Sync boards from Focalboard API."""
+        from ..services.focalboard_client import FocalboardClient
+
+        client = FocalboardClient(connector)
+        boards = client.get_boards(connector.fb_workspace_id)
+
+        for board in boards:
+            existing = self.search([
+                ("connector_id", "=", connector.id),
+                ("fb_board_id", "=", board["id"]),
+            ], limit=1)
+
+            vals = {
+                "connector_id": connector.id,
+                "fb_board_id": board["id"],
+                "fb_workspace_id": board.get("teamId"),
+                "title": board.get("title", "Untitled"),
+                "description": board.get("description"),
+                "icon": board.get("icon"),
+                "last_sync": fields.Datetime.now(),
+            }
+
+            if existing:
+                existing.write(vals)
+            else:
+                self.create(vals)
+
+        return True
+
+    def action_sync_cards(self):
+        """Sync cards for this board."""
+        self.ensure_one()
+        return self.env["ipai.focalboard.card"].sync_cards(self)

--- a/addons/ipai/ipai_focalboard_connector/models/focalboard_card.py
+++ b/addons/ipai/ipai_focalboard_connector/models/focalboard_card.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class FocalboardCard(models.Model):
+    """Cached Focalboard card (task) information."""
+
+    _name = "ipai.focalboard.card"
+    _description = "Focalboard Card"
+    _order = "create_date desc"
+
+    board_id = fields.Many2one(
+        "ipai.focalboard.board",
+        required=True,
+        ondelete="cascade"
+    )
+    connector_id = fields.Many2one(
+        related="board_id.connector_id",
+        store=True
+    )
+
+    # Focalboard IDs
+    fb_card_id = fields.Char(required=True, index=True)
+    fb_parent_id = fields.Char(help="Parent card ID if nested")
+
+    # Card info
+    title = fields.Char(required=True)
+    icon = fields.Char()
+
+    # Properties (stored as JSON)
+    properties_json = fields.Text(help="Card properties as JSON")
+
+    # Linked Odoo task
+    task_id = fields.Many2one(
+        "project.task",
+        string="Linked Task",
+        help="Corresponding Odoo task"
+    )
+
+    # Sync status
+    last_sync = fields.Datetime()
+    sync_status = fields.Selection([
+        ("synced", "Synced"),
+        ("pending", "Pending Sync"),
+        ("conflict", "Conflict"),
+        ("error", "Error"),
+    ], default="pending")
+    sync_error = fields.Text()
+
+    active = fields.Boolean(default=True)
+
+    _sql_constraints = [
+        ("card_uniq", "unique(board_id, fb_card_id)",
+         "Card already exists for this board!"),
+    ]
+
+    @api.model
+    def sync_cards(self, board):
+        """Sync cards from Focalboard API."""
+        from ..services.focalboard_client import FocalboardClient
+
+        client = FocalboardClient(board.connector_id)
+        cards = client.get_cards(board.fb_board_id)
+
+        for card in cards:
+            existing = self.search([
+                ("board_id", "=", board.id),
+                ("fb_card_id", "=", card["id"]),
+            ], limit=1)
+
+            vals = {
+                "board_id": board.id,
+                "fb_card_id": card["id"],
+                "fb_parent_id": card.get("parentId"),
+                "title": card.get("title", "Untitled"),
+                "icon": card.get("icon"),
+                "properties_json": str(card.get("fields", {})),
+                "last_sync": fields.Datetime.now(),
+                "sync_status": "synced",
+            }
+
+            if existing:
+                existing.write(vals)
+            else:
+                self.create(vals)
+
+        board.last_sync = fields.Datetime.now()
+        return True
+
+    def action_create_odoo_task(self):
+        """Create a linked Odoo task from this card."""
+        self.ensure_one()
+        if self.task_id:
+            return {
+                "type": "ir.actions.act_window",
+                "res_model": "project.task",
+                "res_id": self.task_id.id,
+                "view_mode": "form",
+            }
+
+        project = self.board_id.project_id
+        if not project:
+            project = self.env["project.project"].search([], limit=1)
+
+        task = self.env["project.task"].create({
+            "name": self.title,
+            "project_id": project.id if project else False,
+            "fb_card_id": self.fb_card_id,
+        })
+        self.task_id = task.id
+
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "project.task",
+            "res_id": task.id,
+            "view_mode": "form",
+        }

--- a/addons/ipai/ipai_focalboard_connector/models/integration_connector.py
+++ b/addons/ipai/ipai_focalboard_connector/models/integration_connector.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+import logging
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class IntegrationConnector(models.Model):
+    """Extend connector with Focalboard-specific functionality."""
+
+    _inherit = "ipai.integration.connector"
+
+    # Focalboard-specific fields
+    fb_workspace_id = fields.Char(
+        string="Workspace ID",
+        help="Focalboard workspace/team ID"
+    )
+    fb_default_board_id = fields.Char(
+        string="Default Board ID",
+        help="Default board for new cards"
+    )
+
+    def action_test_connection(self):
+        """Test connection to Focalboard API."""
+        self.ensure_one()
+        if self.connector_type != "focalboard":
+            return super().action_test_connection()
+
+        from ..services.focalboard_client import FocalboardClient
+
+        try:
+            client = FocalboardClient(self)
+            result = client.ping()
+            if result:
+                self.write({
+                    "state": "testing",
+                    "last_ping": fields.Datetime.now(),
+                    "last_error": False,
+                })
+                self._log_audit("test_connection", "Connection successful")
+            else:
+                raise Exception("Ping returned unsuccessful status")
+        except Exception as e:
+            _logger.warning("Focalboard connection test failed: %s", e)
+            self.write({
+                "state": "error",
+                "last_error": str(e),
+            })
+            self._log_audit("test_connection", f"Connection failed: {e}", level="error")
+
+        return True
+
+    def fb_sync_boards(self):
+        """Sync boards from Focalboard."""
+        self.ensure_one()
+        if self.connector_type != "focalboard":
+            raise ValueError("Connector is not a Focalboard connector")
+
+        return self.env["ipai.focalboard.board"].sync_boards(self)

--- a/addons/ipai/ipai_focalboard_connector/models/project_task.py
+++ b/addons/ipai/ipai_focalboard_connector/models/project_task.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class ProjectTask(models.Model):
+    """Extend project.task with Focalboard link."""
+
+    _inherit = "project.task"
+
+    fb_card_id = fields.Char(
+        string="Focalboard Card ID",
+        help="Linked Focalboard card ID",
+        index=True
+    )
+    fb_board_id = fields.Many2one(
+        "ipai.focalboard.board",
+        string="Focalboard Board",
+        compute="_compute_fb_board",
+        store=True
+    )
+    fb_sync_enabled = fields.Boolean(
+        string="Sync to Focalboard",
+        default=False
+    )
+
+    @api.depends("fb_card_id")
+    def _compute_fb_board(self):
+        Card = self.env["ipai.focalboard.card"]
+        for task in self:
+            if task.fb_card_id:
+                card = Card.search([
+                    ("fb_card_id", "=", task.fb_card_id)
+                ], limit=1)
+                task.fb_board_id = card.board_id if card else False
+            else:
+                task.fb_board_id = False
+
+    def action_sync_to_focalboard(self):
+        """Sync this task to Focalboard as a card."""
+        self.ensure_one()
+        if not self.project_id:
+            return
+
+        # Find linked board
+        board = self.env["ipai.focalboard.board"].search([
+            ("project_id", "=", self.project_id.id),
+            ("sync_enabled", "=", True),
+        ], limit=1)
+
+        if not board:
+            return {
+                "type": "ir.actions.client",
+                "tag": "display_notification",
+                "params": {
+                    "title": "No Board Linked",
+                    "message": "No Focalboard board is linked to this project.",
+                    "type": "warning",
+                }
+            }
+
+        from ..services.focalboard_client import FocalboardClient
+        client = FocalboardClient(board.connector_id)
+
+        if self.fb_card_id:
+            # Update existing card
+            client.update_card(self.fb_card_id, {"title": self.name})
+        else:
+            # Create new card
+            result = client.create_card(board.fb_board_id, {
+                "title": self.name,
+            })
+            if result:
+                self.fb_card_id = result.get("id")
+
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "title": "Synced",
+                "message": "Task synced to Focalboard.",
+                "type": "success",
+            }
+        }

--- a/addons/ipai/ipai_focalboard_connector/security/ir.model.access.csv
+++ b/addons/ipai/ipai_focalboard_connector/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_focalboard_board_user,ipai.focalboard.board.user,model_ipai_focalboard_board,ipai_integrations.group_integration_user,1,0,0,0
+access_focalboard_board_manager,ipai.focalboard.board.manager,model_ipai_focalboard_board,ipai_integrations.group_integration_manager,1,1,1,1
+access_focalboard_card_user,ipai.focalboard.card.user,model_ipai_focalboard_card,ipai_integrations.group_integration_user,1,0,0,0
+access_focalboard_card_manager,ipai.focalboard.card.manager,model_ipai_focalboard_card,ipai_integrations.group_integration_manager,1,1,1,1

--- a/addons/ipai/ipai_focalboard_connector/services/__init__.py
+++ b/addons/ipai/ipai_focalboard_connector/services/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import focalboard_client

--- a/addons/ipai/ipai_focalboard_connector/services/focalboard_client.py
+++ b/addons/ipai/ipai_focalboard_connector/services/focalboard_client.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+"""
+Focalboard API Client
+
+This module provides a simple client for the Focalboard API.
+"""
+import json
+import logging
+import requests
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 30
+
+
+class FocalboardClient:
+    """Simple Focalboard REST API client."""
+
+    def __init__(self, connector):
+        """
+        Initialize the client with a connector record.
+
+        Args:
+            connector: ipai.integration.connector record
+        """
+        self.connector = connector
+        self.base_url = connector.base_url.rstrip("/")
+        self._token = None
+
+    @property
+    def api_url(self):
+        """Get the full API URL."""
+        return f"{self.base_url}/api/v2"
+
+    @property
+    def token(self):
+        """Get the authentication token."""
+        if self._token is None:
+            ICP = self.connector.env["ir.config_parameter"].sudo()
+            self._token = ICP.get_param(
+                f"ipai_focalboard.token_{self.connector.id}",
+                default=""
+            )
+        return self._token
+
+    def _headers(self):
+        """Get request headers."""
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    def _request(self, method, endpoint, data=None, params=None):
+        """
+        Make an API request.
+
+        Args:
+            method: HTTP method
+            endpoint: API endpoint
+            data: Request body (dict)
+            params: Query parameters (dict)
+
+        Returns:
+            dict or list: Response JSON
+
+        Raises:
+            UserError: On API errors
+        """
+        url = f"{self.api_url}{endpoint}"
+
+        try:
+            response = requests.request(
+                method,
+                url,
+                headers=self._headers(),
+                json=data,
+                params=params,
+                timeout=DEFAULT_TIMEOUT,
+            )
+
+            if response.status_code >= 400:
+                error_msg = response.text
+                try:
+                    error_data = response.json()
+                    error_msg = error_data.get("error", error_msg)
+                except json.JSONDecodeError:
+                    pass
+                _logger.warning(
+                    "Focalboard API error: %s %s -> %s: %s",
+                    method, endpoint, response.status_code, error_msg
+                )
+                raise UserError(f"Focalboard API error: {error_msg}")
+
+            if response.text:
+                return response.json()
+            return {}
+
+        except requests.RequestException as e:
+            _logger.error("Focalboard request failed: %s", e)
+            raise UserError(f"Focalboard connection error: {e}")
+
+    # System endpoints
+
+    def ping(self):
+        """Check if Focalboard is reachable."""
+        try:
+            # Try v2 ping endpoint
+            self._request("GET", "/ping")
+            return True
+        except UserError:
+            # Fallback: try base URL
+            try:
+                response = requests.get(
+                    f"{self.base_url}/api/v2/ping",
+                    timeout=DEFAULT_TIMEOUT
+                )
+                return response.status_code < 400
+            except requests.RequestException:
+                return False
+
+    # Board endpoints
+
+    def get_boards(self, workspace_id=None):
+        """Get all boards in a workspace."""
+        if workspace_id:
+            return self._request("GET", f"/teams/{workspace_id}/boards")
+        return self._request("GET", "/boards")
+
+    def get_board(self, board_id):
+        """Get a specific board."""
+        return self._request("GET", f"/boards/{board_id}")
+
+    def create_board(self, data):
+        """Create a new board."""
+        return self._request("POST", "/boards", data=data)
+
+    # Card endpoints
+
+    def get_cards(self, board_id):
+        """Get all cards in a board."""
+        return self._request("GET", f"/boards/{board_id}/blocks", params={
+            "type": "card"
+        })
+
+    def get_card(self, card_id):
+        """Get a specific card."""
+        return self._request("GET", f"/blocks/{card_id}")
+
+    def create_card(self, board_id, data):
+        """
+        Create a new card on a board.
+
+        Args:
+            board_id: Board ID
+            data: Card data (title, icon, fields, etc.)
+
+        Returns:
+            dict: Created card data
+        """
+        payload = {
+            "boardId": board_id,
+            "type": "card",
+            "title": data.get("title", ""),
+            "fields": data.get("fields", {}),
+        }
+        if data.get("icon"):
+            payload["fields"]["icon"] = data["icon"]
+
+        return self._request("POST", "/blocks", data=[payload])
+
+    def update_card(self, card_id, data):
+        """Update a card."""
+        return self._request("PATCH", f"/blocks/{card_id}", data=data)
+
+    def delete_card(self, card_id):
+        """Delete a card."""
+        return self._request("DELETE", f"/blocks/{card_id}")
+
+    # View endpoints
+
+    def get_views(self, board_id):
+        """Get all views for a board."""
+        return self._request("GET", f"/boards/{board_id}/blocks", params={
+            "type": "view"
+        })

--- a/addons/ipai/ipai_focalboard_connector/static/description/icon.svg
+++ b/addons/ipai/ipai_focalboard_connector/static/description/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="10" fill="#4B5563"/>
+  <rect x="15" y="20" width="20" height="60" rx="3" fill="#fff"/>
+  <rect x="40" y="30" width="20" height="50" rx="3" fill="#fff"/>
+  <rect x="65" y="25" width="20" height="55" rx="3" fill="#fff"/>
+</svg>

--- a/addons/ipai/ipai_focalboard_connector/views/focalboard_views.xml
+++ b/addons/ipai/ipai_focalboard_connector/views/focalboard_views.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Board Tree View -->
+    <record id="view_focalboard_board_tree" model="ir.ui.view">
+        <field name="name">ipai.focalboard.board.tree</field>
+        <field name="model">ipai.focalboard.board</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="title"/>
+                <field name="board_type"/>
+                <field name="project_id"/>
+                <field name="sync_enabled"/>
+                <field name="card_count"/>
+                <field name="last_sync"/>
+                <field name="connector_id"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Board Form View -->
+    <record id="view_focalboard_board_form" model="ir.ui.view">
+        <field name="name">ipai.focalboard.board.form</field>
+        <field name="model">ipai.focalboard.board</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button name="action_sync_cards" type="object" string="Sync Cards" class="btn-primary"/>
+                </header>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="action_sync_cards" type="object" class="oe_stat_button" icon="fa-refresh">
+                            <field name="card_count" widget="statinfo" string="Cards"/>
+                        </button>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="title"/>
+                            <field name="board_type"/>
+                            <field name="icon"/>
+                            <field name="connector_id"/>
+                        </group>
+                        <group>
+                            <field name="fb_board_id"/>
+                            <field name="fb_workspace_id"/>
+                            <field name="project_id"/>
+                            <field name="last_sync"/>
+                        </group>
+                    </group>
+                    <group string="Sync Settings">
+                        <field name="sync_enabled"/>
+                        <field name="sync_direction"/>
+                    </group>
+                    <group>
+                        <field name="description"/>
+                    </group>
+                    <notebook>
+                        <page string="Cards" name="cards">
+                            <field name="card_ids">
+                                <tree>
+                                    <field name="title"/>
+                                    <field name="task_id"/>
+                                    <field name="sync_status" widget="badge"/>
+                                    <field name="last_sync"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Board Action -->
+    <record id="action_focalboard_board" model="ir.actions.act_window">
+        <field name="name">Focalboard Boards</field>
+        <field name="res_model">ipai.focalboard.board</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <!-- Card Tree View -->
+    <record id="view_focalboard_card_tree" model="ir.ui.view">
+        <field name="name">ipai.focalboard.card.tree</field>
+        <field name="model">ipai.focalboard.card</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="title"/>
+                <field name="board_id"/>
+                <field name="task_id"/>
+                <field name="sync_status" widget="badge" decoration-success="sync_status == 'synced'" decoration-warning="sync_status == 'pending'" decoration-danger="sync_status in ('conflict', 'error')"/>
+                <field name="last_sync"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Card Form View -->
+    <record id="view_focalboard_card_form" model="ir.ui.view">
+        <field name="name">ipai.focalboard.card.form</field>
+        <field name="model">ipai.focalboard.card</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button name="action_create_odoo_task" type="object" string="Create Odoo Task" class="btn-primary" invisible="task_id"/>
+                </header>
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="title"/>
+                            <field name="board_id"/>
+                            <field name="task_id"/>
+                        </group>
+                        <group>
+                            <field name="fb_card_id"/>
+                            <field name="sync_status"/>
+                            <field name="last_sync"/>
+                        </group>
+                    </group>
+                    <group string="Properties" invisible="not properties_json">
+                        <field name="properties_json" widget="ace" options="{'mode': 'json'}" nolabel="1"/>
+                    </group>
+                    <group string="Sync Error" invisible="not sync_error">
+                        <field name="sync_error" nolabel="1"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Card Action -->
+    <record id="action_focalboard_card" model="ir.actions.act_window">
+        <field name="name">Focalboard Cards</field>
+        <field name="res_model">ipai.focalboard.card</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <!-- Menu items under Integrations -->
+    <menuitem id="menu_focalboard"
+        name="Focalboard"
+        parent="ipai_integrations.menu_integrations_config"
+        sequence="60"/>
+
+    <menuitem id="menu_focalboard_boards"
+        name="Boards"
+        parent="menu_focalboard"
+        action="action_focalboard_board"
+        sequence="10"/>
+
+    <menuitem id="menu_focalboard_cards"
+        name="Cards"
+        parent="menu_focalboard"
+        action="action_focalboard_card"
+        sequence="20"/>
+</odoo>

--- a/addons/ipai/ipai_integrations/__init__.py
+++ b/addons/ipai/ipai_integrations/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import models
+from . import controllers

--- a/addons/ipai/ipai_integrations/__manifest__.py
+++ b/addons/ipai/ipai_integrations/__manifest__.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "IPAI Integrations",
+    "version": "18.0.1.0.0",
+    "category": "Technical/Integrations",
+    "summary": "Central integration hub for Mattermost, Focalboard, and n8n",
+    "description": """
+IPAI Integrations
+=================
+
+Admin UI for managing external collaboration tool integrations,
+modeled after Mattermost's Integrations menu.
+
+Features:
+---------
+* Webhook registration and management (incoming/outgoing)
+* Bot account configuration
+* OAuth application management
+* Slash command definitions
+* Integration audit logging
+* Connector status monitoring
+
+Supported Integrations:
+-----------------------
+* Mattermost (chat.insightpulseai.net)
+* Focalboard (boards.insightpulseai.net)
+* n8n (n8n.insightpulseai.net)
+
+Architecture:
+-------------
+This module provides the core admin UI. Actual API clients
+and sync jobs are in separate connector modules:
+* ipai_mattermost_connector
+* ipai_focalboard_connector
+* ipai_n8n_connector
+
+Note: Mattermost, Focalboard, and n8n run in a separate
+deployment (ipai-collab-stack), NOT vendored into this repo.
+
+Author: InsightPulse AI
+License: LGPL-3
+    """,
+    "author": "InsightPulse AI",
+    "website": "https://github.com/jgtolentino/odoo-ce",
+    "license": "LGPL-3",
+    "depends": [
+        "base",
+        "web",
+        "mail",
+    ],
+    "data": [
+        "security/integrations_security.xml",
+        "security/ir.model.access.csv",
+        "data/ir_config_parameter.xml",
+        "views/integration_views.xml",
+        "views/webhook_views.xml",
+        "views/bot_views.xml",
+        "views/oauth_views.xml",
+        "views/audit_views.xml",
+        "views/menu.xml",
+    ],
+    "installable": True,
+    "application": True,
+    "auto_install": False,
+}

--- a/addons/ipai/ipai_integrations/controllers/__init__.py
+++ b/addons/ipai/ipai_integrations/controllers/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import webhook_controller

--- a/addons/ipai/ipai_integrations/controllers/webhook_controller.py
+++ b/addons/ipai/ipai_integrations/controllers/webhook_controller.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+import json
+import logging
+from odoo import http
+from odoo.http import request
+
+_logger = logging.getLogger(__name__)
+
+
+class IntegrationWebhookController(http.Controller):
+    """Controller for receiving incoming webhooks from external integrations."""
+
+    @http.route(
+        "/integrations/<string:connector_code>/webhook",
+        type="json",
+        auth="public",
+        methods=["POST"],
+        csrf=False,
+    )
+    def receive_webhook(self, connector_code, **kwargs):
+        """
+        Generic webhook receiver endpoint.
+
+        The actual webhook processing is delegated to the
+        connector-specific modules (ipai_mattermost_connector, etc.)
+        """
+        # Find the connector
+        connector = request.env["ipai.integration.connector"].sudo().search([
+            ("code", "=", connector_code),
+            ("state", "=", "active"),
+        ], limit=1)
+
+        if not connector:
+            _logger.warning("Webhook received for unknown connector: %s", connector_code)
+            return {"status": "error", "message": "Unknown connector"}
+
+        # Log the incoming webhook
+        request.env["ipai.integration.audit"].sudo().log(
+            connector.id,
+            "webhook_received",
+            f"Incoming webhook from {connector_code}",
+            request_method="POST",
+            request_payload=json.dumps(request.jsonrequest or {}),
+        )
+
+        # Find matching webhook configuration
+        # Signature validation is handled by connector-specific code
+
+        return {"status": "ok", "connector": connector_code}
+
+    @http.route(
+        "/integrations/<string:connector_code>/webhook/<string:webhook_id>",
+        type="json",
+        auth="public",
+        methods=["POST"],
+        csrf=False,
+    )
+    def receive_webhook_specific(self, connector_code, webhook_id, **kwargs):
+        """
+        Receive webhook at a specific endpoint.
+
+        This allows multiple webhook endpoints per connector.
+        """
+        webhook = request.env["ipai.integration.webhook"].sudo().search([
+            ("connector_id.code", "=", connector_code),
+            ("id", "=", int(webhook_id)),
+            ("direction", "=", "incoming"),
+            ("active", "=", True),
+        ], limit=1)
+
+        if not webhook:
+            _logger.warning(
+                "Webhook received for unknown endpoint: %s/%s",
+                connector_code, webhook_id
+            )
+            return {"status": "error", "message": "Unknown webhook endpoint"}
+
+        # Validate signature if required
+        signature = request.httprequest.headers.get("X-Signature")
+        if webhook.signing_secret and signature:
+            payload = json.dumps(request.jsonrequest or {})
+            if not webhook.verify_signature(payload, signature):
+                _logger.warning("Invalid webhook signature for %s", webhook_id)
+                return {"status": "error", "message": "Invalid signature"}
+
+        # Update stats
+        webhook.sudo().write({
+            "last_triggered": request.env.cr.now(),
+            "success_count": webhook.success_count + 1,
+        })
+
+        # Log
+        request.env["ipai.integration.audit"].sudo().log(
+            webhook.connector_id.id,
+            "webhook_received",
+            f"Webhook received at {webhook.name}",
+            request_method="POST",
+        )
+
+        return {"status": "ok", "webhook": webhook.name}
+
+    @http.route(
+        "/integrations/slash/<string:bot_username>/<string:command>",
+        type="json",
+        auth="public",
+        methods=["POST"],
+        csrf=False,
+    )
+    def handle_slash_command(self, bot_username, command, **kwargs):
+        """
+        Handle incoming slash commands from chat integrations.
+        """
+        # Find the bot and command
+        bot_command = request.env["ipai.integration.bot.command"].sudo().search([
+            ("bot_id.bot_username", "=", bot_username),
+            ("command", "=", f"/{command}"),
+            ("active", "=", True),
+        ], limit=1)
+
+        if not bot_command:
+            return {
+                "response_type": "ephemeral",
+                "text": f"Unknown command: /{command}",
+            }
+
+        # Delegate to handler model if specified
+        if bot_command.handler_model and bot_command.handler_method:
+            handler = request.env[bot_command.handler_model].sudo()
+            if hasattr(handler, bot_command.handler_method):
+                method = getattr(handler, bot_command.handler_method)
+                return method(bot_command, request.jsonrequest)
+
+        return {
+            "response_type": bot_command.response_type,
+            "text": f"Command /{command} received but no handler configured.",
+        }

--- a/addons/ipai/ipai_integrations/data/ir_config_parameter.xml
+++ b/addons/ipai/ipai_integrations/data/ir_config_parameter.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <!-- Default configuration parameters for integrations -->
+
+    <!-- Mattermost defaults -->
+    <record id="config_mattermost_url" model="ir.config_parameter">
+        <field name="key">ipai_integrations.mattermost_url</field>
+        <field name="value">https://chat.insightpulseai.net</field>
+    </record>
+
+    <!-- Focalboard defaults -->
+    <record id="config_focalboard_url" model="ir.config_parameter">
+        <field name="key">ipai_integrations.focalboard_url</field>
+        <field name="value">https://boards.insightpulseai.net</field>
+    </record>
+
+    <!-- n8n defaults -->
+    <record id="config_n8n_url" model="ir.config_parameter">
+        <field name="key">ipai_integrations.n8n_url</field>
+        <field name="value">https://n8n.insightpulseai.net</field>
+    </record>
+
+    <!-- Audit log retention (days) -->
+    <record id="config_audit_retention" model="ir.config_parameter">
+        <field name="key">ipai_integrations.audit_retention_days</field>
+        <field name="value">90</field>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_integrations/models/__init__.py
+++ b/addons/ipai/ipai_integrations/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from . import integration_connector
+from . import integration_webhook
+from . import integration_bot
+from . import integration_oauth
+from . import integration_audit

--- a/addons/ipai/ipai_integrations/models/integration_audit.py
+++ b/addons/ipai/ipai_integrations/models/integration_audit.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class IntegrationAudit(models.Model):
+    """Audit log for integration activities."""
+
+    _name = "ipai.integration.audit"
+    _description = "Integration Audit Log"
+    _order = "create_date desc"
+    _log_access = True
+
+    connector_id = fields.Many2one(
+        "ipai.integration.connector",
+        ondelete="set null",
+        index=True
+    )
+    connector_type = fields.Selection(
+        related="connector_id.connector_type",
+        store=True
+    )
+
+    action = fields.Char(required=True, index=True)
+    message = fields.Text()
+
+    level = fields.Selection([
+        ("debug", "Debug"),
+        ("info", "Info"),
+        ("warning", "Warning"),
+        ("error", "Error"),
+    ], default="info", index=True)
+
+    # Request/response details
+    request_method = fields.Char()
+    request_url = fields.Char()
+    request_payload = fields.Text()
+    response_code = fields.Integer()
+    response_body = fields.Text()
+
+    # Duration
+    duration_ms = fields.Integer(help="Request duration in milliseconds")
+
+    # User context
+    user_id = fields.Many2one(
+        "res.users",
+        default=lambda self: self.env.user,
+        index=True
+    )
+    ip_address = fields.Char()
+
+    @api.model
+    def log(self, connector_id, action, message, level="info", **kwargs):
+        """Convenience method to create audit log entries."""
+        vals = {
+            "connector_id": connector_id,
+            "action": action,
+            "message": message,
+            "level": level,
+        }
+        vals.update(kwargs)
+        return self.create(vals)
+
+    @api.autovacuum
+    def _gc_old_logs(self):
+        """Clean up old audit logs (keep 90 days)."""
+        limit_date = fields.Datetime.subtract(
+            fields.Datetime.now(),
+            days=90
+        )
+        old_logs = self.search([
+            ("create_date", "<", limit_date),
+            ("level", "in", ["debug", "info"]),
+        ])
+        old_logs.unlink()

--- a/addons/ipai/ipai_integrations/models/integration_bot.py
+++ b/addons/ipai/ipai_integrations/models/integration_bot.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class IntegrationBot(models.Model):
+    """Bot account configuration for integrations."""
+
+    _name = "ipai.integration.bot"
+    _description = "Integration Bot"
+    _order = "name"
+
+    name = fields.Char(required=True)
+    connector_id = fields.Many2one(
+        "ipai.integration.connector",
+        required=True,
+        ondelete="cascade"
+    )
+    active = fields.Boolean(default=True)
+
+    # Bot identity
+    bot_username = fields.Char(required=True)
+    bot_display_name = fields.Char()
+    bot_description = fields.Text()
+    bot_icon = fields.Binary(attachment=True)
+
+    # Authentication
+    bot_token = fields.Char(
+        groups="ipai_integrations.group_integration_admin",
+        help="Bot access token (stored encrypted)"
+    )
+
+    # Permissions
+    permission_post = fields.Boolean(
+        default=True,
+        help="Can post messages to channels"
+    )
+    permission_read = fields.Boolean(
+        default=True,
+        help="Can read channel messages"
+    )
+    permission_manage = fields.Boolean(
+        default=False,
+        help="Can manage channels and users"
+    )
+
+    # Slash commands
+    slash_command_ids = fields.One2many(
+        "ipai.integration.bot.command",
+        "bot_id",
+        string="Slash Commands"
+    )
+
+    # Status
+    state = fields.Selection([
+        ("draft", "Draft"),
+        ("active", "Active"),
+        ("disabled", "Disabled"),
+    ], default="draft")
+    last_active = fields.Datetime(readonly=True)
+
+    def action_activate(self):
+        """Activate the bot."""
+        self.ensure_one()
+        self.state = "active"
+
+    def action_disable(self):
+        """Disable the bot."""
+        self.ensure_one()
+        self.state = "disabled"
+
+
+class IntegrationBotCommand(models.Model):
+    """Slash command definitions for bots."""
+
+    _name = "ipai.integration.bot.command"
+    _description = "Bot Slash Command"
+    _order = "command"
+
+    bot_id = fields.Many2one(
+        "ipai.integration.bot",
+        required=True,
+        ondelete="cascade"
+    )
+    command = fields.Char(
+        required=True,
+        help="Command trigger (e.g., /task, /invoice)"
+    )
+    description = fields.Char(
+        help="Description shown in autocomplete"
+    )
+    hint = fields.Char(
+        help="Usage hint (e.g., '[task name]')"
+    )
+
+    # Handler
+    handler_model = fields.Char(
+        help="Odoo model to handle this command"
+    )
+    handler_method = fields.Char(
+        default="_handle_slash_command",
+        help="Method to call on the handler model"
+    )
+
+    # Response
+    response_type = fields.Selection([
+        ("ephemeral", "Ephemeral (visible only to user)"),
+        ("in_channel", "In Channel (visible to all)"),
+    ], default="ephemeral")
+
+    active = fields.Boolean(default=True)
+
+    _sql_constraints = [
+        ("bot_command_uniq", "unique(bot_id, command)",
+         "Command must be unique per bot!"),
+    ]

--- a/addons/ipai/ipai_integrations/models/integration_connector.py
+++ b/addons/ipai/ipai_integrations/models/integration_connector.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class IntegrationConnector(models.Model):
+    """Base model for external integration connectors."""
+
+    _name = "ipai.integration.connector"
+    _description = "Integration Connector"
+    _order = "sequence, name"
+
+    name = fields.Char(required=True)
+    code = fields.Char(
+        required=True,
+        help="Unique code for the connector (e.g., mattermost, focalboard, n8n)"
+    )
+    sequence = fields.Integer(default=10)
+    active = fields.Boolean(default=True)
+
+    connector_type = fields.Selection([
+        ("mattermost", "Mattermost"),
+        ("focalboard", "Focalboard"),
+        ("n8n", "n8n"),
+        ("custom", "Custom"),
+    ], required=True)
+
+    # Connection settings
+    base_url = fields.Char(
+        string="Base URL",
+        help="Base URL of the external service (e.g., https://chat.insightpulseai.net)"
+    )
+    api_version = fields.Char(default="v4", help="API version to use")
+
+    # Authentication
+    auth_type = fields.Selection([
+        ("token", "Personal Access Token"),
+        ("oauth", "OAuth 2.0"),
+        ("basic", "Basic Auth"),
+        ("none", "None"),
+    ], default="token")
+
+    # Status
+    state = fields.Selection([
+        ("draft", "Not Configured"),
+        ("testing", "Testing"),
+        ("active", "Active"),
+        ("error", "Error"),
+    ], default="draft", readonly=True)
+    last_ping = fields.Datetime(readonly=True)
+    last_error = fields.Text(readonly=True)
+
+    # Related records
+    webhook_ids = fields.One2many(
+        "ipai.integration.webhook", "connector_id", string="Webhooks"
+    )
+    bot_ids = fields.One2many(
+        "ipai.integration.bot", "connector_id", string="Bots"
+    )
+    oauth_app_ids = fields.One2many(
+        "ipai.integration.oauth", "connector_id", string="OAuth Apps"
+    )
+    audit_ids = fields.One2many(
+        "ipai.integration.audit", "connector_id", string="Audit Logs"
+    )
+
+    _sql_constraints = [
+        ("code_uniq", "unique(code)", "Connector code must be unique!"),
+    ]
+
+    def action_test_connection(self):
+        """Test the connection to the external service."""
+        self.ensure_one()
+        self._log_audit("test_connection", "Testing connection...")
+        # Actual implementation in connector-specific modules
+        return True
+
+    def action_activate(self):
+        """Activate the connector after successful test."""
+        self.ensure_one()
+        self.write({"state": "active"})
+        self._log_audit("activate", "Connector activated")
+
+    def _log_audit(self, action, message, level="info"):
+        """Create an audit log entry."""
+        self.env["ipai.integration.audit"].create({
+            "connector_id": self.id,
+            "action": action,
+            "message": message,
+            "level": level,
+        })

--- a/addons/ipai/ipai_integrations/models/integration_oauth.py
+++ b/addons/ipai/ipai_integrations/models/integration_oauth.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+import secrets
+from odoo import api, fields, models
+
+
+class IntegrationOAuth(models.Model):
+    """OAuth application configuration for integrations."""
+
+    _name = "ipai.integration.oauth"
+    _description = "Integration OAuth App"
+    _order = "name"
+
+    name = fields.Char(required=True)
+    connector_id = fields.Many2one(
+        "ipai.integration.connector",
+        required=True,
+        ondelete="cascade"
+    )
+    active = fields.Boolean(default=True)
+
+    # OAuth credentials
+    client_id = fields.Char(readonly=True)
+    client_secret = fields.Char(
+        groups="ipai_integrations.group_integration_admin"
+    )
+
+    # URLs
+    redirect_uris = fields.Text(
+        help="Allowed redirect URIs (one per line)"
+    )
+    homepage_url = fields.Char()
+    icon = fields.Binary(attachment=True)
+
+    # OAuth settings
+    grant_types = fields.Selection([
+        ("authorization_code", "Authorization Code"),
+        ("client_credentials", "Client Credentials"),
+        ("both", "Both"),
+    ], default="authorization_code")
+
+    token_expiry = fields.Integer(
+        default=3600,
+        help="Access token expiry in seconds"
+    )
+    refresh_token_expiry = fields.Integer(
+        default=86400 * 30,
+        help="Refresh token expiry in seconds"
+    )
+
+    # Scopes
+    scope_read = fields.Boolean(default=True)
+    scope_write = fields.Boolean(default=False)
+    scope_admin = fields.Boolean(default=False)
+
+    # Status
+    state = fields.Selection([
+        ("draft", "Draft"),
+        ("active", "Active"),
+        ("revoked", "Revoked"),
+    ], default="draft")
+
+    # Stats
+    token_count = fields.Integer(
+        compute="_compute_token_count",
+        string="Active Tokens"
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if not vals.get("client_id"):
+                vals["client_id"] = secrets.token_urlsafe(24)
+            if not vals.get("client_secret"):
+                vals["client_secret"] = secrets.token_urlsafe(32)
+        return super().create(vals_list)
+
+    def _compute_token_count(self):
+        for rec in self:
+            rec.token_count = 0  # Placeholder - implement token tracking
+
+    def action_regenerate_secret(self):
+        """Regenerate client secret."""
+        self.ensure_one()
+        self.client_secret = secrets.token_urlsafe(32)
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "title": "Secret Regenerated",
+                "message": "Client secret has been regenerated. Update your application.",
+                "type": "warning",
+            }
+        }
+
+    def action_revoke(self):
+        """Revoke the OAuth application."""
+        self.ensure_one()
+        self.state = "revoked"

--- a/addons/ipai/ipai_integrations/models/integration_webhook.py
+++ b/addons/ipai/ipai_integrations/models/integration_webhook.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+import hashlib
+import hmac
+import secrets
+from odoo import api, fields, models
+
+
+class IntegrationWebhook(models.Model):
+    """Webhook configuration for integrations."""
+
+    _name = "ipai.integration.webhook"
+    _description = "Integration Webhook"
+    _order = "name"
+
+    name = fields.Char(required=True)
+    connector_id = fields.Many2one(
+        "ipai.integration.connector",
+        required=True,
+        ondelete="cascade"
+    )
+    active = fields.Boolean(default=True)
+
+    direction = fields.Selection([
+        ("incoming", "Incoming (receive from external)"),
+        ("outgoing", "Outgoing (send to external)"),
+    ], required=True, default="incoming")
+
+    # Incoming webhook settings
+    endpoint_path = fields.Char(
+        help="Local endpoint path (e.g., /integrations/mattermost/webhook)"
+    )
+    signing_secret = fields.Char(
+        help="Secret for validating incoming webhook signatures"
+    )
+
+    # Outgoing webhook settings
+    target_url = fields.Char(
+        help="External URL to send webhooks to"
+    )
+    trigger_model = fields.Char(
+        help="Odoo model that triggers this webhook"
+    )
+    trigger_events = fields.Selection([
+        ("create", "On Create"),
+        ("write", "On Update"),
+        ("unlink", "On Delete"),
+        ("all", "All Events"),
+    ], default="all")
+
+    # Payload settings
+    payload_template = fields.Text(
+        help="JSON template for webhook payload (Jinja2 syntax)"
+    )
+    content_type = fields.Selection([
+        ("application/json", "JSON"),
+        ("application/x-www-form-urlencoded", "Form URL Encoded"),
+    ], default="application/json")
+
+    # Security
+    include_signature = fields.Boolean(
+        default=True,
+        help="Include HMAC signature in outgoing webhooks"
+    )
+
+    # Stats
+    last_triggered = fields.Datetime(readonly=True)
+    success_count = fields.Integer(readonly=True)
+    failure_count = fields.Integer(readonly=True)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if not vals.get("signing_secret"):
+                vals["signing_secret"] = secrets.token_urlsafe(32)
+        return super().create(vals_list)
+
+    def action_regenerate_secret(self):
+        """Generate a new signing secret."""
+        self.ensure_one()
+        self.signing_secret = secrets.token_urlsafe(32)
+        return True
+
+    def verify_signature(self, payload, signature):
+        """Verify incoming webhook signature."""
+        self.ensure_one()
+        if not self.signing_secret:
+            return False
+        expected = hmac.new(
+            self.signing_secret.encode(),
+            payload.encode(),
+            hashlib.sha256
+        ).hexdigest()
+        return hmac.compare_digest(expected, signature)
+
+    def generate_signature(self, payload):
+        """Generate signature for outgoing webhook."""
+        self.ensure_one()
+        if not self.signing_secret:
+            return None
+        return hmac.new(
+            self.signing_secret.encode(),
+            payload.encode(),
+            hashlib.sha256
+        ).hexdigest()

--- a/addons/ipai/ipai_integrations/security/integrations_security.xml
+++ b/addons/ipai/ipai_integrations/security/integrations_security.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Integration Security Groups -->
+    <record id="module_category_integrations" model="ir.module.category">
+        <field name="name">Integrations</field>
+        <field name="description">External integration management</field>
+        <field name="sequence">50</field>
+    </record>
+
+    <record id="group_integration_user" model="res.groups">
+        <field name="name">Integration User</field>
+        <field name="category_id" ref="module_category_integrations"/>
+        <field name="comment">Can view integration status and logs</field>
+    </record>
+
+    <record id="group_integration_manager" model="res.groups">
+        <field name="name">Integration Manager</field>
+        <field name="category_id" ref="module_category_integrations"/>
+        <field name="implied_ids" eval="[(4, ref('group_integration_user'))]"/>
+        <field name="comment">Can configure webhooks and bots</field>
+    </record>
+
+    <record id="group_integration_admin" model="res.groups">
+        <field name="name">Integration Administrator</field>
+        <field name="category_id" ref="module_category_integrations"/>
+        <field name="implied_ids" eval="[(4, ref('group_integration_manager'))]"/>
+        <field name="comment">Full access to all integration settings including secrets</field>
+        <field name="users" eval="[(4, ref('base.user_admin'))]"/>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_integrations/security/ir.model.access.csv
+++ b/addons/ipai/ipai_integrations/security/ir.model.access.csv
@@ -1,0 +1,17 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_integration_connector_user,ipai.integration.connector.user,model_ipai_integration_connector,group_integration_user,1,0,0,0
+access_integration_connector_manager,ipai.integration.connector.manager,model_ipai_integration_connector,group_integration_manager,1,1,1,0
+access_integration_connector_admin,ipai.integration.connector.admin,model_ipai_integration_connector,group_integration_admin,1,1,1,1
+access_integration_webhook_user,ipai.integration.webhook.user,model_ipai_integration_webhook,group_integration_user,1,0,0,0
+access_integration_webhook_manager,ipai.integration.webhook.manager,model_ipai_integration_webhook,group_integration_manager,1,1,1,1
+access_integration_webhook_admin,ipai.integration.webhook.admin,model_ipai_integration_webhook,group_integration_admin,1,1,1,1
+access_integration_bot_user,ipai.integration.bot.user,model_ipai_integration_bot,group_integration_user,1,0,0,0
+access_integration_bot_manager,ipai.integration.bot.manager,model_ipai_integration_bot,group_integration_manager,1,1,1,1
+access_integration_bot_admin,ipai.integration.bot.admin,model_ipai_integration_bot,group_integration_admin,1,1,1,1
+access_integration_bot_command_user,ipai.integration.bot.command.user,model_ipai_integration_bot_command,group_integration_user,1,0,0,0
+access_integration_bot_command_manager,ipai.integration.bot.command.manager,model_ipai_integration_bot_command,group_integration_manager,1,1,1,1
+access_integration_oauth_user,ipai.integration.oauth.user,model_ipai_integration_oauth,group_integration_user,1,0,0,0
+access_integration_oauth_manager,ipai.integration.oauth.manager,model_ipai_integration_oauth,group_integration_manager,1,1,0,0
+access_integration_oauth_admin,ipai.integration.oauth.admin,model_ipai_integration_oauth,group_integration_admin,1,1,1,1
+access_integration_audit_user,ipai.integration.audit.user,model_ipai_integration_audit,group_integration_user,1,0,0,0
+access_integration_audit_admin,ipai.integration.audit.admin,model_ipai_integration_audit,group_integration_admin,1,1,1,1

--- a/addons/ipai/ipai_integrations/static/description/icon.svg
+++ b/addons/ipai/ipai_integrations/static/description/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="10" fill="#714B67"/>
+  <path d="M25 35h50M25 50h50M25 65h50" stroke="#fff" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="75" cy="35" r="8" fill="#00A09D"/>
+  <circle cx="75" cy="50" r="8" fill="#00A09D"/>
+  <circle cx="75" cy="65" r="8" fill="#00A09D"/>
+</svg>

--- a/addons/ipai/ipai_integrations/views/audit_views.xml
+++ b/addons/ipai/ipai_integrations/views/audit_views.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Audit Tree View -->
+    <record id="view_integration_audit_tree" model="ir.ui.view">
+        <field name="name">ipai.integration.audit.tree</field>
+        <field name="model">ipai.integration.audit</field>
+        <field name="arch" type="xml">
+            <tree create="false" edit="false" default_order="create_date desc">
+                <field name="create_date"/>
+                <field name="connector_id"/>
+                <field name="connector_type"/>
+                <field name="action"/>
+                <field name="message"/>
+                <field name="level" widget="badge" decoration-info="level == 'debug'" decoration-success="level == 'info'" decoration-warning="level == 'warning'" decoration-danger="level == 'error'"/>
+                <field name="user_id"/>
+                <field name="duration_ms" optional="hide"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Audit Form View -->
+    <record id="view_integration_audit_form" model="ir.ui.view">
+        <field name="name">ipai.integration.audit.form</field>
+        <field name="model">ipai.integration.audit</field>
+        <field name="arch" type="xml">
+            <form create="false" edit="false">
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="create_date"/>
+                            <field name="connector_id"/>
+                            <field name="action"/>
+                            <field name="level"/>
+                            <field name="user_id"/>
+                        </group>
+                        <group>
+                            <field name="request_method"/>
+                            <field name="request_url"/>
+                            <field name="response_code"/>
+                            <field name="duration_ms"/>
+                            <field name="ip_address"/>
+                        </group>
+                    </group>
+                    <group string="Message">
+                        <field name="message" nolabel="1"/>
+                    </group>
+                    <group string="Request Payload" invisible="not request_payload">
+                        <field name="request_payload" nolabel="1" widget="ace" options="{'mode': 'json'}"/>
+                    </group>
+                    <group string="Response Body" invisible="not response_body">
+                        <field name="response_body" nolabel="1" widget="ace" options="{'mode': 'json'}"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Audit Search View -->
+    <record id="view_integration_audit_search" model="ir.ui.view">
+        <field name="name">ipai.integration.audit.search</field>
+        <field name="model">ipai.integration.audit</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="action"/>
+                <field name="message"/>
+                <field name="connector_id"/>
+                <filter name="errors" string="Errors" domain="[('level', '=', 'error')]"/>
+                <filter name="warnings" string="Warnings" domain="[('level', 'in', ['warning', 'error'])]"/>
+                <filter name="today" string="Today" domain="[('create_date', '>=', context_today().strftime('%Y-%m-%d'))]"/>
+                <separator/>
+                <filter name="mattermost" string="Mattermost" domain="[('connector_type', '=', 'mattermost')]"/>
+                <filter name="focalboard" string="Focalboard" domain="[('connector_type', '=', 'focalboard')]"/>
+                <filter name="n8n" string="n8n" domain="[('connector_type', '=', 'n8n')]"/>
+                <group expand="0" string="Group By">
+                    <filter name="group_connector" string="Connector" context="{'group_by': 'connector_id'}"/>
+                    <filter name="group_level" string="Level" context="{'group_by': 'level'}"/>
+                    <filter name="group_action" string="Action" context="{'group_by': 'action'}"/>
+                    <filter name="group_date" string="Date" context="{'group_by': 'create_date:day'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Audit Action -->
+    <record id="action_integration_audit" model="ir.actions.act_window">
+        <field name="name">Audit Logs</field>
+        <field name="res_model">ipai.integration.audit</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{'search_default_today': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No audit logs yet
+            </p>
+            <p>
+                Audit logs track all integration activity including
+                API calls, webhooks, and configuration changes.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_integrations/views/bot_views.xml
+++ b/addons/ipai/ipai_integrations/views/bot_views.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Bot Tree View -->
+    <record id="view_integration_bot_tree" model="ir.ui.view">
+        <field name="name">ipai.integration.bot.tree</field>
+        <field name="model">ipai.integration.bot</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="connector_id"/>
+                <field name="bot_username"/>
+                <field name="state" widget="badge" decoration-success="state == 'active'" decoration-muted="state == 'draft'" decoration-danger="state == 'disabled'"/>
+                <field name="last_active"/>
+                <field name="active"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Bot Form View -->
+    <record id="view_integration_bot_form" model="ir.ui.view">
+        <field name="name">ipai.integration.bot.form</field>
+        <field name="model">ipai.integration.bot</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button name="action_activate" type="object" string="Activate" class="btn-primary" invisible="state == 'active'"/>
+                    <button name="action_disable" type="object" string="Disable" class="btn-secondary" invisible="state != 'active'"/>
+                    <field name="state" widget="statusbar"/>
+                </header>
+                <sheet>
+                    <field name="bot_icon" widget="image" class="oe_avatar"/>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="Bot Name"/>
+                        </h1>
+                        <h4>
+                            <field name="bot_username" placeholder="@username"/>
+                        </h4>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="connector_id"/>
+                            <field name="bot_display_name"/>
+                            <field name="bot_description"/>
+                            <field name="active"/>
+                        </group>
+                        <group>
+                            <field name="bot_token" password="True" groups="ipai_integrations.group_integration_admin"/>
+                            <field name="last_active" readonly="1"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Permissions" name="permissions">
+                            <group>
+                                <field name="permission_post"/>
+                                <field name="permission_read"/>
+                                <field name="permission_manage"/>
+                            </group>
+                        </page>
+                        <page string="Slash Commands" name="commands">
+                            <field name="slash_command_ids">
+                                <tree editable="bottom">
+                                    <field name="command"/>
+                                    <field name="description"/>
+                                    <field name="hint"/>
+                                    <field name="response_type"/>
+                                    <field name="handler_model"/>
+                                    <field name="active"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Bot Action -->
+    <record id="action_integration_bot" model="ir.actions.act_window">
+        <field name="name">Bots</field>
+        <field name="res_model">ipai.integration.bot</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{'search_default_active': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first bot
+            </p>
+            <p>
+                Bots can post messages to channels, respond to slash commands,
+                and interact with users in Mattermost.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_integrations/views/integration_views.xml
+++ b/addons/ipai/ipai_integrations/views/integration_views.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Connector Tree View -->
+    <record id="view_integration_connector_tree" model="ir.ui.view">
+        <field name="name">ipai.integration.connector.tree</field>
+        <field name="model">ipai.integration.connector</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+                <field name="connector_type"/>
+                <field name="base_url"/>
+                <field name="state" widget="badge" decoration-success="state == 'active'" decoration-warning="state == 'testing'" decoration-danger="state == 'error'" decoration-muted="state == 'draft'"/>
+                <field name="last_ping"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Connector Form View -->
+    <record id="view_integration_connector_form" model="ir.ui.view">
+        <field name="name">ipai.integration.connector.form</field>
+        <field name="model">ipai.integration.connector</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button name="action_test_connection" type="object" string="Test Connection" class="btn-secondary" invisible="state == 'active'"/>
+                    <button name="action_activate" type="object" string="Activate" class="btn-primary" invisible="state != 'testing'"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,testing,active"/>
+                </header>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="%(action_integration_webhook)d" type="action" class="oe_stat_button" icon="fa-link">
+                            <field name="webhook_ids" widget="statinfo" string="Webhooks"/>
+                        </button>
+                        <button name="%(action_integration_bot)d" type="action" class="oe_stat_button" icon="fa-robot">
+                            <field name="bot_ids" widget="statinfo" string="Bots"/>
+                        </button>
+                        <button name="%(action_integration_oauth)d" type="action" class="oe_stat_button" icon="fa-key">
+                            <field name="oauth_app_ids" widget="statinfo" string="OAuth Apps"/>
+                        </button>
+                    </div>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="Connector Name"/>
+                        </h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="code"/>
+                            <field name="connector_type"/>
+                            <field name="active" invisible="1"/>
+                        </group>
+                        <group>
+                            <field name="base_url" widget="url"/>
+                            <field name="api_version"/>
+                            <field name="auth_type"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Status" name="status">
+                            <group>
+                                <field name="last_ping"/>
+                                <field name="last_error" readonly="1"/>
+                            </group>
+                        </page>
+                        <page string="Audit Logs" name="audit">
+                            <field name="audit_ids" readonly="1">
+                                <tree limit="20">
+                                    <field name="create_date"/>
+                                    <field name="action"/>
+                                    <field name="message"/>
+                                    <field name="level" widget="badge"/>
+                                    <field name="user_id"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <!-- Connector Action -->
+    <record id="action_integration_connector" model="ir.actions.act_window">
+        <field name="name">Connectors</field>
+        <field name="res_model">ipai.integration.connector</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create your first integration connector
+            </p>
+            <p>
+                Connectors define connections to external services like
+                Mattermost, Focalboard, and n8n.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_integrations/views/menu.xml
+++ b/addons/ipai/ipai_integrations/views/menu.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Main Menu -->
+    <menuitem id="menu_integrations_root"
+        name="Integrations"
+        web_icon="ipai_integrations,static/description/icon.png"
+        sequence="95"
+        groups="group_integration_user"/>
+
+    <!-- Configuration Menu -->
+    <menuitem id="menu_integrations_config"
+        name="Configuration"
+        parent="menu_integrations_root"
+        sequence="10"/>
+
+    <menuitem id="menu_integration_connector"
+        name="Connectors"
+        parent="menu_integrations_config"
+        action="action_integration_connector"
+        sequence="10"/>
+
+    <menuitem id="menu_integration_webhook"
+        name="Webhooks"
+        parent="menu_integrations_config"
+        action="action_integration_webhook"
+        sequence="20"/>
+
+    <menuitem id="menu_integration_bot"
+        name="Bots"
+        parent="menu_integrations_config"
+        action="action_integration_bot"
+        sequence="30"/>
+
+    <menuitem id="menu_integration_oauth"
+        name="OAuth Apps"
+        parent="menu_integrations_config"
+        action="action_integration_oauth"
+        sequence="40"/>
+
+    <!-- Monitoring Menu -->
+    <menuitem id="menu_integrations_monitoring"
+        name="Monitoring"
+        parent="menu_integrations_root"
+        sequence="20"/>
+
+    <menuitem id="menu_integration_audit"
+        name="Audit Logs"
+        parent="menu_integrations_monitoring"
+        action="action_integration_audit"
+        sequence="10"/>
+</odoo>

--- a/addons/ipai/ipai_integrations/views/oauth_views.xml
+++ b/addons/ipai/ipai_integrations/views/oauth_views.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- OAuth Tree View -->
+    <record id="view_integration_oauth_tree" model="ir.ui.view">
+        <field name="name">ipai.integration.oauth.tree</field>
+        <field name="model">ipai.integration.oauth</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="connector_id"/>
+                <field name="client_id"/>
+                <field name="grant_types"/>
+                <field name="state" widget="badge" decoration-success="state == 'active'" decoration-muted="state == 'draft'" decoration-danger="state == 'revoked'"/>
+                <field name="token_count"/>
+                <field name="active"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- OAuth Form View -->
+    <record id="view_integration_oauth_form" model="ir.ui.view">
+        <field name="name">ipai.integration.oauth.form</field>
+        <field name="model">ipai.integration.oauth</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button name="action_revoke" type="object" string="Revoke" class="btn-danger" invisible="state == 'revoked'" confirm="This will invalidate all tokens. Continue?"/>
+                    <field name="state" widget="statusbar"/>
+                </header>
+                <sheet>
+                    <field name="icon" widget="image" class="oe_avatar"/>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="App Name"/>
+                        </h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="connector_id"/>
+                            <field name="homepage_url" widget="url"/>
+                            <field name="active"/>
+                        </group>
+                        <group>
+                            <field name="client_id" readonly="1"/>
+                            <field name="client_secret" password="True" groups="ipai_integrations.group_integration_admin"/>
+                            <button name="action_regenerate_secret" type="object" string="Regenerate Secret" class="btn-warning" groups="ipai_integrations.group_integration_admin"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Settings" name="settings">
+                            <group>
+                                <group>
+                                    <field name="grant_types"/>
+                                    <field name="token_expiry"/>
+                                    <field name="refresh_token_expiry"/>
+                                </group>
+                                <group string="Scopes">
+                                    <field name="scope_read"/>
+                                    <field name="scope_write"/>
+                                    <field name="scope_admin"/>
+                                </group>
+                            </group>
+                            <group string="Redirect URIs">
+                                <field name="redirect_uris" nolabel="1" placeholder="https://example.com/callback&#10;https://app.example.com/oauth/callback"/>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- OAuth Action -->
+    <record id="action_integration_oauth" model="ir.actions.act_window">
+        <field name="name">OAuth Apps</field>
+        <field name="res_model">ipai.integration.oauth</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{'search_default_active': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Register your first OAuth application
+            </p>
+            <p>
+                OAuth apps allow third-party applications to access Odoo
+                data on behalf of users.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_integrations/views/webhook_views.xml
+++ b/addons/ipai/ipai_integrations/views/webhook_views.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Webhook Tree View -->
+    <record id="view_integration_webhook_tree" model="ir.ui.view">
+        <field name="name">ipai.integration.webhook.tree</field>
+        <field name="model">ipai.integration.webhook</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="connector_id"/>
+                <field name="direction" widget="badge"/>
+                <field name="endpoint_path" invisible="direction == 'outgoing'"/>
+                <field name="target_url" invisible="direction == 'incoming'"/>
+                <field name="last_triggered"/>
+                <field name="success_count"/>
+                <field name="failure_count"/>
+                <field name="active"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Webhook Form View -->
+    <record id="view_integration_webhook_form" model="ir.ui.view">
+        <field name="name">ipai.integration.webhook.form</field>
+        <field name="model">ipai.integration.webhook</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="connector_id"/>
+                            <field name="direction"/>
+                            <field name="active"/>
+                        </group>
+                        <group>
+                            <field name="last_triggered" readonly="1"/>
+                            <field name="success_count" readonly="1"/>
+                            <field name="failure_count" readonly="1"/>
+                        </group>
+                    </group>
+
+                    <notebook>
+                        <page string="Incoming" name="incoming" invisible="direction != 'incoming'">
+                            <group>
+                                <field name="endpoint_path"/>
+                                <field name="signing_secret" password="True" groups="ipai_integrations.group_integration_admin"/>
+                                <button name="action_regenerate_secret" type="object" string="Regenerate Secret" class="btn-secondary" groups="ipai_integrations.group_integration_admin"/>
+                            </group>
+                        </page>
+
+                        <page string="Outgoing" name="outgoing" invisible="direction != 'outgoing'">
+                            <group>
+                                <field name="target_url" widget="url"/>
+                                <field name="trigger_model"/>
+                                <field name="trigger_events"/>
+                                <field name="content_type"/>
+                                <field name="include_signature"/>
+                            </group>
+                            <group string="Payload Template">
+                                <field name="payload_template" nolabel="1" placeholder='{"event": "{{ event }}", "data": {{ record | tojson }}}' widget="ace" options="{'mode': 'json'}"/>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Webhook Action -->
+    <record id="action_integration_webhook" model="ir.actions.act_window">
+        <field name="name">Webhooks</field>
+        <field name="res_model">ipai.integration.webhook</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{'search_default_active': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Configure your first webhook
+            </p>
+            <p>
+                Webhooks allow Odoo to receive events from external services
+                or send events to external endpoints.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_mattermost_connector/__init__.py
+++ b/addons/ipai/ipai_mattermost_connector/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import models
+from . import services

--- a/addons/ipai/ipai_mattermost_connector/__manifest__.py
+++ b/addons/ipai/ipai_mattermost_connector/__manifest__.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "IPAI Mattermost Connector",
+    "version": "18.0.1.0.0",
+    "category": "Technical/Integrations",
+    "summary": "API client and sync for Mattermost chat platform",
+    "description": """
+IPAI Mattermost Connector
+=========================
+
+Connects Odoo to Mattermost for real-time chat and notification integration.
+
+Features:
+---------
+* Mattermost API v4 client
+* Channel/team synchronization
+* Post messages from Odoo workflows
+* Receive and process incoming webhooks
+* Bot account management
+* Slash command handlers
+
+Architecture:
+-------------
+This module provides the Mattermost-specific API client and models.
+For the admin UI, see ipai_integrations module.
+
+External Service:
+-----------------
+Mattermost runs in ipai-ops-stack (NOT vendored here):
+* URL: https://chat.insightpulseai.net
+* API: Mattermost API v4
+
+Author: InsightPulse AI
+License: LGPL-3
+    """,
+    "author": "InsightPulse AI",
+    "website": "https://github.com/jgtolentino/odoo-ce",
+    "license": "LGPL-3",
+    "depends": [
+        "base",
+        "mail",
+        "ipai_integrations",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "data/connector_data.xml",
+        "views/mattermost_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+}

--- a/addons/ipai/ipai_mattermost_connector/data/connector_data.xml
+++ b/addons/ipai/ipai_mattermost_connector/data/connector_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <!-- Default Mattermost connector (demo/template) -->
+    <record id="connector_mattermost_default" model="ipai.integration.connector">
+        <field name="name">Mattermost (InsightPulse AI)</field>
+        <field name="code">mattermost_ipai</field>
+        <field name="connector_type">mattermost</field>
+        <field name="base_url">https://chat.insightpulseai.net</field>
+        <field name="api_version">v4</field>
+        <field name="auth_type">token</field>
+        <field name="state">draft</field>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_mattermost_connector/models/__init__.py
+++ b/addons/ipai/ipai_mattermost_connector/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from . import mattermost_channel
+from . import mattermost_message
+from . import integration_connector

--- a/addons/ipai/ipai_mattermost_connector/models/integration_connector.py
+++ b/addons/ipai/ipai_mattermost_connector/models/integration_connector.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+import logging
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class IntegrationConnector(models.Model):
+    """Extend connector with Mattermost-specific functionality."""
+
+    _inherit = "ipai.integration.connector"
+
+    # Mattermost-specific fields
+    mm_team_id = fields.Char(
+        string="Default Team ID",
+        help="Mattermost team ID for default operations"
+    )
+    mm_default_channel_id = fields.Char(
+        string="Default Channel ID",
+        help="Default channel for notifications"
+    )
+
+    def action_test_connection(self):
+        """Test connection to Mattermost API."""
+        self.ensure_one()
+        if self.connector_type != "mattermost":
+            return super().action_test_connection()
+
+        from ..services.mattermost_client import MattermostClient
+
+        try:
+            client = MattermostClient(self)
+            result = client.ping()
+            if result:
+                self.write({
+                    "state": "testing",
+                    "last_ping": fields.Datetime.now(),
+                    "last_error": False,
+                })
+                self._log_audit("test_connection", "Connection successful")
+            else:
+                raise Exception("Ping returned unsuccessful status")
+        except Exception as e:
+            _logger.warning("Mattermost connection test failed: %s", e)
+            self.write({
+                "state": "error",
+                "last_error": str(e),
+            })
+            self._log_audit("test_connection", f"Connection failed: {e}", level="error")
+
+        return True
+
+    def mm_post_message(self, channel_id, message, props=None):
+        """Post a message to a Mattermost channel."""
+        self.ensure_one()
+        if self.connector_type != "mattermost":
+            raise ValueError("Connector is not a Mattermost connector")
+
+        from ..services.mattermost_client import MattermostClient
+
+        client = MattermostClient(self)
+        return client.post_message(channel_id, message, props)

--- a/addons/ipai/ipai_mattermost_connector/models/mattermost_channel.py
+++ b/addons/ipai/ipai_mattermost_connector/models/mattermost_channel.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class MattermostChannel(models.Model):
+    """Cached Mattermost channel information."""
+
+    _name = "ipai.mattermost.channel"
+    _description = "Mattermost Channel"
+    _order = "display_name"
+
+    connector_id = fields.Many2one(
+        "ipai.integration.connector",
+        required=True,
+        ondelete="cascade",
+        domain="[('connector_type', '=', 'mattermost')]"
+    )
+
+    # Mattermost IDs
+    mm_channel_id = fields.Char(required=True, index=True)
+    mm_team_id = fields.Char(index=True)
+
+    # Channel info
+    name = fields.Char(required=True)
+    display_name = fields.Char()
+    channel_type = fields.Selection([
+        ("O", "Open"),
+        ("P", "Private"),
+        ("D", "Direct"),
+        ("G", "Group"),
+    ])
+    header = fields.Text()
+    purpose = fields.Text()
+
+    # Sync status
+    last_sync = fields.Datetime()
+    active = fields.Boolean(default=True)
+
+    _sql_constraints = [
+        ("channel_uniq", "unique(connector_id, mm_channel_id)",
+         "Channel already exists for this connector!"),
+    ]
+
+    @api.model
+    def sync_channels(self, connector):
+        """Sync channels from Mattermost API."""
+        from ..services.mattermost_client import MattermostClient
+
+        client = MattermostClient(connector)
+        channels = client.get_channels(connector.mm_team_id)
+
+        for ch in channels:
+            existing = self.search([
+                ("connector_id", "=", connector.id),
+                ("mm_channel_id", "=", ch["id"]),
+            ], limit=1)
+
+            vals = {
+                "connector_id": connector.id,
+                "mm_channel_id": ch["id"],
+                "mm_team_id": ch.get("team_id"),
+                "name": ch["name"],
+                "display_name": ch.get("display_name", ch["name"]),
+                "channel_type": ch.get("type"),
+                "header": ch.get("header"),
+                "purpose": ch.get("purpose"),
+                "last_sync": fields.Datetime.now(),
+            }
+
+            if existing:
+                existing.write(vals)
+            else:
+                self.create(vals)
+
+        return True

--- a/addons/ipai/ipai_mattermost_connector/models/mattermost_message.py
+++ b/addons/ipai/ipai_mattermost_connector/models/mattermost_message.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class MattermostMessage(models.Model):
+    """Log of messages sent to/from Mattermost."""
+
+    _name = "ipai.mattermost.message"
+    _description = "Mattermost Message Log"
+    _order = "create_date desc"
+
+    connector_id = fields.Many2one(
+        "ipai.integration.connector",
+        required=True,
+        ondelete="cascade"
+    )
+    channel_id = fields.Many2one(
+        "ipai.mattermost.channel",
+        ondelete="set null"
+    )
+
+    # Message details
+    direction = fields.Selection([
+        ("outbound", "Outbound (Odoo -> Mattermost)"),
+        ("inbound", "Inbound (Mattermost -> Odoo)"),
+    ], required=True)
+
+    mm_post_id = fields.Char(index=True)
+    mm_channel_id = fields.Char()
+    mm_user_id = fields.Char()
+
+    message = fields.Text()
+    props_json = fields.Text(help="Additional message properties (JSON)")
+
+    # Status
+    state = fields.Selection([
+        ("pending", "Pending"),
+        ("sent", "Sent"),
+        ("delivered", "Delivered"),
+        ("failed", "Failed"),
+    ], default="pending")
+    error = fields.Text()
+
+    # Related Odoo records
+    res_model = fields.Char(help="Related Odoo model")
+    res_id = fields.Integer(help="Related Odoo record ID")
+
+    @api.model
+    def log_outbound(self, connector, channel_id, message, result=None, error=None):
+        """Log an outbound message."""
+        return self.create({
+            "connector_id": connector.id,
+            "mm_channel_id": channel_id,
+            "direction": "outbound",
+            "message": message,
+            "mm_post_id": result.get("id") if result else None,
+            "state": "sent" if result else "failed",
+            "error": error,
+        })
+
+    @api.model
+    def log_inbound(self, connector, payload):
+        """Log an inbound message/event."""
+        return self.create({
+            "connector_id": connector.id,
+            "mm_channel_id": payload.get("channel_id"),
+            "mm_user_id": payload.get("user_id"),
+            "mm_post_id": payload.get("post_id"),
+            "direction": "inbound",
+            "message": payload.get("text"),
+            "state": "delivered",
+        })

--- a/addons/ipai/ipai_mattermost_connector/security/ir.model.access.csv
+++ b/addons/ipai/ipai_mattermost_connector/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_mattermost_channel_user,ipai.mattermost.channel.user,model_ipai_mattermost_channel,ipai_integrations.group_integration_user,1,0,0,0
+access_mattermost_channel_manager,ipai.mattermost.channel.manager,model_ipai_mattermost_channel,ipai_integrations.group_integration_manager,1,1,1,1
+access_mattermost_message_user,ipai.mattermost.message.user,model_ipai_mattermost_message,ipai_integrations.group_integration_user,1,0,0,0
+access_mattermost_message_manager,ipai.mattermost.message.manager,model_ipai_mattermost_message,ipai_integrations.group_integration_manager,1,1,1,0

--- a/addons/ipai/ipai_mattermost_connector/services/__init__.py
+++ b/addons/ipai/ipai_mattermost_connector/services/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import mattermost_client

--- a/addons/ipai/ipai_mattermost_connector/services/mattermost_client.py
+++ b/addons/ipai/ipai_mattermost_connector/services/mattermost_client.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8 -*-
+"""
+Mattermost API v4 Client
+
+This module provides a simple client for the Mattermost API.
+It handles authentication and common API operations.
+"""
+import json
+import logging
+import requests
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+# Default timeout for API requests
+DEFAULT_TIMEOUT = 30
+
+
+class MattermostClient:
+    """Simple Mattermost API v4 client."""
+
+    def __init__(self, connector):
+        """
+        Initialize the client with a connector record.
+
+        Args:
+            connector: ipai.integration.connector record
+        """
+        self.connector = connector
+        self.base_url = connector.base_url.rstrip("/")
+        self.api_version = connector.api_version or "v4"
+        self._token = None
+
+    @property
+    def api_url(self):
+        """Get the full API URL."""
+        return f"{self.base_url}/api/{self.api_version}"
+
+    @property
+    def token(self):
+        """Get the authentication token."""
+        if self._token is None:
+            # Token should come from system parameters or secret ref
+            # For now, use ir.config_parameter
+            ICP = self.connector.env["ir.config_parameter"].sudo()
+            self._token = ICP.get_param(
+                f"ipai_mattermost.token_{self.connector.id}",
+                default=""
+            )
+        return self._token
+
+    def _headers(self):
+        """Get request headers."""
+        headers = {
+            "Content-Type": "application/json",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    def _request(self, method, endpoint, data=None, params=None):
+        """
+        Make an API request.
+
+        Args:
+            method: HTTP method (GET, POST, PUT, DELETE)
+            endpoint: API endpoint (e.g., /users/me)
+            data: Request body (dict)
+            params: Query parameters (dict)
+
+        Returns:
+            dict: Response JSON
+
+        Raises:
+            UserError: On API errors
+        """
+        url = f"{self.api_url}{endpoint}"
+
+        try:
+            response = requests.request(
+                method,
+                url,
+                headers=self._headers(),
+                json=data,
+                params=params,
+                timeout=DEFAULT_TIMEOUT,
+            )
+
+            if response.status_code >= 400:
+                error_msg = response.text
+                try:
+                    error_data = response.json()
+                    error_msg = error_data.get("message", error_msg)
+                except json.JSONDecodeError:
+                    pass
+                _logger.warning(
+                    "Mattermost API error: %s %s -> %s: %s",
+                    method, endpoint, response.status_code, error_msg
+                )
+                raise UserError(f"Mattermost API error: {error_msg}")
+
+            if response.text:
+                return response.json()
+            return {}
+
+        except requests.RequestException as e:
+            _logger.error("Mattermost request failed: %s", e)
+            raise UserError(f"Mattermost connection error: {e}")
+
+    # System endpoints
+
+    def ping(self):
+        """Check if Mattermost is reachable."""
+        result = self._request("GET", "/system/ping")
+        return result.get("status") == "OK"
+
+    def get_config(self):
+        """Get server configuration (requires admin)."""
+        return self._request("GET", "/config")
+
+    # User endpoints
+
+    def get_me(self):
+        """Get current user info."""
+        return self._request("GET", "/users/me")
+
+    def get_user(self, user_id):
+        """Get user by ID."""
+        return self._request("GET", f"/users/{user_id}")
+
+    # Team endpoints
+
+    def get_teams(self):
+        """Get all teams the user belongs to."""
+        return self._request("GET", "/users/me/teams")
+
+    def get_team(self, team_id):
+        """Get team by ID."""
+        return self._request("GET", f"/teams/{team_id}")
+
+    # Channel endpoints
+
+    def get_channels(self, team_id):
+        """Get public channels for a team."""
+        return self._request("GET", f"/teams/{team_id}/channels")
+
+    def get_channel(self, channel_id):
+        """Get channel by ID."""
+        return self._request("GET", f"/channels/{channel_id}")
+
+    def get_my_channels(self, team_id):
+        """Get channels the user is a member of."""
+        user = self.get_me()
+        return self._request(
+            "GET",
+            f"/users/{user['id']}/teams/{team_id}/channels"
+        )
+
+    # Post endpoints
+
+    def post_message(self, channel_id, message, props=None):
+        """
+        Post a message to a channel.
+
+        Args:
+            channel_id: Mattermost channel ID
+            message: Message text (supports Markdown)
+            props: Additional message properties (dict)
+
+        Returns:
+            dict: Created post data
+        """
+        data = {
+            "channel_id": channel_id,
+            "message": message,
+        }
+        if props:
+            data["props"] = props
+
+        result = self._request("POST", "/posts", data=data)
+
+        # Log the message
+        self.connector.env["ipai.mattermost.message"].log_outbound(
+            self.connector, channel_id, message, result=result
+        )
+
+        return result
+
+    def get_posts(self, channel_id, page=0, per_page=60):
+        """Get posts from a channel."""
+        return self._request(
+            "GET",
+            f"/channels/{channel_id}/posts",
+            params={"page": page, "per_page": per_page}
+        )
+
+    # Webhook endpoints
+
+    def create_incoming_webhook(self, channel_id, display_name, description=""):
+        """Create an incoming webhook."""
+        return self._request("POST", "/hooks/incoming", data={
+            "channel_id": channel_id,
+            "display_name": display_name,
+            "description": description,
+        })
+
+    def create_outgoing_webhook(self, team_id, channel_id, trigger_words,
+                                 callback_urls, display_name):
+        """Create an outgoing webhook."""
+        return self._request("POST", "/hooks/outgoing", data={
+            "team_id": team_id,
+            "channel_id": channel_id,
+            "trigger_words": trigger_words,
+            "callback_urls": callback_urls,
+            "display_name": display_name,
+        })

--- a/addons/ipai/ipai_mattermost_connector/static/description/icon.svg
+++ b/addons/ipai/ipai_mattermost_connector/static/description/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="10" fill="#0058CC"/>
+  <path d="M30 30h40v10H30zM30 45h35v10H30zM30 60h40v10H30z" fill="#fff"/>
+  <circle cx="75" cy="35" r="5" fill="#22C55E"/>
+</svg>

--- a/addons/ipai/ipai_mattermost_connector/views/mattermost_views.xml
+++ b/addons/ipai/ipai_mattermost_connector/views/mattermost_views.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Channel Tree View -->
+    <record id="view_mattermost_channel_tree" model="ir.ui.view">
+        <field name="name">ipai.mattermost.channel.tree</field>
+        <field name="model">ipai.mattermost.channel</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="display_name"/>
+                <field name="name"/>
+                <field name="channel_type"/>
+                <field name="connector_id"/>
+                <field name="last_sync"/>
+                <field name="active"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Channel Form View -->
+    <record id="view_mattermost_channel_form" model="ir.ui.view">
+        <field name="name">ipai.mattermost.channel.form</field>
+        <field name="model">ipai.mattermost.channel</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="display_name"/>
+                            <field name="name"/>
+                            <field name="channel_type"/>
+                            <field name="connector_id"/>
+                        </group>
+                        <group>
+                            <field name="mm_channel_id"/>
+                            <field name="mm_team_id"/>
+                            <field name="last_sync"/>
+                            <field name="active"/>
+                        </group>
+                    </group>
+                    <group>
+                        <field name="header"/>
+                        <field name="purpose"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Channel Action -->
+    <record id="action_mattermost_channel" model="ir.actions.act_window">
+        <field name="name">Mattermost Channels</field>
+        <field name="res_model">ipai.mattermost.channel</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <!-- Message Tree View -->
+    <record id="view_mattermost_message_tree" model="ir.ui.view">
+        <field name="name">ipai.mattermost.message.tree</field>
+        <field name="model">ipai.mattermost.message</field>
+        <field name="arch" type="xml">
+            <tree default_order="create_date desc">
+                <field name="create_date"/>
+                <field name="direction" widget="badge"/>
+                <field name="mm_channel_id"/>
+                <field name="message" widget="text"/>
+                <field name="state" widget="badge" decoration-success="state == 'sent'" decoration-warning="state == 'pending'" decoration-danger="state == 'failed'"/>
+                <field name="connector_id"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Message Action -->
+    <record id="action_mattermost_message" model="ir.actions.act_window">
+        <field name="name">Message Log</field>
+        <field name="res_model">ipai.mattermost.message</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <!-- Menu items under Integrations -->
+    <menuitem id="menu_mattermost"
+        name="Mattermost"
+        parent="ipai_integrations.menu_integrations_config"
+        sequence="50"/>
+
+    <menuitem id="menu_mattermost_channels"
+        name="Channels"
+        parent="menu_mattermost"
+        action="action_mattermost_channel"
+        sequence="10"/>
+
+    <menuitem id="menu_mattermost_messages"
+        name="Message Log"
+        parent="menu_mattermost"
+        action="action_mattermost_message"
+        sequence="20"/>
+</odoo>

--- a/addons/ipai/ipai_n8n_connector/__init__.py
+++ b/addons/ipai/ipai_n8n_connector/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from . import models
+from . import services
+from . import controllers

--- a/addons/ipai/ipai_n8n_connector/__manifest__.py
+++ b/addons/ipai/ipai_n8n_connector/__manifest__.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "IPAI n8n Connector",
+    "version": "18.0.1.0.0",
+    "category": "Technical/Integrations",
+    "summary": "Workflow automation integration with n8n",
+    "description": """
+IPAI n8n Connector
+==================
+
+Connects Odoo to n8n for workflow automation and orchestration.
+
+Features:
+---------
+* n8n API client for workflow management
+* Webhook endpoints for n8n triggers
+* Outbound webhook calls to n8n
+* Workflow execution tracking
+* Credential management (references only)
+
+Architecture:
+-------------
+This module provides the n8n-specific API client and webhook handlers.
+For the admin UI, see ipai_integrations module.
+
+External Service:
+-----------------
+n8n runs in ipai-ops-stack (NOT vendored here):
+* URL: https://n8n.insightpulseai.net
+* API: n8n REST API
+
+Workflow Storage:
+-----------------
+Workflow JSON exports are stored in the ops repo:
+* ipai-ops-stack/n8n/workflows/*.json
+
+Author: InsightPulse AI
+License: LGPL-3
+    """,
+    "author": "InsightPulse AI",
+    "website": "https://github.com/jgtolentino/odoo-ce",
+    "license": "LGPL-3",
+    "depends": [
+        "base",
+        "mail",
+        "ipai_integrations",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "data/connector_data.xml",
+        "views/n8n_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+}

--- a/addons/ipai/ipai_n8n_connector/controllers/__init__.py
+++ b/addons/ipai/ipai_n8n_connector/controllers/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import n8n_webhook_controller

--- a/addons/ipai/ipai_n8n_connector/controllers/n8n_webhook_controller.py
+++ b/addons/ipai/ipai_n8n_connector/controllers/n8n_webhook_controller.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+"""
+Controller for receiving webhooks from n8n.
+
+n8n can call back to Odoo after workflow execution or as part of
+a workflow that needs to update Odoo data.
+"""
+import json
+import logging
+from odoo import http
+from odoo.http import request
+
+_logger = logging.getLogger(__name__)
+
+
+class N8nWebhookController(http.Controller):
+    """Controller for n8n webhook callbacks."""
+
+    @http.route(
+        "/integrations/n8n/callback",
+        type="json",
+        auth="public",
+        methods=["POST"],
+        csrf=False,
+    )
+    def n8n_callback(self, **kwargs):
+        """
+        Generic callback endpoint for n8n workflows.
+
+        Expected payload:
+        {
+            "workflow_id": "...",
+            "execution_id": "...",
+            "status": "success|error",
+            "data": {...}
+        }
+        """
+        payload = request.jsonrequest or {}
+
+        # Log the callback
+        request.env["ipai.integration.audit"].sudo().log(
+            None,  # No specific connector
+            "n8n_callback",
+            f"Callback from n8n workflow: {payload.get('workflow_id')}",
+            request_method="POST",
+            request_payload=json.dumps(payload),
+        )
+
+        # Find the workflow
+        n8n_workflow_id = payload.get("workflow_id")
+        if n8n_workflow_id:
+            workflow = request.env["ipai.n8n.workflow"].sudo().search([
+                ("n8n_workflow_id", "=", str(n8n_workflow_id))
+            ], limit=1)
+
+            if workflow:
+                # Log execution
+                request.env["ipai.n8n.execution"].sudo().create({
+                    "workflow_id": workflow.id,
+                    "n8n_execution_id": payload.get("execution_id"),
+                    "trigger_source": "webhook",
+                    "status": payload.get("status", "success"),
+                    "output_data": json.dumps(payload.get("data", {})),
+                    "started_at": request.env.cr.now(),
+                    "finished_at": request.env.cr.now(),
+                })
+
+        return {"status": "ok"}
+
+    @http.route(
+        "/integrations/n8n/trigger/<string:action>",
+        type="json",
+        auth="public",
+        methods=["POST"],
+        csrf=False,
+    )
+    def n8n_trigger_action(self, action, **kwargs):
+        """
+        Endpoint for n8n to trigger specific Odoo actions.
+
+        Supported actions:
+        - create_record: Create a new record
+        - update_record: Update an existing record
+        - run_method: Run a method on a model
+        """
+        payload = request.jsonrequest or {}
+
+        # Validate signature if configured
+        signature = request.httprequest.headers.get("X-N8N-Signature")
+        if signature:
+            # Implement signature validation here
+            pass
+
+        result = {"status": "error", "message": "Unknown action"}
+
+        try:
+            if action == "create_record":
+                result = self._handle_create_record(payload)
+            elif action == "update_record":
+                result = self._handle_update_record(payload)
+            elif action == "run_method":
+                result = self._handle_run_method(payload)
+            else:
+                result = {"status": "error", "message": f"Unknown action: {action}"}
+        except Exception as e:
+            _logger.exception("n8n trigger action failed")
+            result = {"status": "error", "message": str(e)}
+
+        return result
+
+    def _handle_create_record(self, payload):
+        """Handle record creation."""
+        model = payload.get("model")
+        values = payload.get("values", {})
+
+        if not model or not values:
+            return {"status": "error", "message": "Missing model or values"}
+
+        try:
+            Model = request.env[model].sudo()
+            record = Model.create(values)
+            return {
+                "status": "success",
+                "record_id": record.id,
+                "record_name": record.display_name if hasattr(record, "display_name") else str(record.id),
+            }
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+
+    def _handle_update_record(self, payload):
+        """Handle record update."""
+        model = payload.get("model")
+        record_id = payload.get("record_id")
+        values = payload.get("values", {})
+
+        if not model or not record_id or not values:
+            return {"status": "error", "message": "Missing model, record_id, or values"}
+
+        try:
+            Model = request.env[model].sudo()
+            record = Model.browse(int(record_id))
+            if not record.exists():
+                return {"status": "error", "message": "Record not found"}
+            record.write(values)
+            return {"status": "success", "record_id": record.id}
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+
+    def _handle_run_method(self, payload):
+        """Handle method execution."""
+        model = payload.get("model")
+        method = payload.get("method")
+        args = payload.get("args", [])
+        kwargs = payload.get("kwargs", {})
+        record_id = payload.get("record_id")
+
+        if not model or not method:
+            return {"status": "error", "message": "Missing model or method"}
+
+        # Whitelist of allowed methods for security
+        allowed_methods = [
+            "action_",  # Prefix for action methods
+            "button_",  # Prefix for button methods
+            "_handle_",  # Prefix for handler methods
+        ]
+
+        is_allowed = any(method.startswith(prefix) for prefix in allowed_methods)
+        if not is_allowed:
+            return {"status": "error", "message": f"Method not allowed: {method}"}
+
+        try:
+            Model = request.env[model].sudo()
+            if record_id:
+                target = Model.browse(int(record_id))
+            else:
+                target = Model
+
+            if not hasattr(target, method):
+                return {"status": "error", "message": f"Method not found: {method}"}
+
+            result = getattr(target, method)(*args, **kwargs)
+            return {"status": "success", "result": str(result) if result else None}
+        except Exception as e:
+            return {"status": "error", "message": str(e)}

--- a/addons/ipai/ipai_n8n_connector/data/connector_data.xml
+++ b/addons/ipai/ipai_n8n_connector/data/connector_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <!-- Default n8n connector (demo/template) -->
+    <record id="connector_n8n_default" model="ipai.integration.connector">
+        <field name="name">n8n (InsightPulse AI)</field>
+        <field name="code">n8n_ipai</field>
+        <field name="connector_type">n8n</field>
+        <field name="base_url">https://n8n.insightpulseai.net</field>
+        <field name="api_version">v1</field>
+        <field name="auth_type">token</field>
+        <field name="state">draft</field>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_n8n_connector/models/__init__.py
+++ b/addons/ipai/ipai_n8n_connector/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from . import n8n_workflow
+from . import n8n_execution
+from . import integration_connector

--- a/addons/ipai/ipai_n8n_connector/models/integration_connector.py
+++ b/addons/ipai/ipai_n8n_connector/models/integration_connector.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+import logging
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class IntegrationConnector(models.Model):
+    """Extend connector with n8n-specific functionality."""
+
+    _inherit = "ipai.integration.connector"
+
+    # n8n-specific fields
+    n8n_webhook_url = fields.Char(
+        string="Webhook Base URL",
+        help="Base URL for n8n webhooks"
+    )
+
+    def action_test_connection(self):
+        """Test connection to n8n API."""
+        self.ensure_one()
+        if self.connector_type != "n8n":
+            return super().action_test_connection()
+
+        from ..services.n8n_client import N8nClient
+
+        try:
+            client = N8nClient(self)
+            result = client.health_check()
+            if result:
+                self.write({
+                    "state": "testing",
+                    "last_ping": fields.Datetime.now(),
+                    "last_error": False,
+                })
+                self._log_audit("test_connection", "Connection successful")
+            else:
+                raise Exception("Health check returned unsuccessful status")
+        except Exception as e:
+            _logger.warning("n8n connection test failed: %s", e)
+            self.write({
+                "state": "error",
+                "last_error": str(e),
+            })
+            self._log_audit("test_connection", f"Connection failed: {e}", level="error")
+
+        return True
+
+    def n8n_trigger_webhook(self, webhook_path, payload):
+        """Trigger an n8n webhook."""
+        self.ensure_one()
+        if self.connector_type != "n8n":
+            raise ValueError("Connector is not an n8n connector")
+
+        from ..services.n8n_client import N8nClient
+
+        client = N8nClient(self)
+        return client.trigger_webhook(webhook_path, payload)
+
+    def n8n_sync_workflows(self):
+        """Sync workflows from n8n."""
+        self.ensure_one()
+        if self.connector_type != "n8n":
+            raise ValueError("Connector is not an n8n connector")
+
+        return self.env["ipai.n8n.workflow"].sync_workflows(self)

--- a/addons/ipai/ipai_n8n_connector/models/n8n_execution.py
+++ b/addons/ipai/ipai_n8n_connector/models/n8n_execution.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class N8nExecution(models.Model):
+    """n8n workflow execution log."""
+
+    _name = "ipai.n8n.execution"
+    _description = "n8n Workflow Execution"
+    _order = "create_date desc"
+
+    workflow_id = fields.Many2one(
+        "ipai.n8n.workflow",
+        required=True,
+        ondelete="cascade"
+    )
+    connector_id = fields.Many2one(
+        related="workflow_id.connector_id",
+        store=True
+    )
+
+    # n8n execution ID
+    n8n_execution_id = fields.Char(index=True)
+
+    # Execution details
+    trigger_source = fields.Selection([
+        ("webhook", "Webhook"),
+        ("schedule", "Schedule"),
+        ("manual", "Manual (n8n UI)"),
+        ("odoo_manual", "Manual (Odoo)"),
+        ("odoo_webhook", "Odoo Webhook"),
+    ])
+
+    status = fields.Selection([
+        ("waiting", "Waiting"),
+        ("running", "Running"),
+        ("success", "Success"),
+        ("error", "Error"),
+        ("canceled", "Canceled"),
+    ], default="waiting")
+
+    # Timing
+    started_at = fields.Datetime()
+    finished_at = fields.Datetime()
+    duration_ms = fields.Integer(compute="_compute_duration")
+
+    # Data
+    input_data = fields.Text(help="Input data (JSON)")
+    output_data = fields.Text(help="Output data (JSON)")
+    error_message = fields.Text()
+
+    # Related Odoo records
+    res_model = fields.Char(help="Related Odoo model")
+    res_id = fields.Integer(help="Related Odoo record ID")
+
+    def _compute_duration(self):
+        for rec in self:
+            if rec.started_at and rec.finished_at:
+                delta = rec.finished_at - rec.started_at
+                rec.duration_ms = int(delta.total_seconds() * 1000)
+            else:
+                rec.duration_ms = 0
+
+    @api.model
+    def log_webhook_trigger(self, workflow, payload, result=None, error=None):
+        """Log a webhook-triggered execution."""
+        return self.create({
+            "workflow_id": workflow.id,
+            "trigger_source": "odoo_webhook",
+            "status": "success" if result else "error",
+            "input_data": str(payload),
+            "output_data": str(result) if result else None,
+            "error_message": error,
+            "started_at": fields.Datetime.now(),
+            "finished_at": fields.Datetime.now(),
+        })

--- a/addons/ipai/ipai_n8n_connector/models/n8n_workflow.py
+++ b/addons/ipai/ipai_n8n_connector/models/n8n_workflow.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class N8nWorkflow(models.Model):
+    """Cached n8n workflow information."""
+
+    _name = "ipai.n8n.workflow"
+    _description = "n8n Workflow"
+    _order = "name"
+
+    connector_id = fields.Many2one(
+        "ipai.integration.connector",
+        required=True,
+        ondelete="cascade",
+        domain="[('connector_type', '=', 'n8n')]"
+    )
+
+    # n8n IDs
+    n8n_workflow_id = fields.Char(required=True, index=True)
+
+    # Workflow info
+    name = fields.Char(required=True)
+    active_in_n8n = fields.Boolean(
+        string="Active in n8n",
+        help="Whether the workflow is active in n8n"
+    )
+    tags = fields.Char(help="Comma-separated tags")
+
+    # Trigger info
+    trigger_type = fields.Selection([
+        ("webhook", "Webhook"),
+        ("schedule", "Schedule/Cron"),
+        ("manual", "Manual"),
+        ("event", "Event"),
+    ])
+    webhook_path = fields.Char(
+        help="Webhook path for triggering this workflow"
+    )
+
+    # Execution tracking
+    execution_ids = fields.One2many(
+        "ipai.n8n.execution", "workflow_id", string="Executions"
+    )
+    last_execution_id = fields.Many2one(
+        "ipai.n8n.execution",
+        compute="_compute_last_execution",
+        string="Last Execution"
+    )
+    execution_count = fields.Integer(compute="_compute_execution_count")
+
+    # Sync status
+    last_sync = fields.Datetime()
+    active = fields.Boolean(default=True)
+
+    _sql_constraints = [
+        ("workflow_uniq", "unique(connector_id, n8n_workflow_id)",
+         "Workflow already exists for this connector!"),
+    ]
+
+    def _compute_last_execution(self):
+        for rec in self:
+            rec.last_execution_id = rec.execution_ids[:1]
+
+    def _compute_execution_count(self):
+        for rec in self:
+            rec.execution_count = len(rec.execution_ids)
+
+    @api.model
+    def sync_workflows(self, connector):
+        """Sync workflows from n8n API."""
+        from ..services.n8n_client import N8nClient
+
+        client = N8nClient(connector)
+        workflows = client.get_workflows()
+
+        for wf in workflows:
+            existing = self.search([
+                ("connector_id", "=", connector.id),
+                ("n8n_workflow_id", "=", str(wf["id"])),
+            ], limit=1)
+
+            # Determine trigger type
+            trigger_type = "manual"
+            webhook_path = None
+            nodes = wf.get("nodes", [])
+            for node in nodes:
+                node_type = node.get("type", "")
+                if "webhook" in node_type.lower():
+                    trigger_type = "webhook"
+                    # Try to extract webhook path
+                    params = node.get("parameters", {})
+                    webhook_path = params.get("path")
+                    break
+                elif "cron" in node_type.lower() or "schedule" in node_type.lower():
+                    trigger_type = "schedule"
+                    break
+
+            vals = {
+                "connector_id": connector.id,
+                "n8n_workflow_id": str(wf["id"]),
+                "name": wf.get("name", "Untitled"),
+                "active_in_n8n": wf.get("active", False),
+                "trigger_type": trigger_type,
+                "webhook_path": webhook_path,
+                "last_sync": fields.Datetime.now(),
+            }
+
+            if existing:
+                existing.write(vals)
+            else:
+                self.create(vals)
+
+        return True
+
+    def action_trigger(self):
+        """Manually trigger this workflow via webhook."""
+        self.ensure_one()
+        if not self.webhook_path:
+            return {
+                "type": "ir.actions.client",
+                "tag": "display_notification",
+                "params": {
+                    "title": "Cannot Trigger",
+                    "message": "This workflow does not have a webhook trigger.",
+                    "type": "warning",
+                }
+            }
+
+        from ..services.n8n_client import N8nClient
+        client = N8nClient(self.connector_id)
+        result = client.trigger_webhook(self.webhook_path, {
+            "triggered_from": "odoo",
+            "workflow_id": self.n8n_workflow_id,
+        })
+
+        # Log execution
+        self.env["ipai.n8n.execution"].create({
+            "workflow_id": self.id,
+            "trigger_source": "odoo_manual",
+            "status": "running" if result else "error",
+        })
+
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "title": "Workflow Triggered",
+                "message": f"Workflow '{self.name}' has been triggered.",
+                "type": "success",
+            }
+        }

--- a/addons/ipai/ipai_n8n_connector/security/ir.model.access.csv
+++ b/addons/ipai/ipai_n8n_connector/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_n8n_workflow_user,ipai.n8n.workflow.user,model_ipai_n8n_workflow,ipai_integrations.group_integration_user,1,0,0,0
+access_n8n_workflow_manager,ipai.n8n.workflow.manager,model_ipai_n8n_workflow,ipai_integrations.group_integration_manager,1,1,1,1
+access_n8n_execution_user,ipai.n8n.execution.user,model_ipai_n8n_execution,ipai_integrations.group_integration_user,1,0,0,0
+access_n8n_execution_manager,ipai.n8n.execution.manager,model_ipai_n8n_execution,ipai_integrations.group_integration_manager,1,1,1,0

--- a/addons/ipai/ipai_n8n_connector/services/__init__.py
+++ b/addons/ipai/ipai_n8n_connector/services/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import n8n_client

--- a/addons/ipai/ipai_n8n_connector/services/n8n_client.py
+++ b/addons/ipai/ipai_n8n_connector/services/n8n_client.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+"""
+n8n API Client
+
+This module provides a client for the n8n REST API.
+"""
+import json
+import logging
+import requests
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 30
+
+
+class N8nClient:
+    """n8n REST API client."""
+
+    def __init__(self, connector):
+        """
+        Initialize the client with a connector record.
+
+        Args:
+            connector: ipai.integration.connector record
+        """
+        self.connector = connector
+        self.base_url = connector.base_url.rstrip("/")
+        self.webhook_base_url = (
+            connector.n8n_webhook_url or connector.base_url
+        ).rstrip("/")
+        self._api_key = None
+
+    @property
+    def api_url(self):
+        """Get the full API URL."""
+        return f"{self.base_url}/api/v1"
+
+    @property
+    def api_key(self):
+        """Get the API key."""
+        if self._api_key is None:
+            ICP = self.connector.env["ir.config_parameter"].sudo()
+            self._api_key = ICP.get_param(
+                f"ipai_n8n.api_key_{self.connector.id}",
+                default=""
+            )
+        return self._api_key
+
+    def _headers(self):
+        """Get request headers."""
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        if self.api_key:
+            headers["X-N8N-API-KEY"] = self.api_key
+        return headers
+
+    def _request(self, method, endpoint, data=None, params=None, use_webhook=False):
+        """
+        Make an API request.
+
+        Args:
+            method: HTTP method
+            endpoint: API endpoint
+            data: Request body (dict)
+            params: Query parameters (dict)
+            use_webhook: If True, use webhook base URL
+
+        Returns:
+            dict or list: Response JSON
+
+        Raises:
+            UserError: On API errors
+        """
+        base = self.webhook_base_url if use_webhook else self.api_url
+        url = f"{base}{endpoint}"
+
+        try:
+            response = requests.request(
+                method,
+                url,
+                headers=self._headers(),
+                json=data,
+                params=params,
+                timeout=DEFAULT_TIMEOUT,
+            )
+
+            if response.status_code >= 400:
+                error_msg = response.text
+                try:
+                    error_data = response.json()
+                    error_msg = error_data.get("message", error_msg)
+                except json.JSONDecodeError:
+                    pass
+                _logger.warning(
+                    "n8n API error: %s %s -> %s: %s",
+                    method, endpoint, response.status_code, error_msg
+                )
+                raise UserError(f"n8n API error: {error_msg}")
+
+            if response.text:
+                return response.json()
+            return {}
+
+        except requests.RequestException as e:
+            _logger.error("n8n request failed: %s", e)
+            raise UserError(f"n8n connection error: {e}")
+
+    # Health endpoints
+
+    def health_check(self):
+        """Check if n8n is reachable."""
+        try:
+            response = requests.get(
+                f"{self.base_url}/healthz",
+                timeout=DEFAULT_TIMEOUT
+            )
+            return response.status_code == 200
+        except requests.RequestException:
+            # Try alternative health endpoint
+            try:
+                response = requests.get(
+                    self.base_url,
+                    timeout=DEFAULT_TIMEOUT
+                )
+                return response.status_code < 400
+            except requests.RequestException:
+                return False
+
+    # Workflow endpoints
+
+    def get_workflows(self, active_only=False):
+        """Get all workflows."""
+        params = {}
+        if active_only:
+            params["active"] = "true"
+        result = self._request("GET", "/workflows", params=params)
+        return result.get("data", []) if isinstance(result, dict) else result
+
+    def get_workflow(self, workflow_id):
+        """Get a specific workflow."""
+        return self._request("GET", f"/workflows/{workflow_id}")
+
+    def activate_workflow(self, workflow_id):
+        """Activate a workflow."""
+        return self._request("POST", f"/workflows/{workflow_id}/activate")
+
+    def deactivate_workflow(self, workflow_id):
+        """Deactivate a workflow."""
+        return self._request("POST", f"/workflows/{workflow_id}/deactivate")
+
+    # Execution endpoints
+
+    def get_executions(self, workflow_id=None, limit=20):
+        """Get workflow executions."""
+        params = {"limit": limit}
+        if workflow_id:
+            params["workflowId"] = workflow_id
+        result = self._request("GET", "/executions", params=params)
+        return result.get("data", []) if isinstance(result, dict) else result
+
+    def get_execution(self, execution_id):
+        """Get a specific execution."""
+        return self._request("GET", f"/executions/{execution_id}")
+
+    # Webhook endpoints
+
+    def trigger_webhook(self, path, payload):
+        """
+        Trigger an n8n webhook.
+
+        Args:
+            path: Webhook path (e.g., /webhook/abc123)
+            payload: Data to send
+
+        Returns:
+            dict: Webhook response
+        """
+        if not path.startswith("/"):
+            path = f"/webhook/{path}"
+
+        try:
+            response = requests.post(
+                f"{self.webhook_base_url}{path}",
+                json=payload,
+                timeout=DEFAULT_TIMEOUT,
+            )
+
+            # Log the execution
+            self.connector.env["ipai.integration.audit"].sudo().log(
+                self.connector.id,
+                "webhook_trigger",
+                f"Triggered webhook: {path}",
+                request_method="POST",
+                request_url=f"{self.webhook_base_url}{path}",
+                response_code=response.status_code,
+            )
+
+            if response.status_code >= 400:
+                _logger.warning(
+                    "n8n webhook error: %s -> %s",
+                    path, response.status_code
+                )
+                return None
+
+            if response.text:
+                return response.json()
+            return {"status": "ok"}
+
+        except requests.RequestException as e:
+            _logger.error("n8n webhook failed: %s", e)
+            return None
+
+    # Credential endpoints (for reference only - don't store actual creds)
+
+    def get_credentials(self):
+        """Get credential metadata (not actual values)."""
+        result = self._request("GET", "/credentials")
+        return result.get("data", []) if isinstance(result, dict) else result

--- a/addons/ipai/ipai_n8n_connector/static/description/icon.svg
+++ b/addons/ipai/ipai_n8n_connector/static/description/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="10" fill="#EA4B71"/>
+  <circle cx="30" cy="50" r="12" fill="#fff"/>
+  <circle cx="70" cy="50" r="12" fill="#fff"/>
+  <path d="M42 50h16" stroke="#fff" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/addons/ipai/ipai_n8n_connector/views/n8n_views.xml
+++ b/addons/ipai/ipai_n8n_connector/views/n8n_views.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Workflow Tree View -->
+    <record id="view_n8n_workflow_tree" model="ir.ui.view">
+        <field name="name">ipai.n8n.workflow.tree</field>
+        <field name="model">ipai.n8n.workflow</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="trigger_type"/>
+                <field name="active_in_n8n"/>
+                <field name="execution_count"/>
+                <field name="last_sync"/>
+                <field name="connector_id"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Workflow Form View -->
+    <record id="view_n8n_workflow_form" model="ir.ui.view">
+        <field name="name">ipai.n8n.workflow.form</field>
+        <field name="model">ipai.n8n.workflow</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button name="action_trigger" type="object" string="Trigger Workflow" class="btn-primary" invisible="trigger_type != 'webhook'"/>
+                </header>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button type="object" name="action_trigger" class="oe_stat_button" icon="fa-play" invisible="trigger_type != 'webhook'">
+                            <span>Trigger</span>
+                        </button>
+                        <button type="action" class="oe_stat_button" icon="fa-history">
+                            <field name="execution_count" widget="statinfo" string="Executions"/>
+                        </button>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="connector_id"/>
+                            <field name="n8n_workflow_id"/>
+                        </group>
+                        <group>
+                            <field name="trigger_type"/>
+                            <field name="webhook_path" invisible="trigger_type != 'webhook'"/>
+                            <field name="active_in_n8n"/>
+                            <field name="last_sync"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Executions" name="executions">
+                            <field name="execution_ids" readonly="1">
+                                <tree limit="20">
+                                    <field name="create_date"/>
+                                    <field name="trigger_source"/>
+                                    <field name="status" widget="badge" decoration-success="status == 'success'" decoration-warning="status == 'running'" decoration-danger="status == 'error'"/>
+                                    <field name="duration_ms"/>
+                                    <field name="n8n_execution_id"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Workflow Action -->
+    <record id="action_n8n_workflow" model="ir.actions.act_window">
+        <field name="name">n8n Workflows</field>
+        <field name="res_model">ipai.n8n.workflow</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <!-- Execution Tree View -->
+    <record id="view_n8n_execution_tree" model="ir.ui.view">
+        <field name="name">ipai.n8n.execution.tree</field>
+        <field name="model">ipai.n8n.execution</field>
+        <field name="arch" type="xml">
+            <tree default_order="create_date desc">
+                <field name="create_date"/>
+                <field name="workflow_id"/>
+                <field name="trigger_source"/>
+                <field name="status" widget="badge" decoration-success="status == 'success'" decoration-warning="status in ('waiting', 'running')" decoration-danger="status == 'error'" decoration-muted="status == 'canceled'"/>
+                <field name="duration_ms"/>
+                <field name="n8n_execution_id"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Execution Form View -->
+    <record id="view_n8n_execution_form" model="ir.ui.view">
+        <field name="name">ipai.n8n.execution.form</field>
+        <field name="model">ipai.n8n.execution</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="workflow_id"/>
+                            <field name="n8n_execution_id"/>
+                            <field name="trigger_source"/>
+                            <field name="status"/>
+                        </group>
+                        <group>
+                            <field name="started_at"/>
+                            <field name="finished_at"/>
+                            <field name="duration_ms"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Input Data" name="input" invisible="not input_data">
+                            <field name="input_data" widget="ace" options="{'mode': 'json'}" nolabel="1"/>
+                        </page>
+                        <page string="Output Data" name="output" invisible="not output_data">
+                            <field name="output_data" widget="ace" options="{'mode': 'json'}" nolabel="1"/>
+                        </page>
+                        <page string="Error" name="error" invisible="status != 'error'">
+                            <field name="error_message" nolabel="1"/>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Execution Action -->
+    <record id="action_n8n_execution" model="ir.actions.act_window">
+        <field name="name">Workflow Executions</field>
+        <field name="res_model">ipai.n8n.execution</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <!-- Menu items under Integrations -->
+    <menuitem id="menu_n8n"
+        name="n8n"
+        parent="ipai_integrations.menu_integrations_config"
+        sequence="70"/>
+
+    <menuitem id="menu_n8n_workflows"
+        name="Workflows"
+        parent="menu_n8n"
+        action="action_n8n_workflow"
+        sequence="10"/>
+
+    <menuitem id="menu_n8n_executions"
+        name="Executions"
+        parent="menu_n8n"
+        action="action_n8n_execution"
+        sequence="20"/>
+</odoo>

--- a/docs/integrations/FOCALBOARD.md
+++ b/docs/integrations/FOCALBOARD.md
@@ -1,0 +1,195 @@
+# Focalboard Integration
+
+## Overview
+
+Focalboard is our Kanban-style project tracking tool, providing visual task management that syncs with Odoo projects.
+
+**Production URL:** https://boards.insightpulseai.net
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Focalboard Integration                        │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│   Odoo CE                          ipai-ops-stack                │
+│   ┌────────────────────┐           ┌──────────────────────┐     │
+│   │ ipai_integrations  │           │   Focalboard Server  │     │
+│   │ - Connector config │◄─────────►│   (Docker)           │     │
+│   │ - Webhooks         │   API v2  │                      │     │
+│   └────────────────────┘           │   PostgreSQL         │     │
+│   ┌────────────────────┐           │   (shared)           │     │
+│   │ ipai_focalboard_   │           └──────────────────────┘     │
+│   │ connector          │                                        │
+│   │ - API client       │                                        │
+│   │ - Board sync       │                                        │
+│   │ - Card <-> Task    │                                        │
+│   └────────────────────┘                                        │
+│   ┌────────────────────┐                                        │
+│   │ project.task       │                                        │
+│   │ (extended)         │                                        │
+│   │ - fb_card_id       │                                        │
+│   │ - fb_sync_enabled  │                                        │
+│   └────────────────────┘                                        │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Odoo Modules
+
+### ipai_focalboard_connector
+
+Focalboard-specific functionality:
+- API v2 client (`FocalboardClient`)
+- Board synchronization
+- Card synchronization
+- Bidirectional sync with `project.task`
+
+## Configuration
+
+### 1. System Parameters
+
+Set these in Odoo (Settings > Technical > Parameters > System Parameters):
+
+| Key | Description |
+|-----|-------------|
+| `ipai_integrations.focalboard_url` | Base URL (default: https://boards.insightpulseai.net) |
+| `ipai_focalboard.token_{connector_id}` | Personal access token |
+
+### 2. Create Connector
+
+1. Go to **Integrations > Configuration > Connectors**
+2. Create new connector:
+   - Name: Focalboard (InsightPulse AI)
+   - Type: Focalboard
+   - Base URL: https://boards.insightpulseai.net
+   - Auth Type: Personal Access Token
+3. Click **Test Connection**
+4. If successful, click **Activate**
+
+### 3. Sync Boards
+
+1. Go to **Integrations > Focalboard > Boards**
+2. Click **Sync Boards** to import boards from Focalboard
+3. For each board you want to sync:
+   - Link to an Odoo Project
+   - Enable sync
+   - Choose sync direction
+
+### 4. Link Projects
+
+1. Edit a Focalboard board in Odoo
+2. Set **Linked Project** to your Odoo project
+3. Enable **Sync Enabled**
+4. Choose sync direction:
+   - Focalboard → Odoo: Cards create/update Odoo tasks
+   - Odoo → Focalboard: Tasks create/update cards
+   - Bidirectional: Two-way sync
+
+## Sync Behavior
+
+### Card → Task Mapping
+
+| Focalboard | Odoo |
+|------------|------|
+| Card title | Task name |
+| Card properties | (stored as JSON) |
+| Card ID | `fb_card_id` field |
+
+### Task → Card Mapping
+
+| Odoo | Focalboard |
+|------|------------|
+| Task name | Card title |
+| Task stage | Card property (if mapped) |
+
+## API Usage
+
+### Sync Boards
+
+```python
+connector = self.env["ipai.integration.connector"].search([
+    ("connector_type", "=", "focalboard"),
+    ("state", "=", "active"),
+], limit=1)
+
+if connector:
+    connector.fb_sync_boards()
+```
+
+### Sync Cards for a Board
+
+```python
+board = self.env["ipai.focalboard.board"].browse(board_id)
+board.action_sync_cards()
+```
+
+### Create Task from Card
+
+```python
+card = self.env["ipai.focalboard.card"].browse(card_id)
+card.action_create_odoo_task()
+```
+
+### Sync Task to Focalboard
+
+```python
+task = self.env["project.task"].browse(task_id)
+task.action_sync_to_focalboard()
+```
+
+## Data Model
+
+### ipai.focalboard.board
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fb_board_id` | Char | Focalboard board ID |
+| `title` | Char | Board title |
+| `project_id` | Many2one | Linked Odoo project |
+| `sync_enabled` | Boolean | Enable sync |
+| `sync_direction` | Selection | Sync direction |
+
+### ipai.focalboard.card
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fb_card_id` | Char | Focalboard card ID |
+| `title` | Char | Card title |
+| `task_id` | Many2one | Linked Odoo task |
+| `sync_status` | Selection | synced/pending/conflict/error |
+
+### project.task (extended)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fb_card_id` | Char | Linked Focalboard card ID |
+| `fb_sync_enabled` | Boolean | Enable sync to Focalboard |
+
+## Troubleshooting
+
+### Connection Failed
+
+1. Verify Focalboard is running: `curl https://boards.insightpulseai.net/api/v2/ping`
+2. Check token is valid
+3. Review audit logs
+
+### Sync Conflicts
+
+When the same item is modified in both systems:
+1. Card/task will be marked with `sync_status = 'conflict'`
+2. Manually resolve by choosing which version to keep
+3. Re-sync
+
+### Cards Not Appearing
+
+1. Check board is synced
+2. Verify workspace ID is correct
+3. Run sync manually
+
+## External Resources
+
+- **Runtime Deployment:** `ipai-ops-stack` repository
+- **Focalboard Docs:** https://www.focalboard.com/docs/
+- **Channel:** #project-management on chat.insightpulseai.net

--- a/docs/integrations/MATTERMOST.md
+++ b/docs/integrations/MATTERMOST.md
@@ -1,0 +1,191 @@
+# Mattermost Integration
+
+## Overview
+
+Mattermost is our team chat platform, providing secure, self-hosted messaging for InsightPulse AI operations.
+
+**Production URL:** https://chat.insightpulseai.net
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Mattermost Integration                        │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│   Odoo CE                          ipai-ops-stack                │
+│   ┌────────────────────┐           ┌──────────────────────┐     │
+│   │ ipai_integrations  │           │   Mattermost Server  │     │
+│   │ - Connector config │◄─────────►│   (Docker)           │     │
+│   │ - Webhooks         │   API v4  │                      │     │
+│   │ - Bot accounts     │           │   PostgreSQL         │     │
+│   │ - Audit logs       │           │   (shared)           │     │
+│   └────────────────────┘           └──────────────────────┘     │
+│   ┌────────────────────┐                                        │
+│   │ ipai_mattermost_   │                                        │
+│   │ connector          │                                        │
+│   │ - API client       │                                        │
+│   │ - Channel sync     │                                        │
+│   │ - Message logs     │                                        │
+│   └────────────────────┘                                        │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Odoo Modules
+
+### ipai_integrations
+
+Central admin UI for all integrations:
+- Connector configuration (URL, auth type)
+- Webhook management (incoming/outgoing)
+- Bot account management
+- OAuth app management
+- Audit logging
+
+### ipai_mattermost_connector
+
+Mattermost-specific functionality:
+- API v4 client (`MattermostClient`)
+- Channel synchronization
+- Message posting from Odoo workflows
+- Message logging
+
+## Configuration
+
+### 1. System Parameters
+
+Set these in Odoo (Settings > Technical > Parameters > System Parameters):
+
+| Key | Description |
+|-----|-------------|
+| `ipai_integrations.mattermost_url` | Base URL (default: https://chat.insightpulseai.net) |
+| `ipai_mattermost.token_{connector_id}` | Bot/Personal access token |
+
+### 2. Create Connector
+
+1. Go to **Integrations > Configuration > Connectors**
+2. Create new connector:
+   - Name: Mattermost (InsightPulse AI)
+   - Type: Mattermost
+   - Base URL: https://chat.insightpulseai.net
+   - Auth Type: Personal Access Token
+3. Click **Test Connection**
+4. If successful, click **Activate**
+
+### 3. Configure Webhooks
+
+#### Incoming Webhooks (Mattermost → Odoo)
+
+1. In Mattermost: Integrations > Incoming Webhooks > Add
+2. Copy the webhook URL
+3. In Odoo: Integrations > Webhooks > Create
+   - Direction: Incoming
+   - Endpoint Path: /integrations/mattermost/webhook
+
+#### Outgoing Webhooks (Odoo → Mattermost)
+
+1. In Odoo: Integrations > Webhooks > Create
+   - Direction: Outgoing
+   - Target URL: Your Mattermost incoming webhook URL
+   - Trigger Model: e.g., `project.task`
+   - Trigger Events: On Create / On Update
+
+### 4. Bot Configuration
+
+1. In Mattermost: Integrations > Bot Accounts > Add
+2. Copy the bot token
+3. In Odoo: Integrations > Bots > Create
+   - Connector: Mattermost
+   - Bot Username: @odoo-bot
+   - Bot Token: (paste token)
+4. Configure slash commands if needed
+
+## API Usage
+
+### Post Message from Odoo
+
+```python
+connector = self.env["ipai.integration.connector"].search([
+    ("connector_type", "=", "mattermost"),
+    ("state", "=", "active"),
+], limit=1)
+
+if connector:
+    connector.mm_post_message(
+        channel_id="abc123",
+        message="Hello from Odoo!",
+        props={"card": {"title": "Task Update"}}
+    )
+```
+
+### Sync Channels
+
+```python
+connector.action_test_connection()  # Verify connection
+self.env["ipai.mattermost.channel"].sync_channels(connector)
+```
+
+## Webhooks
+
+### Incoming Webhook Payload
+
+Mattermost sends this format to Odoo:
+
+```json
+{
+  "token": "verification_token",
+  "team_id": "team_id",
+  "team_domain": "team_name",
+  "channel_id": "channel_id",
+  "channel_name": "channel_name",
+  "timestamp": 1234567890,
+  "user_id": "user_id",
+  "user_name": "username",
+  "post_id": "post_id",
+  "text": "message text",
+  "trigger_word": "keyword"
+}
+```
+
+### Outgoing Webhook Payload
+
+Odoo sends this format to Mattermost:
+
+```json
+{
+  "text": "Message text with **Markdown** support",
+  "channel": "channel_name",
+  "username": "Odoo Bot",
+  "icon_url": "https://example.com/icon.png",
+  "props": {
+    "card": "Optional rich card content"
+  }
+}
+```
+
+## Troubleshooting
+
+### Connection Failed
+
+1. Verify Mattermost is running: `curl https://chat.insightpulseai.net/api/v4/system/ping`
+2. Check token is valid and has correct permissions
+3. Review audit logs in Odoo
+
+### Messages Not Posting
+
+1. Check bot has permission to post in channel
+2. Verify channel ID is correct
+3. Check rate limits haven't been exceeded
+
+### Webhooks Not Firing
+
+1. Verify webhook is enabled in both systems
+2. Check signing secret matches
+3. Review delivery logs in Odoo
+
+## External Resources
+
+- **Runtime Deployment:** `ipai-ops-stack` repository
+- **Mattermost API Docs:** https://api.mattermost.com/
+- **Channel:** #odoo-integrations on chat.insightpulseai.net

--- a/docs/integrations/N8N.md
+++ b/docs/integrations/N8N.md
@@ -1,0 +1,279 @@
+# n8n Integration
+
+## Overview
+
+n8n is our workflow automation platform, enabling no-code/low-code automation between Odoo and external services.
+
+**Production URL:** https://n8n.insightpulseai.net
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                       n8n Integration                            │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│   Odoo CE                          ipai-ops-stack                │
+│   ┌────────────────────┐           ┌──────────────────────┐     │
+│   │ ipai_integrations  │           │   n8n Server         │     │
+│   │ - Connector config │◄─────────►│   (Docker)           │     │
+│   │ - Webhooks         │   REST    │                      │     │
+│   └────────────────────┘           │   PostgreSQL/SQLite  │     │
+│   ┌────────────────────┐           │                      │     │
+│   │ ipai_n8n_connector │           │   Redis (queue)      │     │
+│   │ - API client       │           └──────────────────────┘     │
+│   │ - Workflow sync    │                                        │
+│   │ - Execution logs   │           ┌──────────────────────┐     │
+│   │ - Webhook handlers │           │   n8n/workflows/     │     │
+│   └────────────────────┘           │   (JSON exports)     │     │
+│                                    └──────────────────────┘     │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Odoo Modules
+
+### ipai_n8n_connector
+
+n8n-specific functionality:
+- API client (`N8nClient`)
+- Workflow synchronization
+- Execution tracking
+- Webhook callbacks from n8n
+- Odoo action triggers from n8n
+
+## Configuration
+
+### 1. System Parameters
+
+Set these in Odoo (Settings > Technical > Parameters > System Parameters):
+
+| Key | Description |
+|-----|-------------|
+| `ipai_integrations.n8n_url` | Base URL (default: https://n8n.insightpulseai.net) |
+| `ipai_n8n.api_key_{connector_id}` | n8n API key |
+
+### 2. Create Connector
+
+1. Go to **Integrations > Configuration > Connectors**
+2. Create new connector:
+   - Name: n8n (InsightPulse AI)
+   - Type: n8n
+   - Base URL: https://n8n.insightpulseai.net
+   - Auth Type: Token (API Key)
+3. Set the API key in System Parameters
+4. Click **Test Connection**
+5. If successful, click **Activate**
+
+### 3. Sync Workflows
+
+1. Go to **Integrations > n8n > Workflows**
+2. The connector auto-creates a sync action
+3. Click **Sync Workflows** to import from n8n
+4. Workflows with webhook triggers can be triggered from Odoo
+
+## Workflow Patterns
+
+### Pattern 1: Odoo → n8n (Trigger Workflow)
+
+Odoo triggers an n8n workflow via webhook:
+
+```python
+# In Odoo code
+connector = self.env["ipai.integration.connector"].search([
+    ("connector_type", "=", "n8n"),
+    ("state", "=", "active"),
+], limit=1)
+
+if connector:
+    connector.n8n_trigger_webhook(
+        "/webhook/odoo-task-created",
+        {"task_id": self.id, "name": self.name}
+    )
+```
+
+### Pattern 2: n8n → Odoo (Callback)
+
+n8n calls back to Odoo with results:
+
+**n8n HTTP Request Node:**
+- URL: `https://your-odoo.com/integrations/n8n/callback`
+- Method: POST
+- Body:
+```json
+{
+  "workflow_id": "{{ $workflow.id }}",
+  "execution_id": "{{ $execution.id }}",
+  "status": "success",
+  "data": { "result": "..." }
+}
+```
+
+### Pattern 3: n8n → Odoo (CRUD Operations)
+
+n8n can create/update Odoo records:
+
+**Create Record:**
+- URL: `https://your-odoo.com/integrations/n8n/trigger/create_record`
+- Body:
+```json
+{
+  "model": "project.task",
+  "values": {
+    "name": "New Task from n8n",
+    "project_id": 1
+  }
+}
+```
+
+**Update Record:**
+- URL: `https://your-odoo.com/integrations/n8n/trigger/update_record`
+- Body:
+```json
+{
+  "model": "project.task",
+  "record_id": 123,
+  "values": {"stage_id": 2}
+}
+```
+
+## API Usage
+
+### Sync Workflows
+
+```python
+connector = self.env["ipai.integration.connector"].search([
+    ("connector_type", "=", "n8n"),
+    ("state", "=", "active"),
+], limit=1)
+
+if connector:
+    connector.n8n_sync_workflows()
+```
+
+### Trigger Workflow
+
+```python
+workflow = self.env["ipai.n8n.workflow"].browse(workflow_id)
+workflow.action_trigger()
+```
+
+### Check Executions
+
+```python
+workflow = self.env["ipai.n8n.workflow"].browse(workflow_id)
+for execution in workflow.execution_ids[:10]:
+    print(f"{execution.create_date}: {execution.status}")
+```
+
+## Workflow Storage
+
+Workflows are stored as JSON exports in the ops repo:
+
+```
+ipai-ops-stack/
+  n8n/
+    workflows/
+      odoo-task-sync.json
+      finance-approval.json
+      ...
+    bootstrap/
+      import_workflows.sh
+```
+
+### Export Workflow
+
+1. In n8n UI: Workflow > Export
+2. Save JSON to `ipai-ops-stack/n8n/workflows/`
+3. Commit and push
+
+### Import Workflows
+
+```bash
+# In ipai-ops-stack
+./n8n/bootstrap/import_workflows.sh
+```
+
+## Data Model
+
+### ipai.n8n.workflow
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `n8n_workflow_id` | Char | n8n workflow ID |
+| `name` | Char | Workflow name |
+| `trigger_type` | Selection | webhook/schedule/manual/event |
+| `webhook_path` | Char | Webhook trigger path |
+| `active_in_n8n` | Boolean | Active in n8n |
+
+### ipai.n8n.execution
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `n8n_execution_id` | Char | n8n execution ID |
+| `workflow_id` | Many2one | Linked workflow |
+| `status` | Selection | waiting/running/success/error |
+| `input_data` | Text | Input JSON |
+| `output_data` | Text | Output JSON |
+
+## Security
+
+### Webhook Authentication
+
+For n8n → Odoo webhooks, implement signature validation:
+
+1. Set a shared secret in both systems
+2. n8n sends `X-N8N-Signature` header
+3. Odoo validates HMAC signature
+
+### Allowed Methods
+
+The `run_method` action only allows methods with these prefixes:
+- `action_` (action methods)
+- `button_` (button methods)
+- `_handle_` (handler methods)
+
+## Troubleshooting
+
+### Connection Failed
+
+1. Verify n8n is running: `curl https://n8n.insightpulseai.net/healthz`
+2. Check API key is valid
+3. Review audit logs
+
+### Workflow Not Triggering
+
+1. Verify workflow is active in n8n
+2. Check webhook URL is correct
+3. Review n8n execution history
+
+### Callback Not Received
+
+1. Check Odoo is accessible from n8n
+2. Verify callback URL is correct
+3. Check for firewall/proxy issues
+
+## Common Workflows
+
+### 1. Task Status Sync
+
+Sync task status between Odoo and external systems.
+
+### 2. Approval Notifications
+
+Send Slack/email notifications on approval requests.
+
+### 3. Document Processing
+
+Extract data from uploaded documents and update Odoo records.
+
+### 4. Scheduled Reports
+
+Generate and email reports on schedule.
+
+## External Resources
+
+- **Runtime Deployment:** `ipai-ops-stack` repository
+- **n8n Docs:** https://docs.n8n.io/
+- **Workflow Templates:** `ipai-ops-stack/n8n/workflows/`
+- **Channel:** #automations on chat.insightpulseai.net

--- a/docs/integrations/OCA_SUBTREE_MIGRATION.md
+++ b/docs/integrations/OCA_SUBTREE_MIGRATION.md
@@ -1,0 +1,170 @@
+# OCA Subtree Migration Plan
+
+## Current State
+
+The repository currently uses **git submodules** for OCA repositories at `addons/OCA/`:
+
+```
+addons/OCA/
+├── queue/
+├── server-tools/
+├── web/
+├── server-auth/
+├── server-brand/
+├── server-ux/
+├── reporting-engine/
+├── partner-contact/
+├── automation/
+├── helpdesk/
+├── dms/
+└── account-financial-reporting/
+```
+
+## Target State
+
+Migrate to **git subtree** for deterministic pinning without submodule complexity.
+
+New location: `addons/oca/` (lowercase, separate from existing placeholder)
+
+## Why Subtree Over Submodules
+
+| Aspect | Submodules | Subtree |
+|--------|------------|---------|
+| Clone behavior | Requires `--recursive` | Normal clone |
+| CI complexity | Extra init steps | No extra steps |
+| Pinning | SHA in `.gitmodules` | SHA in git history |
+| Updates | `submodule update` | `subtree pull` |
+| Code visibility | Reference only | Full code in repo |
+
+## Migration Steps
+
+### Phase 1: Prepare (Non-Breaking)
+
+1. **Document current submodule SHAs**
+   ```bash
+   git submodule status > oca-submodule-pins.txt
+   ```
+
+2. **Create subtree target directory**
+   ```bash
+   # addons/oca/ already exists as placeholder
+   # We'll add subtrees there
+   ```
+
+3. **Add subtrees for critical OCA repos**
+   ```bash
+   # Queue jobs (required for async tasks)
+   git subtree add --prefix=addons/oca/queue \
+     https://github.com/OCA/queue.git 18.0 --squash
+
+   # Server tools
+   git subtree add --prefix=addons/oca/server-tools \
+     https://github.com/OCA/server-tools.git 18.0 --squash
+
+   # Web widgets
+   git subtree add --prefix=addons/oca/web \
+     https://github.com/OCA/web.git 18.0 --squash
+   ```
+
+### Phase 2: Update Addons Path
+
+1. **Update `odoo.conf` or compose**
+   ```
+   addons_path = /mnt/extra-addons/ipai,/mnt/extra-addons/oca
+   ```
+
+2. **Test module discovery**
+   ```bash
+   docker compose exec odoo-core odoo shell -d odoo_core
+   >>> self.env['ir.module.module'].search([('name', 'like', 'queue%')])
+   ```
+
+### Phase 3: Remove Submodules (Breaking)
+
+> **Warning:** This changes git history. Coordinate with team.
+
+1. **Remove submodule entries**
+   ```bash
+   git submodule deinit -f addons/OCA/queue
+   git rm -f addons/OCA/queue
+   rm -rf .git/modules/addons/OCA/queue
+   ```
+
+2. **Clean up `.gitmodules`**
+   ```bash
+   # Remove entries for migrated repos
+   git config -f .gitmodules --remove-section submodule.addons/OCA/queue
+   ```
+
+3. **Commit the removal**
+   ```bash
+   git add .gitmodules
+   git commit -m "chore(oca): migrate queue from submodule to subtree"
+   ```
+
+### Phase 4: Update CI
+
+1. **Remove submodule init steps**
+   ```yaml
+   # Before
+   - run: git submodule update --init --recursive
+
+   # After (not needed for subtrees)
+   ```
+
+2. **Update any scripts referencing `addons/OCA/`**
+
+## Subtree Update Commands
+
+When you need to update OCA modules:
+
+```bash
+# Pull latest changes from OCA queue
+git subtree pull --prefix=addons/oca/queue \
+  https://github.com/OCA/queue.git 18.0 --squash
+
+# Pull latest changes from OCA server-tools
+git subtree pull --prefix=addons/oca/server-tools \
+  https://github.com/OCA/server-tools.git 18.0 --squash
+```
+
+## Recommended OCA Modules
+
+### Required for Integration Modules
+
+| Module | OCA Repo | Purpose |
+|--------|----------|---------|
+| `queue_job` | queue | Async job processing |
+| `queue_job_cron_jobrunner` | queue | Cron-based job runner |
+| `base_rest` | rest-framework | REST API framework |
+
+### Optional but Useful
+
+| Module | OCA Repo | Purpose |
+|--------|----------|---------|
+| `web_responsive` | web | Mobile-friendly backend |
+| `web_notify` | web | User notifications |
+| `audit_log` | server-tools | Audit trail |
+
+## Rollback Plan
+
+If issues arise during migration:
+
+1. **Keep submodules until subtrees are verified**
+2. **Test in staging environment first**
+3. **Document all pinned commits**
+
+## Timeline
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| Phase 1: Prepare | Pending | Add subtrees alongside submodules |
+| Phase 2: Update paths | Pending | Point to new location |
+| Phase 3: Remove submodules | Pending | After team coordination |
+| Phase 4: Update CI | Pending | Simplify workflows |
+
+## References
+
+- [Git Subtree Documentation](https://git-scm.com/book/en/v2/Git-Tools-Subtree-Merging)
+- [OCA Guidelines](https://github.com/OCA/maintainer-tools/blob/master/CONTRIBUTING.md)
+- [Current .gitmodules](./.gitmodules)

--- a/docs/integrations/OPS_STACK.md
+++ b/docs/integrations/OPS_STACK.md
@@ -1,0 +1,196 @@
+# Operations Stack Overview
+
+## Introduction
+
+The InsightPulse AI operations stack (`ipai-ops-stack`) hosts all runtime collaboration and automation services. These services are deployed separately from Odoo CE to maintain clean separation of concerns.
+
+## Services
+
+| Service | URL | Purpose |
+|---------|-----|---------|
+| Mattermost | https://chat.insightpulseai.net | Team chat & messaging |
+| Focalboard | https://boards.insightpulseai.net | Kanban project boards |
+| n8n | https://n8n.insightpulseai.net | Workflow automation |
+| Superset | https://superset.insightpulseai.net | Business intelligence |
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     ipai-ops-stack                               │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│   ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐           │
+│   │Mattermost│ │Focalboard│ │   n8n   │  │ Superset│           │
+│   │  :8065   │ │  :8000   │  │  :5678  │  │  :8088  │           │
+│   └────┬─────┘ └────┬─────┘  └────┬────┘  └────┬────┘           │
+│        │            │             │            │                 │
+│   ┌────┴────────────┴─────────────┴────────────┴────┐           │
+│   │              Caddy Reverse Proxy                │           │
+│   │              (TLS termination)                  │           │
+│   └────────────────────────┬────────────────────────┘           │
+│                            │                                     │
+│   ┌────────────────────────┴────────────────────────┐           │
+│   │              PostgreSQL (shared)                │           │
+│   │   - mattermost_db                               │           │
+│   │   - focalboard_db                               │           │
+│   │   - superset_db                                 │           │
+│   └─────────────────────────────────────────────────┘           │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              │ HTTPS
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                        Internet                                  │
+│   chat.insightpulseai.net                                       │
+│   boards.insightpulseai.net                                     │
+│   n8n.insightpulseai.net                                        │
+│   superset.insightpulseai.net                                   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Repository Structure
+
+```
+ipai-ops-stack/
+├── docker/
+│   ├── docker-compose.yml
+│   ├── .env.example
+│   └── .gitignore
+├── caddy/
+│   └── Caddyfile
+├── mattermost/
+│   ├── config/
+│   └── plugins/
+├── focalboard/
+│   └── config.json
+├── n8n/
+│   ├── workflows/          # Committed workflow JSONs
+│   ├── credentials/        # GITIGNORED
+│   └── bootstrap/
+│       └── import_workflows.sh
+├── superset/
+│   └── superset_config.py
+├── scripts/
+│   ├── up.sh
+│   ├── down.sh
+│   ├── logs.sh
+│   ├── healthcheck.sh
+│   ├── backup.sh
+│   └── restore.sh
+└── docs/
+    ├── SETUP.md
+    ├── DNS_TLS.md
+    ├── UPGRADE.md
+    └── BACKUP.md
+```
+
+## Odoo Integration
+
+### What Lives in odoo-ce
+
+- Connector configurations (URLs, settings)
+- Webhook endpoints (receive from ops services)
+- Outbound webhook jobs (send to ops services)
+- Audit logs
+- Data models for sync tracking
+
+### What Does NOT Live in odoo-ce
+
+- Mattermost source code
+- Focalboard source code
+- n8n source code
+- Superset source code
+- Docker images
+- Runtime configuration
+
+## Integration Modules
+
+| Module | Purpose |
+|--------|---------|
+| `ipai_integrations` | Central admin UI |
+| `ipai_mattermost_connector` | Mattermost API client |
+| `ipai_focalboard_connector` | Focalboard API client |
+| `ipai_n8n_connector` | n8n API client |
+| `ipai_superset_connector` | Superset embedding |
+
+## Health Checks
+
+### From Odoo
+
+Each connector provides a `Test Connection` button that verifies:
+- Service is reachable
+- Authentication is valid
+- API version is compatible
+
+### From Ops Stack
+
+```bash
+# Run all health checks
+./scripts/healthcheck.sh
+
+# Individual checks
+curl https://chat.insightpulseai.net/api/v4/system/ping
+curl https://boards.insightpulseai.net/api/v2/ping
+curl https://n8n.insightpulseai.net/healthz
+curl https://superset.insightpulseai.net/health
+```
+
+## Deployment
+
+### Prerequisites
+
+- Docker & Docker Compose
+- Domain with DNS configured
+- SSL certificates (Caddy handles automatically)
+
+### Quick Start
+
+```bash
+cd ipai-ops-stack
+cp docker/.env.example docker/.env
+# Edit .env with your secrets
+
+./scripts/up.sh
+./scripts/healthcheck.sh
+```
+
+### DNS Records
+
+| Subdomain | Type | Value |
+|-----------|------|-------|
+| chat | A | <droplet IP> |
+| boards | A | <droplet IP> |
+| n8n | A | <droplet IP> |
+| superset | A | <droplet IP> |
+
+## Maintenance
+
+### Backup
+
+```bash
+./scripts/backup.sh  # Creates timestamped backup
+```
+
+### Restore
+
+```bash
+./scripts/restore.sh backup-2024-01-15.tar.gz
+```
+
+### Upgrade
+
+```bash
+./scripts/down.sh
+# Edit docker-compose.yml with new image versions
+./scripts/up.sh
+./scripts/healthcheck.sh
+```
+
+## Related Documentation
+
+- [Mattermost Integration](./MATTERMOST.md)
+- [Focalboard Integration](./FOCALBOARD.md)
+- [n8n Integration](./N8N.md)
+- [Superset Integration](../ipai_superset_connector/README.md)

--- a/docs/templates/ipai-ops-stack/README.md
+++ b/docs/templates/ipai-ops-stack/README.md
@@ -1,0 +1,65 @@
+# ipai-ops-stack Template
+
+This directory contains reference templates for the `ipai-ops-stack` repository.
+
+## Overview
+
+The ops stack is a separate repository that hosts runtime collaboration and automation services:
+- Mattermost (chat.insightpulseai.net)
+- Focalboard (boards.insightpulseai.net)
+- n8n (n8n.insightpulseai.net)
+- Superset (superset.insightpulseai.net)
+
+## Usage
+
+1. Create the new repository:
+   ```bash
+   gh repo create jgtolentino/ipai-ops-stack --public
+   ```
+
+2. Copy these templates:
+   ```bash
+   cp -r docs/templates/ipai-ops-stack/* ~/ipai-ops-stack/
+   ```
+
+3. Customize `.env.example` with your values
+
+4. Deploy:
+   ```bash
+   cd ~/ipai-ops-stack
+   cp docker/.env.example docker/.env
+   # Edit docker/.env
+   ./scripts/up.sh
+   ```
+
+## File Structure
+
+```
+ipai-ops-stack/
+├── docker/
+│   ├── docker-compose.yml    # Main compose file
+│   ├── .env.example          # Environment template
+│   └── .gitignore
+├── caddy/
+│   └── Caddyfile             # Reverse proxy config
+├── scripts/
+│   ├── up.sh
+│   ├── down.sh
+│   ├── logs.sh
+│   ├── healthcheck.sh
+│   ├── backup.sh
+│   └── restore.sh
+├── n8n/
+│   └── workflows/            # Exported workflow JSONs
+└── docs/
+    ├── SETUP.md
+    └── DNS_TLS.md
+```
+
+## DNS Requirements
+
+Configure these A records pointing to your server IP:
+- chat.insightpulseai.net
+- boards.insightpulseai.net
+- n8n.insightpulseai.net
+- superset.insightpulseai.net

--- a/docs/templates/ipai-ops-stack/caddy/Caddyfile
+++ b/docs/templates/ipai-ops-stack/caddy/Caddyfile
@@ -1,0 +1,26 @@
+# ipai-ops-stack Caddyfile
+# Automatic TLS via Let's Encrypt
+
+# Mattermost
+chat.insightpulseai.net {
+    reverse_proxy mattermost:8065
+    encode gzip
+}
+
+# Focalboard
+boards.insightpulseai.net {
+    reverse_proxy focalboard:8000
+    encode gzip
+}
+
+# n8n
+n8n.insightpulseai.net {
+    reverse_proxy n8n:5678
+    encode gzip
+}
+
+# Superset
+superset.insightpulseai.net {
+    reverse_proxy superset:8088
+    encode gzip
+}

--- a/docs/templates/ipai-ops-stack/docker/.env.example
+++ b/docs/templates/ipai-ops-stack/docker/.env.example
@@ -1,0 +1,37 @@
+# ipai-ops-stack Environment Configuration
+# Copy to .env and fill in values
+
+# ===========================================
+# General
+# ===========================================
+TZ=Asia/Manila
+
+# ===========================================
+# PostgreSQL
+# ===========================================
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=CHANGE_ME_STRONG_PASSWORD
+
+# ===========================================
+# n8n
+# ===========================================
+# Generate with: openssl rand -base64 32
+N8N_ENCRYPTION_KEY=CHANGE_ME_GENERATE_KEY
+
+# ===========================================
+# Superset
+# ===========================================
+# Generate with: openssl rand -base64 42
+SUPERSET_SECRET_KEY=CHANGE_ME_GENERATE_KEY
+SUPERSET_ADMIN_USER=admin
+SUPERSET_ADMIN_EMAIL=admin@insightpulseai.net
+SUPERSET_ADMIN_PASSWORD=CHANGE_ME_ADMIN_PASSWORD
+
+# ===========================================
+# Domain Configuration
+# ===========================================
+# Update these if using different domains
+MATTERMOST_DOMAIN=chat.insightpulseai.net
+FOCALBOARD_DOMAIN=boards.insightpulseai.net
+N8N_DOMAIN=n8n.insightpulseai.net
+SUPERSET_DOMAIN=superset.insightpulseai.net

--- a/docs/templates/ipai-ops-stack/docker/.gitignore
+++ b/docs/templates/ipai-ops-stack/docker/.gitignore
@@ -1,0 +1,8 @@
+# Environment file with secrets
+.env
+
+# Backup files
+*.tar.gz
+*.sql
+*.dump
+backups/

--- a/docs/templates/ipai-ops-stack/docker/docker-compose.yml
+++ b/docs/templates/ipai-ops-stack/docker/docker-compose.yml
@@ -1,0 +1,223 @@
+# ipai-ops-stack Docker Compose
+# Mattermost + Focalboard + n8n + Superset
+#
+# Usage:
+#   cp .env.example .env
+#   docker compose up -d
+
+version: "3.8"
+
+services:
+  # ===========================================
+  # Reverse Proxy (Caddy - automatic TLS)
+  # ===========================================
+  caddy:
+    image: caddy:2-alpine
+    container_name: caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ../caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - mattermost
+      - focalboard
+      - n8n
+      - superset
+    networks:
+      - ops_network
+
+  # ===========================================
+  # PostgreSQL (shared database server)
+  # ===========================================
+  postgres:
+    image: postgres:16-alpine
+    container_name: postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_MULTIPLE_DATABASES: mattermost,focalboard,superset
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./init-db.sh:/docker-entrypoint-initdb.d/init-db.sh:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - ops_network
+
+  # ===========================================
+  # Mattermost
+  # ===========================================
+  mattermost:
+    image: mattermost/mattermost-team-edition:9.5
+    container_name: mattermost
+    restart: unless-stopped
+    environment:
+      MM_SQLSETTINGS_DRIVERNAME: postgres
+      MM_SQLSETTINGS_DATASOURCE: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/mattermost?sslmode=disable
+      MM_SERVICESETTINGS_SITEURL: https://chat.insightpulseai.net
+      MM_SERVICESETTINGS_LISTENADDRESS: :8065
+    volumes:
+      - mattermost_data:/mattermost/data
+      - mattermost_logs:/mattermost/logs
+      - mattermost_config:/mattermost/config
+      - mattermost_plugins:/mattermost/plugins
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8065/api/v4/system/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - ops_network
+
+  # ===========================================
+  # Focalboard
+  # ===========================================
+  focalboard:
+    image: mattermost/focalboard:7.11
+    container_name: focalboard
+    restart: unless-stopped
+    environment:
+      FOCALBOARD_PORT: 8000
+      FOCALBOARD_DBTYPE: postgres
+      FOCALBOARD_DBCONFIG: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/focalboard?sslmode=disable
+      FOCALBOARD_SERVERROOT: https://boards.insightpulseai.net
+    volumes:
+      - focalboard_data:/opt/focalboard/data
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v2/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - ops_network
+
+  # ===========================================
+  # n8n
+  # ===========================================
+  n8n:
+    image: n8nio/n8n:1.25.1
+    container_name: n8n
+    restart: unless-stopped
+    environment:
+      N8N_HOST: n8n.insightpulseai.net
+      N8N_PROTOCOL: https
+      N8N_PORT: 5678
+      WEBHOOK_URL: https://n8n.insightpulseai.net/
+      GENERIC_TIMEZONE: ${TZ:-Asia/Manila}
+      N8N_ENCRYPTION_KEY: ${N8N_ENCRYPTION_KEY}
+    volumes:
+      - n8n_data:/home/node/.n8n
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5678/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - ops_network
+
+  # ===========================================
+  # Superset
+  # ===========================================
+  superset-redis:
+    image: redis:7-alpine
+    container_name: superset-redis
+    restart: unless-stopped
+    volumes:
+      - superset_redis:/data
+    networks:
+      - ops_network
+
+  superset:
+    image: apache/superset:3.1.0
+    container_name: superset
+    restart: unless-stopped
+    environment:
+      SUPERSET_SECRET_KEY: ${SUPERSET_SECRET_KEY}
+      SQLALCHEMY_DATABASE_URI: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/superset
+      REDIS_HOST: superset-redis
+      REDIS_PORT: 6379
+    volumes:
+      - superset_home:/app/superset_home
+    depends_on:
+      postgres:
+        condition: service_healthy
+      superset-redis:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8088/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - ops_network
+
+  superset-worker:
+    image: apache/superset:3.1.0
+    container_name: superset-worker
+    restart: unless-stopped
+    command: celery --app=superset.tasks.celery_app:app worker -O fair -l INFO
+    environment:
+      SUPERSET_SECRET_KEY: ${SUPERSET_SECRET_KEY}
+      SQLALCHEMY_DATABASE_URI: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/superset
+      REDIS_HOST: superset-redis
+      REDIS_PORT: 6379
+    depends_on:
+      - superset
+      - superset-redis
+    networks:
+      - ops_network
+
+  # Superset init (run once)
+  superset-init:
+    image: apache/superset:3.1.0
+    container_name: superset-init
+    command: >
+      /bin/bash -lc "
+      superset db upgrade &&
+      superset init &&
+      (superset fab create-admin
+        --username ${SUPERSET_ADMIN_USER:-admin}
+        --firstname Admin --lastname User
+        --email ${SUPERSET_ADMIN_EMAIL:-admin@insightpulseai.net}
+        --password ${SUPERSET_ADMIN_PASSWORD} || true)
+      "
+    environment:
+      SUPERSET_SECRET_KEY: ${SUPERSET_SECRET_KEY}
+      SQLALCHEMY_DATABASE_URI: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/superset
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+    networks:
+      - ops_network
+
+networks:
+  ops_network:
+    driver: bridge
+
+volumes:
+  caddy_data:
+  caddy_config:
+  postgres_data:
+  mattermost_data:
+  mattermost_logs:
+  mattermost_config:
+  mattermost_plugins:
+  focalboard_data:
+  n8n_data:
+  superset_redis:
+  superset_home:

--- a/docs/templates/ipai-ops-stack/scripts/backup.sh
+++ b/docs/templates/ipai-ops-stack/scripts/backup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Backup all databases and volumes
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+BACKUP_DIR="$PROJECT_DIR/backups"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+
+mkdir -p "$BACKUP_DIR"
+
+echo "=== ipai-ops-stack Backup ==="
+echo "Timestamp: $TIMESTAMP"
+echo ""
+
+cd "$PROJECT_DIR/docker"
+
+# Backup PostgreSQL databases
+echo "Backing up PostgreSQL databases..."
+for db in mattermost focalboard superset; do
+    echo "  - $db"
+    docker compose exec -T postgres pg_dump -U postgres "$db" > "$BACKUP_DIR/${db}_${TIMESTAMP}.sql"
+done
+
+# Backup n8n data
+echo "Backing up n8n data..."
+docker compose exec -T n8n tar czf - -C /home/node .n8n > "$BACKUP_DIR/n8n_${TIMESTAMP}.tar.gz"
+
+# Create combined archive
+echo "Creating combined archive..."
+cd "$BACKUP_DIR"
+tar czf "backup_${TIMESTAMP}.tar.gz" \
+    mattermost_${TIMESTAMP}.sql \
+    focalboard_${TIMESTAMP}.sql \
+    superset_${TIMESTAMP}.sql \
+    n8n_${TIMESTAMP}.tar.gz
+
+# Clean up individual files
+rm -f mattermost_${TIMESTAMP}.sql focalboard_${TIMESTAMP}.sql superset_${TIMESTAMP}.sql n8n_${TIMESTAMP}.tar.gz
+
+echo ""
+echo "Backup complete: $BACKUP_DIR/backup_${TIMESTAMP}.tar.gz"

--- a/docs/templates/ipai-ops-stack/scripts/down.sh
+++ b/docs/templates/ipai-ops-stack/scripts/down.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Stop the ops stack
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo "Stopping ipai-ops-stack..."
+
+cd "$PROJECT_DIR/docker"
+docker compose down
+
+echo "Stack stopped."

--- a/docs/templates/ipai-ops-stack/scripts/healthcheck.sh
+++ b/docs/templates/ipai-ops-stack/scripts/healthcheck.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Health check for all services
+
+set -e
+
+echo "=== ipai-ops-stack Health Check ==="
+echo ""
+
+PASS=0
+FAIL=0
+
+check_service() {
+    local name="$1"
+    local url="$2"
+    local expected="${3:-200}"
+
+    printf "%-20s " "$name:"
+
+    response=$(curl -s -o /dev/null -w "%{http_code}" "$url" 2>/dev/null || echo "000")
+
+    if [ "$response" = "$expected" ]; then
+        echo "✓ OK ($response)"
+        ((PASS++))
+    else
+        echo "✗ FAIL (got $response, expected $expected)"
+        ((FAIL++))
+    fi
+}
+
+# Check each service
+check_service "Mattermost" "https://chat.insightpulseai.net/api/v4/system/ping"
+check_service "Focalboard" "https://boards.insightpulseai.net/api/v2/ping"
+check_service "n8n" "https://n8n.insightpulseai.net/healthz"
+check_service "Superset" "https://superset.insightpulseai.net/health"
+
+echo ""
+echo "=== Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/docs/templates/ipai-ops-stack/scripts/logs.sh
+++ b/docs/templates/ipai-ops-stack/scripts/logs.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# View logs for the ops stack
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_DIR/docker"
+
+# If service name provided, show that service
+if [ -n "$1" ]; then
+    docker compose logs -f --tail=100 "$1"
+else
+    docker compose logs -f --tail=100
+fi

--- a/docs/templates/ipai-ops-stack/scripts/restore.sh
+++ b/docs/templates/ipai-ops-stack/scripts/restore.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Restore from backup
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <backup_file.tar.gz>"
+    exit 1
+fi
+
+BACKUP_FILE="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+TEMP_DIR=$(mktemp -d)
+
+if [ ! -f "$BACKUP_FILE" ]; then
+    echo "Error: Backup file not found: $BACKUP_FILE"
+    exit 1
+fi
+
+echo "=== ipai-ops-stack Restore ==="
+echo "Backup file: $BACKUP_FILE"
+echo ""
+
+# Extract backup
+echo "Extracting backup..."
+tar xzf "$BACKUP_FILE" -C "$TEMP_DIR"
+
+cd "$PROJECT_DIR/docker"
+
+# Restore PostgreSQL databases
+echo "Restoring PostgreSQL databases..."
+for db in mattermost focalboard superset; do
+    if [ -f "$TEMP_DIR/${db}_*.sql" ]; then
+        echo "  - $db"
+        docker compose exec -T postgres psql -U postgres "$db" < "$TEMP_DIR/${db}_"*.sql
+    fi
+done
+
+# Restore n8n data
+if ls "$TEMP_DIR"/n8n_*.tar.gz 1> /dev/null 2>&1; then
+    echo "Restoring n8n data..."
+    docker compose exec -T n8n tar xzf - -C /home/node < "$TEMP_DIR"/n8n_*.tar.gz
+fi
+
+# Clean up
+rm -rf "$TEMP_DIR"
+
+echo ""
+echo "Restore complete. You may need to restart services:"
+echo "  ./scripts/down.sh && ./scripts/up.sh"

--- a/docs/templates/ipai-ops-stack/scripts/up.sh
+++ b/docs/templates/ipai-ops-stack/scripts/up.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Start the ops stack
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo "Starting ipai-ops-stack..."
+
+cd "$PROJECT_DIR/docker"
+
+# Check for .env file
+if [ ! -f .env ]; then
+    echo "Error: .env file not found. Copy .env.example to .env and configure."
+    exit 1
+fi
+
+# Start services
+docker compose up -d
+
+echo ""
+echo "Stack started. Checking health..."
+sleep 10
+
+"$SCRIPT_DIR/healthcheck.sh"

--- a/infra/links/collab-stack.md
+++ b/infra/links/collab-stack.md
@@ -1,0 +1,65 @@
+# Collaboration Stack Links
+
+> This file contains pointers to the external operations stack.
+> No secrets should be stored here.
+
+## Repository
+
+**GitHub:** https://github.com/jgtolentino/ipai-ops-stack
+
+## Production URLs
+
+| Service | URL | Status Page |
+|---------|-----|-------------|
+| Mattermost | https://chat.insightpulseai.net | /api/v4/system/ping |
+| Focalboard | https://boards.insightpulseai.net | /api/v2/ping |
+| n8n | https://n8n.insightpulseai.net | /healthz |
+| Superset | https://superset.insightpulseai.net | /health |
+
+## Infrastructure
+
+- **Cloud Provider:** DigitalOcean
+- **Region:** SGP1 (Singapore)
+- **Reverse Proxy:** Caddy (automatic TLS)
+- **Database:** PostgreSQL 16 (shared instance)
+
+## Deployment
+
+The ops stack is deployed via Docker Compose on a DigitalOcean droplet.
+
+See the `ipai-ops-stack` repository for:
+- `docker/docker-compose.yml` - Service definitions
+- `scripts/up.sh` - Start stack
+- `scripts/down.sh` - Stop stack
+- `scripts/healthcheck.sh` - Verify all services
+- `scripts/backup.sh` - Database backups
+
+## Odoo Integration
+
+Integration modules in this repository:
+
+| Module | Location |
+|--------|----------|
+| `ipai_integrations` | `addons/ipai/ipai_integrations/` |
+| `ipai_mattermost_connector` | `addons/ipai/ipai_mattermost_connector/` |
+| `ipai_focalboard_connector` | `addons/ipai/ipai_focalboard_connector/` |
+| `ipai_n8n_connector` | `addons/ipai/ipai_n8n_connector/` |
+| `ipai_superset_connector` | `addons/ipai/ipai_superset_connector/` |
+
+## Configuration
+
+System parameters to configure in Odoo:
+
+```
+ipai_integrations.mattermost_url = https://chat.insightpulseai.net
+ipai_integrations.focalboard_url = https://boards.insightpulseai.net
+ipai_integrations.n8n_url = https://n8n.insightpulseai.net
+```
+
+Authentication tokens should be stored in secure system parameters
+(not committed to any repository).
+
+## Contacts
+
+- **Ops Channel:** #infrastructure on chat.insightpulseai.net
+- **Integration Channel:** #odoo-integrations on chat.insightpulseai.net


### PR DESCRIPTION
Add Odoo integration modules for external collaboration services (Mattermost, Focalboard, n8n) without vendoring their source code.

New modules:
- ipai_integrations: Central admin UI for webhooks, bots, OAuth apps
- ipai_mattermost_connector: API client for Mattermost chat
- ipai_focalboard_connector: API client for Focalboard boards
- ipai_n8n_connector: API client for n8n workflows

Architecture:
- Runtime services (Mattermost, Focalboard, n8n, Superset) run in separate ipai-ops-stack repo with Docker Compose
- Only integration code lives in odoo-ce
- No git submodules for collab tools
- OCA subtree migration plan documented

Documentation:
- docs/integrations/ with guides for each service
- docs/templates/ipai-ops-stack/ with reference compose files
- infra/links/collab-stack.md with service URLs

This follows the principle:
- Runtime products → separate ops repo/service
- Odoo integration code → addons/ipai/
- OCA addons → git subtree pinned inside odoo-ce