### PR TITLE
feat(vscode): add Odoo Language Server and ruff tooling

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,11 +6,12 @@
     "ms-azuretools.vscode-docker",
     "ms-python.python",
     "ms-python.vscode-pylance",
-    "ms-python.black-formatter",
+    "charliermarsh.ruff",
     "redhat.vscode-yaml",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
     "editorconfig.editorconfig",
-    "mhutchie.git-graph"
+    "mhutchie.git-graph",
+    "odoo.odoo-language-server"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,10 +9,19 @@
   "files.insertFinalNewline": true,
   "editor.formatOnSave": true,
   "[python]": {
-    "editor.defaultFormatter": "ms-python.black-formatter"
+    "editor.defaultFormatter": "charliermarsh.ruff"
   },
-  "python.formatting.provider": "none",
+  "ruff.enable": true,
+  "ruff.format.args": ["--config", "pyproject.toml"],
   "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.autoSearchPaths": true,
+  "python.analysis.extraPaths": [
+    "odoo",
+    "addons",
+    "addons/ipai",
+    "addons/OCA",
+    "addons/oca"
+  ],
   "[yaml]": {
     "editor.defaultFormatter": "redhat.vscode-yaml"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP"]
+ignore = ["E501"]
+
+[tool.ruff.format]
+quote-style = "double"


### PR DESCRIPTION
- Add odoo.odoo-language-server for ORM autocomplete and jump-to-definition
- Replace black-formatter with ruff for faster linting and formatting
- Configure Python extraPaths for addon indexing (odoo, addons, OCA)
- Add root pyproject.toml with ruff lint/format settings