### PR TITLE
Fix RPC error in Odoo module system

### DIFF
--- a/addons/ipai_grid_view/__manifest__.py
+++ b/addons/ipai_grid_view/__manifest__.py
@@ -35,9 +35,9 @@ Technical Stack:
     "data": [
         "security/security.xml",
         "security/ir.model.access.csv",
-        "views/grid_view_views.xml",
         "views/grid_column_views.xml",
         "views/grid_filter_views.xml",
+        "views/grid_view_views.xml",
         "data/demo_data.xml",
     ],
     "assets": {


### PR DESCRIPTION
The grid_view_views.xml was being loaded before grid_column_views.xml, but it references action_ipai_grid_column which is defined in grid_column_views.xml. This caused a ValueError when trying to install the module:
  External ID not found: ipai_grid_view.action_ipai_grid_column

Reordered the data files so dependencies are loaded first.