### PR TITLE
feat(kg): add Knowledge Graph spec bundle and Supabase migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ temp/
 !infra/lakehouse/**/*.sql
 !tools/audit/*.sql
 !scripts/sql/*.sql
+!db/migrations/*.sql
 
 # Parity audit generated files
 parity_report.json

--- a/db/migrations/20260109_KG.sql
+++ b/db/migrations/20260109_KG.sql
@@ -1,0 +1,530 @@
+-- Migration: Knowledge Graph Schema
+-- Purpose: Create unified organizational memory layer with graph, FTS, and vector search
+-- Target: Supabase (external managed database with pgvector)
+--
+-- This schema implements the Knowledge Graph (KG) system for:
+-- - Infra map: DigitalOcean droplets, domains, DNS records, services
+-- - Code map: GitHub repos, branches, PRs, issues, workflows, Odoo modules
+-- - Why map: Docs, decisions, chat threads linked to entities
+--
+-- Environment: Supabase project spdtwktxdalcfigzeqrz
+
+-- ============================================================================
+-- Extensions
+-- ============================================================================
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- ============================================================================
+-- Schema: kg (Knowledge Graph)
+-- ============================================================================
+
+CREATE SCHEMA IF NOT EXISTS kg;
+
+GRANT USAGE ON SCHEMA kg TO authenticated;
+GRANT USAGE ON SCHEMA kg TO service_role;
+
+-- ============================================================================
+-- kg.nodes - Graph Nodes
+-- ============================================================================
+-- Core entity storage for all organizational objects.
+-- Each node has a type (e.g., Repo, Droplet, OdooModule) and a stable key.
+--
+-- Key patterns by type:
+--   Org:        org:<name>
+--   Repo:       repo:<org>/<name>
+--   Branch:     branch:<org>/<repo>:<name>
+--   PR:         pr:<org>/<repo>#<num>
+--   Issue:      issue:<org>/<repo>#<num>
+--   Workflow:   workflow:<org>/<repo>:<name>
+--   Run:        run:<org>/<repo>:<run_id>
+--   Host:       droplet:<id>
+--   Domain:     domain:<fqdn>
+--   DNSRecord:  dns:<domain>:<type>:<name>
+--   Service:    service:<name> or do-app:<id>
+--   OdooModule: odoo:module:<technical_name>
+--   OdooModel:  odoo:model:<model_name>
+--   OdooView:   odoo:view:<xml_id>
+--   OCARepo:    oca:repo:<name>
+--   OCAModule:  oca:module:<name>
+--   Doc:        doc:<source>:<ref>
+--   Decision:   adr:<slug>
+--   ChatThread: chat:<source>:<thread_id>
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS kg.nodes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Node classification
+    type TEXT NOT NULL,                 -- e.g., Repo, Host, OdooModule, Doc
+    key TEXT NOT NULL,                  -- Stable unique key within type
+
+    -- Human-readable info
+    title TEXT,                         -- Display name
+
+    -- Flexible metadata
+    data JSONB NOT NULL DEFAULT '{}'::JSONB,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Unique constraint: one node per (type, key)
+    UNIQUE (type, key)
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS kg_nodes_type_idx ON kg.nodes(type);
+CREATE INDEX IF NOT EXISTS kg_nodes_key_idx ON kg.nodes(key);
+CREATE INDEX IF NOT EXISTS kg_nodes_data_gin ON kg.nodes USING gin(data);
+
+-- ============================================================================
+-- kg.edges - Graph Edges (Relationships)
+-- ============================================================================
+-- Typed relationships between nodes with optional weight and metadata.
+--
+-- Edge types:
+--   OWNS:       Org → Repo, Module → Model/View
+--   DEPLOYS_TO: Repo → Service/Host
+--   DEPENDS_ON: Module → Module
+--   IMPLEMENTS: PR → Issue
+--   REFERENCES: Doc → Repo/Module
+--   RESOLVES:   Issue → Incident
+--   CONFIGURES: DNSRecord → Service/Host
+--   MENTIONS:   Doc/ChatThread → AnyNode (with confidence score in data)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS kg.edges (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Source and destination nodes
+    src_id UUID NOT NULL REFERENCES kg.nodes(id) ON DELETE CASCADE,
+    dst_id UUID NOT NULL REFERENCES kg.nodes(id) ON DELETE CASCADE,
+
+    -- Relationship type
+    type TEXT NOT NULL,                 -- e.g., DEPENDS_ON, DEPLOYS_TO
+
+    -- Optional weight for ranking/scoring
+    weight DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+
+    -- Flexible metadata
+    data JSONB NOT NULL DEFAULT '{}'::JSONB,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Unique constraint: one edge per (src, dst, type)
+    UNIQUE (src_id, dst_id, type)
+);
+
+-- Indexes for graph traversal
+CREATE INDEX IF NOT EXISTS kg_edges_src_idx ON kg.edges(src_id);
+CREATE INDEX IF NOT EXISTS kg_edges_dst_idx ON kg.edges(dst_id);
+CREATE INDEX IF NOT EXISTS kg_edges_type_idx ON kg.edges(type);
+CREATE INDEX IF NOT EXISTS kg_edges_src_type_idx ON kg.edges(src_id, type);
+CREATE INDEX IF NOT EXISTS kg_edges_dst_type_idx ON kg.edges(dst_id, type);
+
+-- ============================================================================
+-- kg.docs - Documents (Chat, README, PRD, ADR, logs)
+-- ============================================================================
+-- Content storage for RAG retrieval. Each doc has:
+-- - Source identification (github, slack, gdrive, chatgpt, odoo, do)
+-- - Full-text search via tsvector
+-- - Vector embedding for semantic search (1536 dims for OpenAI)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS kg.docs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Source identification
+    source TEXT NOT NULL,               -- github, slack, gdrive, chatgpt, odoo, do
+    source_ref TEXT NOT NULL,           -- URL, message ID, file ID
+
+    -- Content
+    title TEXT,
+    body TEXT NOT NULL,
+
+    -- Flexible metadata
+    meta JSONB NOT NULL DEFAULT '{}'::JSONB,
+
+    -- Full-text search vector (auto-computed via trigger)
+    tsv TSVECTOR,
+
+    -- Embedding for semantic search (OpenAI text-embedding-3-small: 1536 dims)
+    embedding vector(1536),
+
+    -- Timestamps
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Unique constraint: one doc per (source, source_ref)
+    UNIQUE (source, source_ref)
+);
+
+-- Full-text search index
+CREATE INDEX IF NOT EXISTS kg_docs_tsv_gin ON kg.docs USING gin(tsv);
+
+-- Vector similarity index (IVFFlat for balance of speed/accuracy)
+-- lists = 100 is appropriate for < 1M vectors
+CREATE INDEX IF NOT EXISTS kg_docs_embedding_ivf
+    ON kg.docs USING ivfflat (embedding vector_cosine_ops)
+    WITH (lists = 100);
+
+-- Metadata index
+CREATE INDEX IF NOT EXISTS kg_docs_meta_gin ON kg.docs USING gin(meta);
+CREATE INDEX IF NOT EXISTS kg_docs_source_idx ON kg.docs(source);
+
+-- ============================================================================
+-- Trigger: Auto-update tsvector for full-text search
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION kg.docs_tsv_update()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.tsv :=
+        setweight(to_tsvector('english', COALESCE(NEW.title, '')), 'A') ||
+        setweight(to_tsvector('english', COALESCE(NEW.body, '')), 'B');
+    RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS trg_kg_docs_tsv ON kg.docs;
+CREATE TRIGGER trg_kg_docs_tsv
+    BEFORE INSERT OR UPDATE ON kg.docs
+    FOR EACH ROW
+    EXECUTE FUNCTION kg.docs_tsv_update();
+
+-- ============================================================================
+-- kg.mentions - Links between docs and nodes
+-- ============================================================================
+-- Connects documents to the entities they mention.
+-- Used for knowledge graph enrichment and context expansion in RAG.
+--
+-- Kinds:
+--   MENTIONS:   Generic reference
+--   DEFINES:    Doc defines the entity
+--   DECIDES:    Doc contains decision about entity (ADR)
+--   CONFIGURES: Doc configures the entity
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS kg.mentions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- References
+    doc_id UUID NOT NULL REFERENCES kg.docs(id) ON DELETE CASCADE,
+    node_id UUID NOT NULL REFERENCES kg.nodes(id) ON DELETE CASCADE,
+
+    -- Mention classification
+    kind TEXT NOT NULL DEFAULT 'MENTIONS',  -- MENTIONS, DEFINES, DECIDES, CONFIGURES
+
+    -- Confidence score for extracted mentions (0.0 - 1.0)
+    confidence DOUBLE PRECISION NOT NULL DEFAULT 0.5,
+
+    -- Flexible metadata
+    meta JSONB NOT NULL DEFAULT '{}'::JSONB,
+
+    -- Unique constraint: one mention per (doc, node, kind)
+    UNIQUE (doc_id, node_id, kind)
+);
+
+-- Indexes for expansion queries
+CREATE INDEX IF NOT EXISTS kg_mentions_doc_idx ON kg.mentions(doc_id);
+CREATE INDEX IF NOT EXISTS kg_mentions_node_idx ON kg.mentions(node_id);
+CREATE INDEX IF NOT EXISTS kg_mentions_kind_idx ON kg.mentions(kind);
+
+-- ============================================================================
+-- RPC: kg.search_docs - Full-text search
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION kg.search_docs(
+    p_query TEXT,
+    p_limit INT DEFAULT 10
+) RETURNS TABLE (
+    id UUID,
+    source TEXT,
+    source_ref TEXT,
+    title TEXT,
+    body TEXT,
+    rank REAL
+) LANGUAGE sql STABLE AS $$
+    SELECT
+        d.id,
+        d.source,
+        d.source_ref,
+        d.title,
+        d.body,
+        ts_rank(d.tsv, websearch_to_tsquery('english', p_query)) AS rank
+    FROM kg.docs d
+    WHERE d.tsv @@ websearch_to_tsquery('english', p_query)
+    ORDER BY rank DESC
+    LIMIT p_limit;
+$$;
+
+-- ============================================================================
+-- RPC: kg.search_docs_vector - Vector similarity search
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION kg.search_docs_vector(
+    p_embedding vector(1536),
+    p_limit INT DEFAULT 10
+) RETURNS TABLE (
+    id UUID,
+    source TEXT,
+    source_ref TEXT,
+    title TEXT,
+    body TEXT,
+    similarity FLOAT
+) LANGUAGE sql STABLE AS $$
+    SELECT
+        d.id,
+        d.source,
+        d.source_ref,
+        d.title,
+        d.body,
+        1 - (d.embedding <=> p_embedding) AS similarity
+    FROM kg.docs d
+    WHERE d.embedding IS NOT NULL
+    ORDER BY d.embedding <=> p_embedding
+    LIMIT p_limit;
+$$;
+
+-- ============================================================================
+-- RPC: kg.get_neighbors - Graph traversal (1-hop)
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION kg.get_neighbors(
+    p_node_id UUID,
+    p_direction TEXT DEFAULT 'both',  -- 'out', 'in', 'both'
+    p_edge_type TEXT DEFAULT NULL     -- Filter by edge type (optional)
+) RETURNS TABLE (
+    edge_id UUID,
+    edge_type TEXT,
+    neighbor_id UUID,
+    neighbor_type TEXT,
+    neighbor_key TEXT,
+    neighbor_title TEXT,
+    direction TEXT
+) LANGUAGE sql STABLE AS $$
+    -- Outgoing edges
+    SELECT
+        e.id AS edge_id,
+        e.type AS edge_type,
+        n.id AS neighbor_id,
+        n.type AS neighbor_type,
+        n.key AS neighbor_key,
+        n.title AS neighbor_title,
+        'out' AS direction
+    FROM kg.edges e
+    JOIN kg.nodes n ON n.id = e.dst_id
+    WHERE e.src_id = p_node_id
+      AND (p_direction IN ('out', 'both'))
+      AND (p_edge_type IS NULL OR e.type = p_edge_type)
+
+    UNION ALL
+
+    -- Incoming edges
+    SELECT
+        e.id AS edge_id,
+        e.type AS edge_type,
+        n.id AS neighbor_id,
+        n.type AS neighbor_type,
+        n.key AS neighbor_key,
+        n.title AS neighbor_title,
+        'in' AS direction
+    FROM kg.edges e
+    JOIN kg.nodes n ON n.id = e.src_id
+    WHERE e.dst_id = p_node_id
+      AND (p_direction IN ('in', 'both'))
+      AND (p_edge_type IS NULL OR e.type = p_edge_type);
+$$;
+
+-- ============================================================================
+-- RPC: kg.get_node_docs - Get docs mentioning a node
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION kg.get_node_docs(
+    p_node_id UUID,
+    p_limit INT DEFAULT 10
+) RETURNS TABLE (
+    doc_id UUID,
+    source TEXT,
+    source_ref TEXT,
+    title TEXT,
+    mention_kind TEXT,
+    confidence FLOAT
+) LANGUAGE sql STABLE AS $$
+    SELECT
+        d.id AS doc_id,
+        d.source,
+        d.source_ref,
+        d.title,
+        m.kind AS mention_kind,
+        m.confidence
+    FROM kg.mentions m
+    JOIN kg.docs d ON d.id = m.doc_id
+    WHERE m.node_id = p_node_id
+    ORDER BY m.confidence DESC, d.created_at DESC
+    LIMIT p_limit;
+$$;
+
+-- ============================================================================
+-- RPC: kg.upsert_node - Idempotent node upsert
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION kg.upsert_node(
+    p_type TEXT,
+    p_key TEXT,
+    p_title TEXT DEFAULT NULL,
+    p_data JSONB DEFAULT '{}'::JSONB
+) RETURNS UUID LANGUAGE plpgsql AS $$
+DECLARE
+    v_id UUID;
+BEGIN
+    INSERT INTO kg.nodes (type, key, title, data, updated_at)
+    VALUES (p_type, p_key, p_title, p_data, NOW())
+    ON CONFLICT (type, key) DO UPDATE SET
+        title = COALESCE(EXCLUDED.title, kg.nodes.title),
+        data = kg.nodes.data || EXCLUDED.data,
+        updated_at = NOW()
+    RETURNING id INTO v_id;
+
+    RETURN v_id;
+END $$;
+
+-- ============================================================================
+-- RPC: kg.upsert_edge - Idempotent edge upsert
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION kg.upsert_edge(
+    p_src_id UUID,
+    p_dst_id UUID,
+    p_type TEXT,
+    p_weight DOUBLE PRECISION DEFAULT 1.0,
+    p_data JSONB DEFAULT '{}'::JSONB
+) RETURNS UUID LANGUAGE plpgsql AS $$
+DECLARE
+    v_id UUID;
+BEGIN
+    INSERT INTO kg.edges (src_id, dst_id, type, weight, data)
+    VALUES (p_src_id, p_dst_id, p_type, p_weight, p_data)
+    ON CONFLICT (src_id, dst_id, type) DO UPDATE SET
+        weight = EXCLUDED.weight,
+        data = kg.edges.data || EXCLUDED.data
+    RETURNING id INTO v_id;
+
+    RETURN v_id;
+END $$;
+
+-- ============================================================================
+-- RLS Policies
+-- ============================================================================
+-- For now, allow authenticated users full read access.
+-- Service role has full access for ingestion.
+-- TODO: Add org-based isolation if multi-tenant.
+-- ============================================================================
+
+ALTER TABLE kg.nodes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE kg.edges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE kg.docs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE kg.mentions ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users can read everything
+CREATE POLICY "Authenticated read nodes" ON kg.nodes
+    FOR SELECT TO authenticated USING (true);
+
+CREATE POLICY "Authenticated read edges" ON kg.edges
+    FOR SELECT TO authenticated USING (true);
+
+CREATE POLICY "Authenticated read docs" ON kg.docs
+    FOR SELECT TO authenticated USING (true);
+
+CREATE POLICY "Authenticated read mentions" ON kg.mentions
+    FOR SELECT TO authenticated USING (true);
+
+-- Service role has full access (for ingestion)
+CREATE POLICY "Service role full access nodes" ON kg.nodes
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY "Service role full access edges" ON kg.edges
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY "Service role full access docs" ON kg.docs
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY "Service role full access mentions" ON kg.mentions
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ============================================================================
+-- Grants
+-- ============================================================================
+
+GRANT SELECT ON kg.nodes TO authenticated;
+GRANT SELECT ON kg.edges TO authenticated;
+GRANT SELECT ON kg.docs TO authenticated;
+GRANT SELECT ON kg.mentions TO authenticated;
+
+GRANT ALL ON kg.nodes TO service_role;
+GRANT ALL ON kg.edges TO service_role;
+GRANT ALL ON kg.docs TO service_role;
+GRANT ALL ON kg.mentions TO service_role;
+
+GRANT EXECUTE ON FUNCTION kg.search_docs(TEXT, INT) TO authenticated;
+GRANT EXECUTE ON FUNCTION kg.search_docs(TEXT, INT) TO service_role;
+
+GRANT EXECUTE ON FUNCTION kg.search_docs_vector(vector, INT) TO authenticated;
+GRANT EXECUTE ON FUNCTION kg.search_docs_vector(vector, INT) TO service_role;
+
+GRANT EXECUTE ON FUNCTION kg.get_neighbors(UUID, TEXT, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION kg.get_neighbors(UUID, TEXT, TEXT) TO service_role;
+
+GRANT EXECUTE ON FUNCTION kg.get_node_docs(UUID, INT) TO authenticated;
+GRANT EXECUTE ON FUNCTION kg.get_node_docs(UUID, INT) TO service_role;
+
+GRANT EXECUTE ON FUNCTION kg.upsert_node(TEXT, TEXT, TEXT, JSONB) TO service_role;
+GRANT EXECUTE ON FUNCTION kg.upsert_edge(UUID, UUID, TEXT, DOUBLE PRECISION, JSONB) TO service_role;
+
+-- ============================================================================
+-- Trigger: Auto-update updated_at on nodes
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION kg.update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER kg_nodes_updated_at
+    BEFORE UPDATE ON kg.nodes
+    FOR EACH ROW
+    EXECUTE FUNCTION kg.update_updated_at_column();
+
+-- ============================================================================
+-- Comments for documentation
+-- ============================================================================
+
+COMMENT ON SCHEMA kg IS 'Knowledge Graph: unified organizational memory layer';
+
+COMMENT ON TABLE kg.nodes IS 'Graph nodes representing organizational entities (repos, droplets, modules, etc.)';
+COMMENT ON COLUMN kg.nodes.type IS 'Node type: Org, Repo, Branch, PR, Issue, Workflow, Run, Host, Domain, DNSRecord, Service, OdooModule, OdooModel, OdooView, Doc, Decision, ChatThread';
+COMMENT ON COLUMN kg.nodes.key IS 'Stable unique identifier within type (e.g., repo:org/name, droplet:123)';
+COMMENT ON COLUMN kg.nodes.data IS 'Flexible JSONB metadata for type-specific fields';
+
+COMMENT ON TABLE kg.edges IS 'Graph edges representing relationships between nodes';
+COMMENT ON COLUMN kg.edges.type IS 'Edge type: OWNS, DEPLOYS_TO, DEPENDS_ON, IMPLEMENTS, REFERENCES, RESOLVES, CONFIGURES, MENTIONS';
+COMMENT ON COLUMN kg.edges.weight IS 'Optional weight for ranking (default 1.0)';
+
+COMMENT ON TABLE kg.docs IS 'Document storage with FTS and vector search for RAG retrieval';
+COMMENT ON COLUMN kg.docs.source IS 'Document source: github, slack, gdrive, chatgpt, claude, odoo, do';
+COMMENT ON COLUMN kg.docs.embedding IS 'Vector embedding for semantic search (1536 dims for OpenAI text-embedding-3-small)';
+
+COMMENT ON TABLE kg.mentions IS 'Links between documents and nodes they reference';
+COMMENT ON COLUMN kg.mentions.kind IS 'Mention type: MENTIONS, DEFINES, DECIDES, CONFIGURES';
+COMMENT ON COLUMN kg.mentions.confidence IS 'Extraction confidence score (0.0 - 1.0)';
+
+COMMENT ON FUNCTION kg.search_docs IS 'Full-text search across documents using websearch syntax';
+COMMENT ON FUNCTION kg.search_docs_vector IS 'Vector similarity search for semantic retrieval';
+COMMENT ON FUNCTION kg.get_neighbors IS 'Get neighboring nodes via edges (graph traversal)';
+COMMENT ON FUNCTION kg.get_node_docs IS 'Get documents that mention a specific node';
+COMMENT ON FUNCTION kg.upsert_node IS 'Idempotent node insert/update by (type, key)';
+COMMENT ON FUNCTION kg.upsert_edge IS 'Idempotent edge insert/update by (src_id, dst_id, type)';

--- a/spec/knowledge-graph/constitution.md
+++ b/spec/knowledge-graph/constitution.md
@@ -1,0 +1,196 @@
+# Knowledge Graph — Constitution
+
+> **Version**: 1.0.0
+> **Status**: Active
+> **Last Updated**: 2026-01-09
+
+---
+
+## 1. Purpose
+
+The Knowledge Graph (KG) is the **unified organizational memory layer** that connects:
+- **Infrastructure** (DigitalOcean droplets, domains, DNS records, services)
+- **Code** (GitHub repos, branches, PRs, issues, workflows, Odoo modules)
+- **Knowledge** (docs, decisions, chat threads, specs, READMEs)
+
+It treats **everything as nodes and edges** — queryable via graph traversal, full-text search, and vector similarity (RAG).
+
+---
+
+## 2. Governing Principles
+
+### 2.1 Graph-First Data Model
+
+All organizational entities are modeled as:
+- **Nodes**: typed entities with stable keys (e.g., `Repo:org/name`, `Droplet:do:123`)
+- **Edges**: typed relationships with optional weights (e.g., `DEPENDS_ON`, `DEPLOYS_TO`)
+- **Docs**: content blocks with FTS + embeddings linked via mentions
+
+### 2.2 Supabase-Native
+
+The KG runs entirely within Supabase:
+- PostgreSQL tables for graph storage
+- pgvector for embeddings
+- Full-text search via tsvector
+- Edge Functions for ingestion
+- RLS for tenant isolation
+
+### 2.3 Eventually Consistent
+
+Ingestion pipelines sync from truth sources (GitHub, DigitalOcean, Odoo) with:
+- Webhook-driven real-time updates
+- Nightly backfill reconciliation
+- Entity resolution via stable keys
+
+### 2.4 RAG-Ready
+
+All documents are indexed for retrieval:
+- Hybrid search (FTS + vector)
+- Mention extraction links docs to nodes
+- Neighborhood expansion provides context
+
+---
+
+## 3. Node Type Registry
+
+| Category | Node Types | Key Pattern |
+|----------|-----------|-------------|
+| **Organization** | `Org`, `Team` | `org:<name>`, `team:<org>/<name>` |
+| **Code** | `Repo`, `Branch`, `PR`, `Issue`, `Workflow`, `Run` | `repo:<org>/<name>`, `pr:<org>/<repo>#<num>` |
+| **Infrastructure** | `Service`, `Host`, `Domain`, `DNSRecord` | `droplet:<id>`, `domain:<fqdn>` |
+| **Odoo** | `OdooModule`, `OdooModel`, `OdooView`, `OCARepo`, `OCAModule` | `odoo:module:<name>`, `odoo:model:<name>` |
+| **Knowledge** | `Doc`, `Decision`, `ChatThread` | `doc:<source>:<ref>`, `adr:<slug>` |
+
+---
+
+## 4. Edge Type Registry
+
+| Edge Type | Source → Target | Purpose |
+|-----------|-----------------|---------|
+| `OWNS` | Org → Repo | Ownership relationship |
+| `DEPLOYS_TO` | Repo → Service/Host | Deployment mapping |
+| `DEPENDS_ON` | Module → Module | Dependency graph |
+| `IMPLEMENTS` | PR → Issue | Work tracking |
+| `REFERENCES` | Doc → Repo/Module | Documentation links |
+| `RESOLVES` | Issue → Incident | Incident management |
+| `CONFIGURES` | DNSRecord → Service/Host | DNS mapping |
+| `MENTIONS` | Doc/ChatThread → AnyNode | Knowledge linking (scored) |
+
+---
+
+## 5. Architecture Boundaries
+
+### 5.1 KG Core (This System)
+
+- Node/edge/doc storage
+- FTS + vector indexing
+- Mention extraction
+- Query API (hybrid search + graph traversal)
+
+### 5.2 Ingestion Sources (External)
+
+- **GitHub**: Repos, PRs, issues, workflows via webhooks + GraphQL
+- **DigitalOcean**: Droplets, domains, apps via API sync
+- **Odoo**: Modules, models, views via XML-RPC/DB export
+- **Docs**: READMEs, specs, ADRs via file system
+
+### 5.3 Integration Pattern
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         KNOWLEDGE GRAPH                              │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌────────────┐  │
+│  │  kg_nodes   │  │  kg_edges   │  │   kg_docs   │  │ kg_mentions│  │
+│  └─────────────┘  └─────────────┘  └─────────────┘  └────────────┘  │
+│         │               │               │                │          │
+│  ┌─────────────────────────────────────────────────────────────┐    │
+│  │                    QUERY LAYER (RAG)                         │    │
+│  │         FTS + Vector + Graph Traversal                       │    │
+│  └─────────────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────────┘
+         ▲                    ▲                    ▲
+         │                    │                    │
+   ┌──────────┐        ┌──────────┐        ┌──────────┐
+   │  GitHub  │        │    DO    │        │   Odoo   │
+   │ Webhooks │        │   Sync   │        │ Exporter │
+   └──────────┘        └──────────┘        └──────────┘
+```
+
+---
+
+## 6. Governance
+
+### 6.1 Change Control
+
+- Schema changes require migrations in `db/migrations/`
+- Node/edge type additions require constitution update
+- Breaking changes require RFC + approval
+
+### 6.2 Key Normalization
+
+All node keys must be:
+- **Stable**: Same entity always gets same key
+- **Unique**: No collisions across types
+- **Human-readable**: Debuggable without lookups
+
+### 6.3 Retention
+
+| Data Type | Retention | Reason |
+|-----------|-----------|--------|
+| Nodes | Indefinite | Historical graph |
+| Edges | Indefinite | Relationship history |
+| Docs | 7 years | Regulatory compliance |
+| Mentions | Follow doc | Linked lifecycle |
+
+---
+
+## 7. Security & Access
+
+### 7.1 Data Classification
+
+- **Public**: Node types, edge types, schema
+- **Internal**: Node metadata, edge weights
+- **Confidential**: Doc content, embeddings
+- **Restricted**: Credentials (never stored)
+
+### 7.2 Access Control
+
+- RLS policies enforce tenant isolation
+- Service role for cross-tenant operations
+- API keys for external ingestion
+
+---
+
+## 8. Non-Goals
+
+This system does NOT:
+- Replace Odoo's native data model
+- Provide real-time streaming (batch/webhook only)
+- Store application secrets
+- Implement full graph database features (use Neo4j if needed)
+
+---
+
+## 9. Success Metrics
+
+| Metric | Target |
+|--------|--------|
+| Node coverage (repos) | 100% of org repos |
+| Node coverage (droplets) | 100% of DO resources |
+| Node coverage (modules) | 100% of ipai_* modules |
+| Query latency (hybrid) | < 200ms p95 |
+| Doc freshness | < 1 hour lag |
+| Mention extraction accuracy | > 90% |
+
+---
+
+## Appendix A: Related Documents
+
+- `prd.md` — Product Requirements
+- `plan.md` — Implementation Roadmap
+- `tasks.md` — Actionable Work Items
+
+## Appendix B: Schema Location
+
+- Supabase migration: `db/migrations/20260109_KG.sql`
+- Target project: `spdtwktxdalcfigzeqrz`

--- a/spec/knowledge-graph/create-issues.sh
+++ b/spec/knowledge-graph/create-issues.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+# Knowledge Graph - GitHub Issue Creation Script
+# Run this script after configuring gh CLI: gh auth login
+#
+# Usage:
+#   ./create-issues.sh                    # Create all issues
+#   ./create-issues.sh --dry-run          # Preview commands only
+#   ./create-issues.sh --repo ORG/REPO    # Specify target repo
+
+set -euo pipefail
+
+# Configuration
+DEFAULT_REPO="${KG_REPO:-}"
+DRY_RUN=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --repo)
+            DEFAULT_REPO="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Check if gh is available
+if ! command -v gh &> /dev/null; then
+    echo "Error: gh CLI not found. Install from https://cli.github.com/"
+    exit 1
+fi
+
+# Check auth
+if ! gh auth status &> /dev/null; then
+    echo "Error: gh CLI not authenticated. Run: gh auth login"
+    exit 1
+fi
+
+# Set repo if specified
+if [[ -n "$DEFAULT_REPO" ]]; then
+    gh repo set-default "$DEFAULT_REPO"
+fi
+
+create_issue() {
+    local title="$1"
+    local body="$2"
+    local labels="${3:-}"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "Would create issue: $title"
+        echo "---"
+        echo "$body"
+        echo "---"
+        echo ""
+    else
+        if [[ -n "$labels" ]]; then
+            gh issue create --title "$title" --body "$body" --label "$labels"
+        else
+            gh issue create --title "$title" --body "$body"
+        fi
+    fi
+}
+
+echo "Creating Knowledge Graph issues..."
+echo ""
+
+# Issue 1: Schema
+create_issue \
+    "KG MVP: Create kg_nodes/kg_edges/kg_docs schema + indexes" \
+    "$(cat <<'EOF'
+## Summary
+Create the core Knowledge Graph schema in Supabase.
+
+## Details
+- Apply migration `db/migrations/20260109_KG.sql`
+- Tables: `kg.nodes`, `kg.edges`, `kg.docs`, `kg.mentions`
+- Indexes: B-tree on keys, GIN on tsv, IVFFlat on embeddings
+- Functions: `kg.search_docs`, `kg.search_docs_vector`, `kg.get_neighbors`, `kg.upsert_node`, `kg.upsert_edge`
+
+## Acceptance Criteria
+- [ ] Migration applied to Supabase project
+- [ ] RLS policies configured (authenticated read, service_role write)
+- [ ] Smoke test: insert node/edge/doc works
+- [ ] FTS query works
+- [ ] Vector search works (with mock embedding)
+
+## Related
+- Spec: `spec/knowledge-graph/`
+- Migration: `db/migrations/20260109_KG.sql`
+EOF
+)"
+
+# Issue 2: GitHub webhook
+create_issue \
+    "KG Ingest: GitHub webhook -> Edge Function upsert nodes/edges/docs" \
+    "$(cat <<'EOF'
+## Summary
+Create Edge Function to receive GitHub webhooks and populate the knowledge graph.
+
+## Details
+- Create Edge Function `ingest-github-event`
+- Handle events: `push`, `pull_request.*`, `issues.*`, `workflow_run.*`, `check_suite.*`
+- Create nodes: Repo, Branch, PR, Issue, Workflow, Run
+- Create edges: IMPLEMENTS (PR → Issue), OWNS (Org → Repo)
+- Store event summaries as `kg.docs`
+
+## Entity Mapping
+| GitHub Entity | Node Type | Key Pattern |
+|---------------|-----------|-------------|
+| Repository | Repo | `repo:<owner>/<name>` |
+| Pull Request | PR | `pr:<owner>/<repo>#<num>` |
+| Issue | Issue | `issue:<owner>/<repo>#<num>` |
+| Workflow Run | Run | `run:<owner>/<repo>:<run_id>` |
+
+## Acceptance Criteria
+- [ ] Webhook receiver deployed
+- [ ] Signature verification implemented
+- [ ] Nodes created for PR/Issue/Workflow events
+- [ ] Edges created for PR → Issue links
+- [ ] Event payloads stored as docs
+EOF
+)"
+
+# Issue 3: GitHub backfill
+create_issue \
+    "KG Ingest: nightly GitHub GraphQL backfill (repos, issues, PRs, actions)" \
+    "$(cat <<'EOF'
+## Summary
+Create scheduled function to backfill GitHub data and reconcile missed webhooks.
+
+## Details
+- Create scheduled function `backfill-github`
+- Use GitHub GraphQL API for efficient bulk fetching
+- Fetch: repositories, issues, pull requests, workflows, workflow runs
+- Upsert nodes/edges idempotently
+- Schedule: daily at 02:00 UTC
+
+## Acceptance Criteria
+- [ ] GraphQL queries implemented for all entity types
+- [ ] Pagination handled for large result sets
+- [ ] Rate limiting respected (with backoff)
+- [ ] Scheduled in Supabase cron
+- [ ] Can reconstruct graph from scratch if needed
+EOF
+)"
+
+# Issue 4: DigitalOcean sync
+create_issue \
+    "KG Ingest: DigitalOcean sync (droplets/domains/apps/certs)" \
+    "$(cat <<'EOF'
+## Summary
+Create function to sync DigitalOcean infrastructure into the knowledge graph.
+
+## Details
+- Create Edge Function `sync-do-inventory`
+- Sync: Droplets → Host nodes, Domains → Domain nodes, DNS Records → DNSRecord nodes
+- Create edges: CONFIGURES (DNSRecord → Host/Service)
+- Schedule: every 6 hours
+
+## Entity Mapping
+| DO Resource | Node Type | Key Pattern |
+|-------------|-----------|-------------|
+| Droplet | Host | `droplet:<id>` |
+| Domain | Domain | `domain:<name>` |
+| DNS Record | DNSRecord | `dns:<domain>:<type>:<name>` |
+| App | Service | `do-app:<id>` |
+
+## Acceptance Criteria
+- [ ] DO API token stored as secret
+- [ ] All droplets synced as Host nodes
+- [ ] All domains synced as Domain nodes
+- [ ] DNS records create CONFIGURES edges
+- [ ] Scheduled sync working
+EOF
+)"
+
+# Issue 5: Odoo exporter
+create_issue \
+    "KG Ingest: Odoo exporter (installed modules, models, views, key system params)" \
+    "$(cat <<'EOF'
+## Summary
+Create exporter to sync Odoo metadata into the knowledge graph.
+
+## Details
+- Export from `ir.module.module` (installed modules)
+- Parse manifest files for dependencies
+- Create OdooModule nodes
+- Create DEPENDS_ON edges from manifest
+- Optional: Export models/views in phase 2
+
+## Entity Mapping
+| Odoo Entity | Node Type | Key Pattern |
+|-------------|-----------|-------------|
+| Module | OdooModule | `odoo:module:<technical_name>` |
+| Model | OdooModel | `odoo:model:<model_name>` |
+| View | OdooView | `odoo:view:<xml_id>` |
+
+## Acceptance Criteria
+- [ ] All ipai_* modules exported
+- [ ] Dependency graph accurate
+- [ ] Module metadata (version, author, summary) stored
+- [ ] Works with docker-compose Odoo instance
+EOF
+)"
+
+# Issue 6: DNS mapping
+create_issue \
+    "KG Model: DNSRecord node type + CONFIGURES edges" \
+    "$(cat <<'EOF'
+## Summary
+Model DNS records and connect them to target services/hosts.
+
+## Details
+- DNSRecord nodes with type, name, value, TTL
+- CONFIGURES edges:
+  - A/AAAA record → Host (by IP match)
+  - CNAME → Service (by name match)
+- Support subdomain hierarchy
+
+## Acceptance Criteria
+- [ ] DNSRecord schema defined
+- [ ] A records link to droplets by IP
+- [ ] CNAME records link to services
+- [ ] DNS → Service mapping queryable
+EOF
+)"
+
+# Issue 7: Chat ingestion
+create_issue \
+    "KG Docs: ingest ChatGPT/Claude thread + extract mentions" \
+    "$(cat <<'EOF'
+## Summary
+Store AI chat threads as documents and extract entity mentions.
+
+## Details
+- Store conversation as `kg.docs` with source='chatgpt' or 'claude'
+- Extract mentions of:
+  - Repositories (repo:org/name)
+  - Modules (ipai_*, oca_*)
+  - Droplets (by name or IP)
+  - Domains
+- Create `kg.mentions` with confidence scores
+
+## Acceptance Criteria
+- [ ] Chat thread stored as doc
+- [ ] Entity extraction working
+- [ ] Mentions link to existing nodes
+- [ ] Confidence scores assigned
+EOF
+)"
+
+# Issue 8: Embeddings
+create_issue \
+    "KG Index: embed kg_docs + upsert vectors; enable hybrid search" \
+    "$(cat <<'EOF'
+## Summary
+Create embedding pipeline for semantic search.
+
+## Details
+- Create Edge Function `embed-doc`
+- Use OpenAI text-embedding-3-small (1536 dims)
+- Batch processing for backlog
+- Handle rate limiting
+
+## Acceptance Criteria
+- [ ] Embedding function deployed
+- [ ] New docs automatically embedded
+- [ ] Backlog processing working
+- [ ] Vector search returns relevant results
+- [ ] Cost tracking implemented
+EOF
+)"
+
+# Issue 9: Query API
+create_issue \
+    "KG API: /kg_query hybrid search + neighborhood expansion" \
+    "$(cat <<'EOF'
+## Summary
+Create RAG-ready query API combining FTS, vector search, and graph traversal.
+
+## Details
+- Create Edge Function `kg-query`
+- Hybrid search: FTS + vector with RRF ranking
+- Mention expansion: doc → related nodes
+- Graph traversal: include neighboring nodes
+
+## API Contract
+```json
+// Request
+{
+  "query": "What modules depend on ipai_workspace_core?",
+  "embedding": [0.1, ...],
+  "limit": 10
+}
+
+// Response
+{
+  "docs": [...],
+  "nodes": [...],
+  "edges": [...]
+}
+```
+
+## Acceptance Criteria
+- [ ] Endpoint deployed
+- [ ] FTS + vector combined correctly
+- [ ] Mentions expanded to nodes
+- [ ] Graph neighbors included
+- [ ] Response under 200ms p95
+EOF
+)"
+
+# Issue 10: UI
+create_issue \
+    "KG UI: Graph explorer (node view, neighbors, doc evidence)" \
+    "$(cat <<'EOF'
+## Summary
+Create minimal UI for exploring the knowledge graph.
+
+## Details
+- Add page to control-room app
+- Search bar with hybrid search
+- Node detail panel (type, key, data)
+- Edge list (incoming/outgoing)
+- Doc evidence panel
+
+## Features
+- [ ] Search bar
+- [ ] Node view
+- [ ] Edge list
+- [ ] Doc evidence
+- [ ] Basic graph visualization (optional)
+
+## Acceptance Criteria
+- [ ] Can search for any entity
+- [ ] Can view node details
+- [ ] Can see relationships
+- [ ] Can see supporting documents
+EOF
+)"
+
+echo ""
+echo "Done! Created 10 issues for Knowledge Graph implementation."

--- a/spec/knowledge-graph/plan.md
+++ b/spec/knowledge-graph/plan.md
@@ -1,0 +1,293 @@
+# Knowledge Graph — Implementation Plan
+
+> **Version**: 1.0.0
+> **Status**: Active
+> **Last Updated**: 2026-01-09
+
+---
+
+## Overview
+
+This plan outlines the phased implementation of the Knowledge Graph (KG) system.
+The approach prioritizes: **Schema → Ingestion → Search → UI**.
+
+---
+
+## Phase 1: Foundation (Schema + Indexes)
+
+### 1.1 Create Core Schema
+
+**Deliverable**: `db/migrations/20260109_KG.sql`
+
+Tables to create:
+- `kg_nodes` — Graph nodes with type/key/data
+- `kg_edges` — Relationships between nodes
+- `kg_docs` — Document storage with FTS + embeddings
+- `kg_mentions` — Links between docs and nodes
+
+Indexes:
+- B-tree on `kg_nodes(type, key)`
+- B-tree on `kg_edges(src_id)`, `kg_edges(dst_id)`, `kg_edges(type)`
+- GIN on `kg_docs(tsv)` for full-text search
+- IVFFlat on `kg_docs(embedding)` for vector similarity
+
+Functions:
+- `kg_docs_tsv_update()` — Auto-compute tsvector
+- Trigger to maintain FTS index
+
+### 1.2 Apply Migration
+
+```bash
+supabase db push
+# or
+psql $SUPABASE_DB_URL < db/migrations/20260109_KG.sql
+```
+
+### 1.3 Verify Schema
+
+- Insert test node/edge/doc
+- Verify unique constraints
+- Test FTS query
+- Test vector search (mock embedding)
+
+---
+
+## Phase 2: GitHub Ingestion
+
+### 2.1 Webhook Receiver
+
+**Deliverable**: Edge Function `ingest-github-event`
+
+Handles events:
+- `push` → Update `Repo`, `Branch` nodes
+- `pull_request.*` → Create/update `PR` nodes
+- `issues.*` → Create/update `Issue` nodes
+- `workflow_run.*` → Create `Workflow`, `Run` nodes
+- `check_suite.*` → Update `Run` nodes
+
+Edge creation:
+- PR closes issue → `IMPLEMENTS` edge
+- Workflow on repo → `OWNS` edge
+
+### 2.2 Entity Mapping
+
+| GitHub Entity | Node Type | Key Pattern |
+|---------------|-----------|-------------|
+| Repository | `Repo` | `repo:<owner>/<name>` |
+| Branch | `Branch` | `branch:<owner>/<repo>:<name>` |
+| Pull Request | `PR` | `pr:<owner>/<repo>#<num>` |
+| Issue | `Issue` | `issue:<owner>/<repo>#<num>` |
+| Workflow | `Workflow` | `workflow:<owner>/<repo>:<name>` |
+| Workflow Run | `Run` | `run:<owner>/<repo>:<run_id>` |
+
+### 2.3 Nightly Backfill
+
+**Deliverable**: Scheduled function `backfill-github`
+
+- Uses GitHub GraphQL API
+- Fetches repos, issues, PRs, workflows
+- Upserts nodes/edges
+- Fills gaps from missed webhooks
+
+Frequency: Daily at 02:00 UTC
+
+---
+
+## Phase 3: DigitalOcean Ingestion
+
+### 3.1 API Sync Function
+
+**Deliverable**: Edge Function `sync-do-inventory`
+
+Resources to sync:
+- Droplets → `Host` nodes
+- Domains → `Domain` nodes
+- Domain Records → `DNSRecord` nodes
+- Apps → `Service` nodes (optional)
+
+### 3.2 Entity Mapping
+
+| DO Resource | Node Type | Key Pattern |
+|-------------|-----------|-------------|
+| Droplet | `Host` | `droplet:<id>` |
+| Domain | `Domain` | `domain:<name>` |
+| Domain Record | `DNSRecord` | `dns:<domain>:<type>:<name>` |
+| App | `Service` | `do-app:<id>` |
+
+### 3.3 Edge Creation
+
+- `DNSRecord` A/AAAA → `Host` = `CONFIGURES`
+- `DNSRecord` CNAME → `Service` = `CONFIGURES`
+- `Domain` → org = `OWNS`
+
+Frequency: Every 6 hours
+
+---
+
+## Phase 4: Odoo Ingestion
+
+### 4.1 Module Exporter
+
+**Deliverable**: Python script or n8n workflow
+
+Export sources:
+- `ir.module.module` — Installed modules
+- Manifest files — Dependencies
+- `ir.model` — Model definitions (optional phase 2)
+
+### 4.2 Entity Mapping
+
+| Odoo Entity | Node Type | Key Pattern |
+|-------------|-----------|-------------|
+| Module | `OdooModule` | `odoo:module:<technical_name>` |
+| Model | `OdooModel` | `odoo:model:<model_name>` |
+| View | `OdooView` | `odoo:view:<xml_id>` |
+
+### 4.3 Edge Creation
+
+- Module depends on module → `DEPENDS_ON`
+- Model belongs to module → `OWNS`
+- View belongs to module → `OWNS`
+
+---
+
+## Phase 5: Document Indexing + Mentions
+
+### 5.1 Embedding Pipeline
+
+**Deliverable**: Edge Function `embed-doc`
+
+Flow:
+1. New/updated doc in `kg_docs`
+2. Call OpenAI embeddings API
+3. Store 1536-dim vector
+4. Update `embedding` column
+
+Trigger options:
+- On insert/update trigger
+- Batch job for backlog
+
+### 5.2 Mention Extraction
+
+**Deliverable**: Edge Function `extract-mentions`
+
+Approach:
+1. Parse doc body for known patterns:
+   - `repo:org/name` → link to Repo node
+   - `#123` in PR context → link to Issue
+   - `ipai_*` → link to OdooModule
+   - IP addresses → link to Host
+2. Use LLM for fuzzy extraction (optional)
+3. Insert `kg_mentions` with confidence
+
+### 5.3 Chat Thread Ingestion
+
+Store this conversation and future chat threads:
+- Source: `chatgpt` or `claude`
+- Extract entities mentioned
+- Link via mentions
+
+---
+
+## Phase 6: Query API
+
+### 6.1 Hybrid Search Endpoint
+
+**Deliverable**: Edge Function `kg-query`
+
+Input:
+```json
+{
+  "query": "What modules depend on ipai_workspace_core?",
+  "embedding": [0.1, ...],
+  "limit": 10
+}
+```
+
+Logic:
+1. FTS search on `kg_docs.tsv`
+2. Vector search on `kg_docs.embedding`
+3. Combine + rerank by RRF
+4. Expand via `kg_mentions` → related nodes
+5. Traverse `kg_edges` for context
+
+Output:
+```json
+{
+  "docs": [...],
+  "nodes": [...],
+  "edges": [...]
+}
+```
+
+### 6.2 Graph Traversal Helpers
+
+RPC functions:
+- `kg.get_neighbors(node_id, depth)` — N-hop traversal
+- `kg.get_path(src_id, dst_id)` — Shortest path
+- `kg.get_subgraph(node_ids)` — Induced subgraph
+
+---
+
+## Phase 7: UI Explorer
+
+### 7.1 Minimal Graph Explorer
+
+**Deliverable**: Next.js page in control-room
+
+Features:
+- Search bar (hybrid)
+- Node detail panel (type, key, data)
+- Edge list (in/out)
+- Doc evidence panel
+- Basic graph visualization (force-directed)
+
+### 7.2 Integration Points
+
+- Link from Odoo module list → KG node
+- Link from PR → KG node
+- RAG context display in AI responses
+
+---
+
+## Milestones
+
+| Milestone | Deliverables | Target |
+|-----------|--------------|--------|
+| M1: Schema | Migration applied, smoke tested | Week 1 |
+| M2: GitHub | Webhook + backfill working | Week 2 |
+| M3: DO | Infra sync working | Week 3 |
+| M4: Odoo | Module graph populated | Week 4 |
+| M5: Search | Hybrid query API live | Week 5 |
+| M6: UI | Graph explorer deployed | Week 6 |
+
+---
+
+## Dependencies
+
+| Dependency | Owner | Status |
+|------------|-------|--------|
+| Supabase project | Platform | Available |
+| GitHub webhook secret | DevOps | Needed |
+| DO API token | Platform | Available |
+| OpenAI API key | Platform | Available |
+| Odoo DB access | DevOps | Available |
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Embedding cost explosion | Batch, cache, limit doc size |
+| Webhook reliability | Nightly backfill reconciliation |
+| Key collisions | Strict key pattern enforcement |
+| Performance at scale | Proper indexes, IVFFlat tuning |
+
+---
+
+## Appendix: Related Documents
+
+- `constitution.md` — Governing Principles
+- `prd.md` — Product Requirements
+- `tasks.md` — Actionable Work Items

--- a/spec/knowledge-graph/prd.md
+++ b/spec/knowledge-graph/prd.md
@@ -1,0 +1,359 @@
+# Knowledge Graph — Product Requirements Document
+
+> **Version**: 1.0.0
+> **Status**: Draft
+> **Last Updated**: 2026-01-09
+
+---
+
+## 1. Executive Summary
+
+The Knowledge Graph (KG) is a **unified organizational memory** that indexes infrastructure, code, and documentation into a queryable graph with RAG capabilities. It enables AI agents and humans to answer questions like:
+
+- "What services run on this droplet?"
+- "Which modules depend on ipai_workspace_core?"
+- "What was decided about the authentication architecture?"
+
+**Key Value Propositions**:
+1. **Infra Map**: Complete view of DO droplets, domains, DNS, services
+2. **Code Map**: Repository, module, and dependency graph
+3. **Why Map**: Decisions, specs, and chat context linked to entities
+4. **RAG-Ready**: Hybrid search for AI agent context retrieval
+
+---
+
+## 2. Problem Statement
+
+### Current State
+- Infrastructure knowledge scattered across DO dashboard, DNS providers, docs
+- Module dependencies only visible via manifest inspection
+- Decisions buried in chat threads, PRDs, and meeting notes
+- No unified way to query "what do we know about X?"
+- AI agents lack organizational context for accurate responses
+
+### Desired State
+- Single graph connecting all organizational entities
+- Query any entity and see its relationships + evidence
+- AI agents retrieve relevant context via RAG
+- New team members can explore and understand the org
+
+---
+
+## 3. User Personas
+
+### 3.1 AI Agent (Claude/Codex)
+
+- Retrieves context before answering questions
+- Understands module dependencies
+- Knows which services run where
+- References decisions and specs
+
+### 3.2 Developer
+
+- Explores module dependency graph
+- Finds which repos deploy to which services
+- Searches for past decisions on a topic
+
+### 3.3 Platform Engineer
+
+- Maps infrastructure topology
+- Traces DNS to service mappings
+- Understands deployment relationships
+
+### 3.4 Manager/Stakeholder
+
+- Gets high-level view of system landscape
+- Finds relevant documentation
+- Understands what's connected to what
+
+---
+
+## 4. Functional Requirements
+
+### 4.1 Node Management
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| ND-001 | Store nodes with type, key, title, and JSONB data | P1 |
+| ND-002 | Enforce unique constraint on (type, key) | P1 |
+| ND-003 | Support all defined node types (Org, Repo, Droplet, etc.) | P1 |
+| ND-004 | Track created_at and updated_at timestamps | P1 |
+| ND-005 | Upsert nodes idempotently by key | P1 |
+
+### 4.2 Edge Management
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| ED-001 | Store edges with src_id, dst_id, type, and weight | P1 |
+| ED-002 | Enforce unique constraint on (src_id, dst_id, type) | P1 |
+| ED-003 | Support all defined edge types (OWNS, DEPENDS_ON, etc.) | P1 |
+| ED-004 | Store optional metadata as JSONB | P2 |
+| ED-005 | Cascade delete edges when nodes are removed | P1 |
+
+### 4.3 Document Storage
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| DC-001 | Store documents with source, source_ref, title, body | P1 |
+| DC-002 | Compute tsvector for full-text search | P1 |
+| DC-003 | Store 1536-dimension embeddings for vector search | P1 |
+| DC-004 | Support multiple source types (github, odoo, gdrive, etc.) | P1 |
+| DC-005 | Store metadata as JSONB | P2 |
+
+### 4.4 Mention Extraction
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| MN-001 | Link documents to nodes via mentions | P1 |
+| MN-002 | Store mention kind (MENTIONS, DEFINES, DECIDES) | P2 |
+| MN-003 | Store confidence score for extracted mentions | P2 |
+| MN-004 | Cascade delete mentions when doc/node removed | P1 |
+
+### 4.5 Query API
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| QR-001 | Full-text search across documents | P1 |
+| QR-002 | Vector similarity search with embeddings | P1 |
+| QR-003 | Hybrid search combining FTS + vector | P1 |
+| QR-004 | Graph traversal (get neighbors of a node) | P1 |
+| QR-005 | Mention expansion (doc → related nodes) | P2 |
+
+### 4.6 GitHub Ingestion
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| GH-001 | Receive webhooks for PR, issue, push, workflow events | P1 |
+| GH-002 | Create/update Repo, PR, Issue, Workflow, Run nodes | P1 |
+| GH-003 | Create IMPLEMENTS edges (PR → Issue) | P1 |
+| GH-004 | Store event payloads as kg_docs | P2 |
+| GH-005 | Nightly GraphQL backfill for missed events | P2 |
+
+### 4.7 DigitalOcean Ingestion
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| DO-001 | Sync droplets as Host nodes | P1 |
+| DO-002 | Sync domains as Domain nodes | P1 |
+| DO-003 | Sync DNS records as DNSRecord nodes | P1 |
+| DO-004 | Create CONFIGURES edges (DNSRecord → Host/Service) | P1 |
+| DO-005 | Scheduled sync (every 6 hours) | P2 |
+
+### 4.8 Odoo Ingestion
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| OD-001 | Export installed modules as OdooModule nodes | P1 |
+| OD-002 | Export model definitions as OdooModel nodes | P2 |
+| OD-003 | Create DEPENDS_ON edges from manifest | P1 |
+| OD-004 | Export key system parameters | P2 |
+| OD-005 | Support multiple Odoo instances | P3 |
+
+---
+
+## 5. Non-Functional Requirements
+
+### 5.1 Performance
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| PF-001 | Node upsert latency | < 50ms |
+| PF-002 | Full-text search latency | < 100ms |
+| PF-003 | Vector search latency | < 200ms |
+| PF-004 | Graph traversal (1-hop) | < 100ms |
+| PF-005 | Total nodes capacity | > 100,000 |
+
+### 5.2 Reliability
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| RL-001 | Ingestion availability | 99.9% |
+| RL-002 | Data durability | 99.999% |
+| RL-003 | Webhook retry on failure | 3 attempts |
+
+### 5.3 Security
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| SC-001 | RLS tenant isolation | Enforced |
+| SC-002 | Webhook signature verification | Required |
+| SC-003 | API key authentication | Required |
+
+---
+
+## 6. Data Model
+
+### 6.1 Core Tables
+
+```
+┌─────────────────┐       ┌─────────────────┐
+│    kg_nodes     │───────│    kg_edges     │
+├─────────────────┤       ├─────────────────┤
+│ id (PK, UUID)   │       │ id (PK, UUID)   │
+│ type            │       │ src_id (FK)     │
+│ key             │       │ dst_id (FK)     │
+│ title           │       │ type            │
+│ data (JSONB)    │       │ weight          │
+│ created_at      │       │ data (JSONB)    │
+│ updated_at      │       │ created_at      │
+└─────────────────┘       └─────────────────┘
+        │
+        │ via kg_mentions
+        ▼
+┌─────────────────┐       ┌─────────────────┐
+│    kg_docs      │───────│  kg_mentions    │
+├─────────────────┤       ├─────────────────┤
+│ id (PK, UUID)   │       │ id (PK, UUID)   │
+│ source          │       │ doc_id (FK)     │
+│ source_ref      │       │ node_id (FK)    │
+│ title           │       │ kind            │
+│ body            │       │ confidence      │
+│ meta (JSONB)    │       │ meta (JSONB)    │
+│ tsv (tsvector)  │       └─────────────────┘
+│ embedding       │
+│ created_at      │
+└─────────────────┘
+```
+
+### 6.2 Key Patterns
+
+| Node Type | Key Pattern | Example |
+|-----------|-------------|---------|
+| Org | `org:<name>` | `org:insightpulseai-net` |
+| Repo | `repo:<org>/<name>` | `repo:insightpulseai-net/odoo-ce` |
+| PR | `pr:<org>/<repo>#<num>` | `pr:insightpulseai-net/odoo-ce#183` |
+| Droplet | `droplet:<id>` | `droplet:123456789` |
+| Domain | `domain:<fqdn>` | `domain:odoo.insightpulse.ai` |
+| OdooModule | `odoo:module:<name>` | `odoo:module:ipai_workspace_core` |
+
+---
+
+## 7. Integration Contracts
+
+### 7.1 GitHub Webhook → Node/Edge
+
+```json
+{
+  "event": "pull_request.opened",
+  "nodes": [
+    {
+      "type": "PR",
+      "key": "pr:org/repo#123",
+      "title": "feat: add knowledge graph",
+      "data": {"state": "open", "author": "user"}
+    }
+  ],
+  "edges": [
+    {
+      "src_key": "pr:org/repo#123",
+      "dst_key": "issue:org/repo#100",
+      "type": "IMPLEMENTS"
+    }
+  ]
+}
+```
+
+### 7.2 DO Sync → Nodes
+
+```json
+{
+  "nodes": [
+    {
+      "type": "Host",
+      "key": "droplet:123456",
+      "title": "odoo-prod-01",
+      "data": {
+        "ip": "157.245.1.2",
+        "region": "sgp1",
+        "size": "s-2vcpu-4gb"
+      }
+    }
+  ]
+}
+```
+
+### 7.3 RAG Query → Response
+
+```json
+{
+  "query": "What modules depend on ipai_workspace_core?",
+  "embedding": [0.1, 0.2, ...],
+  "results": {
+    "docs": [...],
+    "nodes": [...],
+    "edges": [...]
+  }
+}
+```
+
+---
+
+## 8. UI/UX Requirements
+
+### 8.1 Graph Explorer (v1)
+
+- Node view with type icon and title
+- Edge list showing relationships
+- Doc evidence panel
+- Search bar (hybrid)
+
+### 8.2 API Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/kg/nodes` | GET | List/search nodes |
+| `/kg/nodes/:id` | GET | Get node with edges |
+| `/kg/query` | POST | Hybrid search (RAG) |
+| `/kg/ingest/github` | POST | GitHub webhook receiver |
+| `/kg/sync/do` | POST | Trigger DO sync |
+
+---
+
+## 9. Acceptance Criteria
+
+### 9.1 MVP Acceptance
+
+- [ ] Schema deployed to Supabase
+- [ ] GitHub webhook creates nodes/edges
+- [ ] Full-text search works
+- [ ] Vector search works
+- [ ] Graph traversal returns neighbors
+
+### 9.2 V1.0 Acceptance
+
+- [ ] DO sync populates infra nodes
+- [ ] Odoo exporter populates module nodes
+- [ ] Mention extraction links docs to nodes
+- [ ] Hybrid search returns ranked results
+- [ ] Graph explorer UI navigable
+
+---
+
+## 10. Dependencies
+
+| Dependency | Purpose | Status |
+|------------|---------|--------|
+| Supabase | Database + Auth | Available |
+| pgvector | Embeddings | Available |
+| OpenAI | Embedding generation | Available |
+| GitHub API | Webhook + GraphQL | Available |
+| DO API | Resource sync | Available |
+
+---
+
+## 11. Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Embedding cost | High API spend | Batch + cache embeddings |
+| Key collision | Data corruption | Strict key patterns |
+| Webhook delays | Stale data | Nightly backfill |
+| Entity extraction errors | Bad mentions | Confidence thresholds |
+
+---
+
+## Appendix: Related Documents
+
+- `constitution.md` — Governing Principles
+- `plan.md` — Implementation Roadmap
+- `tasks.md` — Actionable Work Items

--- a/spec/knowledge-graph/tasks.md
+++ b/spec/knowledge-graph/tasks.md
@@ -1,0 +1,218 @@
+# Knowledge Graph — Tasks
+
+> **Last Updated**: 2026-01-09
+
+---
+
+## Legend
+
+- `[ ]` — Pending
+- `[~]` — In Progress
+- `[x]` — Completed
+- `[-]` — Blocked/Cancelled
+
+---
+
+## Phase 1: Foundation
+
+### 1.1 Schema
+
+- [ ] Create `db/migrations/20260109_KG.sql` with:
+  - [ ] `kg_nodes` table (id, type, key, title, data, timestamps)
+  - [ ] `kg_edges` table (id, src_id, dst_id, type, weight, data, timestamps)
+  - [ ] `kg_docs` table (id, source, source_ref, title, body, meta, tsv, embedding, timestamps)
+  - [ ] `kg_mentions` table (id, doc_id, node_id, kind, confidence, meta)
+  - [ ] Unique constraints on (type, key) and (src_id, dst_id, type)
+  - [ ] B-tree indexes on edges (src_id, dst_id, type)
+  - [ ] GIN index on tsv
+  - [ ] IVFFlat index on embedding
+  - [ ] Trigger for auto-updating tsv
+
+### 1.2 Deployment
+
+- [ ] Apply migration to Supabase project `spdtwktxdalcfigzeqrz`
+- [ ] Verify tables created
+- [ ] Insert smoke test data (1 node, 1 edge, 1 doc)
+- [ ] Verify FTS query works
+- [ ] Verify vector search works (mock embedding)
+
+---
+
+## Phase 2: GitHub Ingestion
+
+### 2.1 Webhook Receiver
+
+- [ ] Create Edge Function `ingest-github-event`
+- [ ] Handle `push` events → Repo/Branch nodes
+- [ ] Handle `pull_request.*` events → PR nodes
+- [ ] Handle `issues.*` events → Issue nodes
+- [ ] Handle `workflow_run.*` events → Workflow/Run nodes
+- [ ] Create IMPLEMENTS edges (PR → Issue)
+- [ ] Store event summaries as kg_docs
+
+### 2.2 Backfill
+
+- [ ] Create scheduled function `backfill-github`
+- [ ] Fetch repos via GraphQL
+- [ ] Fetch issues via GraphQL
+- [ ] Fetch PRs via GraphQL
+- [ ] Fetch workflows via GraphQL
+- [ ] Upsert nodes/edges
+- [ ] Schedule daily at 02:00 UTC
+
+### 2.3 Testing
+
+- [ ] Deploy webhook to test environment
+- [ ] Trigger test PR
+- [ ] Verify nodes created
+- [ ] Verify edges created
+- [ ] Run backfill manually
+- [ ] Verify reconciliation works
+
+---
+
+## Phase 3: DigitalOcean Ingestion
+
+### 3.1 Sync Function
+
+- [ ] Create Edge Function `sync-do-inventory`
+- [ ] Sync droplets → Host nodes
+- [ ] Sync domains → Domain nodes
+- [ ] Sync domain records → DNSRecord nodes
+- [ ] Create CONFIGURES edges (DNS → Host/Service)
+
+### 3.2 Deployment
+
+- [ ] Store DO API token as secret
+- [ ] Schedule sync every 6 hours
+- [ ] Test initial sync
+- [ ] Verify all droplets present
+- [ ] Verify all domains present
+- [ ] Verify DNS records mapped correctly
+
+---
+
+## Phase 4: Odoo Ingestion
+
+### 4.1 Exporter
+
+- [ ] Create exporter script (Python or n8n)
+- [ ] Export installed modules from `ir.module.module`
+- [ ] Parse manifest files for dependencies
+- [ ] Create OdooModule nodes
+- [ ] Create DEPENDS_ON edges
+
+### 4.2 Extended Export (v2)
+
+- [ ] Export model definitions from `ir.model`
+- [ ] Create OdooModel nodes
+- [ ] Export view definitions from `ir.ui.view`
+- [ ] Create OdooView nodes
+- [ ] Create OWNS edges (Module → Model/View)
+
+### 4.3 Deployment
+
+- [ ] Test against odoo-core instance
+- [ ] Verify module count matches
+- [ ] Verify dependency graph accurate
+- [ ] Schedule periodic export
+
+---
+
+## Phase 5: Document Indexing
+
+### 5.1 Embedding Pipeline
+
+- [ ] Create Edge Function `embed-doc`
+- [ ] Integrate OpenAI embeddings API
+- [ ] Handle rate limiting
+- [ ] Batch processing for backlog
+- [ ] Update kg_docs.embedding column
+
+### 5.2 Mention Extraction
+
+- [ ] Create Edge Function `extract-mentions`
+- [ ] Pattern matching for repo references
+- [ ] Pattern matching for issue/PR numbers
+- [ ] Pattern matching for module names
+- [ ] Pattern matching for IP addresses/hostnames
+- [ ] Insert kg_mentions with confidence scores
+
+### 5.3 Chat Ingestion
+
+- [ ] Define source format for chat threads
+- [ ] Create ingestion endpoint
+- [ ] Extract entities from this conversation
+- [ ] Store as kg_docs
+- [ ] Link via kg_mentions
+
+---
+
+## Phase 6: Query API
+
+### 6.1 Hybrid Search
+
+- [ ] Create Edge Function `kg-query`
+- [ ] Implement FTS search
+- [ ] Implement vector search
+- [ ] Implement RRF ranking
+- [ ] Implement mention expansion
+- [ ] Return docs + nodes + edges
+
+### 6.2 Graph Traversal
+
+- [ ] Create RPC `kg.get_neighbors(node_id, depth)`
+- [ ] Create RPC `kg.get_path(src_id, dst_id)`
+- [ ] Create RPC `kg.get_subgraph(node_ids)`
+- [ ] Test with real data
+
+### 6.3 Documentation
+
+- [ ] Document API endpoints
+- [ ] Create example queries
+- [ ] Add to README
+
+---
+
+## Phase 7: UI Explorer
+
+### 7.1 Implementation
+
+- [ ] Create KG explorer page in control-room
+- [ ] Implement search bar
+- [ ] Implement node detail panel
+- [ ] Implement edge list
+- [ ] Implement doc evidence panel
+- [ ] Basic graph visualization
+
+### 7.2 Integration
+
+- [ ] Link from Odoo module list
+- [ ] Link from GitHub PR view
+- [ ] Display RAG context in AI responses
+
+---
+
+## GitHub Issues (Tracking)
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| #TBD | KG MVP: Create kg_nodes/kg_edges/kg_docs schema + indexes | Pending |
+| #TBD | KG Ingest: GitHub webhook → Edge Function upsert nodes/edges/docs | Pending |
+| #TBD | KG Ingest: nightly GitHub GraphQL backfill | Pending |
+| #TBD | KG Ingest: DigitalOcean sync (droplets/domains/apps/certs) | Pending |
+| #TBD | KG Ingest: Odoo exporter (installed modules, models, views) | Pending |
+| #TBD | KG Model: DNSRecord node type + CONFIGURES edges | Pending |
+| #TBD | KG Docs: ingest ChatGPT thread + extract mentions | Pending |
+| #TBD | KG Index: embed kg_docs + upsert vectors; enable hybrid search | Pending |
+| #TBD | KG API: /kg_query hybrid search + neighborhood expansion | Pending |
+| #TBD | KG UI: Graph explorer (node view, neighbors, doc evidence) | Pending |
+
+---
+
+## Notes
+
+- All node keys must follow patterns defined in constitution.md
+- RLS policies must be applied before production use
+- Embeddings use OpenAI text-embedding-3-small (1536 dims)
+- IVFFlat index requires `lists = 100` for < 1M vectors


### PR DESCRIPTION
Implements organizational knowledge graph for unified memory across:
- Infrastructure (DO droplets, domains, DNS records, services)
- Code (GitHub repos, PRs, issues, workflows, Odoo modules)
- Knowledge (docs, decisions, chat threads with RAG)

Includes:
- spec/knowledge-graph/: constitution, PRD, plan, tasks
- db/migrations/20260109_KG.sql: core schema with:
  - kg.nodes, kg.edges for graph storage
  - kg.docs with FTS (tsvector) + vector search (pgvector)
  - kg.mentions for doc-to-node linking
  - RPC functions for hybrid search and graph traversal
- create-issues.sh: script to create 10 GitHub tracking issues
- .gitignore: allow db/migrations/*.sql

Schema follows Supabase-first design with RLS policies for
tenant isolation and service_role for ingestion pipelines.