### PR TITLE
docs(releases): add deployment report for prod-20260109-2219

### DIFF
--- a/docs/releases/DEPLOYMENT_PROOFS/prod-20260109-2219/README.md
+++ b/docs/releases/DEPLOYMENT_PROOFS/prod-20260109-2219/README.md
@@ -1,0 +1,154 @@
+# Deployment Proofs: prod-20260109-2219
+
+**Release Tag:** `prod-20260109-2219`
+**Generated:** 2026-01-09T22:19:00Z
+
+---
+
+## Git State
+
+| Field | Value |
+|-------|-------|
+| Branch | `main` |
+| HEAD SHA | `6bbe81e9413c8036e1a826b80e3864d63c616c73` |
+| Previous Tag | `prod-20260109-2217` |
+| Previous SHA | `52c69e170875e896e30ff0a96b4bac93b461ac2b` |
+
+### Diffstat
+
+```
+ SITEMAP.md                                   |   5 +-
+ TREE.md                                      |  20 +-
+ artifacts/supabase_verify/report.json        | 117 ++++
+ docs/ops/SUPABASE_DEPLOYMENT_VERIFICATION.md | 200 ++++++
+ scripts/verify_supabase_deploy.sh            | 970 +++++++++++++++++++++++++++
+ 5 files changed, 1306 insertions(+), 6 deletions(-)
+```
+
+---
+
+## Links
+
+| Resource | URL |
+|----------|-----|
+| GitHub Release | https://github.com/jgtolentino/odoo-ce/releases/tag/prod-20260109-2219 |
+| Compare View | https://github.com/jgtolentino/odoo-ce/compare/prod-20260109-2217...prod-20260109-2219 |
+| PR #191 | https://github.com/jgtolentino/odoo-ce/pull/191 |
+| Commit 6bbe81e9 | https://github.com/jgtolentino/odoo-ce/commit/6bbe81e9413c8036e1a826b80e3864d63c616c73 |
+| Commit d8bbeb13 | https://github.com/jgtolentino/odoo-ce/commit/d8bbeb1356b11a4fe805157da2164d404dee86fe |
+
+---
+
+## CI Proof
+
+| Field | Status |
+|-------|--------|
+| Workflow Name | `Deploy to Production` |
+| Workflow File | `.github/workflows/deploy-production.yml` |
+| Run URL | UNVERIFIED - GitHub API not accessible |
+| Run ID | UNVERIFIED |
+| Status | UNVERIFIED |
+| Artifacts | UNVERIFIED |
+
+**Note:** GitHub API was not accessible during report generation. Workflow run details cannot be confirmed.
+
+---
+
+## Runtime Proof
+
+### Docker Image
+
+| Field | Value | Status |
+|-------|-------|--------|
+| Registry | `ghcr.io` | Expected per workflow |
+| Image | `jgtolentino/odoo-ce` | Expected per workflow |
+| Tag | `edge-standard` | Expected per workflow |
+| Digest | - | UNVERIFIED |
+
+### Service Health
+
+| Endpoint | Status |
+|----------|--------|
+| `https://erp.insightpulseai.net/web/health` | UNVERIFIED |
+| `http://localhost:8069/web/health` (internal) | UNVERIFIED |
+
+---
+
+## Container Proof
+
+| Field | Status |
+|-------|--------|
+| Container Name | UNVERIFIED |
+| Image Digest | UNVERIFIED |
+| Container Status | UNVERIFIED |
+| Last Logs | UNVERIFIED |
+
+---
+
+## Database Proof
+
+| Field | Status | Notes |
+|-------|--------|-------|
+| Odoo DB Connectivity | UNVERIFIED | No DB changes in this release |
+| Migration Status | N/A | No Odoo migrations |
+| Supabase Migrations | N/A | No Supabase migrations in commit range |
+
+---
+
+## App Proof
+
+| Check | Status |
+|-------|--------|
+| `/web/login` returns 200 | UNVERIFIED |
+| `/web/health` returns 200 | UNVERIFIED |
+| Version banner | UNVERIFIED |
+
+---
+
+## Verification Commands
+
+To verify this deployment manually:
+
+```bash
+# 1. Check release exists
+gh release view prod-20260109-2219
+
+# 2. Compare commits
+git log --oneline prod-20260109-2217..prod-20260109-2219
+
+# 3. Check workflow runs
+gh run list --workflow=deploy-production.yml --limit=5
+
+# 4. Check production health (requires access)
+curl -sf https://erp.insightpulseai.net/web/health
+
+# 5. Check container status (requires SSH access)
+ssh user@erp.insightpulseai.net 'docker compose ps'
+```
+
+---
+
+## Evidence Files in This Directory
+
+| File | Description | Status |
+|------|-------------|--------|
+| `README.md` | This file | Generated |
+| `workflow_run.json` | Workflow run details | NOT AVAILABLE |
+| `health_check.txt` | Health endpoint response | NOT AVAILABLE |
+| `container_logs.txt` | Container startup logs | NOT AVAILABLE |
+| `image_digest.txt` | Docker image digest | NOT AVAILABLE |
+
+---
+
+## Summary
+
+This release (`prod-20260109-2219`) contains **documentation and tooling changes only**:
+
+1. Added Supabase verification script and documentation
+2. Auto-generated SITEMAP.md and TREE.md updates
+
+**No runtime code changes** were deployed. The deployment workflow restarts containers with the same image (`edge-standard`), but no Odoo modules or Supabase artifacts changed.
+
+---
+
+*Proofs generated from git artifacts. Items marked UNVERIFIED require GitHub API or production server access.*

--- a/docs/releases/GO_LIVE_MANIFEST_prod-20260109-2219.md
+++ b/docs/releases/GO_LIVE_MANIFEST_prod-20260109-2219.md
@@ -1,0 +1,106 @@
+# Go-Live Manifest: prod-20260109-2219
+
+**Release:** `prod-20260109-2219`
+**Deployment Type:** Documentation / Tooling Only
+**Production Impact:** Minimal (container restart only, no code changes)
+
+---
+
+## Pre-Deployment Checklist
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Code freeze confirmed | N/A | Docs-only release |
+| All CI gates passed | ASSUMED | Release tag created by workflow |
+| Database backup taken | N/A | No DB changes |
+| Rollback plan documented | N/A | No runtime changes to rollback |
+
+---
+
+## Deployment Verification
+
+### Component Verification Matrix
+
+| Component | Expected State | Actual State | Pass/Fail |
+|-----------|---------------|--------------|-----------|
+| Odoo Modules | No changes | No changes | PASS |
+| Supabase Migrations | No changes | No changes | PASS |
+| Supabase Functions | No changes | No changes | PASS |
+| Docker Image | `edge-standard` | UNVERIFIED | UNVERIFIED |
+| Workflow Completion | Success | UNVERIFIED | UNVERIFIED |
+
+### Health Endpoints
+
+| Endpoint | Expected | Actual | Status |
+|----------|----------|--------|--------|
+| `https://erp.insightpulseai.net/web/health` | 200 OK | - | UNVERIFIED |
+| `https://erp.insightpulseai.net/web/login` | 200 OK | - | UNVERIFIED |
+
+---
+
+## What Shipped
+
+### Code Changes
+
+1. **PR #191: chore(ops): verify supabase deploy**
+   - Added `scripts/verify_supabase_deploy.sh` - comprehensive Supabase verification script
+   - Added `docs/ops/SUPABASE_DEPLOYMENT_VERIFICATION.md` - verification documentation
+   - Added `artifacts/supabase_verify/report.json` - verification report template
+   - **Impact:** Tooling only, no runtime changes
+
+2. **Auto-generated docs update**
+   - Updated `SITEMAP.md` and `TREE.md`
+   - **Impact:** Documentation only
+
+### Runtime Changes
+
+| Change | Applied? | Evidence |
+|--------|----------|----------|
+| Docker containers restarted | UNVERIFIED | Per workflow: `docker compose up -d --force-recreate` |
+| Odoo modules upgraded | NO | No `-u` flag in deployment script |
+| Database migrations | NO | No Supabase migrations in commit range |
+
+---
+
+## Rollback Procedure
+
+**Risk Level:** LOW - No runtime code changes deployed.
+
+**If rollback needed:**
+```bash
+# This release contains only docs/tooling - no rollback needed
+# If container issues occur, redeploy previous tag:
+git checkout prod-20260109-2217
+docker compose up -d --force-recreate
+```
+
+---
+
+## Sign-Off
+
+| Role | Name | Date | Status |
+|------|------|------|--------|
+| Release Manager | - | - | PENDING |
+| QA | - | - | N/A (docs-only) |
+| Ops | - | - | PENDING |
+
+---
+
+## Evidence Links
+
+- **GitHub Release:** [prod-20260109-2219](https://github.com/jgtolentino/odoo-ce/releases/tag/prod-20260109-2219)
+- **Compare View:** [prod-20260109-2217...prod-20260109-2219](https://github.com/jgtolentino/odoo-ce/compare/prod-20260109-2217...prod-20260109-2219)
+- **PR #191:** [chore(ops): verify supabase deploy](https://github.com/jgtolentino/odoo-ce/pull/191)
+- **Deployment Proofs:** [DEPLOYMENT_PROOFS/prod-20260109-2219/](./DEPLOYMENT_PROOFS/prod-20260109-2219/)
+
+---
+
+## Post-Deployment Tasks
+
+- [ ] Run `./scripts/verify_supabase_deploy.sh` to populate verification results (requires Supabase credentials)
+- [ ] Verify production health at `https://erp.insightpulseai.net/web/health`
+- [ ] Update status in this manifest after verification
+
+---
+
+*Manifest generated: 2026-01-09T22:19:00Z*

--- a/docs/releases/WHAT_DEPLOYED_prod-20260109-2219.json
+++ b/docs/releases/WHAT_DEPLOYED_prod-20260109-2219.json
@@ -1,0 +1,183 @@
+{
+  "release": {
+    "tag": "prod-20260109-2219",
+    "commit": "6bbe81e9413c8036e1a826b80e3864d63c616c73",
+    "previous_tag": "prod-20260109-2217",
+    "previous_commit": "52c69e170875e896e30ff0a96b4bac93b461ac2b",
+    "compare_url": "https://github.com/jgtolentino/odoo-ce/compare/prod-20260109-2217...prod-20260109-2219",
+    "generated_at": "2026-01-09T22:19:00Z"
+  },
+  "executive_summary": {
+    "odoo": {
+      "deployed": false,
+      "evidence": "No changes in addons/ - git diff shows 0 files"
+    },
+    "supabase": {
+      "deployed": false,
+      "evidence": "No changes in supabase/ - git diff shows 0 files"
+    },
+    "infra_deploy": {
+      "deployed": false,
+      "evidence": "No changes in deploy/, docker/, services/"
+    },
+    "ci_workflows": {
+      "deployed": false,
+      "evidence": "No changes in .github/workflows/"
+    },
+    "docs_scripts": {
+      "deployed": true,
+      "evidence": "5 files changed: verification tooling + docs"
+    },
+    "docker_image": {
+      "deployed": "UNVERIFIED",
+      "evidence": "Expected ghcr.io/jgtolentino/odoo-ce:edge-standard per workflow"
+    },
+    "workflow_run": {
+      "deployed": "UNVERIFIED",
+      "evidence": "GitHub API not accessible - cannot confirm run ID"
+    }
+  },
+  "commits_included": [
+    {
+      "hash": "6bbe81e9413c8036e1a826b80e3864d63c616c73",
+      "short_hash": "6bbe81e9",
+      "subject": "chore(ops): verify supabase deploy (migrations, hooks, edge functions)",
+      "author": "jgtolentino",
+      "email": "jgtolentino_rn@yahoo.com",
+      "date": "2026-01-10T06:17:10+08:00",
+      "pr_number": 191,
+      "pr_url": "https://github.com/jgtolentino/odoo-ce/pull/191"
+    },
+    {
+      "hash": "d8bbeb1356b11a4fe805157da2164d404dee86fe",
+      "short_hash": "d8bbeb13",
+      "subject": "docs: auto-update SITEMAP.md and TREE.md [skip ci]",
+      "author": "github-actions[bot]",
+      "email": "github-actions[bot]@users.noreply.github.com",
+      "date": "2026-01-09T22:15:57Z",
+      "pr_number": null,
+      "pr_url": null
+    }
+  ],
+  "commits_excluded": [
+    {
+      "hash": "5b4a06b6",
+      "subject": "docs: auto-update SITEMAP.md and TREE.md [skip ci]",
+      "author": "github-actions[bot]",
+      "status": "EXCLUDED"
+    },
+    {
+      "hash": "32ce14e3",
+      "subject": "chore(oca): add OCA-style chore scope conventions (#192)",
+      "author": null,
+      "status": "EXCLUDED"
+    },
+    {
+      "hash": "98165acf",
+      "subject": "docs: auto-update SITEMAP.md and TREE.md [skip ci]",
+      "author": "github-actions[bot]",
+      "status": "EXCLUDED"
+    }
+  ],
+  "files_changed": [
+    {
+      "status": "M",
+      "path": "SITEMAP.md",
+      "category": "docs"
+    },
+    {
+      "status": "M",
+      "path": "TREE.md",
+      "category": "docs"
+    },
+    {
+      "status": "A",
+      "path": "artifacts/supabase_verify/report.json",
+      "category": "other"
+    },
+    {
+      "status": "A",
+      "path": "docs/ops/SUPABASE_DEPLOYMENT_VERIFICATION.md",
+      "category": "docs"
+    },
+    {
+      "status": "A",
+      "path": "scripts/verify_supabase_deploy.sh",
+      "category": "other"
+    }
+  ],
+  "change_stats": {
+    "total_files": 5,
+    "insertions": 1306,
+    "deletions": 6,
+    "by_category": {
+      "odoo": 0,
+      "supabase": 0,
+      "infra_deploy": 0,
+      "ci_workflows": 0,
+      "docs": 4,
+      "other": 1
+    }
+  },
+  "runtime_evidence": {
+    "docker_image": {
+      "registry": "ghcr.io",
+      "image": "jgtolentino/odoo-ce",
+      "tag": "edge-standard",
+      "digest": null,
+      "status": "UNVERIFIED"
+    },
+    "workflow_run": {
+      "name": "Deploy to Production",
+      "run_url": null,
+      "run_id": null,
+      "environment": "production",
+      "target_url": "https://erp.insightpulseai.net",
+      "conclusion": null,
+      "status": "UNVERIFIED"
+    }
+  },
+  "component_status": {
+    "supabase": {
+      "deployed": false,
+      "migrations_changed": [],
+      "functions_changed": [],
+      "config_changed": false,
+      "proof": "git diff --name-only prod-20260109-2217..prod-20260109-2219 -- supabase/ returns empty"
+    },
+    "odoo": {
+      "deployed": false,
+      "modules_changed": [],
+      "runtime_restart": "UNVERIFIED",
+      "module_upgrade_executed": false,
+      "proof": "git diff --name-only prod-20260109-2217..prod-20260109-2219 -- addons/ returns empty"
+    }
+  },
+  "risks": [
+    {
+      "item": "Workflow run URL",
+      "status": "UNVERIFIED",
+      "missing_evidence": "GitHub API not accessible to retrieve run ID"
+    },
+    {
+      "item": "Docker image digest",
+      "status": "UNVERIFIED",
+      "missing_evidence": "Cannot access container registry to verify sha256"
+    },
+    {
+      "item": "Production health check",
+      "status": "UNVERIFIED",
+      "missing_evidence": "Cannot access erp.insightpulseai.net/web/health"
+    },
+    {
+      "item": "Odoo service restart",
+      "status": "UNVERIFIED",
+      "missing_evidence": "No logs from production deployment"
+    },
+    {
+      "item": "Supabase verification results",
+      "status": "PENDING",
+      "missing_evidence": "verify_supabase_deploy.sh has not been executed"
+    }
+  ]
+}

--- a/docs/releases/WHAT_DEPLOYED_prod-20260109-2219.md
+++ b/docs/releases/WHAT_DEPLOYED_prod-20260109-2219.md
@@ -1,0 +1,163 @@
+# What's Deployed: prod-20260109-2219
+
+**Release Tag:** `prod-20260109-2219`
+**Release Commit:** `6bbe81e9413c8036e1a826b80e3864d63c616c73`
+**Previous Tag:** `prod-20260109-2217`
+**Previous Commit:** `52c69e170875e896e30ff0a96b4bac93b461ac2b`
+**Compare Range:** [`prod-20260109-2217..prod-20260109-2219`](https://github.com/jgtolentino/odoo-ce/compare/prod-20260109-2217...prod-20260109-2219)
+**Report Generated:** 2026-01-09T22:19:00Z
+
+---
+
+## Executive Summary
+
+| Component | Deployed? | Evidence |
+|-----------|-----------|----------|
+| Odoo (addons, modules) | NO | No changes in `addons/` - git diff shows 0 files |
+| Supabase (migrations, functions) | NO | No changes in `supabase/` - git diff shows 0 files |
+| Infra/Deploy (docker, services) | NO | No changes in `deploy/`, `docker/`, `services/` |
+| CI/Workflows | NO | No changes in `.github/workflows/` |
+| Docs/Scripts | YES | 5 files changed: verification tooling + docs |
+| Docker Image | UNVERIFIED | Expected `ghcr.io/jgtolentino/odoo-ce:edge-standard` per workflow |
+| Workflow Run | UNVERIFIED | GitHub API not accessible - cannot confirm run ID |
+
+**Deployment Type:** Documentation and tooling only - no runtime changes.
+
+---
+
+## Changes Included
+
+### Commits in Range (2 commits)
+
+| Hash | Subject | Author | Date | PR |
+|------|---------|--------|------|---|
+| `6bbe81e9` | chore(ops): verify supabase deploy (migrations, hooks, edge functions) | jgtolentino | 2026-01-10T06:17:10+08:00 | [#191](https://github.com/jgtolentino/odoo-ce/pull/191) |
+| `d8bbeb13` | docs: auto-update SITEMAP.md and TREE.md [skip ci] | github-actions[bot] | 2026-01-09T22:15:57Z | - |
+
+### Files Changed (5 files, +1306/-6)
+
+| Status | File | Category |
+|--------|------|----------|
+| M | `SITEMAP.md` | Docs-only |
+| M | `TREE.md` | Docs-only |
+| A | `artifacts/supabase_verify/report.json` | Other (verification tooling) |
+| A | `docs/ops/SUPABASE_DEPLOYMENT_VERIFICATION.md` | Docs-only |
+| A | `scripts/verify_supabase_deploy.sh` | Other (verification script) |
+
+### Change Categorization
+
+| Category | Files Changed | Lines |
+|----------|---------------|-------|
+| Odoo (addons/, odoo/, config/, patches/) | 0 | 0 |
+| Supabase (supabase/migrations, supabase/functions) | 0 | 0 |
+| Infra/Deploy (deploy/, services/, docker/) | 0 | 0 |
+| CI/Workflows (.github/workflows) | 0 | 0 |
+| Docs-only (docs/, *.md) | 4 | +225/-6 |
+| Other (scripts, artifacts) | 1 | +1087/0 |
+
+---
+
+## Commits NOT Included (3 commits to main after this release)
+
+These commits exist on `main` but are **NOT** part of this release:
+
+| Hash | Subject | Author | Status |
+|------|---------|--------|--------|
+| `5b4a06b6` | docs: auto-update SITEMAP.md and TREE.md [skip ci] | github-actions[bot] | EXCLUDED |
+| `32ce14e3` | chore(oca): add OCA-style chore scope conventions (#192) | - | EXCLUDED |
+| `98165acf` | docs: auto-update SITEMAP.md and TREE.md [skip ci] | github-actions[bot] | EXCLUDED |
+
+---
+
+## Runtime Evidence
+
+### Docker Image
+
+| Field | Value | Status |
+|-------|-------|--------|
+| Registry | `ghcr.io` | Expected per workflow |
+| Image | `jgtolentino/odoo-ce` | Expected per workflow |
+| Tag | `edge-standard` | Expected per workflow |
+| Digest (sha256) | - | UNVERIFIED - cannot access registry |
+
+### Workflow Run
+
+| Field | Value | Status |
+|-------|-------|--------|
+| Workflow Name | `Deploy to Production` | Per `.github/workflows/deploy-production.yml` |
+| Run URL | - | UNVERIFIED - GitHub API not accessible |
+| Run ID | - | UNVERIFIED |
+| Environment | `production` | Per workflow |
+| Target URL | `https://erp.insightpulseai.net` | Per workflow |
+| Conclusion | - | UNVERIFIED |
+
+### Deployment Steps (Expected per Workflow)
+
+1. Pre-flight checks (verify image exists)
+2. SSH to production server
+3. `git fetch origin main && git checkout main && git pull origin main`
+4. `git submodule update --init --recursive`
+5. `docker compose pull`
+6. `docker compose up -d --force-recreate`
+7. Health check: `curl -sf http://localhost:8069/web/health`
+8. Create release tag
+
+---
+
+## Supabase Status
+
+**Supabase: NO CHANGES DEPLOYED**
+
+**Proof:** `git diff --name-only prod-20260109-2217..prod-20260109-2219 -- supabase/` returns empty.
+
+- No migrations added or modified
+- No Edge Functions added or modified
+- No config.toml changes
+
+The commit `6bbe81e9` adds **verification tooling** (`scripts/verify_supabase_deploy.sh`) to audit existing Supabase deployments, but does NOT deploy any Supabase artifacts.
+
+The `artifacts/supabase_verify/report.json` shows `"overall_status": "PENDING"` - it's a template awaiting actual verification runs.
+
+---
+
+## Odoo Status
+
+**Odoo Modules: NO CHANGES DEPLOYED**
+
+**Proof:** `git diff --name-only prod-20260109-2217..prod-20260109-2219 -- addons/` returns empty.
+
+- No module code changes
+- No manifest changes
+- No migration scripts
+
+**Runtime Restart:** UNVERIFIED
+
+The deployment workflow runs `docker compose up -d --force-recreate` which restarts Odoo containers, but does NOT explicitly run:
+- `-u all` (module upgrade)
+- `--stop-after-init` (verification)
+
+---
+
+## Risks / Unknowns
+
+| Item | Status | Missing Evidence |
+|------|--------|------------------|
+| Workflow run URL | UNVERIFIED | GitHub API not accessible to retrieve run ID |
+| Docker image digest | UNVERIFIED | Cannot access container registry to verify sha256 |
+| Production health check | UNVERIFIED | Cannot access `erp.insightpulseai.net/web/health` |
+| Odoo service restart | UNVERIFIED | No logs from production deployment |
+| Supabase verification results | PENDING | `verify_supabase_deploy.sh` has not been executed |
+
+**Mitigation:** This release contains only documentation and verification tooling. No runtime artifacts were changed in the codebase. Any production runtime changes are limited to container restarts (same image).
+
+---
+
+## Evidence Files
+
+- [GO_LIVE_MANIFEST_prod-20260109-2219.md](./GO_LIVE_MANIFEST_prod-20260109-2219.md)
+- [WHAT_DEPLOYED_prod-20260109-2219.json](./WHAT_DEPLOYED_prod-20260109-2219.json)
+- [DEPLOYMENT_PROOFS/prod-20260109-2219/README.md](./DEPLOYMENT_PROOFS/prod-20260109-2219/README.md)
+
+---
+
+*Report generated deterministically from git artifacts. UNVERIFIED items require GitHub API access or production server access to confirm.*


### PR DESCRIPTION
Generate deterministic "What's Deployed" report for release prod-20260109-2219:
- WHAT_DEPLOYED markdown and JSON reports
- GO_LIVE_MANIFEST for go-live tracking
- DEPLOYMENT_PROOFS with evidence links

Analysis summary:
- 2 commits included (PR #191 + auto-generated docs)
- 3 commits excluded (after release tag)
- No Odoo module changes (addons/ unchanged)
- No Supabase migrations/functions (supabase/ unchanged)
- Docs/tooling only release (verification scripts)
- Runtime evidence UNVERIFIED (GitHub API not accessible)