### PR TITLE
Fix Vercel build configuration for Scout Vite app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,11 +65,21 @@ DEV_MODE=
 # Project: spdtwktxdalcfigzeqrz
 SUPABASE_PROJECT_REF=spdtwktxdalcfigzeqrz
 SUPABASE_URL=https://spdtwktxdalcfigzeqrz.supabase.co
-NEXT_PUBLIC_SUPABASE_URL=https://spdtwktxdalcfigzeqrz.supabase.co
 
-# Authentication Keys
-SUPABASE_ANON_KEY=your_anon_key_here
+# Next.js public vars
+NEXT_PUBLIC_SUPABASE_URL=https://spdtwktxdalcfigzeqrz.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
+
+# Vite public vars (for Vite-based apps)
+VITE_PUBLIC_SUPABASE_URL=https://spdtwktxdalcfigzeqrz.supabase.co
+VITE_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
+
+# Expo public vars (for mobile app)
+EXPO_PUBLIC_SUPABASE_URL=https://spdtwktxdalcfigzeqrz.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
+
+# Authentication Keys (server-side only)
+SUPABASE_ANON_KEY=your_anon_key_here
 SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
 
 # PostgreSQL Connection (Pooled - Port 6543)

--- a/packages/env-config/package.json
+++ b/packages/env-config/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@ipai/env-config",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/env-config/src/index.ts
+++ b/packages/env-config/src/index.ts
@@ -1,0 +1,176 @@
+/**
+ * Universal environment configuration for IPAI monorepo
+ * Handles Vite, Next.js, and Expo environment variable prefixes
+ */
+
+type EnvSource = Record<string, string | undefined>
+
+/**
+ * Pick the first defined value from multiple possible env var names
+ * Supports: VITE_PUBLIC_, VITE_, NEXT_PUBLIC_, EXPO_PUBLIC_, and unprefixed
+ */
+function pick(sources: EnvSource[], ...keys: string[]): string {
+  for (const key of keys) {
+    for (const source of sources) {
+      const value = source[key]
+      if (typeof value === 'string' && value.length > 0) {
+        return value
+      }
+    }
+  }
+  return ''
+}
+
+/**
+ * Get all available env sources based on runtime
+ */
+function getEnvSources(): EnvSource[] {
+  const sources: EnvSource[] = []
+
+  // Vite compile-time env (import.meta.env)
+  if (typeof import.meta !== 'undefined' && (import.meta as any).env) {
+    sources.push((import.meta as any).env)
+  }
+
+  // Node.js / Next.js runtime env
+  if (typeof process !== 'undefined' && process.env) {
+    sources.push(process.env as EnvSource)
+  }
+
+  // Global fallback (for some edge runtimes)
+  if (typeof globalThis !== 'undefined') {
+    sources.push(globalThis as unknown as EnvSource)
+  }
+
+  return sources
+}
+
+/**
+ * Supabase configuration with multi-prefix support
+ */
+export function getSupabaseConfig() {
+  const sources = getEnvSources()
+
+  const url = pick(
+    sources,
+    'VITE_PUBLIC_SUPABASE_URL',
+    'VITE_SUPABASE_URL',
+    'NEXT_PUBLIC_SUPABASE_URL',
+    'EXPO_PUBLIC_SUPABASE_URL',
+    'SUPABASE_URL'
+  )
+
+  const anonKey = pick(
+    sources,
+    'VITE_PUBLIC_SUPABASE_ANON_KEY',
+    'VITE_SUPABASE_ANON_KEY',
+    'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+    'EXPO_PUBLIC_SUPABASE_ANON_KEY',
+    'SUPABASE_ANON_KEY'
+  )
+
+  const serviceRoleKey = pick(
+    sources,
+    'SUPABASE_SERVICE_ROLE_KEY'
+  )
+
+  return { url, anonKey, serviceRoleKey }
+}
+
+/**
+ * OpenAI/AI provider configuration
+ */
+export function getAIConfig() {
+  const sources = getEnvSources()
+
+  return {
+    openaiApiKey: pick(sources, 'OPENAI_API_KEY'),
+    anthropicApiKey: pick(sources, 'ANTHROPIC_API_KEY'),
+    geminiApiKey: pick(sources, 'GEMINI_API_KEY', 'GOOGLE_AI_API_KEY'),
+  }
+}
+
+/**
+ * General app configuration
+ */
+export function getAppConfig() {
+  const sources = getEnvSources()
+
+  return {
+    appUrl: pick(
+      sources,
+      'VITE_PUBLIC_APP_URL',
+      'NEXT_PUBLIC_APP_URL',
+      'EXPO_PUBLIC_APP_URL',
+      'APP_URL'
+    ),
+    siteUrl: pick(
+      sources,
+      'VITE_PUBLIC_SITE_URL',
+      'NEXT_PUBLIC_SITE_URL',
+      'SITE_URL'
+    ),
+    tenantId: pick(sources, 'TENANT_ID'),
+  }
+}
+
+/**
+ * Validate required environment variables and throw if missing
+ */
+export function validateEnv(config: Record<string, string>, required: string[]): void {
+  const missing = required.filter((key) => !config[key])
+  if (missing.length > 0) {
+    throw new Error(`Missing or invalid environment variables: ${missing.join(', ')}`)
+  }
+}
+
+/**
+ * Get and validate Supabase config - throws if required vars missing
+ */
+export function getRequiredSupabaseConfig() {
+  const config = getSupabaseConfig()
+  validateEnv(config, ['url', 'anonKey'])
+  return config as { url: string; anonKey: string; serviceRoleKey: string }
+}
+
+/**
+ * Environment type detection
+ */
+export function getEnvType(): 'vite' | 'next' | 'expo' | 'node' | 'unknown' {
+  if (typeof import.meta !== 'undefined' && (import.meta as any).env?.MODE) {
+    return 'vite'
+  }
+  if (typeof process !== 'undefined' && process.env.NEXT_RUNTIME) {
+    return 'next'
+  }
+  if (typeof process !== 'undefined' && process.env.EXPO_PUBLIC_URL) {
+    return 'expo'
+  }
+  if (typeof process !== 'undefined' && process.versions?.node) {
+    return 'node'
+  }
+  return 'unknown'
+}
+
+/**
+ * Check if running in production
+ */
+export function isProduction(): boolean {
+  const sources = getEnvSources()
+  const nodeEnv = pick(sources, 'NODE_ENV')
+  const mode = pick(sources, 'MODE')
+  return nodeEnv === 'production' || mode === 'production'
+}
+
+/**
+ * Check if running in development
+ */
+export function isDevelopment(): boolean {
+  const sources = getEnvSources()
+  const nodeEnv = pick(sources, 'NODE_ENV')
+  const mode = pick(sources, 'MODE')
+  return nodeEnv === 'development' || mode === 'development'
+}
+
+// Re-export types
+export type { EnvSource }

--- a/packages/env-config/tsconfig.json
+++ b/packages/env-config/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,38 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "version": 2,
+  "installCommand": "npm ci",
+  "framework": null,
   "projects": [
     {
       "name": "ipai-control-center-docs",
       "rootDirectory": "apps/ipai-control-center-docs",
-      "framework": "nextjs"
+      "framework": "nextjs",
+      "buildCommand": "npm run build",
+      "outputDirectory": ".next"
+    },
+    {
+      "name": "ipai-web",
+      "rootDirectory": "apps/web",
+      "framework": "nextjs",
+      "buildCommand": "npm run build",
+      "outputDirectory": ".next"
+    },
+    {
+      "name": "ipai-control-room",
+      "rootDirectory": "apps/control-room",
+      "framework": "nextjs",
+      "buildCommand": "npm run build",
+      "outputDirectory": ".next"
+    }
+  ],
+  "builds": [
+    {
+      "src": "apps/ipai-chatgpt-app/web/package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
     }
   ],
   "functions": {
@@ -15,6 +44,10 @@
     "SUPABASE_URL": "@supabase-url",
     "SUPABASE_SERVICE_ROLE_KEY": "@supabase-service-role-key",
     "OPENAI_API_KEY": "@openai-api-key",
-    "TENANT_ID": "@tenant-id"
+    "TENANT_ID": "@tenant-id",
+    "NEXT_PUBLIC_SUPABASE_URL": "@supabase-url",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY": "@supabase-anon-key",
+    "VITE_PUBLIC_SUPABASE_URL": "@supabase-url",
+    "VITE_PUBLIC_SUPABASE_ANON_KEY": "@supabase-anon-key"
   }
 }


### PR DESCRIPTION
- Add schema and version to vercel.json for proper validation
- Configure multiple Next.js projects (docs, web, control-room)
- Add Vite static build config for ipai-chatgpt-app/web
- Add multi-prefix env vars (NEXT_PUBLIC_, VITE_PUBLIC_) to env config
- Create @ipai/env-config package for universal env handling
- Update .env.example with all framework prefixes (Vite/Next/Expo)

Resolves Vercel build issues where:
- Production overrides were forcing wrong build behavior
- Vite apps were incorrectly built as Next.js
- Supabase env sync prefix didn't match client validation