### PR TITLE
feat(theme): align design tokens with Scout dashboard spec

### DIFF
--- a/addons/ipai_platform_theme/static/src/scss/tokens.scss
+++ b/addons/ipai_platform_theme/static/src/scss/tokens.scss
@@ -3,63 +3,126 @@
 // ============================================================================
 // Single source of truth for all IPAI/Odoo theming.
 // These CSS custom properties can be overridden by skin modules.
+// All other IPAI modules should reference these tokens, NOT hex codes.
 // ============================================================================
 
 :root {
   // ============================================================================
   // BRAND TOKENS (Override these in skin modules like ipai_theme_tbwa_backend)
   // ============================================================================
+  // These are brand-agnostic slots that skins override with their brand colors.
 
-  // Primary brand color - used for buttons, links, focus states
-  --ipai-brand-primary: #F9C300;     // TBWA Yellow (default)
-  --ipai-brand-primary-hover: #FFDD2D;
+  // Primary brand color - used for buttons, links, focus states, accents
+  --ipai-brand-primary: #FFCC00;        // Default yellow (override in skin)
+  --ipai-brand-primary-hover: #FFD633;
   --ipai-brand-primary-light: #FFF8E3;
-  --ipai-brand-primary-rgb: 249, 195, 0;  // For rgba() usage
+  --ipai-brand-primary-rgb: 255, 204, 0;  // For rgba() usage
 
-  // Ink color - text on primary backgrounds
-  --ipai-brand-ink: #0B0B0B;
+  // Ink color - text on primary backgrounds (ensure contrast)
+  --ipai-brand-ink: #000000;
 
-  // Surface colors
-  --ipai-brand-surface: #FFFFFF;
-  --ipai-brand-surface-alt: #F7F9FC;
-  --ipai-brand-muted: #F5F5F5;
-  --ipai-brand-border: #E5E7EB;
+  // ============================================================================
+  // SURFACE TOKENS (Canvas, Cards, Panels)
+  // ============================================================================
 
-  // Text colors
-  --ipai-text-primary: #111827;
-  --ipai-text-secondary: #6B7280;
-  --ipai-text-muted: #9CA3AF;
-  --ipai-text-inverse: #FFFFFF;
+  --ipai-surface-canvas: #FAFAFA;       // Page background
+  --ipai-surface-card: #FFFFFF;         // Cards and panels
+  --ipai-surface-elevated: #FFFFFF;     // Elevated surfaces (modals, dropdowns)
+  --ipai-surface-muted: #F5F5F5;        // Subtle backgrounds
+  --ipai-surface-warm: #FFF8E3;         // Warm panels (insights, recommendations)
+
+  // Border colors
+  --ipai-border-subtle: #E5E5E5;        // Default borders
+  --ipai-border-strong: #D1D5DB;        // Emphasized borders
+
+  // ============================================================================
+  // NEUTRAL COLOR SCALE
+  // ============================================================================
+  // Full neutral palette for text, backgrounds, and UI elements
+
+  --ipai-neutral-900: #0D0D0D;          // Near black
+  --ipai-neutral-800: #1A1A1A;
+  --ipai-neutral-700: #333333;
+  --ipai-neutral-600: #4D4D4D;
+  --ipai-neutral-500: #666666;          // Mid gray
+  --ipai-neutral-400: #808080;
+  --ipai-neutral-300: #B3B3B3;
+  --ipai-neutral-200: #D9D9D9;
+  --ipai-neutral-100: #EDEDED;
+  --ipai-neutral-050: #FAFAFA;          // Near white
+
+  // ============================================================================
+  // TEXT TOKENS
+  // ============================================================================
+
+  --ipai-text-primary: #111111;         // Primary text (headings, body)
+  --ipai-text-secondary: #444444;       // Secondary text
+  --ipai-text-muted: #6B7280;           // Muted/placeholder text
+  --ipai-text-disabled: #9CA3AF;        // Disabled text
+  --ipai-text-inverse: #FFFFFF;         // Text on dark backgrounds
 
   // ============================================================================
   // SEMANTIC COLORS
   // ============================================================================
+  // Use for status indicators, alerts, badges - NOT for brand accent
 
-  --ipai-success: #10B981;
-  --ipai-success-light: #D1FAE5;
-  --ipai-success-dark: #059669;
+  --ipai-semantic-info: #3B82F6;
+  --ipai-semantic-info-light: #DBEAFE;
+  --ipai-semantic-info-dark: #2563EB;
 
-  --ipai-warning: #F59E0B;
-  --ipai-warning-light: #FEF3C7;
-  --ipai-warning-dark: #D97706;
+  --ipai-semantic-success: #22C55E;
+  --ipai-semantic-success-light: #DCFCE7;
+  --ipai-semantic-success-dark: #16A34A;
 
-  --ipai-error: #EF4444;
-  --ipai-error-light: #FEE2E2;
-  --ipai-error-dark: #DC2626;
+  --ipai-semantic-warn: #F59E0B;
+  --ipai-semantic-warn-light: #FEF3C7;
+  --ipai-semantic-warn-dark: #D97706;
 
-  --ipai-info: #3B82F6;
-  --ipai-info-light: #DBEAFE;
-  --ipai-info-dark: #2563EB;
+  --ipai-semantic-error: #EF4444;
+  --ipai-semantic-error-light: #FEE2E2;
+  --ipai-semantic-error-dark: #DC2626;
+
+  // Legacy aliases (for backward compatibility)
+  --ipai-success: var(--ipai-semantic-success);
+  --ipai-success-light: var(--ipai-semantic-success-light);
+  --ipai-success-dark: var(--ipai-semantic-success-dark);
+  --ipai-warning: var(--ipai-semantic-warn);
+  --ipai-warning-light: var(--ipai-semantic-warn-light);
+  --ipai-warning-dark: var(--ipai-semantic-warn-dark);
+  --ipai-error: var(--ipai-semantic-error);
+  --ipai-error-light: var(--ipai-semantic-error-light);
+  --ipai-error-dark: var(--ipai-semantic-error-dark);
+  --ipai-info: var(--ipai-semantic-info);
+  --ipai-info-light: var(--ipai-semantic-info-light);
+  --ipai-info-dark: var(--ipai-semantic-info-dark);
+
+  // Legacy surface aliases (for backward compatibility)
+  --ipai-brand-surface: var(--ipai-surface-card);
+  --ipai-brand-surface-alt: var(--ipai-surface-canvas);
+  --ipai-brand-muted: var(--ipai-surface-muted);
+  --ipai-brand-border: var(--ipai-border-subtle);
 
   // ============================================================================
-  // ODOO VARIABLE MAPPING
-  // Map IPAI tokens to Odoo's CSS custom properties
+  // ODOO/BOOTSTRAP VARIABLE MAPPING
+  // Map IPAI tokens to Odoo's and Bootstrap's CSS custom properties
   // ============================================================================
 
+  // Odoo brand colors
   --o-brand-primary: var(--ipai-brand-primary);
   --o-brand-odoo: var(--ipai-brand-primary);
   --o-enterprise-color: var(--ipai-brand-primary);
   --o-community-color: var(--ipai-brand-primary);
+
+  // Bootstrap semantic colors
+  --bs-primary: var(--ipai-brand-primary);
+  --bs-success: var(--ipai-semantic-success);
+  --bs-warning: var(--ipai-semantic-warn);
+  --bs-danger: var(--ipai-semantic-error);
+  --bs-info: var(--ipai-semantic-info);
+
+  // Body colors
+  --bs-body-bg: var(--ipai-surface-canvas);
+  --bs-body-color: var(--ipai-text-primary);
 
   // ============================================================================
   // TYPOGRAPHY TOKENS

--- a/addons/ipai_theme_tbwa_backend/__manifest__.py
+++ b/addons/ipai_theme_tbwa_backend/__manifest__.py
@@ -1,37 +1,55 @@
 # -*- coding: utf-8 -*-
 {
-    "name": "TBWA Backend Theme (DEPRECATED)",
-    "summary": "DEPRECATED - Use ipai_theme_tbwa instead",
+    "name": "TBWA Backend Theme",
+    "summary": "TBWA brand skin for Odoo backend (Yellow + Black)",
     "description": """
-TBWA Backend Theme - DEPRECATED
-===============================
+TBWA Backend Theme
+==================
 
-**THIS MODULE IS DEPRECATED AND SHOULD NOT BE INSTALLED.**
+This module provides the TBWA brand skin for the Odoo backend.
+It overrides the design tokens from `ipai_platform_theme` with
+TBWA-specific brand values (Yellow #FFD800 + Black).
 
-Please use `ipai_theme_tbwa` instead, which provides:
-- Simpler architecture (no complex asset hooks)
-- Black chrome + Yellow accent
-- Clean white/gray surfaces
-- No Bootstrap compilation conflicts
+Architecture:
+- ipai_platform_theme = design system source of truth (tokens, mappings)
+- ipai_theme_tbwa_backend = TBWA skin that overrides those tokens
 
-To migrate:
-1. Uninstall this module: Settings > Apps > ipai_theme_tbwa_backend > Uninstall
-2. Install ipai_theme_tbwa: Settings > Apps > ipai_theme_tbwa > Install
-3. Clear browser cache and reload
+This module does NOT define new tokens, only overrides existing ones:
+- --ipai-brand-primary: #FFD800 (TBWA Yellow)
+- --ipai-brand-ink: #000000 (Black)
+- --ipai-surface-canvas: #F5F5F5
+- --ipai-surface-card: #FFFFFF
+
+Key Features:
+- Black navbar and sidebar chrome
+- Yellow accent color for buttons, active states
+- Scout Analytics / InsightPulse UI alignment
+- Premium rounded corners (16px cards)
     """,
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.3.0",
     "category": "Themes/Backend",
-    "license": "AGPL-3",
+    "license": "LGPL-3",
     "author": "InsightPulse AI / TBWA Finance",
     "website": "https://insightpulseai.net",
     "depends": [
-        "web",
+        "ipai_platform_theme",
     ],
     "excludes": [
         "web_enterprise",
     ],
-    "assets": {},
-    "installable": False,
+    "assets": {
+        # Load SCSS variables BEFORE Odoo/Bootstrap compiles
+        "web._assets_primary_variables": [
+            ("prepend", "ipai_theme_tbwa_backend/static/src/scss/variables.scss"),
+        ],
+        # Load token overrides and component styles AFTER platform theme
+        "web.assets_backend": [
+            "ipai_theme_tbwa_backend/static/src/scss/fonts.scss",
+            "ipai_theme_tbwa_backend/static/src/scss/tbwa_tokens.scss",
+            "ipai_theme_tbwa_backend/static/src/scss/backend.scss",
+        ],
+    },
+    "installable": True,
     "application": False,
     "auto_install": False,
 }

--- a/addons/ipai_theme_tbwa_backend/static/src/scss/backend.scss
+++ b/addons/ipai_theme_tbwa_backend/static/src/scss/backend.scss
@@ -1,342 +1,444 @@
 // ============================================================================
-// TBWA Backend Theme - UI Styling
+// TBWA Backend Theme - Component Overrides
 // ============================================================================
-// This file contains component-level styling that can't be done via variables
-// Loaded in web.assets_backend bundle
+// This file contains component-level styling for the TBWA skin.
+// All styles should reference --ipai-* tokens from ipai_platform_theme.
+// Loaded in web.assets_backend bundle AFTER token overrides.
 // ============================================================================
 
 // =============================================================================
-// Primary Buttons - Yellow background needs BLACK text
+// NAVBAR (Black Chrome)
+// =============================================================================
+
+.o_main_navbar {
+  background-color: var(--ipai-brand-ink) !important;
+  border-bottom: none !important;
+
+  // App switcher button
+  .o_navbar_apps_menu .dropdown-toggle {
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.1) !important;
+    }
+  }
+
+  // Menu sections
+  .o_menu_sections {
+    .dropdown-toggle,
+    .o_nav_entry {
+      color: var(--ipai-text-inverse) !important;
+
+      &:hover {
+        background-color: rgba(255, 255, 255, 0.08) !important;
+      }
+
+      &.active,
+      &:active {
+        background-color: var(--ipai-brand-primary) !important;
+        color: var(--ipai-brand-ink) !important;
+      }
+    }
+
+    .dropdown-item {
+      &.active,
+      &:active {
+        background-color: rgba(var(--ipai-brand-primary-rgb), 0.14) !important;
+        color: var(--ipai-text-inverse) !important;
+      }
+
+      &:hover {
+        background-color: rgba(255, 255, 255, 0.08) !important;
+      }
+    }
+  }
+
+  // Current app name
+  .o_menu_brand {
+    color: var(--ipai-text-inverse) !important;
+    font-weight: 600;
+  }
+
+  // Systray (user menu, etc)
+  .o_menu_systray {
+    .dropdown-toggle,
+    a {
+      color: var(--ipai-text-inverse) !important;
+
+      &:hover {
+        color: var(--ipai-brand-primary) !important;
+      }
+    }
+  }
+}
+
+// =============================================================================
+// SIDEBAR (Black + Yellow Active - Scout Analytics Style)
+// =============================================================================
+
+.o_apps_sidebar,
+.mk_apps_sidebar_panel,
+[class*="sidebar"]:not(.o_content *) {
+  background-color: var(--ipai-brand-ink) !important;
+
+  .nav-link,
+  a:not(.btn) {
+    color: var(--ipai-text-inverse) !important;
+    border-radius: var(--ipai-radius-sm) !important;
+    transition: all 150ms ease-out;
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.1) !important;
+    }
+
+    // Active state: Yellow background with black text
+    &.active {
+      background-color: var(--ipai-brand-primary) !important;
+      color: var(--ipai-brand-ink) !important;
+      font-weight: 600;
+    }
+  }
+}
+
+// MuK Apps Sidebar compatibility
+.mk_apps_sidebar_panel {
+  .mk_apps_sidebar_menu {
+    > li {
+      &.active > a,
+      &:hover > a {
+        background-color: rgba(var(--ipai-brand-primary-rgb), 0.14) !important;
+        border-left: 3px solid var(--ipai-brand-primary) !important;
+      }
+
+      > a {
+        border-left: 3px solid transparent;
+      }
+    }
+  }
+}
+
+// =============================================================================
+// PRIMARY BUTTONS (Yellow + Black Text)
 // =============================================================================
 
 .btn-primary,
 .o_btn_primary,
+.btn-fill-primary,
 .btn-primary.o_form_button_save,
 .o_statusbar_buttons .btn-primary {
-    color: #000000 !important;
-    font-weight: 600;
-    
-    &:hover,
-    &:focus,
-    &:active {
-        color: #000000 !important;
-        background-color: #FFDD2D !important;
-        border-color: #FFDD2D !important;
-    }
-    
-    &:disabled {
-        color: rgba(0, 0, 0, 0.5) !important;
-    }
+  background-color: var(--ipai-brand-primary) !important;
+  border-color: var(--ipai-brand-primary) !important;
+  color: var(--ipai-brand-ink) !important;
+  font-weight: 600;
+  border-radius: var(--ipai-radius) !important;
+
+  &:hover,
+  &:focus,
+  &:active {
+    background-color: var(--ipai-brand-primary-hover) !important;
+    border-color: var(--ipai-brand-primary-hover) !important;
+    color: var(--ipai-brand-ink) !important;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    color: var(--ipai-brand-ink) !important;
+  }
 }
 
 // Secondary/outline buttons
 .btn-outline-primary {
-    color: #111827;
-    border-color: #FFD800;
-    
+  color: var(--ipai-text-primary) !important;
+  border-color: var(--ipai-brand-primary) !important;
+  background: transparent !important;
+
+  &:hover {
+    color: var(--ipai-brand-ink) !important;
+    background-color: var(--ipai-brand-primary) !important;
+  }
+}
+
+// =============================================================================
+// APPS GRID CARDS (Scout Dashboard Style)
+// =============================================================================
+
+.o_apps {
+  .o_kanban_record.o_app,
+  .o_app {
+    background-color: var(--ipai-surface-card) !important;
+    border-radius: 16px !important;
+    border: 1px solid var(--ipai-border-subtle) !important;
+    transition: all 200ms ease-out;
+
     &:hover {
-        color: #000000;
-        background-color: #FFD800;
+      box-shadow: var(--ipai-shadow-md) !important;
+      transform: translateY(-2px);
     }
+  }
 }
 
 // =============================================================================
-// Navbar Styling
-// =============================================================================
-
-.o_main_navbar {
-    background-color: #000000;
-    
-    // App switcher button
-    .o_navbar_apps_menu .dropdown-toggle {
-        &:hover {
-            background-color: rgba(255, 216, 0, 0.14);
-        }
-    }
-    
-    // Menu sections
-    .o_menu_sections {
-        .dropdown-item {
-            &.active,
-            &:active {
-                background-color: rgba(255, 216, 0, 0.14) !important;
-                color: #FFFFFF;
-            }
-            
-            &:hover {
-                background-color: rgba(255, 255, 255, 0.08);
-            }
-        }
-    }
-    
-    // Current app name
-    .o_menu_brand {
-        color: #FFFFFF;
-        font-weight: 600;
-    }
-}
-
-// =============================================================================
-// Sidebar (MuK AppsBar compatible)
-// =============================================================================
-
-.mk_apps_sidebar_panel {
-    background-color: #000000;
-    
-    .mk_apps_sidebar_menu {
-        > li {
-            &.active > a,
-            &:hover > a {
-                background-color: rgba(255, 216, 0, 0.14) !important;
-                border-left: 3px solid #FFD800;
-            }
-            
-            > a {
-                border-left: 3px solid transparent;
-            }
-        }
-    }
-}
-
-// =============================================================================
-// Cards & Kanban
+// KANBAN CARDS
 // =============================================================================
 
 .o_kanban_view {
-    .o_kanban_record {
-        border-radius: 16px;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-        border: 1px solid #E5E7EB;
-        
-        &:hover {
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-        }
+  .o_kanban_record {
+    border-radius: 16px !important;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06) !important;
+    border: 1px solid var(--ipai-border-subtle) !important;
+
+    &:hover {
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08) !important;
     }
-    
-    .o_kanban_group {
-        .o_kanban_header {
-            background-color: transparent;
-            
-            .o_column_title {
-                font-weight: 600;
-                color: #111827;
-            }
-        }
+  }
+
+  .o_kanban_group {
+    .o_kanban_header {
+      background-color: transparent !important;
+
+      .o_column_title {
+        font-weight: 600;
+        color: var(--ipai-text-primary) !important;
+      }
     }
+  }
 }
 
 // =============================================================================
-// Form Views
+// FORM VIEWS
 // =============================================================================
 
 .o_form_view {
-    .o_form_sheet_bg {
-        background-color: #F7F9FC;
+  .o_form_sheet_bg {
+    background-color: var(--ipai-surface-canvas) !important;
+  }
+
+  .o_form_sheet {
+    border-radius: 16px !important;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06) !important;
+    border: 1px solid var(--ipai-border-subtle) !important;
+  }
+
+  // Field focus state
+  .o_field_widget {
+    .o_input:focus {
+      border-color: var(--ipai-brand-primary) !important;
+      box-shadow: 0 0 0 3px rgba(var(--ipai-brand-primary-rgb), 0.15) !important;
     }
-    
-    .o_form_sheet {
-        border-radius: 16px;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-        border: 1px solid #E5E7EB;
+  }
+
+  // Required fields
+  .o_required_modifier .o_input {
+    border-color: var(--ipai-border-strong) !important;
+
+    &:focus {
+      border-color: var(--ipai-brand-primary) !important;
     }
-    
-    // Field focus state
-    .o_field_widget {
-        .o_input:focus {
-            border-color: #FFD800;
-            box-shadow: 0 0 0 3px rgba(255, 216, 0, 0.15);
-        }
-    }
-    
-    // Required fields
-    .o_required_modifier .o_input {
-        border-color: #D1D5DB;
-        
-        &:focus {
-            border-color: #FFD800;
-        }
-    }
+  }
 }
 
 // =============================================================================
-// Status Bar
+// STATUS BAR
 // =============================================================================
 
 .o_statusbar_status {
-    .o_arrow_button {
-        &.o_arrow_button_current {
-            background-color: #FFD800;
-            color: #000000;
-            font-weight: 600;
-        }
-        
-        &:hover:not(.o_arrow_button_current):not(.disabled) {
-            background-color: rgba(255, 216, 0, 0.14);
-        }
+  .o_arrow_button {
+    &.o_arrow_button_current {
+      background-color: var(--ipai-brand-primary) !important;
+      color: var(--ipai-brand-ink) !important;
+      font-weight: 600;
     }
+
+    &:hover:not(.o_arrow_button_current):not(.disabled) {
+      background-color: var(--ipai-brand-primary-light) !important;
+    }
+  }
 }
 
 // =============================================================================
-// Control Panel / Search
+// CONTROL PANEL / SEARCH
 // =============================================================================
 
 .o_control_panel {
-    background-color: #FFFFFF;
-    border-bottom: 1px solid #E5E7EB;
-    
-    .o_searchview {
-        border-radius: 10px;
-        border: 1px solid #E5E7EB;
-        
-        &:focus-within {
-            border-color: #FFD800;
-            box-shadow: 0 0 0 3px rgba(255, 216, 0, 0.15);
-        }
+  background-color: var(--ipai-surface-card) !important;
+  border-bottom: 1px solid var(--ipai-border-subtle) !important;
+
+  .o_searchview {
+    border-radius: var(--ipai-radius-sm) !important;
+    border: 1px solid var(--ipai-border-subtle) !important;
+
+    &:focus-within {
+      border-color: var(--ipai-brand-primary) !important;
+      box-shadow: 0 0 0 3px rgba(var(--ipai-brand-primary-rgb), 0.15) !important;
     }
+  }
 }
 
 // =============================================================================
-// Badges & Tags
+// BADGES & TAGS (Semantic colors, NOT brand yellow)
 // =============================================================================
 
 .badge-primary,
 .o_tag.o_tag_color_0 {
-    background-color: #FFD800 !important;
-    color: #000000 !important;
+  background-color: var(--ipai-brand-primary) !important;
+  color: var(--ipai-brand-ink) !important;
+}
+
+// Status badges use semantic colors
+.badge-success,
+.o_tag_success {
+  background-color: var(--ipai-semantic-success) !important;
+  color: var(--ipai-text-inverse) !important;
+}
+
+.badge-warning,
+.o_tag_warning {
+  background-color: var(--ipai-semantic-warn) !important;
+  color: var(--ipai-brand-ink) !important;
+}
+
+.badge-danger,
+.o_tag_danger {
+  background-color: var(--ipai-semantic-error) !important;
+  color: var(--ipai-text-inverse) !important;
+}
+
+.badge-info,
+.o_tag_info {
+  background-color: var(--ipai-semantic-info) !important;
+  color: var(--ipai-text-inverse) !important;
 }
 
 // =============================================================================
-// Chatter
-// =============================================================================
-
-.o-mail-Chatter {
-    .o-mail-Chatter-top {
-        border-bottom: 1px solid #E5E7EB;
-    }
-    
-    .o-mail-Message {
-        border-radius: 12px;
-    }
-}
-
-// =============================================================================
-// Lists & Tables
+// LISTS & TABLES
 // =============================================================================
 
 .o_list_view {
-    .o_list_table {
-        thead th {
-            background-color: #F7F9FC;
-            font-weight: 600;
-            color: #111827;
-        }
-        
-        tbody tr {
-            &:hover td {
-                background-color: rgba(255, 216, 0, 0.05);
-            }
-            
-            &.o_data_row_selected td {
-                background-color: rgba(255, 216, 0, 0.14);
-            }
-        }
+  .o_list_table {
+    thead th {
+      background-color: var(--ipai-surface-canvas) !important;
+      font-weight: 600;
+      color: var(--ipai-text-primary) !important;
     }
+
+    tbody tr {
+      &:hover td {
+        background-color: rgba(var(--ipai-brand-primary-rgb), 0.05) !important;
+      }
+
+      &.o_data_row_selected td {
+        background-color: rgba(var(--ipai-brand-primary-rgb), 0.14) !important;
+      }
+    }
+  }
 }
 
 // =============================================================================
-// Apps Menu (MuK Theme compatible)
+// CHATTER
 // =============================================================================
 
-.mk_app_menu.dropdown-menu {
-    .o_app {
-        > a {
-            .o_caption {
-                color: rgba(255, 255, 255, 0.95);
-                font-weight: 500;
-            }
-            
-            &:hover {
-                .mk_app_icon {
-                    box-shadow: 0 4px 12px rgba(255, 216, 0, 0.3);
-                }
-            }
-        }
-    }
+.o-mail-Chatter {
+  .o-mail-Chatter-top {
+    border-bottom: 1px solid var(--ipai-border-subtle) !important;
+  }
+
+  .o-mail-Message {
+    border-radius: 12px !important;
+  }
 }
 
 // =============================================================================
-// Dialogs / Modals
+// DIALOGS / MODALS
 // =============================================================================
 
 .modal-content {
-    border-radius: 16px;
-    border: none;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+  border-radius: 16px !important;
+  border: none !important;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15) !important;
 }
 
 .modal-header {
-    border-bottom: 1px solid #E5E7EB;
-    
-    .modal-title {
-        font-weight: 600;
-        color: #111827;
-    }
+  border-bottom: 1px solid var(--ipai-border-subtle) !important;
+
+  .modal-title {
+    font-weight: 600;
+    color: var(--ipai-text-primary) !important;
+  }
 }
 
 // =============================================================================
-// Calendar
+// CALENDAR
 // =============================================================================
 
 .o_calendar_view {
-    .fc-event-main {
-        background-color: #FFD800;
-        color: #000000;
-        border: none;
-        border-radius: 6px;
-    }
+  .fc-event-main {
+    background-color: var(--ipai-brand-primary) !important;
+    color: var(--ipai-brand-ink) !important;
+    border: none !important;
+    border-radius: 6px !important;
+  }
 }
 
 // =============================================================================
-// Dashboard / Reports
+// DASHBOARD / REPORTS
 // =============================================================================
 
 .o_graph_view,
 .o_pivot_view {
-    .o_graph_canvas_container,
-    .o_pivot_table {
-        border-radius: 12px;
-        background: #FFFFFF;
-        padding: 16px;
-    }
+  .o_graph_canvas_container,
+  .o_pivot_table {
+    border-radius: 12px !important;
+    background: var(--ipai-surface-card) !important;
+    padding: 16px;
+  }
 }
 
 // =============================================================================
-// Loading Indicator
+// LOADING INDICATOR
 // =============================================================================
 
 .o_loading_indicator {
-    background-color: #FFD800;
-    color: #000000;
+  background-color: var(--ipai-brand-primary) !important;
+  color: var(--ipai-brand-ink) !important;
 }
 
 // =============================================================================
-// Scrollbars (WebKit)
+// SCROLLBARS (WebKit)
 // =============================================================================
 
 ::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {
-    background: #F3F4F6;
+  background: var(--ipai-surface-muted);
 }
 
 ::-webkit-scrollbar-thumb {
-    background: #D1D5DB;
-    border-radius: 4px;
-    
-    &:hover {
-        background: #9CA3AF;
+  background: var(--ipai-border-strong);
+  border-radius: 4px;
+
+  &:hover {
+    background: var(--ipai-text-muted);
+  }
+}
+
+// =============================================================================
+// APPS MENU (MuK Theme compatible)
+// =============================================================================
+
+.mk_app_menu.dropdown-menu {
+  .o_app {
+    > a {
+      .o_caption {
+        color: rgba(255, 255, 255, 0.95) !important;
+        font-weight: 500;
+      }
+
+      &:hover {
+        .mk_app_icon {
+          box-shadow: 0 4px 12px rgba(var(--ipai-brand-primary-rgb), 0.3) !important;
+        }
+      }
     }
+  }
 }

--- a/addons/ipai_theme_tbwa_backend/static/src/scss/tbwa_tokens.scss
+++ b/addons/ipai_theme_tbwa_backend/static/src/scss/tbwa_tokens.scss
@@ -2,7 +2,11 @@
 // TBWA Token Overrides
 // ============================================================================
 // This file overrides ipai_platform_theme CSS custom properties with
-// TBWA-specific brand values. It loads AFTER tokens.scss.
+// TBWA-specific brand values. It loads AFTER the platform tokens.scss.
+//
+// IMPORTANT: This file should ONLY override existing token values.
+// It should NOT define new token names. All --ipai-* tokens are defined
+// in ipai_platform_theme/tokens.scss.
 // ============================================================================
 
 :root {
@@ -10,26 +14,47 @@
   // TBWA BRAND COLOR OVERRIDES
   // ============================================================================
 
-  // Primary brand color - TBWA Yellow
+  // Primary brand color - TBWA Yellow (per brand guide)
   --ipai-brand-primary: #FFD800;
   --ipai-brand-primary-hover: #FFDD2D;
   --ipai-brand-primary-light: #FFF8E3;
   --ipai-brand-primary-rgb: 255, 216, 0;
 
-  // Ink color - pure black for TBWA
+  // Ink color - pure black for high contrast on yellow
   --ipai-brand-ink: #000000;
 
-  // Surface colors - clean whites with subtle gray
-  --ipai-brand-surface: #FFFFFF;
-  --ipai-brand-surface-alt: #F7F9FC;
-  --ipai-brand-muted: #F3F4F6;
-  --ipai-brand-border: #E5E7EB;
+  // ============================================================================
+  // TBWA SURFACE OVERRIDES (Optional - slightly different from default)
+  // ============================================================================
 
-  // Text colors - TBWA uses darker grays
-  --ipai-text-primary: #111827;
+  --ipai-surface-canvas: #F5F5F5;       // TBWA prefers slightly warmer gray
+  --ipai-surface-card: #FFFFFF;
+  --ipai-surface-elevated: #FFFFFF;
+  --ipai-surface-muted: #F3F4F6;
+  --ipai-surface-warm: #FFF8E3;         // Yellow tint for insights panels
+
+  // Border colors
+  --ipai-border-subtle: #E5E7EB;
+  --ipai-border-strong: #D1D5DB;
+
+  // ============================================================================
+  // TBWA TEXT OVERRIDES
+  // ============================================================================
+
+  --ipai-text-primary: #111827;         // Slightly darker for TBWA
   --ipai-text-secondary: #6B7280;
   --ipai-text-muted: #9CA3AF;
   --ipai-text-inverse: #FFFFFF;
+
+  // ============================================================================
+  // TBWA RADIUS OVERRIDES (Scout/InsightPulse style - more rounded)
+  // ============================================================================
+
+  --ipai-radius: 14px;
+  --ipai-radius-sm: 10px;
+  --ipai-radius-md: 14px;
+  --ipai-radius-lg: 16px;
+  --ipai-radius-xl: 20px;
 
   // ============================================================================
   // ODOO VARIABLE RE-MAPPING
@@ -40,20 +65,4 @@
   --o-brand-odoo: #FFD800;
   --o-enterprise-color: #FFD800;
   --o-community-color: #FFD800;
-
-  // ============================================================================
-  // TBWA TYPOGRAPHY
-  // ============================================================================
-
-  --ipai-font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-
-  // ============================================================================
-  // TBWA SPACING/RADIUS (Scout/InsightPulse style - more rounded)
-  // ============================================================================
-
-  --ipai-radius: 14px;
-  --ipai-radius-sm: 10px;
-  --ipai-radius-md: 14px;
-  --ipai-radius-lg: 16px;
-  --ipai-radius-xl: 20px;
 }


### PR DESCRIPTION
Updates ipai_platform_theme and ipai_theme_tbwa_backend to implement the Scout dashboard design system architecture:

ipai_platform_theme (design system source of truth):
- Added brand-agnostic token system with --ipai-* custom properties
- Added full neutral color scale (neutral-900 to neutral-050)
- Added semantic color tokens (info, success, warn, error)
- Added surface tokens (canvas, card, elevated, muted, warm)
- Added Bootstrap/Odoo variable mappings
- Added legacy aliases for backward compatibility

ipai_theme_tbwa_backend (TBWA skin):
- Re-enabled module (was deprecated)
- Now depends on ipai_platform_theme
- Only overrides brand values, does not define new tokens
- Updated backend.scss to use --ipai-* tokens instead of hex codes
- Component overrides for navbar, sidebar, buttons, cards

Architecture:
- ipai_platform_theme = single source of truth for tokens
- ipai_theme_tbwa_backend = TBWA skin that overrides token values

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Supabase security review | [View](https://hub.continue.dev/tasks/0a08be23-8159-4a08-9051-7cae7985b58a) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->