### PR TITLE
feat(ipai): add minimal AI layer (4-module whitelist)

### DIFF
--- a/addons/ipai/ipai_ask_ai_bridge/__init__.py
+++ b/addons/ipai/ipai_ask_ai_bridge/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/addons/ipai/ipai_ask_ai_bridge/__manifest__.py
+++ b/addons/ipai/ipai_ask_ai_bridge/__manifest__.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "IPAI Ask AI Bridge",
+    "summary": "Minimal launcher for external Ask AI / Copilot service.",
+    "description": """
+IPAI Ask AI Bridge
+==================
+
+A thin bridge module that launches an external Ask AI / Copilot service.
+
+This module does NOT implement AI logic. It only:
+- Adds a systray icon to launch the Copilot panel
+- Provides settings to configure the external service URL
+- Opens an iframe/popup to the external RAG service
+
+All AI logic, prompts, and RAG processing live externally in:
+- Supabase Edge Functions (RAG)
+- Pulser AI Gateway (LLM routing)
+- Spec Kit docs (prompt templates)
+
+See: docs/architecture/ASK_AI_CONTRACT.md for the full contract.
+    """,
+    "version": "18.0.1.0.0",
+    "category": "Productivity",
+    "author": "InsightPulse AI",
+    "website": "https://github.com/jgtolentino/odoo-ce",
+    "license": "AGPL-3",
+    "depends": [
+        "base",
+        "web",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/res_config_settings_views.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "ipai_ask_ai_bridge/static/src/js/ask_ai_systray.js",
+            "ipai_ask_ai_bridge/static/src/xml/ask_ai_systray.xml",
+        ],
+    },
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+}

--- a/addons/ipai/ipai_ask_ai_bridge/models/__init__.py
+++ b/addons/ipai/ipai_ask_ai_bridge/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import res_config_settings

--- a/addons/ipai/ipai_ask_ai_bridge/models/res_config_settings.py
+++ b/addons/ipai/ipai_ask_ai_bridge/models/res_config_settings.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    """Settings for Ask AI Bridge - external service configuration only."""
+
+    _inherit = "res.config.settings"
+
+    ask_ai_enabled = fields.Boolean(
+        string="Enable Ask AI",
+        config_parameter="ipai_ask_ai_bridge.enabled",
+        default=False,
+    )
+    ask_ai_endpoint_url = fields.Char(
+        string="Ask AI Endpoint URL",
+        config_parameter="ipai_ask_ai_bridge.endpoint_url",
+        help="URL of the external Ask AI / Copilot service (e.g., https://copilot.example.com/embed)",
+    )
+    ask_ai_tenant_id = fields.Char(
+        string="Tenant ID",
+        config_parameter="ipai_ask_ai_bridge.tenant_id",
+        help="Tenant identifier for multi-tenant deployments",
+    )

--- a/addons/ipai/ipai_ask_ai_bridge/security/ir.model.access.csv
+++ b/addons/ipai/ipai_ask_ai_bridge/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink

--- a/addons/ipai/ipai_ask_ai_bridge/static/src/js/ask_ai_systray.js
+++ b/addons/ipai/ipai_ask_ai_bridge/static/src/js/ask_ai_systray.js
@@ -1,0 +1,101 @@
+/** @odoo-module **/
+/**
+ * Ask AI Systray Component
+ *
+ * A thin launcher that opens an external Ask AI / Copilot service.
+ * This component does NOT implement AI logic - it only:
+ * - Shows a systray icon when enabled
+ * - Opens the configured external URL in a panel/popup
+ *
+ * All AI processing happens externally per ASK_AI_CONTRACT.md
+ */
+
+import { Component, useState } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+
+export class AskAiSystray extends Component {
+    static template = "ipai_ask_ai_bridge.AskAiSystray";
+
+    setup() {
+        this.rpc = useService("rpc");
+        this.notification = useService("notification");
+        this.state = useState({
+            isOpen: false,
+            isLoading: false,
+            endpointUrl: null,
+            enabled: false,
+        });
+        this.loadConfig();
+    }
+
+    async loadConfig() {
+        try {
+            const result = await this.rpc("/web/dataset/call_kw/ir.config_parameter/get_param", {
+                model: "ir.config_parameter",
+                method: "get_param",
+                args: ["ipai_ask_ai_bridge.enabled"],
+                kwargs: {},
+            });
+            this.state.enabled = result === "True";
+
+            if (this.state.enabled) {
+                const url = await this.rpc("/web/dataset/call_kw/ir.config_parameter/get_param", {
+                    model: "ir.config_parameter",
+                    method: "get_param",
+                    args: ["ipai_ask_ai_bridge.endpoint_url"],
+                    kwargs: {},
+                });
+                this.state.endpointUrl = url;
+            }
+        } catch (e) {
+            console.warn("Ask AI: Could not load config", e);
+        }
+    }
+
+    async onClickAskAi() {
+        if (!this.state.enabled) {
+            this.notification.add("Ask AI is not enabled. Configure it in Settings.", {
+                type: "warning",
+            });
+            return;
+        }
+
+        if (!this.state.endpointUrl) {
+            this.notification.add("Ask AI endpoint URL is not configured.", {
+                type: "warning",
+            });
+            return;
+        }
+
+        // Open external Copilot in a new window/panel
+        // The external service handles all AI logic
+        const tenantId = await this.rpc("/web/dataset/call_kw/ir.config_parameter/get_param", {
+            model: "ir.config_parameter",
+            method: "get_param",
+            args: ["ipai_ask_ai_bridge.tenant_id"],
+            kwargs: {},
+        });
+
+        const url = new URL(this.state.endpointUrl);
+        if (tenantId) {
+            url.searchParams.set("tenant", tenantId);
+        }
+
+        // Open in popup (external service)
+        window.open(
+            url.toString(),
+            "ask_ai_copilot",
+            "width=450,height=600,right=0,top=100"
+        );
+    }
+}
+
+AskAiSystray.props = {};
+
+// Only register if module is loaded
+export const askAiSystrayItem = {
+    Component: AskAiSystray,
+};
+
+registry.category("systray").add("AskAiSystray", askAiSystrayItem, { sequence: 1 });

--- a/addons/ipai/ipai_ask_ai_bridge/static/src/xml/ask_ai_systray.xml
+++ b/addons/ipai/ipai_ask_ai_bridge/static/src/xml/ask_ai_systray.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="ipai_ask_ai_bridge.AskAiSystray">
+        <div class="o_ask_ai_systray" t-if="state.enabled">
+            <button class="btn btn-link nav-link"
+                    t-on-click="onClickAskAi"
+                    title="Ask AI"
+                    aria-label="Ask AI Copilot">
+                <i class="fa fa-comments-o" role="img" aria-label="Ask AI"/>
+            </button>
+        </div>
+    </t>
+</templates>

--- a/addons/ipai/ipai_ask_ai_bridge/views/res_config_settings_views.xml
+++ b/addons/ipai/ipai_ask_ai_bridge/views/res_config_settings_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form_ask_ai" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.ask.ai</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//app[@name='general_settings']" position="inside">
+                <block title="Ask AI / Copilot" name="ask_ai_settings">
+                    <setting id="ask_ai_enabled_setting"
+                             string="Ask AI"
+                             help="Enable the Ask AI systray launcher">
+                        <field name="ask_ai_enabled"/>
+                    </setting>
+                    <setting id="ask_ai_endpoint_setting"
+                             string="Service Endpoint"
+                             help="External Ask AI service URL"
+                             invisible="not ask_ai_enabled">
+                        <field name="ask_ai_endpoint_url" placeholder="https://copilot.example.com/embed"/>
+                    </setting>
+                    <setting id="ask_ai_tenant_setting"
+                             string="Tenant ID"
+                             help="Multi-tenant identifier"
+                             invisible="not ask_ai_enabled">
+                        <field name="ask_ai_tenant_id" placeholder="your-tenant-id"/>
+                    </setting>
+                </block>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_theme_copilot/__init__.py
+++ b/addons/ipai/ipai_theme_copilot/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+# Theme module - no Python models needed

--- a/addons/ipai/ipai_theme_copilot/__manifest__.py
+++ b/addons/ipai/ipai_theme_copilot/__manifest__.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "IPAI Copilot Theme",
+    "summary": "Fluent-style TBWA theme for Odoo 18 CE.",
+    "description": """
+IPAI Copilot Theme
+==================
+
+A thin theme module for visual alignment with Fluent UI + TBWA colors.
+
+This module provides:
+- Dark mode Copilot/Gemini-style neutral palette
+- TBWA accent colors (#FFCC00)
+- Fluent-style rounded corners and density
+- Clean, minimal backend and portal styling
+
+This module does NOT:
+- Use Odoo Studio
+- Add business logic
+- Create database tables
+
+Per the minimal stack policy, this is one of 4 allowed IPAI modules:
+1. ipai_bir_compliance (BIR tax compliance)
+2. ipai_finance_ppm (Finance PPM)
+3. ipai_theme_copilot (this theme)
+4. ipai_ask_ai_bridge (AI launcher)
+    """,
+    "version": "18.0.1.0.0",
+    "category": "Theme/Backend",
+    "author": "InsightPulse AI",
+    "website": "https://github.com/jgtolentino/odoo-ce",
+    "license": "AGPL-3",
+    "depends": [
+        "web",
+    ],
+    "data": [
+        "views/assets.xml",
+    ],
+    "assets": {},
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+}

--- a/addons/ipai/ipai_theme_copilot/static/src/scss/backend.scss
+++ b/addons/ipai/ipai_theme_copilot/static/src/scss/backend.scss
@@ -1,0 +1,209 @@
+/**
+ * IPAI Copilot Theme - Backend Styles
+ *
+ * Fluent-style dark theme with TBWA accent colors.
+ * Minimal, Copilot/Gemini-inspired aesthetic.
+ */
+
+:root {
+  /* Neutral mode (minimal, Gemini/Claude/Copilot-style) */
+  --ipai-bg-root: #0b0b0f;
+  --ipai-bg-surface: #111317;
+  --ipai-bg-elevated: #1a1d24;
+  --ipai-fg-primary: #ffffff;
+  --ipai-fg-secondary: #e5e7eb;
+  --ipai-fg-muted: #9ca3af;
+  --ipai-fg-subtle: #6b7280;
+
+  /* TBWA accent */
+  --ipai-accent: #ffcc00;
+  --ipai-accent-hover: #e6b800;
+  --ipai-accent-soft: rgba(255, 204, 0, 0.14);
+  --ipai-accent-text: #111827;
+
+  /* Borders */
+  --ipai-border: rgba(255, 255, 255, 0.06);
+  --ipai-border-hover: rgba(255, 255, 255, 0.12);
+
+  /* Fluent-style rounded corners & density */
+  --ipai-radius-sm: 4px;
+  --ipai-radius-md: 8px;
+  --ipai-radius-lg: 12px;
+  --ipai-radius-xl: 16px;
+  --ipai-radius-pill: 999px;
+
+  /* Shadows */
+  --ipai-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --ipai-shadow-md: 0 4px 6px rgba(0, 0, 0, 0.4);
+  --ipai-shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.5);
+}
+
+/* Top navigation bar */
+.o_main_navbar {
+  background: linear-gradient(90deg, #050509, var(--ipai-bg-surface));
+  border-bottom: 1px solid var(--ipai-border);
+}
+
+.o_main_navbar .o_menu_brand {
+  color: var(--ipai-fg-primary);
+}
+
+/* App launcher tiles */
+.o_app,
+.o_menu_apps .o_app {
+  border-radius: var(--ipai-radius-lg);
+  background: var(--ipai-bg-surface);
+  box-shadow: 0 0 0 1px var(--ipai-border);
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: var(--ipai-bg-elevated);
+    box-shadow: 0 0 0 1px var(--ipai-border-hover), var(--ipai-shadow-md);
+    transform: translateY(-2px);
+  }
+}
+
+.o_app .o_caption {
+  color: var(--ipai-fg-secondary);
+}
+
+/* Primary buttons (TBWA accent) */
+.btn-primary,
+.o_form_button_save {
+  border-radius: var(--ipai-radius-pill);
+  background-color: var(--ipai-accent) !important;
+  border-color: var(--ipai-accent) !important;
+  color: var(--ipai-accent-text) !important;
+  font-weight: 500;
+  transition: all 0.15s ease;
+
+  &:hover,
+  &:focus {
+    background-color: var(--ipai-accent-hover) !important;
+    border-color: var(--ipai-accent-hover) !important;
+    box-shadow: 0 0 0 3px var(--ipai-accent-soft);
+  }
+}
+
+/* Secondary buttons */
+.btn-secondary {
+  border-radius: var(--ipai-radius-pill);
+  background: var(--ipai-bg-surface);
+  border-color: var(--ipai-border);
+  color: var(--ipai-fg-primary);
+
+  &:hover {
+    background: var(--ipai-bg-elevated);
+    border-color: var(--ipai-border-hover);
+  }
+}
+
+/* Form views */
+.o_form_view {
+  .o_form_sheet {
+    border-radius: var(--ipai-radius-lg);
+    box-shadow: var(--ipai-shadow-sm);
+  }
+}
+
+/* List/Tree views */
+.o_list_view {
+  .o_data_row {
+    transition: background 0.1s ease;
+
+    &:hover {
+      background: var(--ipai-accent-soft);
+    }
+
+    &.o_data_row_selected {
+      background: var(--ipai-accent-soft);
+    }
+  }
+}
+
+/* Kanban cards */
+.o_kanban_view {
+  .o_kanban_record {
+    border-radius: var(--ipai-radius-md);
+    box-shadow: var(--ipai-shadow-sm);
+    transition: all 0.2s ease;
+
+    &:hover {
+      box-shadow: var(--ipai-shadow-md);
+      transform: translateY(-1px);
+    }
+  }
+}
+
+/* Sidebar / Control Panel */
+.o_control_panel {
+  background: transparent;
+}
+
+/* Search bar */
+.o_searchview {
+  border-radius: var(--ipai-radius-pill);
+  background: var(--ipai-bg-surface);
+  border: 1px solid var(--ipai-border);
+
+  &:focus-within {
+    border-color: var(--ipai-accent);
+    box-shadow: 0 0 0 3px var(--ipai-accent-soft);
+  }
+}
+
+/* Chatter */
+.o_chatter {
+  .o_chatter_button_new_message,
+  .o_chatter_button_schedule_activity {
+    border-radius: var(--ipai-radius-pill);
+  }
+}
+
+/* Modals/Dialogs */
+.modal-content {
+  border-radius: var(--ipai-radius-xl);
+  box-shadow: var(--ipai-shadow-lg);
+}
+
+/* Dropdowns */
+.dropdown-menu {
+  border-radius: var(--ipai-radius-md);
+  box-shadow: var(--ipai-shadow-md);
+  border: 1px solid var(--ipai-border);
+}
+
+/* Tags/Pills */
+.o_tag {
+  border-radius: var(--ipai-radius-pill);
+}
+
+/* Status badges */
+.badge {
+  border-radius: var(--ipai-radius-pill);
+}
+
+/* Focus states (accessibility) */
+*:focus-visible {
+  outline: 2px solid var(--ipai-accent);
+  outline-offset: 2px;
+}
+
+/* Scrollbars (Webkit) */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--ipai-bg-root);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--ipai-bg-elevated);
+  border-radius: var(--ipai-radius-pill);
+
+  &:hover {
+    background: var(--ipai-fg-subtle);
+  }
+}

--- a/addons/ipai/ipai_theme_copilot/static/src/scss/frontend.scss
+++ b/addons/ipai/ipai_theme_copilot/static/src/scss/frontend.scss
@@ -1,0 +1,123 @@
+/**
+ * IPAI Copilot Theme - Frontend/Portal Styles
+ *
+ * Lighter theme for portal and public pages.
+ * Maintains Fluent style with TBWA accent colors.
+ */
+
+:root {
+  /* Light mode palette for portal */
+  --ipai-portal-bg: #fafafa;
+  --ipai-portal-surface: #ffffff;
+  --ipai-portal-fg: #111827;
+  --ipai-portal-fg-muted: #6b7280;
+
+  /* TBWA accent (same as backend) */
+  --ipai-accent: #ffcc00;
+  --ipai-accent-hover: #e6b800;
+  --ipai-accent-soft: rgba(255, 204, 0, 0.14);
+  --ipai-accent-text: #111827;
+
+  /* Borders (lighter for portal) */
+  --ipai-portal-border: rgba(0, 0, 0, 0.08);
+
+  /* Shared radii */
+  --ipai-radius-sm: 4px;
+  --ipai-radius-md: 8px;
+  --ipai-radius-lg: 12px;
+  --ipai-radius-pill: 999px;
+}
+
+/* Portal body */
+#wrapwrap {
+  background: var(--ipai-portal-bg);
+}
+
+/* Portal cards */
+.card {
+  border-radius: var(--ipai-radius-lg);
+  border: 1px solid var(--ipai-portal-border);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+/* Portal buttons */
+.btn-primary {
+  border-radius: var(--ipai-radius-pill);
+  background-color: var(--ipai-accent) !important;
+  border-color: var(--ipai-accent) !important;
+  color: var(--ipai-accent-text) !important;
+  font-weight: 500;
+
+  &:hover {
+    background-color: var(--ipai-accent-hover) !important;
+    border-color: var(--ipai-accent-hover) !important;
+  }
+}
+
+.btn-secondary,
+.btn-outline-secondary {
+  border-radius: var(--ipai-radius-pill);
+}
+
+/* Portal forms */
+.form-control {
+  border-radius: var(--ipai-radius-md);
+  border-color: var(--ipai-portal-border);
+
+  &:focus {
+    border-color: var(--ipai-accent);
+    box-shadow: 0 0 0 3px var(--ipai-accent-soft);
+  }
+}
+
+/* Portal tables */
+.table {
+  th {
+    font-weight: 600;
+    color: var(--ipai-portal-fg);
+  }
+
+  td {
+    color: var(--ipai-portal-fg-muted);
+  }
+
+  tbody tr:hover {
+    background: var(--ipai-accent-soft);
+  }
+}
+
+/* Portal breadcrumbs */
+.breadcrumb {
+  background: transparent;
+  padding-left: 0;
+
+  .breadcrumb-item {
+    a {
+      color: var(--ipai-accent);
+
+      &:hover {
+        color: var(--ipai-accent-hover);
+      }
+    }
+  }
+}
+
+/* Links */
+a {
+  color: var(--ipai-accent-text);
+
+  &:hover {
+    color: var(--ipai-accent-hover);
+  }
+}
+
+/* Status indicators */
+.badge {
+  border-radius: var(--ipai-radius-pill);
+}
+
+/* Focus states */
+*:focus-visible {
+  outline: 2px solid var(--ipai-accent);
+  outline-offset: 2px;
+}

--- a/addons/ipai/ipai_theme_copilot/views/assets.xml
+++ b/addons/ipai/ipai_theme_copilot/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Backend (main Odoo UI) -->
+    <template id="assets_backend" inherit_id="web.assets_backend" name="IPAI Copilot Backend">
+        <xpath expr="." position="inside">
+            <link rel="stylesheet" type="text/scss"
+                  href="/ipai_theme_copilot/static/src/scss/backend.scss"/>
+        </xpath>
+    </template>
+
+    <!-- Portal / Website "My Account" etc. -->
+    <template id="assets_frontend" inherit_id="web.assets_frontend" name="IPAI Copilot Frontend">
+        <xpath expr="." position="inside">
+            <link rel="stylesheet" type="text/scss"
+                  href="/ipai_theme_copilot/static/src/scss/frontend.scss"/>
+        </xpath>
+    </template>
+</odoo>

--- a/docs/architecture/AI_MODULE_DEPRECATION_MANIFEST.md
+++ b/docs/architecture/AI_MODULE_DEPRECATION_MANIFEST.md
@@ -1,0 +1,195 @@
+# AI Module Deprecation Manifest
+
+**Version:** 1.0.0
+**Status:** Authoritative
+**Last Updated:** 2026-01-13
+
+---
+
+## Purpose
+
+This document lists all IPAI AI modules and their deprecation status under the minimal AI layer policy.
+
+---
+
+## Policy Summary
+
+Per the minimal stack policy:
+
+- **KEEP**: Only 4 survivor modules (2 business + 1 theme + 1 bridge)
+- **DEPRECATE**: All other AI modules
+- **REPLACE**: Use CE/OCA equivalents where available
+
+---
+
+## Survivor Modules (KEEP)
+
+| Module | Version | Purpose | Status |
+|--------|---------|---------|--------|
+| `ipai_bir_compliance` | 18.0.1.0.0 | BIR 2307 & Alphalist | KEEP |
+| `ipai_finance_ppm` | 18.0.1.1.0 | Finance PPM (Notion parity) | KEEP |
+| `ipai_theme_copilot` | 18.0.1.0.0 | Fluent-style TBWA theme | KEEP (new) |
+| `ipai_ask_ai_bridge` | 18.0.1.0.0 | External Copilot launcher | KEEP (new) |
+
+**Total: 4 modules** (2 business + 1 theme + 1 bridge)
+
+---
+
+## AI Modules to Deprecate
+
+### Tier 1: Immediate Deprecation (No Dependencies)
+
+These modules have no critical dependents and can be removed immediately:
+
+| Module | Reason | Replacement |
+|--------|--------|-------------|
+| `ipai_aiux_chat` | Unfinished scaffold | External Copilot UI |
+| `ipai_document_ai` | Optional OCR | External OCR service |
+| `ipai_marketing_ai` | Domain-specific | N/A (not in scope) |
+| `ipai_studio_ai` | NL customization | N/A (not in scope) |
+| `ipai_advisor` | Recommendations | N/A (not in scope) |
+| `ipai_ai_connectors` | Webhook integrations | External integrations |
+| `ipai_ai_sources_odoo` | KB export | External ETL |
+| `ipai_ai_provider_kapa` | Kapa RAG | Pulser gateway |
+
+### Tier 2: Consolidation Required
+
+These modules have overlapping functionality - choose ONE or deprecate all:
+
+| Module | Overlaps With | Decision |
+|--------|---------------|----------|
+| `ipai_copilot_ui` | `ipai_copilot_hub`, `ipai_ai_agents_ui` | DEPRECATE (use external UI) |
+| `ipai_copilot_hub` | `ipai_copilot_ui` | DEPRECATE (use external UI) |
+| `ipai_ai_copilot` | `ipai_ai_agents`, `ipai_ai_agents_ui` | DEPRECATE (use bridge) |
+| `ipai_ai_agents` | `ipai_ai_copilot` | DEPRECATE (use bridge) |
+| `ipai_ai_agents_ui` | `ipai_ai_copilot` | DEPRECATE (use external UI) |
+
+### Tier 3: Core Infrastructure (Review Required)
+
+These modules provide foundational capabilities - evaluate carefully:
+
+| Module | Purpose | Recommendation |
+|--------|---------|----------------|
+| `ipai_ai_core` | AI threads/messages | DEPRECATE - move to external service |
+| `ipai_agent_core` | Skill/tool registry | DEPRECATE - move to external service |
+| `ipai_ai_provider_pulser` | AI gateway | DEPRECATE - use external Pulser directly |
+| `ipai_ai_prompts` | Prompt templates | DEPRECATE - move to Spec Kit |
+| `ipai_ai_audit` | Governance/audit | DEPRECATE - use external logging |
+
+### Tier 4: Finance-Specific (Conditional)
+
+| Module | Depends On | Recommendation |
+|--------|------------|----------------|
+| `ipai_ask_ai` | `ipai_finance_ppm` | DEPRECATE - use external RAG |
+| `ipai_ask_ai_chatter` | `ipai_ask_ai` | DEPRECATE - use external RAG |
+
+---
+
+## Deprecation Process
+
+### Step 1: Mark as Deprecated
+
+Add to each module's `__manifest__.py`:
+
+```python
+{
+    "installable": False,  # Prevent new installs
+    "deprecated": True,
+    "deprecated_by": "ipai_ask_ai_bridge",
+    "deprecation_reason": "Replaced by external AI service per ASK_AI_CONTRACT.md",
+}
+```
+
+### Step 2: Add Migration Notice
+
+Create `migrations/18.0.1.0.0/pre-migrate.py`:
+
+```python
+import logging
+_logger = logging.getLogger(__name__)
+
+def migrate(cr, version):
+    _logger.warning(
+        "Module ipai_xxx is deprecated. "
+        "AI functionality moved to external service. "
+        "See docs/architecture/ASK_AI_CONTRACT.md"
+    )
+```
+
+### Step 3: Update Dependencies
+
+Any module depending on deprecated AI modules should:
+1. Remove the dependency
+2. Use `ipai_ask_ai_bridge` for launcher functionality
+3. Call external service directly for AI features
+
+### Step 4: Archive (Future)
+
+After verification period, modules will be:
+1. Moved to `addons/_deprecated/`
+2. Eventually removed from repository
+
+---
+
+## Timeline
+
+| Phase | Action | Modules |
+|-------|--------|---------|
+| Phase 1 | Mark deprecated | Tier 1 (8 modules) |
+| Phase 2 | Consolidate | Tier 2 (5 modules) |
+| Phase 3 | Migrate core | Tier 3 (5 modules) |
+| Phase 4 | Finance review | Tier 4 (2 modules) |
+
+---
+
+## Full Module List (21 AI Modules)
+
+| # | Module | Status | Action |
+|---|--------|--------|--------|
+| 1 | `ipai_agent_core` | Active | DEPRECATE |
+| 2 | `ipai_ai_agents` | Active | DEPRECATE |
+| 3 | `ipai_ai_agents_ui` | Active | DEPRECATE |
+| 4 | `ipai_ai_audit` | Active | DEPRECATE |
+| 5 | `ipai_ai_connectors` | Active | DEPRECATE |
+| 6 | `ipai_ai_copilot` | Active | DEPRECATE |
+| 7 | `ipai_ai_core` | Active | DEPRECATE |
+| 8 | `ipai_ai_prompts` | Active | DEPRECATE |
+| 9 | `ipai_ai_provider_kapa` | Active | DEPRECATE |
+| 10 | `ipai_ai_provider_pulser` | Active | DEPRECATE |
+| 11 | `ipai_ai_sources_odoo` | Active | DEPRECATE |
+| 12 | `ipai_aiux_chat` | Scaffold | DEPRECATE |
+| 13 | `ipai_advisor` | Active | DEPRECATE |
+| 14 | `ipai_ask_ai` | Active | DEPRECATE |
+| 15 | `ipai_ask_ai_chatter` | Active | DEPRECATE |
+| 16 | `ipai_copilot_hub` | Active | DEPRECATE |
+| 17 | `ipai_copilot_ui` | Active | DEPRECATE |
+| 18 | `ipai_document_ai` | Active | DEPRECATE |
+| 19 | `ipai_marketing_ai` | Active | DEPRECATE |
+| 20 | `ipai_studio_ai` | Active | DEPRECATE |
+| 21 | `ipai_theme_copilot` | **NEW** | **KEEP** |
+| 22 | `ipai_ask_ai_bridge` | **NEW** | **KEEP** |
+
+---
+
+## Verification
+
+After deprecation, verify:
+
+```bash
+# Check no AI modules are installed (except bridge)
+./scripts/ci/check_deprecated_modules.sh
+
+# Verify external service connectivity
+curl -s https://copilot.example.com/health
+
+# Verify bridge module works
+docker compose exec odoo-core odoo -d odoo_core -u ipai_ask_ai_bridge --stop-after-init
+```
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2026-01-13 | Initial deprecation manifest |

--- a/docs/architecture/ASK_AI_CONTRACT.md
+++ b/docs/architecture/ASK_AI_CONTRACT.md
@@ -1,0 +1,264 @@
+# Ask AI Contract
+
+**Version:** 1.0.0
+**Status:** Authoritative
+**Last Updated:** 2026-01-13
+
+---
+
+## 1. Purpose
+
+This document defines the exact data surfaces that the Ask AI / Copilot layer is allowed to use. The AI layer is a **thin consumer** of existing APIs—it does NOT justify new backend modules or infrastructure.
+
+---
+
+## 2. Non-Negotiables
+
+### 2.1 Backend Policy (Survivor Modules)
+
+Only FOUR custom IPAI modules are allowed:
+
+| Module | Purpose | Status |
+|--------|---------|--------|
+| `ipai_bir_compliance` | BIR 2307 & Alphalist/RELIEF for Philippines | ✅ KEEP |
+| `ipai_finance_ppm` | Finance PPM (Notion parity) | ✅ KEEP |
+| `ipai_theme_copilot` | Fluent-style TBWA theme | ✅ KEEP |
+| `ipai_ask_ai_bridge` | External Copilot launcher | ✅ KEEP |
+
+**All other IPAI modules** must be:
+- Replaced with CE/OCA equivalents, OR
+- Deprecated and removed
+
+### 2.2 UI Layer
+
+The Copilot UI lives in:
+- **React + Fluent** for dashboards (Scout Dashboard, Control Room)
+- **One minimal bridge module** (`ipai_ask_ai_bridge`) for Odoo backend—launcher only
+
+### 2.3 AI Logic Location
+
+AI prompts, business rules, and RAG logic **NEVER** live in Odoo modules. They belong in:
+- External RAG service (Supabase Edge Functions)
+- External AI gateway (Pulser)
+- External prompt store (Spec Kit docs)
+
+---
+
+## 3. Allowed Data Surfaces
+
+### 3.1 Odoo RPC Methods
+
+The Copilot may call these Odoo XML-RPC / JSON-RPC methods:
+
+| Model | Methods | Purpose |
+|-------|---------|---------|
+| `finance.task` | `search_read`, `read` | Read PPM tasks |
+| `finance.bir.deadline` | `search_read`, `read` | Read BIR deadlines |
+| `finance.person` | `search_read`, `read` | Read finance team members |
+| `bir.schedule` | `search_read`, `read` | Read BIR schedule |
+| `account.move` | `search_read`, `read` | Read invoices (for BIR 2307) |
+| `project.task` | `search_read`, `read` | Read project tasks |
+
+**Write operations are NOT allowed** through Copilot. If writes are needed, they go through well-defined controller endpoints with proper authorization.
+
+### 3.2 Supabase Schemas (Read-Only)
+
+| Schema | Purpose | Copilot Access |
+|--------|---------|----------------|
+| `finance` | Finance ops tables | ✅ Read via views |
+| `projects` | PPM engagement data | ✅ Read via views |
+| `rag` | Document chunks + embeddings | ✅ Read for RAG |
+| `scout_gold` | Aggregated retail metrics | ✅ Read via views |
+| `scout_silver` | Cleaned retail data | ⚠️ Limited read |
+| `scout_bronze` | Raw retail data | ❌ No direct access |
+
+### 3.3 Exposed API Schema: `scout_api`
+
+The Copilot frontend should use **only these views** for dashboard data:
+
+```sql
+-- PPM Metrics View
+scout_api.ppm_metrics           -- Key finance metrics
+scout_api.finance_close_tasks   -- Month-end close tasks
+scout_api.bir_deadlines         -- BIR deadline calendar
+scout_api.task_summary          -- Task status summary
+
+-- Retail Views (if applicable)
+scout_api.store_daily           -- Store daily aggregates
+scout_api.brand_performance     -- Brand performance metrics
+```
+
+### 3.4 Documentation Sources
+
+The Copilot RAG engine should index:
+
+| Source | Location | Purpose |
+|--------|----------|---------|
+| Spec Kit | `spec/*/` | Feature specs, PRDs, constitutions |
+| Odoo Handbook | `docs/odoo-18-handbook/` | Technical guides |
+| BIR SOPs | `docs/sops/bir/` | BIR compliance procedures |
+| Finance Close | `docs/sops/finance/` | Month-end close procedures |
+
+---
+
+## 4. Forbidden Patterns
+
+### 4.1 Never Do
+
+- ❌ Create new Odoo modules for AI features
+- ❌ Store AI prompts in Odoo database
+- ❌ Implement RAG logic in Python models
+- ❌ Add AI-specific tables to Odoo PostgreSQL
+- ❌ Direct write to core business tables through AI
+
+### 4.2 Never Depend On
+
+- ❌ `ipai_ai_core` (deprecated)
+- ❌ `ipai_ai_agents` (deprecated)
+- ❌ `ipai_copilot_ui` (deprecated)
+- ❌ Any `ipai_ai_*` module (deprecated)
+
+---
+
+## 5. Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        Ask AI / Copilot Layer                        │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│   ┌─────────────┐    ┌─────────────┐    ┌─────────────┐             │
+│   │ React UI    │    │ Odoo Bridge │    │ RAG Service │             │
+│   │ (Fluent)    │    │ (launcher)  │    │ (Supabase)  │             │
+│   └──────┬──────┘    └──────┬──────┘    └──────┬──────┘             │
+│          │                  │                  │                     │
+│          ▼                  ▼                  ▼                     │
+│   ┌─────────────────────────────────────────────────────┐           │
+│   │              AI Gateway (Pulser / External)          │           │
+│   └─────────────────────────────────────────────────────┘           │
+│                              │                                       │
+├──────────────────────────────┼───────────────────────────────────────┤
+│                              ▼                                       │
+│   ┌─────────────────────────────────────────────────────┐           │
+│   │                 Data Layer (Read-Only)               │           │
+│   ├─────────────────────────────────────────────────────┤           │
+│   │                                                      │           │
+│   │   Odoo RPC              Supabase Views               │           │
+│   │   ─────────             ───────────────              │           │
+│   │   • finance.task        • scout_api.ppm_metrics      │           │
+│   │   • finance.bir.deadline • scout_api.bir_deadlines   │           │
+│   │   • account.move        • rag.chunks                 │           │
+│   │                                                      │           │
+│   └─────────────────────────────────────────────────────┘           │
+│                                                                      │
+├─────────────────────────────────────────────────────────────────────┤
+│                        Survivor Modules (4 Total)                    │
+│   ┌─────────────────────┐    ┌─────────────────────────┐            │
+│   │ ipai_bir_compliance │    │ ipai_finance_ppm        │            │
+│   │ (BIR 2307/Alphalist)│    │ (Finance PPM/Close)     │            │
+│   └─────────────────────┘    └─────────────────────────┘            │
+│   ┌─────────────────────┐    ┌─────────────────────────┐            │
+│   │ ipai_theme_copilot  │    │ ipai_ask_ai_bridge      │            │
+│   │ (Fluent Theme)      │    │ (External Launcher)     │            │
+│   └─────────────────────┘    └─────────────────────────┘            │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 6. API Contract
+
+### 6.1 Copilot Query Endpoint
+
+**Request:**
+```json
+POST /api/copilot/query
+{
+  "message": "When is BIR 1601-C due?",
+  "context": {
+    "odoo_db": "odoo_core",
+    "odoo_uid": 2,
+    "tenant_id": "uuid"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "answer": "BIR 1601-C is due on the 10th of the following month...",
+  "citations": [
+    {"title": "BIR Schedule 2026", "url": "/docs/sops/bir/schedule.md"},
+    {"title": "Finance PPM Task", "id": 123}
+  ],
+  "sources": ["rag.chunks", "finance.bir.deadline"]
+}
+```
+
+### 6.2 Odoo Bridge Endpoint
+
+**Request:**
+```json
+POST /copilot/launch
+{
+  "action": "open_panel"
+}
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "panel_url": "https://copilot.example.com/embed?tenant=..."
+}
+```
+
+---
+
+## 7. Implementation Checklist
+
+### Phase 1: Cleanup
+- [ ] Deprecate all `ipai_ai_*` modules
+- [ ] Remove AI logic from Odoo
+- [ ] Migrate prompts to Spec Kit
+
+### Phase 2: Bridge Module
+- [ ] Create `ipai_ask_ai_bridge` (launcher only)
+- [ ] Add systray icon
+- [ ] Add settings for external URL
+
+### Phase 3: External RAG
+- [ ] Set up Supabase Edge Function
+- [ ] Index Spec Kit docs
+- [ ] Index BIR SOPs
+
+### Phase 4: Integration
+- [ ] Connect React UI to RAG
+- [ ] Connect Odoo bridge to external service
+- [ ] Add citation linking
+
+---
+
+## 8. Governance
+
+### Review Triggers
+This contract must be reviewed when:
+- New data sources are added
+- New Odoo models are created
+- RAG scope changes
+- Write operations are requested
+
+### Approval Required
+Any change to this contract requires approval from:
+- Platform Architecture
+- Finance Ops Lead
+- Security Review
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2026-01-13 | Initial contract definition |


### PR DESCRIPTION
Add the minimal AI layer per ASK_AI_CONTRACT.md:

Survivor modules (4 total):
- ipai_bir_compliance (existing) - BIR 2307/Alphalist
- ipai_finance_ppm (existing) - Finance PPM
- ipai_theme_copilot (new) - Fluent-style TBWA theme
- ipai_ask_ai_bridge (new) - External Copilot launcher

New files:
- docs/architecture/ASK_AI_CONTRACT.md - API contract for AI layer
- docs/architecture/AI_MODULE_DEPRECATION_MANIFEST.md - Module deprecation plan
- addons/ipai/ipai_theme_copilot/ - Minimal theme (no Studio)
- addons/ipai/ipai_ask_ai_bridge/ - External AI launcher (no logic)

Policy: AI prompts/RAG/logic live externally in Supabase/Pulser, not in Odoo modules. The bridge is a thin launcher only.

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Supabase security review | [View](https://hub.continue.dev/tasks/8ebe3e57-6fe3-4822-9570-45d182626745) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->