### PR TITLE
Create meta addons for vertical one-click install

### DIFF
--- a/addons/ipai/ipai_ces_bundle/__init__.py
+++ b/addons/ipai/ipai_ces_bundle/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# IPAI CES Bundle (Creative Ops)
+# Meta-installer module - no code, only dependencies

--- a/addons/ipai/ipai_ces_bundle/__manifest__.py
+++ b/addons/ipai/ipai_ces_bundle/__manifest__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "IPAI CES Bundle (Creative Ops)",
+    "summary": "One-click meta-installer for CES creative effectiveness vertical",
+    "version": "18.0.1.0.0",
+    "category": "InsightPulse/Vertical",
+    "author": "InsightPulse AI",
+    "website": "https://github.com/jgtolentino/odoo-ce/tree/18.0/addons/ipai/ipai_ces_bundle",
+    "license": "AGPL-3",
+    "depends": [
+        # CE core services backbone
+        "project",
+        "hr",
+        "hr_timesheet",
+        "mail",
+        "portal",
+
+        # OCA governance baseline
+        "base_tier_validation",
+        "base_exception",
+        "date_range",
+
+        # IPAI bridge (the only custom code layer)
+        "ipai_enterprise_bridge",
+    ],
+    # No data, no models - this is a pure meta-installer
+    "data": [],
+    "installable": True,
+    "application": True,
+    "auto_install": False,
+}

--- a/addons/ipai/ipai_enterprise_bridge/__init__.py
+++ b/addons/ipai/ipai_enterprise_bridge/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import models
+from .hooks import post_init_hook

--- a/addons/ipai/ipai_enterprise_bridge/__manifest__.py
+++ b/addons/ipai/ipai_enterprise_bridge/__manifest__.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "IPAI Enterprise Bridge",
+    "summary": "Thin glue layer for CE+OCA parity: config, approvals, AI/infra integration",
+    "version": "18.0.1.0.0",
+    "category": "InsightPulse/Core",
+    "author": "InsightPulse AI",
+    "website": "https://github.com/jgtolentino/odoo-ce/tree/18.0/addons/ipai/ipai_enterprise_bridge",
+    "license": "AGPL-3",
+    "depends": [
+        # CE core platform
+        "base",
+        "web",
+        "mail",
+        "contacts",
+        # CE business backbone
+        "account",
+        "sale_management",
+        "purchase",
+        "stock",
+        "project",
+        "hr",
+        "hr_timesheet",
+        # OCA governance baseline (only stable modules)
+        "base_tier_validation",
+        "base_exception",
+        "date_range",
+        # IPAI foundation
+        "ipai_workspace_core",
+    ],
+    "data": [
+        "security/security.xml",
+        "security/ir.model.access.csv",
+        "data/groups.xml",
+        "data/sequences.xml",
+        "data/scheduled_actions.xml",
+        "views/res_config_settings_views.xml",
+        "views/ipai_policy_views.xml",
+        "views/ipai_close_views.xml",
+        "views/product_views.xml",
+    ],
+    "post_init_hook": "post_init_hook",
+    "installable": True,
+    "application": False,
+}

--- a/addons/ipai/ipai_enterprise_bridge/data/groups.xml
+++ b/addons/ipai/ipai_enterprise_bridge/data/groups.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Category for IPAI Bridge -->
+    <record id="module_category_ipai_bridge" model="ir.module.category">
+        <field name="name">IPAI Bridge</field>
+        <field name="description">Enterprise Bridge for CE+OCA parity</field>
+        <field name="sequence">100</field>
+    </record>
+
+    <!-- Update group categories -->
+    <record id="group_ipai_bridge_user" model="res.groups">
+        <field name="category_id" ref="module_category_ipai_bridge"/>
+    </record>
+
+    <record id="group_ipai_bridge_manager" model="res.groups">
+        <field name="category_id" ref="module_category_ipai_bridge"/>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_enterprise_bridge/data/scheduled_actions.xml
+++ b/addons/ipai/ipai_enterprise_bridge/data/scheduled_actions.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Scheduled action to process pending jobs -->
+    <record id="ir_cron_process_ipai_jobs" model="ir.cron">
+        <field name="name">IPAI Bridge: Process Pending Jobs</field>
+        <field name="model_id" ref="model_ipai_job"/>
+        <field name="state">code</field>
+        <field name="code">model.process_pending_jobs()</field>
+        <field name="interval_number">5</field>
+        <field name="interval_type">minutes</field>
+        <field name="numbercall">-1</field>
+        <field name="active">True</field>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_enterprise_bridge/data/sequences.xml
+++ b/addons/ipai/ipai_enterprise_bridge/data/sequences.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Sequences for IPAI Bridge -->
+    <record id="seq_ipai_job" model="ir.sequence">
+        <field name="name">IPAI Job Sequence</field>
+        <field name="code">ipai.job</field>
+        <field name="prefix">JOB/</field>
+        <field name="padding">6</field>
+        <field name="company_id" eval="False"/>
+    </record>
+
+    <record id="seq_ipai_close_checklist" model="ir.sequence">
+        <field name="name">IPAI Close Checklist Sequence</field>
+        <field name="code">ipai.close.checklist</field>
+        <field name="prefix">CLOSE/</field>
+        <field name="padding">4</field>
+        <field name="company_id" eval="False"/>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_enterprise_bridge/hooks.py
+++ b/addons/ipai/ipai_enterprise_bridge/hooks.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def post_init_hook(env):
+    """Idempotent seeding of defaults for enterprise bridge.
+
+    This hook runs after module installation to set up:
+    - Default system parameters for Supabase/AI integration
+    - Default policy records
+    - Default close checklist templates
+    """
+    _logger.info("IPAI Enterprise Bridge: Running post_init_hook")
+
+    # Set default system parameters (only if not already set)
+    IrConfigParameter = env["ir.config_parameter"].sudo()
+
+    defaults = {
+        "ipai_bridge.supabase_url": "",
+        "ipai_bridge.supabase_anon_key": "",
+        "ipai_bridge.ai_endpoint_url": "",
+        "ipai_bridge.enable_scout": "False",
+        "ipai_bridge.enable_ces": "False",
+        "ipai_bridge.enable_retail_sync": "False",
+        "ipai_bridge.enable_project_sync": "False",
+    }
+
+    for key, default_value in defaults.items():
+        if not IrConfigParameter.get_param(key):
+            IrConfigParameter.set_param(key, default_value)
+
+    _logger.info("IPAI Enterprise Bridge: post_init_hook completed")

--- a/addons/ipai/ipai_enterprise_bridge/models/__init__.py
+++ b/addons/ipai/ipai_enterprise_bridge/models/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+from . import res_config_settings
+from . import ipai_policy
+from . import ipai_close_checklist
+from . import product_template
+from . import account_move
+from . import purchase_order
+from . import ai_mixin
+from . import ipai_job

--- a/addons/ipai/ipai_enterprise_bridge/models/account_move.py
+++ b/addons/ipai/ipai_enterprise_bridge/models/account_move.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class AccountMove(models.Model):
+    """Invoice/bill overlay for bridge integration."""
+
+    _inherit = "account.move"
+
+    # External sync tracking
+    ipai_external_id = fields.Char(
+        string="External Transaction ID",
+        index=True,
+        help="External system reference ID for sync",
+    )
+    ipai_exported = fields.Boolean(
+        string="Exported to External System",
+        default=False,
+    )
+    ipai_export_date = fields.Datetime(
+        string="Export Date",
+    )
+
+    # BIR compliance fields (PH localization)
+    ipai_bir_form_type = fields.Selection(
+        [
+            ("2307", "BIR Form 2307"),
+            ("2316", "BIR Form 2316"),
+            ("1601c", "BIR Form 1601-C"),
+            ("2550m", "BIR Form 2550M"),
+            ("2550q", "BIR Form 2550Q"),
+        ],
+        string="BIR Form Type",
+        help="Philippine BIR tax form classification",
+    )
+
+    def action_mark_exported(self):
+        """Mark invoice as exported to external system."""
+        self.write({
+            "ipai_exported": True,
+            "ipai_export_date": fields.Datetime.now(),
+        })

--- a/addons/ipai/ipai_enterprise_bridge/models/ai_mixin.py
+++ b/addons/ipai/ipai_enterprise_bridge/models/ai_mixin.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class IpaiAiMixin(models.AbstractModel):
+    """Abstract mixin for AI-enhanced records.
+
+    Inherit this mixin to add AI metadata fields to any model:
+        class MyModel(models.Model):
+            _name = 'my.model'
+            _inherit = ['ipai.ai.mixin']
+    """
+
+    _name = "ipai.ai.mixin"
+    _description = "IPAI AI Mixin"
+
+    ipai_ai_summary = fields.Text(
+        string="AI Summary",
+        help="AI-generated summary of this record",
+    )
+    ipai_ai_tags = fields.Char(
+        string="AI Tags",
+        help="Comma-separated AI-generated tags",
+    )
+    ipai_ai_confidence = fields.Float(
+        string="AI Confidence",
+        help="Confidence score of AI analysis (0-1)",
+    )
+    ipai_ai_last_run = fields.Datetime(
+        string="AI Last Run",
+        help="Last time AI analysis was performed",
+    )
+    ipai_ai_model_version = fields.Char(
+        string="AI Model Version",
+        help="Version of AI model used for analysis",
+    )
+
+    def action_run_ai_analysis(self):
+        """Trigger AI analysis for this record.
+
+        Override in inheriting models to implement specific analysis logic.
+        By default, this enqueues a job to the external AI system.
+        """
+        IpaiJob = self.env["ipai.job"]
+        for record in self:
+            IpaiJob.create({
+                "name": f"AI Analysis: {record.display_name}",
+                "job_type": "ai_analysis",
+                "model_name": record._name,
+                "record_id": record.id,
+                "state": "pending",
+            })

--- a/addons/ipai/ipai_enterprise_bridge/models/ipai_close_checklist.py
+++ b/addons/ipai/ipai_enterprise_bridge/models/ipai_close_checklist.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class IpaiCloseChecklist(models.Model):
+    """Month-end close checklist for PH finance PPM overlay."""
+
+    _name = "ipai.close.checklist"
+    _description = "Month-End Close Checklist"
+    _order = "period_id desc, sequence"
+
+    name = fields.Char(string="Checklist Name", required=True)
+    period_id = fields.Many2one(
+        "date.range",
+        string="Period",
+        domain="[('type_id.name', '=', 'Fiscal Month')]",
+        help="The accounting period this checklist belongs to",
+    )
+    company_id = fields.Many2one(
+        "res.company",
+        string="Company",
+        required=True,
+        default=lambda self: self.env.company,
+    )
+    sequence = fields.Integer(default=10)
+    state = fields.Selection(
+        [
+            ("draft", "Draft"),
+            ("in_progress", "In Progress"),
+            ("completed", "Completed"),
+            ("blocked", "Blocked"),
+        ],
+        string="Status",
+        default="draft",
+    )
+    item_ids = fields.One2many(
+        "ipai.close.checklist.item",
+        "checklist_id",
+        string="Checklist Items",
+    )
+    notes = fields.Text(string="Notes")
+    completion_date = fields.Datetime(string="Completion Date")
+    assigned_user_id = fields.Many2one(
+        "res.users",
+        string="Assigned To",
+    )
+
+    def action_start(self):
+        """Start the checklist."""
+        self.write({"state": "in_progress"})
+
+    def action_complete(self):
+        """Mark checklist as complete."""
+        self.write({
+            "state": "completed",
+            "completion_date": fields.Datetime.now(),
+        })
+
+
+class IpaiCloseChecklistItem(models.Model):
+    """Individual items in a month-end close checklist."""
+
+    _name = "ipai.close.checklist.item"
+    _description = "Close Checklist Item"
+    _order = "sequence, id"
+
+    checklist_id = fields.Many2one(
+        "ipai.close.checklist",
+        string="Checklist",
+        required=True,
+        ondelete="cascade",
+    )
+    name = fields.Char(string="Task", required=True)
+    sequence = fields.Integer(default=10)
+    is_completed = fields.Boolean(string="Completed", default=False)
+    completed_by = fields.Many2one("res.users", string="Completed By")
+    completed_date = fields.Datetime(string="Completed Date")
+    notes = fields.Text(string="Notes")
+    blocking_reason = fields.Text(string="Blocking Reason")
+
+    def action_toggle_complete(self):
+        """Toggle completion status."""
+        for item in self:
+            if item.is_completed:
+                item.write({
+                    "is_completed": False,
+                    "completed_by": False,
+                    "completed_date": False,
+                })
+            else:
+                item.write({
+                    "is_completed": True,
+                    "completed_by": self.env.user.id,
+                    "completed_date": fields.Datetime.now(),
+                })

--- a/addons/ipai/ipai_enterprise_bridge/models/ipai_job.py
+++ b/addons/ipai/ipai_enterprise_bridge/models/ipai_job.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+import json
+import logging
+
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class IpaiJob(models.Model):
+    """Outbound job queue for external integrations.
+
+    This model implements a simple queue/outbox pattern for:
+    - AI analysis requests
+    - Sync events to Supabase
+    - Webhook callbacks
+    """
+
+    _name = "ipai.job"
+    _description = "IPAI Integration Job"
+    _order = "create_date desc"
+
+    name = fields.Char(string="Job Name", required=True)
+    job_type = fields.Selection(
+        [
+            ("ai_analysis", "AI Analysis"),
+            ("sync_event", "Sync Event"),
+            ("webhook", "Webhook Callback"),
+            ("export", "Data Export"),
+        ],
+        string="Job Type",
+        required=True,
+    )
+    state = fields.Selection(
+        [
+            ("pending", "Pending"),
+            ("processing", "Processing"),
+            ("completed", "Completed"),
+            ("failed", "Failed"),
+            ("cancelled", "Cancelled"),
+        ],
+        string="State",
+        default="pending",
+        index=True,
+    )
+    model_name = fields.Char(string="Model Name")
+    record_id = fields.Integer(string="Record ID")
+    payload = fields.Text(string="Payload (JSON)")
+    result = fields.Text(string="Result (JSON)")
+    error_message = fields.Text(string="Error Message")
+    retry_count = fields.Integer(string="Retry Count", default=0)
+    max_retries = fields.Integer(string="Max Retries", default=3)
+    scheduled_date = fields.Datetime(string="Scheduled Date")
+    completed_date = fields.Datetime(string="Completed Date")
+
+    @api.model
+    def process_pending_jobs(self, limit=100):
+        """Cron job to process pending jobs.
+
+        This method is called by scheduled action to process
+        pending jobs in the queue.
+        """
+        pending_jobs = self.search(
+            [
+                ("state", "=", "pending"),
+                "|",
+                ("scheduled_date", "=", False),
+                ("scheduled_date", "<=", fields.Datetime.now()),
+            ],
+            limit=limit,
+            order="create_date asc",
+        )
+
+        for job in pending_jobs:
+            try:
+                job._process_job()
+            except Exception as e:
+                _logger.exception(f"Error processing job {job.id}: {e}")
+                job._mark_failed(str(e))
+
+    def _process_job(self):
+        """Process a single job. Override per job_type."""
+        self.ensure_one()
+        self.write({"state": "processing"})
+
+        # Route to appropriate handler
+        handler = getattr(self, f"_process_{self.job_type}", None)
+        if handler:
+            handler()
+        else:
+            _logger.warning(f"No handler for job type: {self.job_type}")
+            self._mark_completed({})
+
+    def _process_ai_analysis(self):
+        """Process AI analysis job."""
+        # Placeholder: would call external AI endpoint
+        IrConfigParameter = self.env["ir.config_parameter"].sudo()
+        endpoint = IrConfigParameter.get_param("ipai_bridge.ai_endpoint_url")
+
+        if not endpoint:
+            self._mark_failed("AI endpoint not configured")
+            return
+
+        # TODO: Implement actual HTTP call to AI endpoint
+        # For now, mark as completed with placeholder
+        self._mark_completed({"status": "placeholder", "endpoint": endpoint})
+
+    def _process_sync_event(self):
+        """Process sync event job."""
+        # Placeholder: would push to Supabase
+        self._mark_completed({"status": "placeholder"})
+
+    def _process_webhook(self):
+        """Process webhook callback job."""
+        # Placeholder: would call webhook URL
+        self._mark_completed({"status": "placeholder"})
+
+    def _process_export(self):
+        """Process data export job."""
+        # Placeholder: would export data
+        self._mark_completed({"status": "placeholder"})
+
+    def _mark_completed(self, result):
+        """Mark job as completed with result."""
+        self.write({
+            "state": "completed",
+            "result": json.dumps(result) if result else None,
+            "completed_date": fields.Datetime.now(),
+        })
+
+    def _mark_failed(self, error_message):
+        """Mark job as failed or retry if retries remaining."""
+        self.ensure_one()
+        if self.retry_count < self.max_retries:
+            self.write({
+                "state": "pending",
+                "retry_count": self.retry_count + 1,
+                "error_message": error_message,
+            })
+        else:
+            self.write({
+                "state": "failed",
+                "error_message": error_message,
+            })

--- a/addons/ipai/ipai_enterprise_bridge/models/ipai_policy.py
+++ b/addons/ipai/ipai_enterprise_bridge/models/ipai_policy.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class IpaiPolicy(models.Model):
+    """Company-level policy configuration for approvals and governance."""
+
+    _name = "ipai.policy"
+    _description = "IPAI Policy Configuration"
+
+    name = fields.Char(string="Policy Name", required=True)
+    company_id = fields.Many2one(
+        "res.company",
+        string="Company",
+        required=True,
+        default=lambda self: self.env.company,
+    )
+    active = fields.Boolean(default=True)
+
+    # Approval policies
+    require_attachment_for_bills = fields.Boolean(
+        string="Require Attachment for Bills",
+        default=True,
+        help="Require at least one attachment for vendor bills before approval",
+    )
+    min_approval_amount = fields.Float(
+        string="Min Approval Amount",
+        default=5000.0,
+        help="Minimum amount requiring manager approval",
+    )
+    max_approval_amount = fields.Float(
+        string="Max Approval Amount",
+        default=50000.0,
+        help="Amount requiring director-level approval",
+    )
+
+    # Document policies
+    enforce_dms_linking = fields.Boolean(
+        string="Enforce DMS Linking",
+        default=False,
+        help="Require DMS folder linking for key documents (if DMS installed)",
+    )
+
+    @api.model
+    def get_company_policy(self, company_id=None):
+        """Get the active policy for a company."""
+        company = company_id or self.env.company.id
+        policy = self.search(
+            [("company_id", "=", company), ("active", "=", True)],
+            limit=1,
+        )
+        return policy

--- a/addons/ipai/ipai_enterprise_bridge/models/product_template.py
+++ b/addons/ipai/ipai_enterprise_bridge/models/product_template.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class ProductTemplate(models.Model):
+    """Retail/grocery overlay fields for Scout vertical."""
+
+    _inherit = "product.template"
+
+    # Scout retail fields
+    ipai_is_grocery = fields.Boolean(
+        string="Is Grocery Item",
+        default=False,
+        help="Mark as grocery/FMCG item for Scout tracking",
+    )
+    ipai_shelf_code = fields.Char(
+        string="Shelf Code",
+        help="Shelf/aisle location code for retail stores",
+    )
+    ipai_expiry_required = fields.Boolean(
+        string="Expiry Required",
+        default=False,
+        help="Requires expiry date tracking",
+    )
+    ipai_substitution_group_id = fields.Many2one(
+        "ipai.substitution.group",
+        string="Substitution Group",
+        help="Group of products that can substitute this item",
+    )
+
+
+class IpaiSubstitutionGroup(models.Model):
+    """Product substitution groups for retail."""
+
+    _name = "ipai.substitution.group"
+    _description = "Product Substitution Group"
+
+    name = fields.Char(string="Group Name", required=True)
+    product_ids = fields.One2many(
+        "product.template",
+        "ipai_substitution_group_id",
+        string="Products",
+    )
+    priority_order = fields.Text(
+        string="Priority Order",
+        help="JSON list of product IDs in substitution priority order",
+    )
+    active = fields.Boolean(default=True)

--- a/addons/ipai/ipai_enterprise_bridge/models/purchase_order.py
+++ b/addons/ipai/ipai_enterprise_bridge/models/purchase_order.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class PurchaseOrder(models.Model):
+    """Purchase order overlay for bridge integration."""
+
+    _inherit = "purchase.order"
+
+    # External sync tracking
+    ipai_external_id = fields.Char(
+        string="External Transaction ID",
+        index=True,
+        help="External system reference ID for sync",
+    )
+    ipai_exported = fields.Boolean(
+        string="Exported to External System",
+        default=False,
+    )
+    ipai_export_date = fields.Datetime(
+        string="Export Date",
+    )
+
+    # Supplier catalog reference
+    ipai_supplier_catalog_ref = fields.Char(
+        string="Supplier Catalog Reference",
+        help="Reference to supplier's catalog system",
+    )
+
+    def action_mark_exported(self):
+        """Mark PO as exported to external system."""
+        self.write({
+            "ipai_exported": True,
+            "ipai_export_date": fields.Datetime.now(),
+        })

--- a/addons/ipai/ipai_enterprise_bridge/models/res_config_settings.py
+++ b/addons/ipai/ipai_enterprise_bridge/models/res_config_settings.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    # Supabase integration settings
+    ipai_supabase_url = fields.Char(
+        string="Supabase URL",
+        config_parameter="ipai_bridge.supabase_url",
+        help="Supabase project URL for external integrations",
+    )
+    ipai_supabase_anon_key = fields.Char(
+        string="Supabase Anon Key",
+        config_parameter="ipai_bridge.supabase_anon_key",
+        help="Supabase anonymous key for public API access",
+    )
+
+    # AI integration settings
+    ipai_ai_endpoint_url = fields.Char(
+        string="AI Endpoint URL",
+        config_parameter="ipai_bridge.ai_endpoint_url",
+        help="URL for AI inference endpoint (n8n/Edge Functions)",
+    )
+
+    # Vertical toggles
+    ipai_enable_scout = fields.Boolean(
+        string="Enable Scout (Retail)",
+        config_parameter="ipai_bridge.enable_scout",
+        help="Enable Scout retail intelligence features",
+    )
+    ipai_enable_ces = fields.Boolean(
+        string="Enable CES (Creative Ops)",
+        config_parameter="ipai_bridge.enable_ces",
+        help="Enable CES creative effectiveness features",
+    )
+
+    # Sync toggles
+    ipai_enable_retail_sync = fields.Boolean(
+        string="Enable Retail Sync",
+        config_parameter="ipai_bridge.enable_retail_sync",
+        help="Enable POS/inventory event sync to Supabase",
+    )
+    ipai_enable_project_sync = fields.Boolean(
+        string="Enable Project Sync",
+        config_parameter="ipai_bridge.enable_project_sync",
+        help="Enable project/task event sync to Supabase",
+    )

--- a/addons/ipai/ipai_enterprise_bridge/security/ir.model.access.csv
+++ b/addons/ipai/ipai_enterprise_bridge/security/ir.model.access.csv
@@ -1,0 +1,11 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_ipai_policy_user,ipai.policy.user,model_ipai_policy,group_ipai_bridge_user,1,0,0,0
+access_ipai_policy_manager,ipai.policy.manager,model_ipai_policy,group_ipai_bridge_manager,1,1,1,1
+access_ipai_close_checklist_user,ipai.close.checklist.user,model_ipai_close_checklist,group_ipai_bridge_user,1,0,0,0
+access_ipai_close_checklist_manager,ipai.close.checklist.manager,model_ipai_close_checklist,group_ipai_bridge_manager,1,1,1,1
+access_ipai_close_checklist_item_user,ipai.close.checklist.item.user,model_ipai_close_checklist_item,group_ipai_bridge_user,1,1,0,0
+access_ipai_close_checklist_item_manager,ipai.close.checklist.item.manager,model_ipai_close_checklist_item,group_ipai_bridge_manager,1,1,1,1
+access_ipai_substitution_group_user,ipai.substitution.group.user,model_ipai_substitution_group,group_ipai_bridge_user,1,0,0,0
+access_ipai_substitution_group_manager,ipai.substitution.group.manager,model_ipai_substitution_group,group_ipai_bridge_manager,1,1,1,1
+access_ipai_job_user,ipai.job.user,model_ipai_job,group_ipai_bridge_user,1,0,0,0
+access_ipai_job_manager,ipai.job.manager,model_ipai_job,group_ipai_bridge_manager,1,1,1,1

--- a/addons/ipai/ipai_enterprise_bridge/security/security.xml
+++ b/addons/ipai/ipai_enterprise_bridge/security/security.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Groups -->
+    <record id="group_ipai_bridge_user" model="res.groups">
+        <field name="name">IPAI Bridge User</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
+
+    <record id="group_ipai_bridge_manager" model="res.groups">
+        <field name="name">IPAI Bridge Manager</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+        <field name="implied_ids" eval="[(4, ref('group_ipai_bridge_user'))]"/>
+    </record>
+
+    <!-- Record Rules -->
+    <record id="ipai_policy_company_rule" model="ir.rule">
+        <field name="name">IPAI Policy: Company Access</field>
+        <field name="model_id" ref="model_ipai_policy"/>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+    </record>
+
+    <record id="ipai_close_checklist_company_rule" model="ir.rule">
+        <field name="name">IPAI Close Checklist: Company Access</field>
+        <field name="model_id" ref="model_ipai_close_checklist"/>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_enterprise_bridge/views/ipai_close_views.xml
+++ b/addons/ipai/ipai_enterprise_bridge/views/ipai_close_views.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- IPAI Close Checklist Tree View -->
+    <record id="ipai_close_checklist_view_tree" model="ir.ui.view">
+        <field name="name">ipai.close.checklist.view.tree</field>
+        <field name="model">ipai.close.checklist</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="name"/>
+                <field name="period_id"/>
+                <field name="company_id" groups="base.group_multi_company"/>
+                <field name="assigned_user_id"/>
+                <field name="state" widget="badge"
+                       decoration-info="state == 'draft'"
+                       decoration-warning="state == 'in_progress'"
+                       decoration-success="state == 'completed'"
+                       decoration-danger="state == 'blocked'"/>
+                <field name="completion_date"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- IPAI Close Checklist Form View -->
+    <record id="ipai_close_checklist_view_form" model="ir.ui.view">
+        <field name="name">ipai.close.checklist.view.form</field>
+        <field name="model">ipai.close.checklist</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button name="action_start" string="Start" type="object"
+                            invisible="state != 'draft'" class="btn-primary"/>
+                    <button name="action_complete" string="Mark Complete" type="object"
+                            invisible="state != 'in_progress'" class="btn-success"/>
+                    <field name="state" widget="statusbar"
+                           statusbar_visible="draft,in_progress,completed"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" placeholder="Checklist Name"/></h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="period_id"/>
+                            <field name="assigned_user_id"/>
+                        </group>
+                        <group>
+                            <field name="company_id" groups="base.group_multi_company"/>
+                            <field name="completion_date" invisible="state != 'completed'"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Checklist Items" name="items">
+                            <field name="item_ids">
+                                <list editable="bottom">
+                                    <field name="sequence" widget="handle"/>
+                                    <field name="name"/>
+                                    <field name="is_completed"/>
+                                    <field name="completed_by" readonly="1"/>
+                                    <field name="completed_date" readonly="1"/>
+                                    <field name="notes"/>
+                                </list>
+                            </field>
+                        </page>
+                        <page string="Notes" name="notes">
+                            <field name="notes" placeholder="Add notes..."/>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Action -->
+    <record id="ipai_close_checklist_action" model="ir.actions.act_window">
+        <field name="name">Close Checklists</field>
+        <field name="res_model">ipai.close.checklist</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <!-- Menu -->
+    <menuitem id="menu_ipai_bridge_finance"
+              name="Finance"
+              parent="menu_ipai_bridge_root"
+              sequence="20"/>
+
+    <menuitem id="menu_ipai_close_checklist"
+              name="Close Checklists"
+              parent="menu_ipai_bridge_finance"
+              action="ipai_close_checklist_action"
+              sequence="10"/>
+</odoo>

--- a/addons/ipai/ipai_enterprise_bridge/views/ipai_policy_views.xml
+++ b/addons/ipai/ipai_enterprise_bridge/views/ipai_policy_views.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- IPAI Policy Tree View -->
+    <record id="ipai_policy_view_tree" model="ir.ui.view">
+        <field name="name">ipai.policy.view.tree</field>
+        <field name="model">ipai.policy</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="name"/>
+                <field name="company_id" groups="base.group_multi_company"/>
+                <field name="min_approval_amount"/>
+                <field name="max_approval_amount"/>
+                <field name="require_attachment_for_bills"/>
+                <field name="active"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- IPAI Policy Form View -->
+    <record id="ipai_policy_view_form" model="ir.ui.view">
+        <field name="name">ipai.policy.view.form</field>
+        <field name="model">ipai.policy</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div class="oe_button_box" name="button_box"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" placeholder="Policy Name"/></h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="company_id" groups="base.group_multi_company"/>
+                            <field name="active" invisible="1"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Approval Policies" name="approvals">
+                            <group>
+                                <group string="Bill Approvals">
+                                    <field name="require_attachment_for_bills"/>
+                                    <field name="min_approval_amount"/>
+                                    <field name="max_approval_amount"/>
+                                </group>
+                                <group string="Document Policies">
+                                    <field name="enforce_dms_linking"/>
+                                </group>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Action -->
+    <record id="ipai_policy_action" model="ir.actions.act_window">
+        <field name="name">IPAI Policies</field>
+        <field name="res_model">ipai.policy</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <!-- Menu -->
+    <menuitem id="menu_ipai_bridge_root"
+              name="IPAI Bridge"
+              sequence="100"/>
+
+    <menuitem id="menu_ipai_bridge_config"
+              name="Configuration"
+              parent="menu_ipai_bridge_root"
+              sequence="10"/>
+
+    <menuitem id="menu_ipai_policy"
+              name="Policies"
+              parent="menu_ipai_bridge_config"
+              action="ipai_policy_action"
+              sequence="10"/>
+</odoo>

--- a/addons/ipai/ipai_enterprise_bridge/views/product_views.xml
+++ b/addons/ipai/ipai_enterprise_bridge/views/product_views.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Product Template Form Extension for Scout Retail Fields -->
+    <record id="product_template_view_form_ipai_bridge" model="ir.ui.view">
+        <field name="name">product.template.view.form.ipai.bridge</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_only_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='inventory']" position="after">
+                <page string="Scout Retail" name="scout_retail"
+                      groups="ipai_enterprise_bridge.group_ipai_bridge_user">
+                    <group>
+                        <group string="Retail Classification">
+                            <field name="ipai_is_grocery"/>
+                            <field name="ipai_expiry_required"/>
+                        </group>
+                        <group string="Store Layout">
+                            <field name="ipai_shelf_code"/>
+                            <field name="ipai_substitution_group_id"/>
+                        </group>
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+    <!-- Substitution Group Tree View -->
+    <record id="ipai_substitution_group_view_tree" model="ir.ui.view">
+        <field name="name">ipai.substitution.group.view.tree</field>
+        <field name="model">ipai.substitution.group</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="name"/>
+                <field name="product_ids" widget="many2many_tags"/>
+                <field name="active"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Substitution Group Form View -->
+    <record id="ipai_substitution_group_view_form" model="ir.ui.view">
+        <field name="name">ipai.substitution.group.view.form</field>
+        <field name="model">ipai.substitution.group</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                    <div class="oe_title">
+                        <label for="name"/>
+                        <h1><field name="name" placeholder="Group Name"/></h1>
+                    </div>
+                    <group>
+                        <field name="active" invisible="1"/>
+                    </group>
+                    <notebook>
+                        <page string="Products" name="products">
+                            <field name="product_ids">
+                                <list>
+                                    <field name="name"/>
+                                    <field name="default_code"/>
+                                    <field name="list_price"/>
+                                </list>
+                            </field>
+                        </page>
+                        <page string="Priority Order" name="priority">
+                            <field name="priority_order" placeholder='["product_id_1", "product_id_2", ...]'/>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Action -->
+    <record id="ipai_substitution_group_action" model="ir.actions.act_window">
+        <field name="name">Substitution Groups</field>
+        <field name="res_model">ipai.substitution.group</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <!-- Menu -->
+    <menuitem id="menu_ipai_bridge_retail"
+              name="Retail (Scout)"
+              parent="menu_ipai_bridge_root"
+              sequence="30"/>
+
+    <menuitem id="menu_ipai_substitution_group"
+              name="Substitution Groups"
+              parent="menu_ipai_bridge_retail"
+              action="ipai_substitution_group_action"
+              sequence="10"/>
+</odoo>

--- a/addons/ipai/ipai_enterprise_bridge/views/res_config_settings_views.xml
+++ b/addons/ipai/ipai_enterprise_bridge/views/res_config_settings_views.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form_ipai_bridge" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.ipai.bridge</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base.res_config_settings_view_form"/>
+        <field name="priority">99</field>
+        <field name="arch" type="xml">
+            <xpath expr="//form" position="inside">
+                <app data-string="IPAI Bridge" string="IPAI Bridge" name="ipai_enterprise_bridge">
+                    <block title="Supabase Integration" name="supabase_settings">
+                        <setting string="Supabase URL" help="Configure Supabase project URL for external integrations">
+                            <field name="ipai_supabase_url"/>
+                        </setting>
+                        <setting string="Supabase Anon Key" help="Anonymous key for public API access">
+                            <field name="ipai_supabase_anon_key" password="True"/>
+                        </setting>
+                    </block>
+                    <block title="AI Integration" name="ai_settings">
+                        <setting string="AI Endpoint URL" help="URL for AI inference endpoint (n8n/Edge Functions)">
+                            <field name="ipai_ai_endpoint_url"/>
+                        </setting>
+                    </block>
+                    <block title="Vertical Features" name="vertical_settings">
+                        <setting string="Enable Scout (Retail)" help="Enable retail intelligence features for POS and inventory">
+                            <field name="ipai_enable_scout"/>
+                        </setting>
+                        <setting string="Enable CES (Creative Ops)" help="Enable creative effectiveness features for projects and timesheets">
+                            <field name="ipai_enable_ces"/>
+                        </setting>
+                    </block>
+                    <block title="Sync Settings" name="sync_settings">
+                        <setting string="Enable Retail Sync" help="Sync POS orders and inventory events to Supabase">
+                            <field name="ipai_enable_retail_sync"/>
+                        </setting>
+                        <setting string="Enable Project Sync" help="Sync project tasks and timesheets to Supabase">
+                            <field name="ipai_enable_project_sync"/>
+                        </setting>
+                    </block>
+                </app>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/ipai/ipai_scout_bundle/__init__.py
+++ b/addons/ipai/ipai_scout_bundle/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# IPAI Scout Bundle (Retail)
+# Meta-installer module - no code, only dependencies

--- a/addons/ipai/ipai_scout_bundle/__manifest__.py
+++ b/addons/ipai/ipai_scout_bundle/__manifest__.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "IPAI Scout Bundle (Retail)",
+    "summary": "One-click meta-installer for Scout retail intelligence vertical",
+    "version": "18.0.1.0.0",
+    "category": "InsightPulse/Vertical",
+    "author": "InsightPulse AI",
+    "website": "https://github.com/jgtolentino/odoo-ce/tree/18.0/addons/ipai/ipai_scout_bundle",
+    "license": "AGPL-3",
+    "depends": [
+        # CE core retail backbone
+        "sale_management",
+        "purchase",
+        "stock",
+        "stock_account",
+        "point_of_sale",
+        "account",
+
+        # OCA governance baseline
+        "base_tier_validation",
+        "base_exception",
+        "date_range",
+
+        # IPAI bridge (the only custom code layer)
+        "ipai_enterprise_bridge",
+    ],
+    # No data, no models - this is a pure meta-installer
+    "data": [],
+    "installable": True,
+    "application": True,
+    "auto_install": False,
+}


### PR DESCRIPTION
Add three new IPAI modules for CE+OCA enterprise parity:

1. ipai_enterprise_bridge - Thin glue layer with:
   - Supabase/AI integration settings (res.config.settings)
   - Policy configuration for approvals/governance
   - Month-end close checklist models (PH finance PPM)
   - Retail product fields for Scout (grocery/shelf/substitution)
   - Invoice/PO external sync tracking + BIR form types
   - AI mixin for AI-enhanced records
   - Job queue/outbox for external integrations

2. ipai_scout_bundle - Meta-installer for retail vertical
   - Depends on CE retail apps (POS, stock, sale, purchase)
   - Depends on OCA governance baseline
   - One-click install for Scout retail intelligence

3. ipai_ces_bundle - Meta-installer for creative ops vertical
   - Depends on CE services apps (project, hr, timesheet)
   - Depends on OCA governance baseline
   - One-click install for CES creative effectiveness

Both bundles are pure dependency manifests with no code - all glue logic lives in ipai_enterprise_bridge.

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Supabase security review | [View](https://hub.continue.dev/tasks/f2630819-8812-4dd4-a429-1c81332934b9) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->