### PR TITLE
feat(mcp): add Agent-to-Agent (A2A) communication server

### DIFF
--- a/.claude/mcp-servers.json
+++ b/.claude/mcp-servers.json
@@ -154,11 +154,21 @@
         "SUPABASE_SERVICE_KEY": "${SUPABASE_SERVICE_KEY}"
       },
       "description": "Verified memory system - repository-scoped, cross-agent learning with citation verification"
+    },
+
+    "agent-coordination": {
+      "command": "node",
+      "args": ["mcp/servers/agent-coordination-server/dist/index.js"],
+      "env": {
+        "SUPABASE_URL": "${SUPABASE_URL}",
+        "SUPABASE_SERVICE_ROLE_KEY": "${SUPABASE_SERVICE_ROLE_KEY}"
+      },
+      "description": "A2A coordination - agent registry, discovery, inter-agent invocation following Microsoft's MCP pattern"
     }
   },
 
   "serverGroups": {
-    "core": ["supabase", "github", "dbhub", "odoo-erp", "memory"],
+    "core": ["supabase", "github", "dbhub", "odoo-erp", "memory", "agent-coordination"],
     "design": ["figma", "notion"],
     "data": ["firecrawl", "huggingface"],
     "infra": ["digitalocean", "vercel"],

--- a/db/migrations/20260120_agent_coordination_schema.sql
+++ b/db/migrations/20260120_agent_coordination_schema.sql
@@ -1,0 +1,344 @@
+-- Agent Coordination Schema for A2A Communication
+-- Implements the service discovery and message routing pattern
+-- Based on Microsoft's A2A on MCP architecture
+--
+-- @see https://developer.microsoft.com/blog/can-you-build-agent2agent-communication-on-mcp-yes
+
+-- Create schema for agent coordination
+CREATE SCHEMA IF NOT EXISTS agent_coordination;
+
+-- ============ Agent Registry Table ============
+-- Stores metadata about registered agents
+CREATE TABLE IF NOT EXISTS agent_coordination.agent_registry (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    version TEXT NOT NULL,
+    description TEXT NOT NULL,
+    capabilities TEXT[] NOT NULL DEFAULT '{}',
+    transport TEXT NOT NULL CHECK (transport IN ('stdio', 'http', 'grpc', 'websocket')),
+    endpoint TEXT,
+    mcp_server TEXT,
+    tools TEXT[] DEFAULT '{}',
+    input_schema JSONB,
+    output_schema JSONB,
+    timeout_ms INTEGER NOT NULL DEFAULT 30000,
+    max_concurrent INTEGER NOT NULL DEFAULT 5,
+    retry_policy JSONB,
+    tags TEXT[] DEFAULT '{}',
+    owner TEXT,
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'idle', 'busy', 'offline', 'maintenance')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_heartbeat TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_agent_registry_capabilities ON agent_coordination.agent_registry USING GIN (capabilities);
+CREATE INDEX IF NOT EXISTS idx_agent_registry_status ON agent_coordination.agent_registry (status);
+CREATE INDEX IF NOT EXISTS idx_agent_registry_tags ON agent_coordination.agent_registry USING GIN (tags);
+CREATE INDEX IF NOT EXISTS idx_agent_registry_tools ON agent_coordination.agent_registry USING GIN (tools);
+CREATE INDEX IF NOT EXISTS idx_agent_registry_heartbeat ON agent_coordination.agent_registry (last_heartbeat);
+
+-- ============ Agent State Table ============
+-- Runtime state for active agents
+CREATE TABLE IF NOT EXISTS agent_coordination.agent_state (
+    agent_id TEXT PRIMARY KEY REFERENCES agent_coordination.agent_registry(id) ON DELETE CASCADE,
+    status TEXT NOT NULL DEFAULT 'idle' CHECK (status IN ('active', 'idle', 'busy', 'offline', 'maintenance')),
+    current_task_id TEXT,
+    queue_depth INTEGER NOT NULL DEFAULT 0,
+    last_heartbeat TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    resource_usage JSONB,
+    metrics JSONB,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ============ Agent Messages Table ============
+-- Inter-agent message log
+CREATE TABLE IF NOT EXISTS agent_coordination.agent_messages (
+    message_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    from_agent_id TEXT NOT NULL,
+    to_agent_id TEXT NOT NULL,
+    request_type TEXT NOT NULL CHECK (request_type IN ('tool_call', 'query', 'stream', 'event', 'handoff', 'delegate')),
+    payload JSONB NOT NULL,
+    context JSONB,
+    priority TEXT NOT NULL DEFAULT 'normal' CHECK (priority IN ('critical', 'high', 'normal', 'low')),
+    timeout_ms INTEGER NOT NULL DEFAULT 30000,
+    requires_ack BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ
+);
+
+-- Indexes for message queries
+CREATE INDEX IF NOT EXISTS idx_agent_messages_from ON agent_coordination.agent_messages (from_agent_id);
+CREATE INDEX IF NOT EXISTS idx_agent_messages_to ON agent_coordination.agent_messages (to_agent_id);
+CREATE INDEX IF NOT EXISTS idx_agent_messages_created ON agent_coordination.agent_messages (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_messages_priority ON agent_coordination.agent_messages (priority) WHERE priority IN ('critical', 'high');
+
+-- ============ Agent Responses Table ============
+-- Responses to inter-agent messages
+CREATE TABLE IF NOT EXISTS agent_coordination.agent_responses (
+    message_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    in_reply_to UUID NOT NULL REFERENCES agent_coordination.agent_messages(message_id),
+    from_agent_id TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('success', 'error', 'timeout', 'cancelled', 'partial')),
+    result JSONB,
+    error JSONB,
+    execution_time_ms INTEGER,
+    tokens_used INTEGER,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_responses_reply ON agent_coordination.agent_responses (in_reply_to);
+
+-- ============ Agent Jobs Table ============
+-- Async job queue for agent tasks
+CREATE TABLE IF NOT EXISTS agent_coordination.agent_jobs (
+    job_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source_agent_id TEXT NOT NULL,
+    target_agent_id TEXT NOT NULL,
+    request_type TEXT NOT NULL DEFAULT 'tool_call',
+    payload JSONB NOT NULL,
+    context JSONB,
+    priority TEXT NOT NULL DEFAULT 'normal' CHECK (priority IN ('critical', 'high', 'normal', 'low')),
+    status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued', 'processing', 'completed', 'failed', 'cancelled')),
+    result JSONB,
+    error JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    max_retries INTEGER NOT NULL DEFAULT 3
+);
+
+-- Indexes for job queue operations
+CREATE INDEX IF NOT EXISTS idx_agent_jobs_target ON agent_coordination.agent_jobs (target_agent_id);
+CREATE INDEX IF NOT EXISTS idx_agent_jobs_status ON agent_coordination.agent_jobs (status);
+CREATE INDEX IF NOT EXISTS idx_agent_jobs_queue ON agent_coordination.agent_jobs (status, priority, created_at)
+    WHERE status = 'queued';
+
+-- ============ RPC Functions ============
+
+-- Register or update an agent
+CREATE OR REPLACE FUNCTION agent_coordination.upsert_agent(
+    p_id TEXT,
+    p_name TEXT,
+    p_version TEXT,
+    p_description TEXT,
+    p_capabilities TEXT[],
+    p_transport TEXT,
+    p_endpoint TEXT DEFAULT NULL,
+    p_mcp_server TEXT DEFAULT NULL,
+    p_tools TEXT[] DEFAULT '{}',
+    p_timeout_ms INTEGER DEFAULT 30000,
+    p_max_concurrent INTEGER DEFAULT 5,
+    p_tags TEXT[] DEFAULT '{}'
+) RETURNS agent_coordination.agent_registry AS $$
+DECLARE
+    v_result agent_coordination.agent_registry;
+BEGIN
+    INSERT INTO agent_coordination.agent_registry (
+        id, name, version, description, capabilities, transport,
+        endpoint, mcp_server, tools, timeout_ms, max_concurrent, tags
+    ) VALUES (
+        p_id, p_name, p_version, p_description, p_capabilities, p_transport,
+        p_endpoint, p_mcp_server, p_tools, p_timeout_ms, p_max_concurrent, p_tags
+    )
+    ON CONFLICT (id) DO UPDATE SET
+        name = EXCLUDED.name,
+        version = EXCLUDED.version,
+        description = EXCLUDED.description,
+        capabilities = EXCLUDED.capabilities,
+        transport = EXCLUDED.transport,
+        endpoint = EXCLUDED.endpoint,
+        mcp_server = EXCLUDED.mcp_server,
+        tools = EXCLUDED.tools,
+        timeout_ms = EXCLUDED.timeout_ms,
+        max_concurrent = EXCLUDED.max_concurrent,
+        tags = EXCLUDED.tags,
+        updated_at = NOW(),
+        last_heartbeat = NOW()
+    RETURNING * INTO v_result;
+
+    RETURN v_result;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Send heartbeat to keep agent alive
+CREATE OR REPLACE FUNCTION agent_coordination.agent_heartbeat(
+    p_agent_id TEXT
+) RETURNS BOOLEAN AS $$
+BEGIN
+    UPDATE agent_coordination.agent_registry
+    SET last_heartbeat = NOW(),
+        status = 'active'
+    WHERE id = p_agent_id;
+
+    RETURN FOUND;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Discover agents by criteria
+CREATE OR REPLACE FUNCTION agent_coordination.discover_agents(
+    p_capabilities TEXT[] DEFAULT NULL,
+    p_status TEXT[] DEFAULT NULL,
+    p_tags TEXT[] DEFAULT NULL,
+    p_tools TEXT[] DEFAULT NULL,
+    p_max_results INTEGER DEFAULT 50
+) RETURNS SETOF agent_coordination.agent_registry AS $$
+BEGIN
+    RETURN QUERY
+    SELECT *
+    FROM agent_coordination.agent_registry
+    WHERE (p_capabilities IS NULL OR capabilities && p_capabilities)
+      AND (p_status IS NULL OR status = ANY(p_status))
+      AND (p_tags IS NULL OR tags && p_tags)
+      AND (p_tools IS NULL OR tools && p_tools)
+    ORDER BY last_heartbeat DESC NULLS LAST
+    LIMIT p_max_results;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Claim next job from queue (atomic operation)
+CREATE OR REPLACE FUNCTION agent_coordination.claim_next_job(
+    p_agent_id TEXT
+) RETURNS agent_coordination.agent_jobs AS $$
+DECLARE
+    v_job agent_coordination.agent_jobs;
+BEGIN
+    SELECT * INTO v_job
+    FROM agent_coordination.agent_jobs
+    WHERE target_agent_id = p_agent_id
+      AND status = 'queued'
+    ORDER BY
+        CASE priority
+            WHEN 'critical' THEN 1
+            WHEN 'high' THEN 2
+            WHEN 'normal' THEN 3
+            WHEN 'low' THEN 4
+        END,
+        created_at ASC
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED;
+
+    IF v_job.job_id IS NOT NULL THEN
+        UPDATE agent_coordination.agent_jobs
+        SET status = 'processing',
+            started_at = NOW()
+        WHERE job_id = v_job.job_id;
+
+        v_job.status := 'processing';
+        v_job.started_at := NOW();
+    END IF;
+
+    RETURN v_job;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Complete a job
+CREATE OR REPLACE FUNCTION agent_coordination.complete_job(
+    p_job_id UUID,
+    p_result JSONB
+) RETURNS BOOLEAN AS $$
+BEGIN
+    UPDATE agent_coordination.agent_jobs
+    SET status = 'completed',
+        result = p_result,
+        completed_at = NOW()
+    WHERE job_id = p_job_id
+      AND status = 'processing';
+
+    RETURN FOUND;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Fail a job (with optional retry)
+CREATE OR REPLACE FUNCTION agent_coordination.fail_job(
+    p_job_id UUID,
+    p_error JSONB
+) RETURNS TEXT AS $$
+DECLARE
+    v_job agent_coordination.agent_jobs;
+    v_new_status TEXT;
+BEGIN
+    SELECT * INTO v_job
+    FROM agent_coordination.agent_jobs
+    WHERE job_id = p_job_id;
+
+    IF v_job.retry_count < v_job.max_retries THEN
+        -- Retry: re-queue the job
+        UPDATE agent_coordination.agent_jobs
+        SET status = 'queued',
+            retry_count = retry_count + 1,
+            error = p_error,
+            started_at = NULL
+        WHERE job_id = p_job_id;
+        v_new_status := 'queued';
+    ELSE
+        -- Max retries reached: mark as failed
+        UPDATE agent_coordination.agent_jobs
+        SET status = 'failed',
+            error = p_error,
+            completed_at = NOW()
+        WHERE job_id = p_job_id;
+        v_new_status := 'failed';
+    END IF;
+
+    RETURN v_new_status;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Mark stale agents as offline
+CREATE OR REPLACE FUNCTION agent_coordination.mark_stale_offline(
+    p_threshold_ms INTEGER DEFAULT 300000  -- 5 minutes
+) RETURNS INTEGER AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    WITH updated AS (
+        UPDATE agent_coordination.agent_registry
+        SET status = 'offline'
+        WHERE last_heartbeat < NOW() - (p_threshold_ms || ' milliseconds')::INTERVAL
+          AND status != 'offline'
+        RETURNING 1
+    )
+    SELECT COUNT(*) INTO v_count FROM updated;
+
+    RETURN v_count;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Get registry statistics
+CREATE OR REPLACE FUNCTION agent_coordination.get_stats()
+RETURNS TABLE (
+    total_agents BIGINT,
+    active_agents BIGINT,
+    idle_agents BIGINT,
+    busy_agents BIGINT,
+    offline_agents BIGINT,
+    pending_jobs BIGINT,
+    processing_jobs BIGINT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        (SELECT COUNT(*) FROM agent_coordination.agent_registry),
+        (SELECT COUNT(*) FROM agent_coordination.agent_registry WHERE status = 'active'),
+        (SELECT COUNT(*) FROM agent_coordination.agent_registry WHERE status = 'idle'),
+        (SELECT COUNT(*) FROM agent_coordination.agent_registry WHERE status = 'busy'),
+        (SELECT COUNT(*) FROM agent_coordination.agent_registry WHERE status = 'offline'),
+        (SELECT COUNT(*) FROM agent_coordination.agent_jobs WHERE status = 'queued'),
+        (SELECT COUNT(*) FROM agent_coordination.agent_jobs WHERE status = 'processing');
+END;
+$$ LANGUAGE plpgsql;
+
+-- Grant permissions for service role
+GRANT USAGE ON SCHEMA agent_coordination TO service_role;
+GRANT ALL ON ALL TABLES IN SCHEMA agent_coordination TO service_role;
+GRANT ALL ON ALL FUNCTIONS IN SCHEMA agent_coordination TO service_role;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA agent_coordination TO service_role;
+
+-- Comment for documentation
+COMMENT ON SCHEMA agent_coordination IS 'Agent-to-Agent (A2A) coordination schema for MCP multi-agent communication';
+COMMENT ON TABLE agent_coordination.agent_registry IS 'Registry of available agents with their capabilities and transport configuration';
+COMMENT ON TABLE agent_coordination.agent_messages IS 'Inter-agent message log for A2A communication tracing';
+COMMENT ON TABLE agent_coordination.agent_jobs IS 'Async job queue for agent task execution';

--- a/docs/evidence/20260120-agent-communication/IMPLEMENTATION.md
+++ b/docs/evidence/20260120-agent-communication/IMPLEMENTATION.md
@@ -1,0 +1,134 @@
+# A2A Communication Implementation Evidence
+
+**Date**: 2026-01-20
+**Scope**: Agent-to-Agent Communication on MCP
+**Reference**: https://developer.microsoft.com/blog/can-you-build-agent2agent-communication-on-mcp-yes
+
+## Summary
+
+Implemented Agent-to-Agent (A2A) communication capabilities following Microsoft's multi-agent orchestration pattern on MCP.
+
+## Files Created
+
+### MCP Server (`mcp/servers/agent-coordination-server/`)
+- `package.json` - NPM package configuration
+- `tsconfig.json` - TypeScript configuration
+- `src/types.ts` - Type definitions for A2A protocol
+- `src/agent-registry.ts` - Supabase-backed agent registry
+- `src/coordinator.ts` - A2A coordination logic
+- `src/index.ts` - Main MCP server with 22 tools
+- `README.md` - Documentation
+
+### Database Schema
+- `db/migrations/20260120_agent_coordination_schema.sql`
+  - Tables: agent_registry, agent_state, agent_messages, agent_responses, agent_jobs
+  - RPCs: upsert_agent, agent_heartbeat, discover_agents, claim_next_job, complete_job, fail_job
+
+### Configuration Updates
+- `.claude/mcp-servers.json` - Added agent-coordination server
+- `mcp/coordinator/app/config.py` - Added agent_coordination_url
+- `mcp/coordinator/app/routing.py` - Added A2A routing context
+
+## Tools Implemented (22 total)
+
+### Registry (5)
+1. `register_agent` - Register/update agent
+2. `unregister_agent` - Remove agent
+3. `discover_agents` - Find by criteria
+4. `list_agents` - List all
+5. `get_agent` - Get details
+
+### Invocation (5)
+6. `invoke_agent` - Synchronous call
+7. `submit_job` - Async job
+8. `get_job_status` - Poll status
+9. `cancel_job` - Cancel queued
+10. `list_pending_jobs` - List queue
+
+### Coordination (4)
+11. `handoff` - Transfer conversation
+12. `delegate` - Assign subtask
+13. `broadcast` - Multi-agent send
+14. `invoke_by_capability` - Capability-based routing
+
+### State (4)
+15. `get_agent_state` - Get runtime state
+16. `update_agent_state` - Update state
+17. `heartbeat` - Keep-alive
+18. `update_agent_status` - Change status
+
+### History/Stats (4)
+19. `get_message_history` - Message log
+20. `get_registry_stats` - Statistics
+21. `cleanup_stale_agents` - Maintenance
+
+## Architecture Pattern
+
+```
+Orchestrator Agent (Claude CLI / Human)
+         │
+         ▼
+Agent Coordination Server (MCP)
+    ├── Registry (Supabase)
+    ├── Coordinator (A2A RPC)
+    └── Job Queue (mcp-jobs integration)
+         │
+    ┌────┴────┬────────────┐
+    ▼         ▼            ▼
+Odoo ERP  Finance      Analytics
+ Agent     Agent        Agent
+```
+
+## Key Features
+
+1. **Service Discovery**: Agents register capabilities, tools, transport type
+2. **Context Propagation**: Session ID, call chain, trace ID across calls
+3. **Multiple Invocation Patterns**:
+   - Sync: Wait for response
+   - Async: Job queue with polling
+   - Broadcast: Multiple agents
+   - Capability-based: Auto-select best agent
+4. **Handoff/Delegation**: Transfer tasks with context
+5. **Load Balancing**: Route to agent with lowest queue depth
+
+## Verification
+
+### Build Verification
+```bash
+cd mcp/servers/agent-coordination-server
+npm install
+npm run build
+```
+
+### Schema Verification
+```bash
+psql "$SUPABASE_URL" -f db/migrations/20260120_agent_coordination_schema.sql
+```
+
+### Integration Test
+```bash
+# Start server
+node mcp/servers/agent-coordination-server/dist/index.js
+
+# Register test agent
+echo '{"method":"tools/call","params":{"name":"register_agent","arguments":{"id":"test-agent","name":"Test","version":"1.0.0","description":"Test agent","capabilities":["testing"],"transport":"http"}}}' | nc localhost 8768
+```
+
+## Dependencies
+
+- `@modelcontextprotocol/sdk`: ^0.5.0
+- `@supabase/supabase-js`: ^2.39.0
+- `uuid`: ^9.0.0
+
+## Environment Variables
+
+```bash
+SUPABASE_URL=https://spdtwktxdalcfigzeqrz.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=<service_role_key>
+```
+
+## Related Documents
+
+- [Microsoft A2A Blog](https://developer.microsoft.com/blog/can-you-build-agent2agent-communication-on-mcp-yes)
+- [MCP Jobs System](../../infra/MCP_JOBS_SYSTEM.md)
+- [Server README](../../../mcp/servers/agent-coordination-server/README.md)

--- a/mcp/coordinator/app/config.py
+++ b/mcp/coordinator/app/config.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     # MCP Server endpoints
     odoo_prod_mcp_url: str = "http://odoo-prod-mcp:8767"
     odoo_lab_mcp_url: str = "http://localhost:8765"
+    agent_coordination_url: str = "http://localhost:8768"
 
     # Supabase connection
     supabase_url: str

--- a/mcp/coordinator/app/routing.py
+++ b/mcp/coordinator/app/routing.py
@@ -1,5 +1,12 @@
 """
 Intelligent routing logic for MCP Coordinator
+
+Supports Agent-to-Agent (A2A) communication patterns:
+- Context propagation across agent calls
+- Agent capability-based routing
+- Call chain tracing for distributed operations
+
+@see https://developer.microsoft.com/blog/can-you-build-agent2agent-communication-on-mcp-yes
 """
 from typing import Dict, List, Optional, Any
 from enum import Enum
@@ -11,6 +18,7 @@ class MCPTarget(str, Enum):
     """Available MCP targets"""
     ODOO_PROD = "odoo_prod"
     ODOO_LAB = "odoo_lab"
+    AGENT_COORDINATION = "agent_coordination"
 
 
 class RoutingDecision:
@@ -29,13 +37,50 @@ class RoutingDecision:
         self.fallback = fallback
 
 
+class A2AContext:
+    """Agent-to-Agent context for call chain tracing"""
+
+    def __init__(
+        self,
+        session_id: Optional[str] = None,
+        caller_agent_id: Optional[str] = None,
+        call_chain: Optional[List[str]] = None,
+        trace_id: Optional[str] = None,
+    ):
+        self.session_id = session_id
+        self.caller_agent_id = caller_agent_id
+        self.call_chain = call_chain or []
+        self.trace_id = trace_id
+
+    @classmethod
+    def from_request(cls, request_data: Dict[str, Any]) -> "A2AContext":
+        """Extract A2A context from request"""
+        ctx = request_data.get("a2a_context", {})
+        return cls(
+            session_id=ctx.get("session_id"),
+            caller_agent_id=ctx.get("caller_agent_id"),
+            call_chain=ctx.get("call_chain", []),
+            trace_id=ctx.get("trace_id"),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for propagation"""
+        return {
+            "session_id": self.session_id,
+            "caller_agent_id": self.caller_agent_id,
+            "call_chain": self.call_chain,
+            "trace_id": self.trace_id,
+        }
+
+
 class MCPRouter:
-    """Intelligent MCP request router"""
+    """Intelligent MCP request router with A2A support"""
 
     def __init__(self):
         self.target_urls = {
             MCPTarget.ODOO_PROD: settings.odoo_prod_mcp_url,
             MCPTarget.ODOO_LAB: settings.odoo_lab_mcp_url,
+            MCPTarget.AGENT_COORDINATION: settings.agent_coordination_url,
         }
 
     def route_request(self, request_data: Dict[str, Any]) -> RoutingDecision:
@@ -44,8 +89,9 @@ class MCPRouter:
 
         Priority:
         1. Explicit target override
-        2. Context-based routing (finance-ssc → prod, migration/oca → lab)
-        3. Default with failover
+        2. A2A agent invocation requests
+        3. Context-based routing (finance-ssc → prod, migration/oca → lab)
+        4. Default with failover
         """
         # Check for explicit target
         if "target" in request_data:
@@ -56,6 +102,21 @@ class MCPRouter:
                     reason="Explicit target specified",
                     confidence=1.0,
                 )
+
+        # A2A coordination requests
+        a2a_context = A2AContext.from_request(request_data)
+        tool_name = request_data.get("tool_name", "").lower()
+
+        if a2a_context.caller_agent_id or any(
+            keyword in tool_name
+            for keyword in ["invoke_agent", "discover_agents", "register_agent", "handoff", "delegate"]
+        ):
+            return RoutingDecision(
+                target=MCPTarget.AGENT_COORDINATION,
+                reason="A2A coordination request",
+                confidence=0.98,
+                fallback=MCPTarget.ODOO_LAB,
+            )
 
         # Context-based routing
         context = request_data.get("context", {})
@@ -89,6 +150,18 @@ class MCPRouter:
             confidence=0.75,
             fallback=MCPTarget.ODOO_LAB,
         )
+
+    def propagate_a2a_context(
+        self, request_data: Dict[str, Any], current_agent_id: str
+    ) -> Dict[str, Any]:
+        """Add A2A context to outgoing requests for call chain tracing"""
+        a2a_context = A2AContext.from_request(request_data)
+        a2a_context.call_chain.append(current_agent_id)
+
+        return {
+            **request_data,
+            "a2a_context": a2a_context.to_dict(),
+        }
 
     async def forward_request(
         self, target: MCPTarget, endpoint: str, method: str = "GET", **kwargs

--- a/mcp/servers/agent-coordination-server/README.md
+++ b/mcp/servers/agent-coordination-server/README.md
@@ -1,0 +1,245 @@
+# Agent Coordination MCP Server
+
+Agent-to-Agent (A2A) communication server implementing Microsoft's multi-agent orchestration pattern on MCP.
+
+## Overview
+
+This MCP server enables direct agent-to-agent communication, following the pattern described in [Microsoft's A2A on MCP blog post](https://developer.microsoft.com/blog/can-you-build-agent2agent-communication-on-mcp-yes).
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Orchestrator Agent                          │
+│                    (Human/Claude CLI)                           │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                  Agent Coordination Server                       │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────────┐  │
+│  │   Registry   │  │  Coordinator │  │   Message Queue      │  │
+│  │  (Supabase)  │  │   (A2A RPC)  │  │   (Jobs System)      │  │
+│  └──────────────┘  └──────────────┘  └──────────────────────┘  │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+          ┌───────────────────┼───────────────────┐
+          │                   │                   │
+          ▼                   ▼                   ▼
+    ┌───────────┐       ┌───────────┐       ┌───────────┐
+    │  Odoo ERP │       │  Finance  │       │   Infra   │
+    │   Agent   │       │   Agent   │       │   Agent   │
+    └───────────┘       └───────────┘       └───────────┘
+```
+
+## Features
+
+### Agent Registry
+- Register agents with capabilities, transport type, and tools
+- Discover agents by capability, status, tags, or tools
+- Heartbeat mechanism for health monitoring
+- Automatic stale agent cleanup
+
+### Inter-Agent Communication
+- **Synchronous invocation**: `invoke_agent` - wait for response
+- **Async jobs**: `submit_job` - fire and forget with status polling
+- **Handoff**: Transfer conversation context to another agent
+- **Delegation**: Assign subtasks with constraints
+- **Broadcast**: Send to multiple agents simultaneously
+
+### Context Propagation
+- Session tracking across agent calls
+- Call chain tracing for distributed debugging
+- Workspace context (Odoo instance, company, user)
+- Memory references for knowledge sharing
+
+## Installation
+
+```bash
+cd mcp/servers/agent-coordination-server
+npm install
+npm run build
+```
+
+## Configuration
+
+Required environment variables:
+
+```bash
+# Supabase for registry persistence
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+```
+
+## Usage
+
+### Register an Agent
+
+```typescript
+// Register the Odoo ERP agent
+await invoke("register_agent", {
+  id: "odoo-erp-agent",
+  name: "Odoo ERP Agent",
+  version: "1.0.0",
+  description: "Handles accounting, HR, and inventory operations",
+  capabilities: ["odoo_erp", "finance", "hr", "inventory"],
+  transport: "http",
+  endpoint: "http://localhost:8767",
+  tools: ["create_invoice", "post_journal_entry", "get_partners"],
+  timeout_ms: 30000,
+  max_concurrent: 5,
+  tags: ["production", "core"]
+});
+```
+
+### Discover Agents
+
+```typescript
+// Find all finance-capable agents
+const agents = await invoke("discover_agents", {
+  capabilities: ["finance"],
+  status: ["active", "idle"]
+});
+```
+
+### Invoke Agent (Synchronous)
+
+```typescript
+// Call another agent and wait for response
+const response = await invoke("invoke_agent", {
+  target_agent_id: "odoo-erp-agent",
+  tool_name: "create_invoice",
+  arguments: {
+    partner_id: 123,
+    lines: [{ product_id: 456, quantity: 1, price: 100 }]
+  },
+  caller_agent_id: "orchestrator",
+  priority: "normal"
+});
+```
+
+### Submit Async Job
+
+```typescript
+// Submit job without waiting
+const job = await invoke("submit_job", {
+  source_agent_id: "orchestrator",
+  target_agent_id: "analytics-agent",
+  tool_name: "generate_report",
+  arguments: { report_type: "monthly_sales" },
+  priority: "low",
+  max_retries: 3
+});
+
+// Poll for status
+const status = await invoke("get_job_status", { job_id: job.job_id });
+```
+
+### Handoff Conversation
+
+```typescript
+// Transfer to specialist agent
+await invoke("handoff", {
+  from_agent_id: "general-agent",
+  to_agent_id: "finance-specialist",
+  reason: "User needs detailed tax advice",
+  conversation_context: { messages: [...] },
+  user_intent: "Calculate Q4 tax liability"
+});
+```
+
+### Delegate Task
+
+```typescript
+// Delegate with constraints
+await invoke("delegate", {
+  delegator_id: "orchestrator",
+  delegate_id: "research-agent",
+  tool_name: "search_documents",
+  arguments: { query: "compliance requirements" },
+  timeout_ms: 60000,
+  allowed_tools: ["search", "read"]
+});
+```
+
+### Invoke by Capability
+
+```typescript
+// Let the system find the best agent
+const response = await invoke("invoke_by_capability", {
+  capability: "analytics",
+  tool_name: "analyze_data",
+  arguments: { dataset: "sales_2024" }
+});
+```
+
+## Tools Reference
+
+### Registry Tools
+| Tool | Description |
+|------|-------------|
+| `register_agent` | Register or update agent in registry |
+| `unregister_agent` | Remove agent from registry |
+| `discover_agents` | Find agents by criteria |
+| `list_agents` | List all registered agents |
+| `get_agent` | Get specific agent details |
+
+### Invocation Tools
+| Tool | Description |
+|------|-------------|
+| `invoke_agent` | Synchronous agent call |
+| `submit_job` | Async job submission |
+| `get_job_status` | Get job status |
+| `cancel_job` | Cancel queued job |
+| `list_pending_jobs` | List agent's pending jobs |
+
+### Coordination Tools
+| Tool | Description |
+|------|-------------|
+| `handoff` | Transfer conversation to another agent |
+| `delegate` | Assign subtask with constraints |
+| `broadcast` | Send to multiple agents |
+| `invoke_by_capability` | Find and invoke best agent |
+
+### State Tools
+| Tool | Description |
+|------|-------------|
+| `get_agent_state` | Get runtime state |
+| `update_agent_state` | Update runtime state |
+| `heartbeat` | Send keep-alive |
+| `update_agent_status` | Change agent status |
+
+### History/Stats Tools
+| Tool | Description |
+|------|-------------|
+| `get_message_history` | Get messages between agents |
+| `get_registry_stats` | Get registry statistics |
+| `cleanup_stale_agents` | Mark inactive agents offline |
+
+## Database Schema
+
+The server uses Supabase with the `agent_coordination` schema:
+
+- `agent_registry` - Agent metadata and capabilities
+- `agent_state` - Runtime state (queue depth, current task)
+- `agent_messages` - Inter-agent message log
+- `agent_responses` - Response history
+- `agent_jobs` - Async job queue
+
+See `db/migrations/20260120_agent_coordination_schema.sql` for full schema.
+
+## Integration with MCP Coordinator
+
+The MCP Coordinator automatically routes A2A requests:
+
+```python
+# Requests with a2a_context or A2A tool names route to agent-coordination
+if a2a_context.caller_agent_id or "invoke_agent" in tool_name:
+    return MCPTarget.AGENT_COORDINATION
+```
+
+## Related Documentation
+
+- [Microsoft A2A on MCP Blog](https://developer.microsoft.com/blog/can-you-build-agent2agent-communication-on-mcp-yes)
+- [MCP Jobs System](../../../docs/infra/MCP_JOBS_SYSTEM.md)
+- [MCP Stack README](../../../docs/README_MCP_STACK.md)

--- a/mcp/servers/agent-coordination-server/package.json
+++ b/mcp/servers/agent-coordination-server/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@tbwa/agent-coordination-server",
+  "version": "1.0.0",
+  "description": "MCP server for Agent-to-Agent (A2A) communication and coordination",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "agent-coordination-server": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "start": "node dist/index.js",
+    "test": "jest",
+    "lint": "eslint src --ext .ts",
+    "format": "prettier --write \"src/**/*.ts\""
+  },
+  "keywords": [
+    "mcp",
+    "a2a",
+    "agent-to-agent",
+    "coordination",
+    "orchestration",
+    "multi-agent"
+  ],
+  "author": "TBWA InsightPulse AI <dev@insightpulseai.net>",
+  "license": "AGPL-3.0",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^0.5.0",
+    "@supabase/supabase-js": "^2.39.0",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.6",
+    "@types/uuid": "^9.0.7",
+    "typescript": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/mcp/servers/agent-coordination-server/src/agent-registry.ts
+++ b/mcp/servers/agent-coordination-server/src/agent-registry.ts
@@ -1,0 +1,365 @@
+/**
+ * Agent Registry - Supabase-backed agent discovery and registration
+ *
+ * Implements the service discovery pattern for A2A communication,
+ * allowing agents to register, discover, and track other agents.
+ */
+
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import {
+  AgentMetadata,
+  AgentState,
+  DiscoveryQuery,
+  AgentStatus,
+} from "./types.js";
+
+const SUPABASE_URL = process.env.SUPABASE_URL || "";
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+
+/**
+ * Agent Registry client for managing agent metadata and state
+ */
+export class AgentRegistry {
+  private supabase: SupabaseClient | null = null;
+  private localCache: Map<string, AgentMetadata> = new Map();
+  private cacheExpiry: number = 60000; // 1 minute
+  private lastCacheUpdate: number = 0;
+
+  constructor() {
+    if (SUPABASE_URL && SUPABASE_SERVICE_KEY) {
+      this.supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+    }
+  }
+
+  /**
+   * Register a new agent or update existing registration
+   */
+  async register(agent: AgentMetadata): Promise<AgentMetadata> {
+    const now = new Date().toISOString();
+    const record = {
+      ...agent,
+      updated_at: now,
+      last_heartbeat: now,
+    };
+
+    if (this.supabase) {
+      const { data, error } = await this.supabase
+        .from("agent_registry")
+        .upsert(record, { onConflict: "id" })
+        .select()
+        .single();
+
+      if (error) {
+        throw new Error(`Registration failed: ${error.message}`);
+      }
+      this.localCache.set(agent.id, data);
+      return data;
+    }
+
+    // Fallback to local cache only
+    this.localCache.set(agent.id, record);
+    return record;
+  }
+
+  /**
+   * Unregister an agent from the registry
+   */
+  async unregister(agentId: string): Promise<void> {
+    if (this.supabase) {
+      const { error } = await this.supabase
+        .from("agent_registry")
+        .delete()
+        .eq("id", agentId);
+
+      if (error) {
+        throw new Error(`Unregistration failed: ${error.message}`);
+      }
+    }
+    this.localCache.delete(agentId);
+  }
+
+  /**
+   * Get agent by ID
+   */
+  async get(agentId: string): Promise<AgentMetadata | null> {
+    // Check cache first
+    if (this.localCache.has(agentId)) {
+      return this.localCache.get(agentId) || null;
+    }
+
+    if (this.supabase) {
+      const { data, error } = await this.supabase
+        .from("agent_registry")
+        .select("*")
+        .eq("id", agentId)
+        .single();
+
+      if (error) {
+        if (error.code === "PGRST116") return null; // Not found
+        throw new Error(`Get agent failed: ${error.message}`);
+      }
+      this.localCache.set(agentId, data);
+      return data;
+    }
+
+    return null;
+  }
+
+  /**
+   * Discover agents matching query criteria
+   */
+  async discover(query: DiscoveryQuery): Promise<AgentMetadata[]> {
+    if (this.supabase) {
+      let q = this.supabase.from("agent_registry").select("*");
+
+      // Filter by capabilities (array overlap)
+      if (query.capabilities?.length) {
+        q = q.overlaps("capabilities", query.capabilities);
+      }
+
+      // Filter by status
+      if (query.status?.length) {
+        q = q.in("status", query.status);
+      }
+
+      // Filter by tags
+      if (query.tags?.length) {
+        q = q.overlaps("tags", query.tags);
+      }
+
+      // Filter by tools
+      if (query.tools?.length) {
+        q = q.overlaps("tools", query.tools);
+      }
+
+      // Limit results
+      if (query.max_results) {
+        q = q.limit(query.max_results);
+      }
+
+      const { data, error } = await q;
+
+      if (error) {
+        throw new Error(`Discovery failed: ${error.message}`);
+      }
+
+      // Update cache
+      for (const agent of data || []) {
+        this.localCache.set(agent.id, agent);
+      }
+
+      return data || [];
+    }
+
+    // Fallback: filter local cache
+    let results = Array.from(this.localCache.values());
+
+    if (query.capabilities?.length) {
+      results = results.filter((a) =>
+        query.capabilities!.some((c) => a.capabilities?.includes(c))
+      );
+    }
+
+    if (query.status?.length) {
+      results = results.filter((a) =>
+        query.status!.includes(a.status as AgentStatus)
+      );
+    }
+
+    if (query.tags?.length) {
+      results = results.filter((a) =>
+        query.tags!.some((t) => a.tags?.includes(t))
+      );
+    }
+
+    if (query.max_results) {
+      results = results.slice(0, query.max_results);
+    }
+
+    return results;
+  }
+
+  /**
+   * List all registered agents
+   */
+  async listAll(): Promise<AgentMetadata[]> {
+    if (this.supabase) {
+      const { data, error } = await this.supabase
+        .from("agent_registry")
+        .select("*")
+        .order("name");
+
+      if (error) {
+        throw new Error(`List failed: ${error.message}`);
+      }
+
+      return data || [];
+    }
+
+    return Array.from(this.localCache.values());
+  }
+
+  /**
+   * Update agent heartbeat (keep-alive)
+   */
+  async heartbeat(agentId: string): Promise<void> {
+    const now = new Date().toISOString();
+
+    if (this.supabase) {
+      const { error } = await this.supabase
+        .from("agent_registry")
+        .update({ last_heartbeat: now, status: "active" })
+        .eq("id", agentId);
+
+      if (error) {
+        throw new Error(`Heartbeat failed: ${error.message}`);
+      }
+    }
+
+    const cached = this.localCache.get(agentId);
+    if (cached) {
+      cached.last_heartbeat = now;
+    }
+  }
+
+  /**
+   * Update agent status
+   */
+  async updateStatus(agentId: string, status: AgentStatus): Promise<void> {
+    if (this.supabase) {
+      const { error } = await this.supabase
+        .from("agent_registry")
+        .update({ status, updated_at: new Date().toISOString() })
+        .eq("id", agentId);
+
+      if (error) {
+        throw new Error(`Status update failed: ${error.message}`);
+      }
+    }
+
+    const cached = this.localCache.get(agentId);
+    if (cached) {
+      (cached as AgentMetadata & { status: AgentStatus }).status = status;
+    }
+  }
+
+  /**
+   * Get agent state (runtime info)
+   */
+  async getState(agentId: string): Promise<AgentState | null> {
+    if (this.supabase) {
+      const { data, error } = await this.supabase
+        .from("agent_state")
+        .select("*")
+        .eq("agent_id", agentId)
+        .single();
+
+      if (error) {
+        if (error.code === "PGRST116") return null;
+        throw new Error(`Get state failed: ${error.message}`);
+      }
+
+      return data;
+    }
+
+    return null;
+  }
+
+  /**
+   * Update agent state
+   */
+  async updateState(state: AgentState): Promise<void> {
+    if (this.supabase) {
+      const { error } = await this.supabase
+        .from("agent_state")
+        .upsert(state, { onConflict: "agent_id" });
+
+      if (error) {
+        throw new Error(`State update failed: ${error.message}`);
+      }
+    }
+  }
+
+  /**
+   * Find agents capable of handling a specific tool
+   */
+  async findByTool(toolName: string): Promise<AgentMetadata[]> {
+    return this.discover({ tools: [toolName] });
+  }
+
+  /**
+   * Find active agents with specific capability
+   */
+  async findActiveByCapability(
+    capability: string
+  ): Promise<AgentMetadata[]> {
+    return this.discover({
+      capabilities: [capability as AgentMetadata["capabilities"][number]],
+      status: ["active", "idle"],
+    });
+  }
+
+  /**
+   * Mark stale agents as offline (cleanup job)
+   */
+  async markStaleOffline(thresholdMs: number = 300000): Promise<number> {
+    if (!this.supabase) return 0;
+
+    const threshold = new Date(Date.now() - thresholdMs).toISOString();
+
+    const { data, error } = await this.supabase
+      .from("agent_registry")
+      .update({ status: "offline" })
+      .lt("last_heartbeat", threshold)
+      .neq("status", "offline")
+      .select("id");
+
+    if (error) {
+      throw new Error(`Stale cleanup failed: ${error.message}`);
+    }
+
+    return data?.length || 0;
+  }
+
+  /**
+   * Get registry statistics
+   */
+  async getStats(): Promise<Record<string, number>> {
+    if (this.supabase) {
+      const { data, error } = await this.supabase
+        .from("agent_registry")
+        .select("status");
+
+      if (error) {
+        throw new Error(`Stats failed: ${error.message}`);
+      }
+
+      const stats: Record<string, number> = {
+        total: data?.length || 0,
+        active: 0,
+        idle: 0,
+        busy: 0,
+        offline: 0,
+        maintenance: 0,
+      };
+
+      for (const row of data || []) {
+        const status = row.status as string;
+        if (status in stats) {
+          stats[status]++;
+        }
+      }
+
+      return stats;
+    }
+
+    const agents = Array.from(this.localCache.values());
+    return {
+      total: agents.length,
+      cached: agents.length,
+    };
+  }
+}
+
+// Singleton instance
+export const registry = new AgentRegistry();

--- a/mcp/servers/agent-coordination-server/src/coordinator.ts
+++ b/mcp/servers/agent-coordination-server/src/coordinator.ts
@@ -1,0 +1,548 @@
+/**
+ * A2A Coordinator - Agent-to-Agent communication orchestration
+ *
+ * Implements the orchestrator pattern from Microsoft's A2A on MCP:
+ * - Intelligent task decomposition
+ * - Multi-agent coordination
+ * - Context propagation
+ * - Error handling and retries
+ */
+
+import { v4 as uuidv4 } from "uuid";
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import {
+  AgentMessage,
+  AgentResponse,
+  AgentContext,
+  AgentJob,
+  MessagePayload,
+  MessagePriority,
+  RequestType,
+  HandoffRequest,
+  DelegationRequest,
+  AgentError,
+} from "./types.js";
+import { registry } from "./agent-registry.js";
+
+const SUPABASE_URL = process.env.SUPABASE_URL || "";
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+
+/**
+ * A2A Coordinator for managing inter-agent communication
+ */
+export class A2ACoordinator {
+  private supabase: SupabaseClient | null = null;
+  private pendingMessages: Map<string, AgentMessage> = new Map();
+  private localResults: Map<string, AgentResponse> = new Map();
+
+  constructor() {
+    if (SUPABASE_URL && SUPABASE_SERVICE_KEY) {
+      this.supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+    }
+  }
+
+  /**
+   * Invoke an agent synchronously
+   * Waits for response up to timeout
+   */
+  async invokeAgent(
+    targetAgentId: string,
+    payload: MessagePayload,
+    context?: Partial<AgentContext>,
+    options?: {
+      priority?: MessagePriority;
+      timeout_ms?: number;
+    }
+  ): Promise<AgentResponse> {
+    const agent = await registry.get(targetAgentId);
+    if (!agent) {
+      return this.createErrorResponse(
+        "",
+        targetAgentId,
+        {
+          code: "AGENT_NOT_FOUND",
+          message: `Agent ${targetAgentId} not found in registry`,
+          recoverable: false,
+        },
+        0
+      );
+    }
+
+    const message = this.createMessage(
+      context?.caller_agent_id || "coordinator",
+      targetAgentId,
+      "tool_call",
+      payload,
+      context,
+      options?.priority || "normal",
+      options?.timeout_ms || agent.timeout_ms
+    );
+
+    // Store message for tracking
+    await this.storeMessage(message);
+
+    try {
+      // Route based on transport type
+      const startTime = Date.now();
+      let result: unknown;
+
+      switch (agent.transport) {
+        case "http":
+          result = await this.invokeHttp(agent.endpoint!, payload, message);
+          break;
+        case "stdio":
+          // For stdio agents, we queue the job for the pulser to handle
+          result = await this.queueForStdio(message);
+          break;
+        default:
+          throw new Error(`Unsupported transport: ${agent.transport}`);
+      }
+
+      const executionTime = Date.now() - startTime;
+      const response = this.createSuccessResponse(
+        message.message_id,
+        targetAgentId,
+        result,
+        executionTime
+      );
+
+      await this.storeResponse(response);
+      return response;
+    } catch (error) {
+      const executionTime = Date.now() - Date.parse(message.created_at);
+      const response = this.createErrorResponse(
+        message.message_id,
+        targetAgentId,
+        {
+          code: "INVOCATION_FAILED",
+          message: error instanceof Error ? error.message : String(error),
+          recoverable: true,
+          suggested_retry: true,
+        },
+        executionTime
+      );
+
+      await this.storeResponse(response);
+      return response;
+    }
+  }
+
+  /**
+   * Submit an async job to an agent
+   * Returns immediately with job ID
+   */
+  async submitJob(
+    sourceAgentId: string,
+    targetAgentId: string,
+    payload: MessagePayload,
+    context?: Partial<AgentContext>,
+    options?: {
+      priority?: MessagePriority;
+      max_retries?: number;
+    }
+  ): Promise<AgentJob> {
+    const job: AgentJob = {
+      job_id: uuidv4(),
+      source_agent_id: sourceAgentId,
+      target_agent_id: targetAgentId,
+      request_type: "tool_call",
+      payload,
+      context: this.buildContext(sourceAgentId, context),
+      priority: options?.priority || "normal",
+      status: "queued",
+      created_at: new Date().toISOString(),
+      retry_count: 0,
+      max_retries: options?.max_retries || 3,
+    };
+
+    if (this.supabase) {
+      const { error } = await this.supabase.from("agent_jobs").insert(job);
+
+      if (error) {
+        throw new Error(`Job submission failed: ${error.message}`);
+      }
+    }
+
+    return job;
+  }
+
+  /**
+   * Get job status
+   */
+  async getJobStatus(jobId: string): Promise<AgentJob | null> {
+    if (this.supabase) {
+      const { data, error } = await this.supabase
+        .from("agent_jobs")
+        .select("*")
+        .eq("job_id", jobId)
+        .single();
+
+      if (error) {
+        if (error.code === "PGRST116") return null;
+        throw new Error(`Get job failed: ${error.message}`);
+      }
+
+      return data;
+    }
+
+    return null;
+  }
+
+  /**
+   * Cancel a queued job
+   */
+  async cancelJob(jobId: string): Promise<boolean> {
+    if (this.supabase) {
+      const { data, error } = await this.supabase
+        .from("agent_jobs")
+        .update({ status: "cancelled" })
+        .eq("job_id", jobId)
+        .eq("status", "queued")
+        .select();
+
+      if (error) {
+        throw new Error(`Cancel failed: ${error.message}`);
+      }
+
+      return (data?.length || 0) > 0;
+    }
+
+    return false;
+  }
+
+  /**
+   * Handoff conversation to another agent
+   */
+  async handoff(request: HandoffRequest): Promise<AgentResponse> {
+    const message = this.createMessage(
+      request.from_agent_id,
+      request.to_agent_id,
+      "handoff",
+      {
+        data: {
+          reason: request.reason,
+          conversation_context: request.conversation_context,
+          memory_refs: request.memory_refs,
+          user_intent: request.user_intent,
+        },
+      },
+      undefined,
+      "high",
+      30000
+    );
+
+    await this.storeMessage(message);
+
+    // Notify target agent of handoff
+    return this.invokeAgent(
+      request.to_agent_id,
+      message.payload,
+      {
+        caller_agent_id: request.from_agent_id,
+        memory_refs: request.memory_refs,
+      },
+      { priority: "high" }
+    );
+  }
+
+  /**
+   * Delegate task to another agent with constraints
+   */
+  async delegate(request: DelegationRequest): Promise<AgentJob> {
+    const context: Partial<AgentContext> = {
+      caller_agent_id: request.delegator_id,
+      deadline: request.constraints?.timeout_ms
+        ? new Date(Date.now() + request.constraints.timeout_ms).toISOString()
+        : undefined,
+    };
+
+    return this.submitJob(
+      request.delegator_id,
+      request.delegate_id,
+      request.task,
+      context,
+      { priority: "normal" }
+    );
+  }
+
+  /**
+   * Broadcast message to multiple agents
+   */
+  async broadcast(
+    fromAgentId: string,
+    targetAgentIds: string[],
+    payload: MessagePayload,
+    context?: Partial<AgentContext>
+  ): Promise<Map<string, AgentResponse>> {
+    const results = new Map<string, AgentResponse>();
+
+    const promises = targetAgentIds.map(async (targetId) => {
+      try {
+        const response = await this.invokeAgent(targetId, payload, {
+          ...context,
+          caller_agent_id: fromAgentId,
+        });
+        results.set(targetId, response);
+      } catch (error) {
+        results.set(
+          targetId,
+          this.createErrorResponse(
+            "",
+            targetId,
+            {
+              code: "BROADCAST_FAILED",
+              message: error instanceof Error ? error.message : String(error),
+              recoverable: true,
+            },
+            0
+          )
+        );
+      }
+    });
+
+    await Promise.all(promises);
+    return results;
+  }
+
+  /**
+   * Find and invoke best agent for a capability
+   */
+  async invokeByCapability(
+    capability: string,
+    payload: MessagePayload,
+    context?: Partial<AgentContext>
+  ): Promise<AgentResponse> {
+    const agents = await registry.findActiveByCapability(capability);
+
+    if (agents.length === 0) {
+      return this.createErrorResponse(
+        "",
+        "unknown",
+        {
+          code: "NO_CAPABLE_AGENT",
+          message: `No active agent found with capability: ${capability}`,
+          recoverable: false,
+        },
+        0
+      );
+    }
+
+    // Select agent with lowest queue depth (simple load balancing)
+    let selectedAgent = agents[0];
+    let lowestQueue = Infinity;
+
+    for (const agent of agents) {
+      const state = await registry.getState(agent.id);
+      if (state && state.queue_depth < lowestQueue) {
+        lowestQueue = state.queue_depth;
+        selectedAgent = agent;
+      }
+    }
+
+    return this.invokeAgent(selectedAgent.id, payload, context);
+  }
+
+  /**
+   * List pending jobs for an agent
+   */
+  async listPendingJobs(
+    agentId: string,
+    limit: number = 20
+  ): Promise<AgentJob[]> {
+    if (this.supabase) {
+      const { data, error } = await this.supabase
+        .from("agent_jobs")
+        .select("*")
+        .eq("target_agent_id", agentId)
+        .in("status", ["queued", "processing"])
+        .order("created_at", { ascending: true })
+        .limit(limit);
+
+      if (error) {
+        throw new Error(`List jobs failed: ${error.message}`);
+      }
+
+      return data || [];
+    }
+
+    return [];
+  }
+
+  /**
+   * Get message history between agents
+   */
+  async getMessageHistory(
+    agentId1: string,
+    agentId2: string,
+    limit: number = 50
+  ): Promise<AgentMessage[]> {
+    if (this.supabase) {
+      const { data, error } = await this.supabase
+        .from("agent_messages")
+        .select("*")
+        .or(
+          `and(from_agent_id.eq.${agentId1},to_agent_id.eq.${agentId2}),` +
+            `and(from_agent_id.eq.${agentId2},to_agent_id.eq.${agentId1})`
+        )
+        .order("created_at", { ascending: false })
+        .limit(limit);
+
+      if (error) {
+        throw new Error(`Get history failed: ${error.message}`);
+      }
+
+      return data || [];
+    }
+
+    return [];
+  }
+
+  // Private helpers
+
+  private createMessage(
+    fromAgentId: string,
+    toAgentId: string,
+    requestType: RequestType,
+    payload: MessagePayload,
+    context?: Partial<AgentContext>,
+    priority: MessagePriority = "normal",
+    timeout_ms: number = 30000
+  ): AgentMessage {
+    return {
+      message_id: uuidv4(),
+      from_agent_id: fromAgentId,
+      to_agent_id: toAgentId,
+      request_type: requestType,
+      payload,
+      context: this.buildContext(fromAgentId, context),
+      priority,
+      timeout_ms,
+      requires_ack: true,
+      created_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + timeout_ms).toISOString(),
+    };
+  }
+
+  private buildContext(
+    callerId: string,
+    partial?: Partial<AgentContext>
+  ): AgentContext {
+    const existingChain = partial?.call_chain || [];
+    return {
+      session_id: partial?.session_id || uuidv4(),
+      caller_agent_id: callerId,
+      call_chain: [...existingChain, callerId],
+      workspace: partial?.workspace,
+      parent_message_id: partial?.parent_message_id,
+      deadline: partial?.deadline,
+      trace_id: partial?.trace_id || uuidv4(),
+      memory_refs: partial?.memory_refs,
+    };
+  }
+
+  private createSuccessResponse(
+    messageId: string,
+    fromAgentId: string,
+    result: unknown,
+    executionTime: number
+  ): AgentResponse {
+    return {
+      message_id: uuidv4(),
+      in_reply_to: messageId,
+      from_agent_id: fromAgentId,
+      status: "success",
+      result,
+      execution_time_ms: executionTime,
+      created_at: new Date().toISOString(),
+    };
+  }
+
+  private createErrorResponse(
+    messageId: string,
+    fromAgentId: string,
+    error: AgentError,
+    executionTime: number
+  ): AgentResponse {
+    return {
+      message_id: uuidv4(),
+      in_reply_to: messageId,
+      from_agent_id: fromAgentId,
+      status: "error",
+      error,
+      execution_time_ms: executionTime,
+      created_at: new Date().toISOString(),
+    };
+  }
+
+  private async storeMessage(message: AgentMessage): Promise<void> {
+    this.pendingMessages.set(message.message_id, message);
+
+    if (this.supabase) {
+      await this.supabase.from("agent_messages").insert(message);
+    }
+  }
+
+  private async storeResponse(response: AgentResponse): Promise<void> {
+    this.localResults.set(response.in_reply_to, response);
+
+    if (this.supabase) {
+      await this.supabase.from("agent_responses").insert(response);
+    }
+  }
+
+  private async invokeHttp(
+    endpoint: string,
+    payload: MessagePayload,
+    message: AgentMessage
+  ): Promise<unknown> {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Message-ID": message.message_id,
+        "X-Caller-Agent": message.from_agent_id,
+        "X-Trace-ID": message.context?.trace_id || "",
+      },
+      body: JSON.stringify({
+        tool_name: payload.tool_name,
+        arguments: payload.arguments,
+        context: message.context,
+      }),
+      signal: AbortSignal.timeout(message.timeout_ms),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+    }
+
+    return response.json();
+  }
+
+  private async queueForStdio(message: AgentMessage): Promise<unknown> {
+    // For stdio agents, submit to mcp-jobs queue
+    if (this.supabase) {
+      const { data, error } = await this.supabase.rpc("enqueue_job", {
+        p_source: message.from_agent_id,
+        p_job_type: "agent_invocation",
+        p_payload: {
+          target_agent_id: message.to_agent_id,
+          message_id: message.message_id,
+          payload: message.payload,
+          context: message.context,
+        },
+        p_priority: message.priority === "critical" ? 1 : message.priority === "high" ? 3 : 5,
+      });
+
+      if (error) {
+        throw new Error(`Queue failed: ${error.message}`);
+      }
+
+      return { queued: true, job_id: data };
+    }
+
+    throw new Error("Supabase not configured for stdio agent invocation");
+  }
+}
+
+// Singleton instance
+export const coordinator = new A2ACoordinator();

--- a/mcp/servers/agent-coordination-server/src/index.ts
+++ b/mcp/servers/agent-coordination-server/src/index.ts
@@ -1,0 +1,701 @@
+#!/usr/bin/env node
+/**
+ * Agent Coordination MCP Server
+ *
+ * Implements Agent-to-Agent (A2A) communication on MCP following
+ * Microsoft's pattern for multi-agent orchestration.
+ *
+ * Tools:
+ * - Registry: register, unregister, discover, list agents
+ * - Invocation: invoke_agent, submit_job, get_job_status
+ * - Coordination: handoff, delegate, broadcast
+ * - State: get_agent_state, update_agent_state, heartbeat
+ *
+ * @see https://developer.microsoft.com/blog/can-you-build-agent2agent-communication-on-mcp-yes
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  Tool,
+} from "@modelcontextprotocol/sdk/types.js";
+import { registry } from "./agent-registry.js";
+import { coordinator } from "./coordinator.js";
+import {
+  AgentMetadata,
+  AgentCapability,
+  AgentStatus,
+  AgentState,
+  MessagePayload,
+  MessagePriority,
+  HandoffRequest,
+  DelegationRequest,
+} from "./types.js";
+
+const tools: Tool[] = [
+  // ============ Registry Tools ============
+  {
+    name: "register_agent",
+    description:
+      "Register a new agent or update existing registration in the A2A registry",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "Unique agent identifier" },
+        name: { type: "string", description: "Human-readable agent name" },
+        version: { type: "string", description: "Agent version" },
+        description: {
+          type: "string",
+          description: "What this agent does",
+        },
+        capabilities: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Agent capabilities (odoo_erp, finance, hr, analytics, etc.)",
+        },
+        transport: {
+          type: "string",
+          enum: ["stdio", "http", "grpc", "websocket"],
+          description: "Communication transport type",
+        },
+        endpoint: {
+          type: "string",
+          description: "HTTP endpoint for http transport",
+        },
+        mcp_server: {
+          type: "string",
+          description: "MCP server name for stdio transport",
+        },
+        tools: {
+          type: "array",
+          items: { type: "string" },
+          description: "List of tools this agent exposes",
+        },
+        timeout_ms: {
+          type: "number",
+          description: "Default timeout for invocations (ms)",
+        },
+        max_concurrent: {
+          type: "number",
+          description: "Maximum concurrent requests",
+        },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description: "Tags for discovery filtering",
+        },
+      },
+      required: ["id", "name", "version", "description", "capabilities", "transport"],
+    },
+  },
+  {
+    name: "unregister_agent",
+    description: "Remove an agent from the A2A registry",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agent_id: { type: "string", description: "Agent ID to unregister" },
+      },
+      required: ["agent_id"],
+    },
+  },
+  {
+    name: "discover_agents",
+    description:
+      "Find agents matching criteria (capabilities, status, tags, tools)",
+    inputSchema: {
+      type: "object",
+      properties: {
+        capabilities: {
+          type: "array",
+          items: { type: "string" },
+          description: "Filter by capabilities",
+        },
+        status: {
+          type: "array",
+          items: {
+            type: "string",
+            enum: ["active", "idle", "busy", "offline", "maintenance"],
+          },
+          description: "Filter by status",
+        },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description: "Filter by tags",
+        },
+        tools: {
+          type: "array",
+          items: { type: "string" },
+          description: "Filter by tools the agent exposes",
+        },
+        max_results: {
+          type: "number",
+          description: "Maximum number of results",
+        },
+      },
+    },
+  },
+  {
+    name: "list_agents",
+    description: "List all registered agents in the A2A registry",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "get_agent",
+    description: "Get detailed information about a specific agent",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agent_id: { type: "string", description: "Agent ID" },
+      },
+      required: ["agent_id"],
+    },
+  },
+
+  // ============ Invocation Tools ============
+  {
+    name: "invoke_agent",
+    description:
+      "Invoke an agent synchronously and wait for response (A2A call)",
+    inputSchema: {
+      type: "object",
+      properties: {
+        target_agent_id: {
+          type: "string",
+          description: "ID of the agent to invoke",
+        },
+        tool_name: {
+          type: "string",
+          description: "Name of the tool to call on the target agent",
+        },
+        arguments: {
+          type: "object",
+          description: "Arguments to pass to the tool",
+        },
+        caller_agent_id: {
+          type: "string",
+          description: "ID of the calling agent (for context propagation)",
+        },
+        priority: {
+          type: "string",
+          enum: ["critical", "high", "normal", "low"],
+          description: "Message priority",
+        },
+        timeout_ms: {
+          type: "number",
+          description: "Timeout for this invocation (ms)",
+        },
+      },
+      required: ["target_agent_id", "tool_name"],
+    },
+  },
+  {
+    name: "submit_job",
+    description:
+      "Submit an async job to an agent (returns immediately with job ID)",
+    inputSchema: {
+      type: "object",
+      properties: {
+        source_agent_id: {
+          type: "string",
+          description: "ID of the agent submitting the job",
+        },
+        target_agent_id: {
+          type: "string",
+          description: "ID of the agent to execute the job",
+        },
+        tool_name: {
+          type: "string",
+          description: "Tool to invoke",
+        },
+        arguments: {
+          type: "object",
+          description: "Tool arguments",
+        },
+        priority: {
+          type: "string",
+          enum: ["critical", "high", "normal", "low"],
+        },
+        max_retries: {
+          type: "number",
+          description: "Maximum retry attempts",
+        },
+      },
+      required: ["source_agent_id", "target_agent_id", "tool_name"],
+    },
+  },
+  {
+    name: "get_job_status",
+    description: "Get the status of an async agent job",
+    inputSchema: {
+      type: "object",
+      properties: {
+        job_id: { type: "string", description: "Job ID" },
+      },
+      required: ["job_id"],
+    },
+  },
+  {
+    name: "cancel_job",
+    description: "Cancel a queued job (cannot cancel running jobs)",
+    inputSchema: {
+      type: "object",
+      properties: {
+        job_id: { type: "string", description: "Job ID to cancel" },
+      },
+      required: ["job_id"],
+    },
+  },
+  {
+    name: "list_pending_jobs",
+    description: "List pending jobs for an agent",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agent_id: { type: "string", description: "Agent ID" },
+        limit: { type: "number", description: "Max results (default 20)" },
+      },
+      required: ["agent_id"],
+    },
+  },
+
+  // ============ Coordination Tools ============
+  {
+    name: "handoff",
+    description:
+      "Transfer conversation/task from one agent to another with context",
+    inputSchema: {
+      type: "object",
+      properties: {
+        from_agent_id: { type: "string", description: "Source agent ID" },
+        to_agent_id: { type: "string", description: "Target agent ID" },
+        reason: {
+          type: "string",
+          description: "Why the handoff is happening",
+        },
+        conversation_context: {
+          type: "object",
+          description: "Context to transfer to the new agent",
+        },
+        memory_refs: {
+          type: "array",
+          items: { type: "string" },
+          description: "Memory references to include",
+        },
+        user_intent: {
+          type: "string",
+          description: "What the user is trying to accomplish",
+        },
+      },
+      required: ["from_agent_id", "to_agent_id", "reason", "conversation_context"],
+    },
+  },
+  {
+    name: "delegate",
+    description: "Delegate a subtask to another agent with constraints",
+    inputSchema: {
+      type: "object",
+      properties: {
+        delegator_id: {
+          type: "string",
+          description: "Agent delegating the task",
+        },
+        delegate_id: {
+          type: "string",
+          description: "Agent receiving the task",
+        },
+        tool_name: { type: "string", description: "Tool to invoke" },
+        arguments: { type: "object", description: "Tool arguments" },
+        timeout_ms: {
+          type: "number",
+          description: "Timeout constraint",
+        },
+        max_tokens: {
+          type: "number",
+          description: "Token limit constraint",
+        },
+        allowed_tools: {
+          type: "array",
+          items: { type: "string" },
+          description: "Tools the delegate is allowed to use",
+        },
+      },
+      required: ["delegator_id", "delegate_id", "tool_name"],
+    },
+  },
+  {
+    name: "broadcast",
+    description: "Send a message to multiple agents simultaneously",
+    inputSchema: {
+      type: "object",
+      properties: {
+        from_agent_id: { type: "string", description: "Sender agent ID" },
+        target_agent_ids: {
+          type: "array",
+          items: { type: "string" },
+          description: "List of recipient agent IDs",
+        },
+        tool_name: { type: "string", description: "Tool to invoke on all" },
+        arguments: { type: "object", description: "Tool arguments" },
+      },
+      required: ["from_agent_id", "target_agent_ids", "tool_name"],
+    },
+  },
+  {
+    name: "invoke_by_capability",
+    description:
+      "Find and invoke the best available agent with a specific capability",
+    inputSchema: {
+      type: "object",
+      properties: {
+        capability: {
+          type: "string",
+          description: "Required capability (odoo_erp, finance, hr, etc.)",
+        },
+        tool_name: { type: "string", description: "Tool to invoke" },
+        arguments: { type: "object", description: "Tool arguments" },
+        caller_agent_id: { type: "string", description: "Calling agent ID" },
+      },
+      required: ["capability", "tool_name"],
+    },
+  },
+
+  // ============ State Tools ============
+  {
+    name: "get_agent_state",
+    description: "Get runtime state of an agent (status, queue depth, metrics)",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agent_id: { type: "string", description: "Agent ID" },
+      },
+      required: ["agent_id"],
+    },
+  },
+  {
+    name: "update_agent_state",
+    description: "Update runtime state of an agent",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agent_id: { type: "string", description: "Agent ID" },
+        status: {
+          type: "string",
+          enum: ["active", "idle", "busy", "offline", "maintenance"],
+        },
+        current_task_id: { type: "string", description: "Current task ID" },
+        queue_depth: { type: "number", description: "Items in queue" },
+      },
+      required: ["agent_id"],
+    },
+  },
+  {
+    name: "heartbeat",
+    description: "Send heartbeat to keep agent registration active",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agent_id: { type: "string", description: "Agent ID" },
+      },
+      required: ["agent_id"],
+    },
+  },
+  {
+    name: "update_agent_status",
+    description: "Update agent status in the registry",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agent_id: { type: "string", description: "Agent ID" },
+        status: {
+          type: "string",
+          enum: ["active", "idle", "busy", "offline", "maintenance"],
+          description: "New status",
+        },
+      },
+      required: ["agent_id", "status"],
+    },
+  },
+
+  // ============ History/Stats Tools ============
+  {
+    name: "get_message_history",
+    description: "Get message history between two agents",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agent_id_1: { type: "string", description: "First agent ID" },
+        agent_id_2: { type: "string", description: "Second agent ID" },
+        limit: { type: "number", description: "Max messages to return" },
+      },
+      required: ["agent_id_1", "agent_id_2"],
+    },
+  },
+  {
+    name: "get_registry_stats",
+    description: "Get statistics about the agent registry",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "cleanup_stale_agents",
+    description: "Mark agents without recent heartbeat as offline",
+    inputSchema: {
+      type: "object",
+      properties: {
+        threshold_ms: {
+          type: "number",
+          description: "Threshold in ms (default 5 minutes)",
+        },
+      },
+    },
+  },
+];
+
+const server = new Server(
+  {
+    name: "agent-coordination-server",
+    version: "1.0.0",
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools,
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  try {
+    let result: unknown;
+
+    switch (name) {
+      // Registry tools
+      case "register_agent": {
+        const agent: AgentMetadata = {
+          id: args.id as string,
+          name: args.name as string,
+          version: args.version as string,
+          description: args.description as string,
+          capabilities: args.capabilities as AgentCapability[],
+          transport: args.transport as AgentMetadata["transport"],
+          endpoint: args.endpoint as string | undefined,
+          mcp_server: args.mcp_server as string | undefined,
+          tools: args.tools as string[] | undefined,
+          timeout_ms: (args.timeout_ms as number) || 30000,
+          max_concurrent: (args.max_concurrent as number) || 5,
+          tags: args.tags as string[] | undefined,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        };
+        result = await registry.register(agent);
+        break;
+      }
+      case "unregister_agent":
+        await registry.unregister(args.agent_id as string);
+        result = { success: true, agent_id: args.agent_id };
+        break;
+      case "discover_agents":
+        result = await registry.discover({
+          capabilities: args.capabilities as AgentCapability[],
+          status: args.status as AgentStatus[],
+          tags: args.tags as string[],
+          tools: args.tools as string[],
+          max_results: args.max_results as number,
+        });
+        break;
+      case "list_agents":
+        result = await registry.listAll();
+        break;
+      case "get_agent":
+        result = await registry.get(args.agent_id as string);
+        break;
+
+      // Invocation tools
+      case "invoke_agent": {
+        const payload: MessagePayload = {
+          tool_name: args.tool_name as string,
+          arguments: args.arguments as Record<string, unknown>,
+        };
+        result = await coordinator.invokeAgent(
+          args.target_agent_id as string,
+          payload,
+          { caller_agent_id: args.caller_agent_id as string },
+          {
+            priority: args.priority as MessagePriority,
+            timeout_ms: args.timeout_ms as number,
+          }
+        );
+        break;
+      }
+      case "submit_job": {
+        const jobPayload: MessagePayload = {
+          tool_name: args.tool_name as string,
+          arguments: args.arguments as Record<string, unknown>,
+        };
+        result = await coordinator.submitJob(
+          args.source_agent_id as string,
+          args.target_agent_id as string,
+          jobPayload,
+          undefined,
+          {
+            priority: args.priority as MessagePriority,
+            max_retries: args.max_retries as number,
+          }
+        );
+        break;
+      }
+      case "get_job_status":
+        result = await coordinator.getJobStatus(args.job_id as string);
+        break;
+      case "cancel_job":
+        result = await coordinator.cancelJob(args.job_id as string);
+        break;
+      case "list_pending_jobs":
+        result = await coordinator.listPendingJobs(
+          args.agent_id as string,
+          args.limit as number
+        );
+        break;
+
+      // Coordination tools
+      case "handoff": {
+        const handoffReq: HandoffRequest = {
+          from_agent_id: args.from_agent_id as string,
+          to_agent_id: args.to_agent_id as string,
+          reason: args.reason as string,
+          conversation_context: args.conversation_context as unknown,
+          memory_refs: args.memory_refs as string[],
+          user_intent: args.user_intent as string,
+        };
+        result = await coordinator.handoff(handoffReq);
+        break;
+      }
+      case "delegate": {
+        const delegateReq: DelegationRequest = {
+          delegator_id: args.delegator_id as string,
+          delegate_id: args.delegate_id as string,
+          task: {
+            tool_name: args.tool_name as string,
+            arguments: args.arguments as Record<string, unknown>,
+          },
+          constraints: {
+            timeout_ms: args.timeout_ms as number,
+            max_tokens: args.max_tokens as number,
+            allowed_tools: args.allowed_tools as string[],
+          },
+        };
+        result = await coordinator.delegate(delegateReq);
+        break;
+      }
+      case "broadcast": {
+        const broadcastPayload: MessagePayload = {
+          tool_name: args.tool_name as string,
+          arguments: args.arguments as Record<string, unknown>,
+        };
+        const broadcastResults = await coordinator.broadcast(
+          args.from_agent_id as string,
+          args.target_agent_ids as string[],
+          broadcastPayload
+        );
+        result = Object.fromEntries(broadcastResults);
+        break;
+      }
+      case "invoke_by_capability": {
+        const capPayload: MessagePayload = {
+          tool_name: args.tool_name as string,
+          arguments: args.arguments as Record<string, unknown>,
+        };
+        result = await coordinator.invokeByCapability(
+          args.capability as string,
+          capPayload,
+          { caller_agent_id: args.caller_agent_id as string }
+        );
+        break;
+      }
+
+      // State tools
+      case "get_agent_state":
+        result = await registry.getState(args.agent_id as string);
+        break;
+      case "update_agent_state": {
+        const state: AgentState = {
+          agent_id: args.agent_id as string,
+          status: (args.status as AgentStatus) || "active",
+          current_task_id: args.current_task_id as string,
+          queue_depth: (args.queue_depth as number) || 0,
+          last_heartbeat: new Date().toISOString(),
+        };
+        await registry.updateState(state);
+        result = { success: true, state };
+        break;
+      }
+      case "heartbeat":
+        await registry.heartbeat(args.agent_id as string);
+        result = { success: true, agent_id: args.agent_id };
+        break;
+      case "update_agent_status":
+        await registry.updateStatus(
+          args.agent_id as string,
+          args.status as AgentStatus
+        );
+        result = { success: true, agent_id: args.agent_id, status: args.status };
+        break;
+
+      // History/Stats tools
+      case "get_message_history":
+        result = await coordinator.getMessageHistory(
+          args.agent_id_1 as string,
+          args.agent_id_2 as string,
+          args.limit as number
+        );
+        break;
+      case "get_registry_stats":
+        result = await registry.getStats();
+        break;
+      case "cleanup_stale_agents": {
+        const count = await registry.markStaleOffline(
+          args.threshold_ms as number
+        );
+        result = { success: true, marked_offline: count };
+        break;
+      }
+
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Error: ${message}` }],
+      isError: true,
+    };
+  }
+});
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("Agent Coordination MCP Server running on stdio");
+  console.error("A2A communication enabled following Microsoft's pattern");
+}
+
+main().catch(console.error);

--- a/mcp/servers/agent-coordination-server/src/types.ts
+++ b/mcp/servers/agent-coordination-server/src/types.ts
@@ -1,0 +1,289 @@
+/**
+ * Agent-to-Agent (A2A) Communication Types
+ *
+ * Based on Microsoft's A2A on MCP pattern:
+ * https://developer.microsoft.com/blog/can-you-build-agent2agent-communication-on-mcp-yes
+ */
+
+/**
+ * Transport type for agent communication
+ */
+export type AgentTransport = "stdio" | "http" | "grpc" | "websocket";
+
+/**
+ * Agent capability categories
+ */
+export type AgentCapability =
+  | "odoo_erp"
+  | "finance"
+  | "hr"
+  | "inventory"
+  | "sales"
+  | "analytics"
+  | "infrastructure"
+  | "deployment"
+  | "documentation"
+  | "research"
+  | "code_generation"
+  | "testing"
+  | "monitoring"
+  | "custom";
+
+/**
+ * Agent status in the registry
+ */
+export type AgentStatus =
+  | "active"
+  | "idle"
+  | "busy"
+  | "offline"
+  | "maintenance";
+
+/**
+ * Message priority levels
+ */
+export type MessagePriority = "critical" | "high" | "normal" | "low";
+
+/**
+ * Request types for inter-agent communication
+ */
+export type RequestType =
+  | "tool_call"
+  | "query"
+  | "stream"
+  | "event"
+  | "handoff"
+  | "delegate";
+
+/**
+ * Agent metadata for registry
+ */
+export interface AgentMetadata {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  capabilities: AgentCapability[];
+  transport: AgentTransport;
+  endpoint?: string;
+  mcp_server?: string;
+  tools?: string[];
+  input_schema?: Record<string, unknown>;
+  output_schema?: Record<string, unknown>;
+  timeout_ms: number;
+  max_concurrent: number;
+  retry_policy?: RetryPolicy;
+  tags?: string[];
+  owner?: string;
+  created_at: string;
+  updated_at: string;
+  last_heartbeat?: string;
+}
+
+/**
+ * Retry policy configuration
+ */
+export interface RetryPolicy {
+  max_retries: number;
+  initial_delay_ms: number;
+  max_delay_ms: number;
+  backoff_multiplier: number;
+}
+
+/**
+ * Agent context for propagation across calls
+ */
+export interface AgentContext {
+  session_id: string;
+  caller_agent_id: string;
+  call_chain: string[];
+  workspace?: WorkspaceContext;
+  parent_message_id?: string;
+  deadline?: string;
+  trace_id?: string;
+  memory_refs?: string[];
+}
+
+/**
+ * Workspace context for Odoo/IPAI environment
+ */
+export interface WorkspaceContext {
+  odoo_instance: "odoo_lab" | "odoo_erp" | "odoo_prod";
+  database?: string;
+  company_id?: number;
+  user_id?: number;
+  timezone?: string;
+}
+
+/**
+ * Inter-agent message format
+ */
+export interface AgentMessage {
+  message_id: string;
+  from_agent_id: string;
+  to_agent_id: string;
+  request_type: RequestType;
+  payload: MessagePayload;
+  context?: AgentContext;
+  priority: MessagePriority;
+  timeout_ms: number;
+  requires_ack: boolean;
+  created_at: string;
+  expires_at?: string;
+}
+
+/**
+ * Message payload variants
+ */
+export interface MessagePayload {
+  tool_name?: string;
+  arguments?: Record<string, unknown>;
+  query?: string;
+  data?: unknown;
+  stream_config?: StreamConfig;
+}
+
+/**
+ * Stream configuration for streaming responses
+ */
+export interface StreamConfig {
+  chunk_size?: number;
+  format?: "json" | "text" | "binary";
+  callback_url?: string;
+}
+
+/**
+ * Response from agent invocation
+ */
+export interface AgentResponse {
+  message_id: string;
+  in_reply_to: string;
+  from_agent_id: string;
+  status: "success" | "error" | "timeout" | "cancelled" | "partial";
+  result?: unknown;
+  error?: AgentError;
+  execution_time_ms: number;
+  tokens_used?: number;
+  created_at: string;
+}
+
+/**
+ * Error details for failed invocations
+ */
+export interface AgentError {
+  code: string;
+  message: string;
+  details?: unknown;
+  recoverable: boolean;
+  suggested_retry?: boolean;
+}
+
+/**
+ * Agent state for coordination
+ */
+export interface AgentState {
+  agent_id: string;
+  status: AgentStatus;
+  current_task_id?: string;
+  queue_depth: number;
+  last_heartbeat: string;
+  resource_usage?: ResourceUsage;
+  metrics?: AgentMetrics;
+}
+
+/**
+ * Resource usage metrics
+ */
+export interface ResourceUsage {
+  cpu_percent?: number;
+  memory_mb?: number;
+  token_count?: number;
+  active_connections?: number;
+}
+
+/**
+ * Agent performance metrics
+ */
+export interface AgentMetrics {
+  total_requests: number;
+  success_count: number;
+  error_count: number;
+  avg_latency_ms: number;
+  p95_latency_ms: number;
+  last_hour_requests: number;
+}
+
+/**
+ * Discovery query for finding agents
+ */
+export interface DiscoveryQuery {
+  capabilities?: AgentCapability[];
+  status?: AgentStatus[];
+  tags?: string[];
+  tools?: string[];
+  max_results?: number;
+}
+
+/**
+ * Job specification for async agent tasks
+ */
+export interface AgentJob {
+  job_id: string;
+  source_agent_id: string;
+  target_agent_id: string;
+  request_type: RequestType;
+  payload: MessagePayload;
+  context?: AgentContext;
+  priority: MessagePriority;
+  status: "queued" | "processing" | "completed" | "failed" | "cancelled";
+  result?: unknown;
+  error?: AgentError;
+  created_at: string;
+  started_at?: string;
+  completed_at?: string;
+  retry_count: number;
+  max_retries: number;
+}
+
+/**
+ * Handoff request for transferring conversation
+ */
+export interface HandoffRequest {
+  from_agent_id: string;
+  to_agent_id: string;
+  reason: string;
+  conversation_context: unknown;
+  memory_refs?: string[];
+  user_intent?: string;
+}
+
+/**
+ * Delegation request for task assignment
+ */
+export interface DelegationRequest {
+  delegator_id: string;
+  delegate_id: string;
+  task: MessagePayload;
+  constraints?: DelegationConstraints;
+  callback?: CallbackConfig;
+}
+
+/**
+ * Constraints for delegated tasks
+ */
+export interface DelegationConstraints {
+  timeout_ms?: number;
+  max_tokens?: number;
+  allowed_tools?: string[];
+  forbidden_tools?: string[];
+  require_approval?: boolean;
+}
+
+/**
+ * Callback configuration for async results
+ */
+export interface CallbackConfig {
+  url?: string;
+  agent_id?: string;
+  tool_name?: string;
+}

--- a/mcp/servers/agent-coordination-server/tsconfig.json
+++ b/mcp/servers/agent-coordination-server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Implements Microsoft's A2A on MCP pattern for multi-agent orchestration:
- Agent registry with Supabase persistence (register, discover, heartbeat)
- Inter-agent invocation (sync, async jobs, broadcast)
- Context propagation (session, call chain, trace)
- Handoff and delegation patterns
- 22 MCP tools for full A2A capability

Files:
- mcp/servers/agent-coordination-server/ (TypeScript MCP server)
- db/migrations/20260120_agent_coordination_schema.sql
- Updated MCP coordinator routing for A2A requests

Ref: https://developer.microsoft.com/blog/can-you-build-agent2agent-communication-on-mcp-yes

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Supabase security review | [View](https://hub.continue.dev/tasks/a308893e-6b9c-4997-a501-a5767b371f90) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->