### PR TITLE
Add local-first process mining to Odoo Copilot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ temp/
 !db/migrations/*.sql
 !db/migrations/**/*.sql
 !db/audit/*.sql
+!db/process_mining/*.sql
 !scripts/erd_dot.sql
 !docs/data-model/*.sql
 

--- a/db/process_mining/001_pm_schema.sql
+++ b/db/process_mining/001_pm_schema.sql
@@ -1,0 +1,144 @@
+-- Process Mining Schema for Odoo Copilot
+-- Local-first event log storage and analytics
+--
+-- Usage:
+--   psql -h $ODOO_DB_HOST -U $ODOO_DB_USER -d $ODOO_DB_NAME -f 001_pm_schema.sql
+
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS pm;
+
+COMMENT ON SCHEMA pm IS 'Process Mining schema for Odoo Copilot - local-first event logs and analytics';
+
+-- Track ETL runs (incremental, idempotent)
+CREATE TABLE IF NOT EXISTS pm.job_state (
+  job_name        text PRIMARY KEY,
+  last_run_ts     timestamptz NOT NULL DEFAULT '1970-01-01',
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE pm.job_state IS 'Tracks last successful run of each ETL job for incremental processing';
+
+-- Canonical process cases (one case per business document)
+CREATE TABLE IF NOT EXISTS pm.case (
+  case_id         text PRIMARY KEY,           -- e.g., 'p2p:po:<id>'
+  process         text NOT NULL,              -- 'p2p', 'o2c', 'r2r', etc.
+  source_model    text NOT NULL,              -- 'purchase.order', 'sale.order', etc.
+  source_id       bigint NOT NULL,            -- FK to source document
+  company_id      bigint NULL,
+  start_ts        timestamptz NULL,
+  end_ts          timestamptz NULL,
+  duration_s      bigint NULL,
+  variant_id      text NULL,
+  attrs_json      jsonb NOT NULL DEFAULT '{}'::jsonb,
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pm_case_process_company ON pm.case(process, company_id);
+CREATE INDEX IF NOT EXISTS idx_pm_case_updated_at ON pm.case(updated_at);
+CREATE INDEX IF NOT EXISTS idx_pm_case_variant ON pm.case(variant_id) WHERE variant_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_pm_case_source ON pm.case(source_model, source_id);
+
+COMMENT ON TABLE pm.case IS 'Process cases - one per business document (PO, SO, etc.)';
+
+-- Event log (XES-like structure)
+CREATE TABLE IF NOT EXISTS pm.event (
+  event_id        bigserial PRIMARY KEY,
+  case_id         text NOT NULL REFERENCES pm.case(case_id) ON DELETE CASCADE,
+  process         text NOT NULL,
+  activity        text NOT NULL,
+  ts              timestamptz NOT NULL,
+  resource        text NULL,                  -- user / partner / system
+  source_model    text NULL,                  -- purchase.order, stock.picking, account.move, ...
+  source_id       bigint NULL,
+  attrs_json      jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_pm_event_case_ts ON pm.event(case_id, ts);
+CREATE INDEX IF NOT EXISTS idx_pm_event_process_activity_ts ON pm.event(process, activity, ts);
+CREATE INDEX IF NOT EXISTS idx_pm_event_ts ON pm.event(ts);
+
+COMMENT ON TABLE pm.event IS 'Event log entries - activities with timestamps per case';
+
+-- Variant catalog (unique activity sequences)
+CREATE TABLE IF NOT EXISTS pm.variant (
+  variant_id      text PRIMARY KEY,           -- md5(sequence)
+  process         text NOT NULL,
+  sequence        text[] NOT NULL,            -- ordered activity list
+  sequence_hash   text NOT NULL,
+  case_count      bigint NOT NULL DEFAULT 0,
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pm_variant_process_count ON pm.variant(process, case_count DESC);
+
+COMMENT ON TABLE pm.variant IS 'Variant catalog - unique activity sequences with frequency';
+
+-- DFG edges with latency stats (aggregated)
+CREATE TABLE IF NOT EXISTS pm.edge (
+  process         text NOT NULL,
+  activity_from   text NOT NULL,
+  activity_to     text NOT NULL,
+  edge_count      bigint NOT NULL,
+  p50_s           bigint NULL,                -- median latency in seconds
+  p95_s           bigint NULL,                -- 95th percentile latency
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY(process, activity_from, activity_to)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pm_edge_bottleneck ON pm.edge(process, p95_s DESC NULLS LAST);
+
+COMMENT ON TABLE pm.edge IS 'Directly-follows graph edges with latency percentiles';
+
+-- Deviations (rule-based conformance)
+CREATE TABLE IF NOT EXISTS pm.deviation (
+  deviation_id    bigserial PRIMARY KEY,
+  process         text NOT NULL,
+  case_id         text NOT NULL REFERENCES pm.case(case_id) ON DELETE CASCADE,
+  rule_id         text NOT NULL,
+  severity        text NOT NULL CHECK (severity IN ('low','medium','high')),
+  details_json    jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pm_deviation_process_rule ON pm.deviation(process, rule_id);
+CREATE INDEX IF NOT EXISTS idx_pm_deviation_case ON pm.deviation(case_id);
+CREATE INDEX IF NOT EXISTS idx_pm_deviation_severity ON pm.deviation(process, severity, created_at DESC);
+
+COMMENT ON TABLE pm.deviation IS 'Conformance deviations detected by rule engine';
+
+-- Insights (generated recommendations)
+CREATE TABLE IF NOT EXISTS pm.insight (
+  insight_id      bigserial PRIMARY KEY,
+  process         text NOT NULL,
+  insight_type    text NOT NULL,              -- 'bottleneck', 'rework', 'compliance', 'optimization'
+  summary         text NOT NULL,
+  evidence_json   jsonb NOT NULL DEFAULT '{}'::jsonb,
+  action_json     jsonb NULL,                 -- suggested actions
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  expires_at      timestamptz NULL,           -- for time-sensitive insights
+  acknowledged    boolean NOT NULL DEFAULT false
+);
+
+CREATE INDEX IF NOT EXISTS idx_pm_insight_process_type ON pm.insight(process, insight_type, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_pm_insight_active ON pm.insight(process, acknowledged, created_at DESC) WHERE NOT acknowledged;
+
+COMMENT ON TABLE pm.insight IS 'Generated insights and recommendations for Copilot';
+
+-- Redaction configuration (for PII compliance)
+CREATE TABLE IF NOT EXISTS pm.redaction_config (
+  config_id       serial PRIMARY KEY,
+  source_model    text NOT NULL,
+  field_name      text NOT NULL,
+  redaction_type  text NOT NULL CHECK (redaction_type IN ('mask', 'hash', 'remove')),
+  enabled         boolean NOT NULL DEFAULT true,
+  UNIQUE(source_model, field_name)
+);
+
+COMMENT ON TABLE pm.redaction_config IS 'Configuration for PII field redaction in event attributes';
+
+-- Insert default job state entries
+INSERT INTO pm.job_state(job_name) VALUES ('p2p_etl'), ('o2c_etl'), ('r2r_etl')
+ON CONFLICT (job_name) DO NOTHING;
+
+COMMIT;

--- a/db/process_mining/010_p2p_etl.sql
+++ b/db/process_mining/010_p2p_etl.sql
@@ -1,0 +1,392 @@
+-- P2P (Procure-to-Pay) Process Mining ETL
+-- Extracts events from Odoo purchase/receiving/billing/payment flow
+--
+-- Usage:
+--   -- Apply schema first
+--   psql -f 001_pm_schema.sql
+--   -- Then apply this ETL function
+--   psql -f 010_p2p_etl.sql
+--   -- Run backfill
+--   SELECT pm.run_p2p_etl('1970-01-01'::timestamptz, now());
+--   -- Run incremental (uses last_run_ts from job_state)
+--   SELECT pm.run_p2p_etl();
+
+BEGIN;
+
+-- P2P ETL: builds pm.case + pm.event for impacted purchase orders,
+-- then recomputes variants/edges/deviations.
+--
+-- Notes:
+-- - Odoo table names assumed as default: purchase_order, stock_picking, account_move
+-- - Some fields vary by version/customization; guarded with COALESCE where possible.
+-- - Payment mapping is provided as "best-effort" via ref matching (see TODO for strict reconciliation).
+
+CREATE OR REPLACE FUNCTION pm.run_p2p_etl(
+  p_from timestamptz DEFAULT NULL,
+  p_to timestamptz DEFAULT now()
+)
+RETURNS TABLE(cases_processed int, events_created int, deviations_found int)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_job text := 'p2p_etl';
+  v_last timestamptz;
+  v_from timestamptz;
+  v_cases_count int := 0;
+  v_events_count int := 0;
+  v_deviations_count int := 0;
+BEGIN
+  -- Initialize job state if not exists
+  INSERT INTO pm.job_state(job_name) VALUES (v_job)
+  ON CONFLICT (job_name) DO NOTHING;
+
+  -- Get last run timestamp with row lock
+  SELECT last_run_ts INTO v_last FROM pm.job_state WHERE job_name = v_job FOR UPDATE;
+  v_from := COALESCE(p_from, v_last);
+
+  -- Buffer window to catch late writes (Odoo async updates)
+  v_from := v_from - interval '10 minutes';
+
+  -- 1) Identify impacted purchase orders by write_date/create_date in window
+  DROP TABLE IF EXISTS tmp_impacted_po;
+  CREATE TEMP TABLE tmp_impacted_po (po_id bigint PRIMARY KEY) ON COMMIT DROP;
+
+  INSERT INTO tmp_impacted_po(po_id)
+  SELECT po.id AS po_id
+  FROM purchase_order po
+  WHERE COALESCE(po.write_date, po.create_date) >= v_from
+    AND COALESCE(po.write_date, po.create_date) < p_to;
+
+  -- Also include POs whose related docs changed recently (receipt or bill)
+  INSERT INTO tmp_impacted_po(po_id)
+  SELECT DISTINCT po.id
+  FROM purchase_order po
+  JOIN stock_picking sp
+    ON (sp.origin = po.name OR sp.origin ILIKE '%' || po.name || '%')
+  WHERE COALESCE(sp.write_date, sp.create_date) >= v_from
+    AND COALESCE(sp.write_date, sp.create_date) < p_to
+  ON CONFLICT (po_id) DO NOTHING;
+
+  INSERT INTO tmp_impacted_po(po_id)
+  SELECT DISTINCT po.id
+  FROM purchase_order po
+  JOIN account_move am
+    ON (am.invoice_origin = po.name OR am.invoice_origin ILIKE '%' || po.name || '%')
+  WHERE COALESCE(am.write_date, am.create_date) >= v_from
+    AND COALESCE(am.write_date, am.create_date) < p_to
+  ON CONFLICT (po_id) DO NOTHING;
+
+  GET DIAGNOSTICS v_cases_count = ROW_COUNT;
+
+  -- 2) Upsert pm.case for impacted POs
+  INSERT INTO pm.case(case_id, process, source_model, source_id, company_id, attrs_json, updated_at)
+  SELECT
+    'p2p:po:' || po.id::text AS case_id,
+    'p2p' AS process,
+    'purchase.order' AS source_model,
+    po.id AS source_id,
+    po.company_id,
+    jsonb_build_object(
+      'po_name', po.name,
+      'state', po.state,
+      'partner_id', po.partner_id,
+      'user_id', po.user_id,
+      'amount_total', po.amount_total,
+      'currency_id', po.currency_id
+    ) AS attrs_json,
+    now() AS updated_at
+  FROM purchase_order po
+  JOIN tmp_impacted_po t ON t.po_id = po.id
+  ON CONFLICT (case_id) DO UPDATE
+    SET company_id = EXCLUDED.company_id,
+        attrs_json = EXCLUDED.attrs_json,
+        updated_at = now();
+
+  -- 3) Rebuild events for impacted cases (idempotent: delete + insert)
+  DELETE FROM pm.event e
+  WHERE e.case_id IN (
+    SELECT 'p2p:po:' || t.po_id::text FROM tmp_impacted_po t
+  )
+  AND e.process = 'p2p';
+
+  -- 3A) PO Created
+  INSERT INTO pm.event(case_id, process, activity, ts, resource, source_model, source_id, attrs_json)
+  SELECT
+    'p2p:po:' || po.id::text,
+    'p2p',
+    'PO Created',
+    po.create_date,
+    NULL,
+    'purchase.order',
+    po.id,
+    jsonb_build_object('po_name', po.name, 'state', po.state)
+  FROM purchase_order po
+  JOIN tmp_impacted_po t ON t.po_id = po.id
+  WHERE po.create_date IS NOT NULL;
+
+  -- 3B) PO Confirmed/Approved (best-effort: use date_approve if available, else write_date)
+  INSERT INTO pm.event(case_id, process, activity, ts, resource, source_model, source_id, attrs_json)
+  SELECT
+    'p2p:po:' || po.id::text,
+    'p2p',
+    'PO Approved',
+    COALESCE(po.date_approve, po.write_date, po.create_date),
+    NULL,
+    'purchase.order',
+    po.id,
+    jsonb_build_object('po_name', po.name, 'state', po.state)
+  FROM purchase_order po
+  JOIN tmp_impacted_po t ON t.po_id = po.id
+  WHERE po.state IN ('purchase','done')
+    AND COALESCE(po.date_approve, po.write_date, po.create_date) IS NOT NULL;
+
+  -- 3C) Goods Receipt Done (incoming pickings linked by origin)
+  INSERT INTO pm.event(case_id, process, activity, ts, resource, source_model, source_id, attrs_json)
+  SELECT
+    'p2p:po:' || po.id::text,
+    'p2p',
+    'Goods Received',
+    COALESCE(sp.date_done, sp.scheduled_date, sp.write_date, sp.create_date),
+    NULL,
+    'stock.picking',
+    sp.id,
+    jsonb_build_object('picking_name', sp.name, 'state', sp.state, 'origin', sp.origin)
+  FROM purchase_order po
+  JOIN tmp_impacted_po t ON t.po_id = po.id
+  JOIN stock_picking sp
+    ON (sp.origin = po.name OR sp.origin ILIKE '%' || po.name || '%')
+  WHERE sp.state = 'done';
+
+  -- 3D) Vendor Bill Posted (in_invoice) linked by invoice_origin
+  INSERT INTO pm.event(case_id, process, activity, ts, resource, source_model, source_id, attrs_json)
+  SELECT
+    'p2p:po:' || po.id::text,
+    'p2p',
+    'Vendor Bill Posted',
+    COALESCE(am.invoice_date, am.date, am.write_date, am.create_date),
+    NULL,
+    'account.move',
+    am.id,
+    jsonb_build_object('move_name', am.name, 'state', am.state, 'invoice_origin', am.invoice_origin, 'amount_total', am.amount_total)
+  FROM purchase_order po
+  JOIN tmp_impacted_po t ON t.po_id = po.id
+  JOIN account_move am
+    ON (am.invoice_origin = po.name OR am.invoice_origin ILIKE '%' || po.name || '%')
+  WHERE am.move_type = 'in_invoice'
+    AND am.state = 'posted';
+
+  -- 3E) Payment Posted (best-effort heuristic)
+  -- TODO: For strict accuracy, implement reconciliation via account_partial_reconcile
+  -- Current approach: match payment ref to PO name or vendor bill name
+  INSERT INTO pm.event(case_id, process, activity, ts, resource, source_model, source_id, attrs_json)
+  SELECT DISTINCT ON (po.id, pay.id)
+    'p2p:po:' || po.id::text,
+    'p2p',
+    'Payment Posted',
+    COALESCE(pay.date, pay.write_date, pay.create_date),
+    NULL,
+    'account.payment',
+    pay.id,
+    jsonb_build_object('payment_ref', pay.ref, 'amount', pay.amount, 'state', pay.state)
+  FROM purchase_order po
+  JOIN tmp_impacted_po t ON t.po_id = po.id
+  JOIN account_payment pay
+    ON (
+      pay.ref ILIKE '%' || po.name || '%'
+      OR EXISTS (
+        SELECT 1
+        FROM account_move am
+        WHERE (am.invoice_origin = po.name OR am.invoice_origin ILIKE '%' || po.name || '%')
+          AND am.move_type = 'in_invoice'
+          AND (pay.ref ILIKE '%' || am.name || '%' OR pay.ref ILIKE '%' || COALESCE(am.payment_reference, '') || '%')
+      )
+    )
+  WHERE pay.state IN ('posted','reconciled');
+
+  -- Count events created
+  SELECT COUNT(*) INTO v_events_count
+  FROM pm.event
+  WHERE case_id IN (SELECT 'p2p:po:' || po_id::text FROM tmp_impacted_po);
+
+  -- 4) Compute start/end/duration for impacted cases
+  UPDATE pm.case c
+  SET start_ts = x.min_ts,
+      end_ts   = x.max_ts,
+      duration_s = EXTRACT(EPOCH FROM (x.max_ts - x.min_ts))::bigint,
+      updated_at = now()
+  FROM (
+    SELECT case_id, MIN(ts) AS min_ts, MAX(ts) AS max_ts
+    FROM pm.event
+    WHERE process = 'p2p'
+      AND case_id IN (SELECT 'p2p:po:' || po_id::text FROM tmp_impacted_po)
+    GROUP BY case_id
+  ) x
+  WHERE c.case_id = x.case_id;
+
+  -- 5) Compute variants for impacted cases
+  DROP TABLE IF EXISTS tmp_case_seq;
+  CREATE TEMP TABLE tmp_case_seq AS
+  SELECT
+    e.case_id,
+    array_agg(e.activity ORDER BY e.ts, e.event_id) AS seq
+  FROM pm.event e
+  WHERE e.process = 'p2p'
+    AND e.case_id IN (SELECT 'p2p:po:' || po_id::text FROM tmp_impacted_po)
+  GROUP BY e.case_id;
+
+  -- Upsert variant catalog
+  INSERT INTO pm.variant(variant_id, process, sequence, sequence_hash, case_count, updated_at)
+  SELECT
+    md5(array_to_string(seq, '→')) AS variant_id,
+    'p2p' AS process,
+    seq AS sequence,
+    md5(array_to_string(seq, '→')) AS sequence_hash,
+    0,
+    now()
+  FROM tmp_case_seq
+  ON CONFLICT (variant_id) DO UPDATE
+    SET sequence = EXCLUDED.sequence,
+        updated_at = now();
+
+  -- Assign variant_id to cases
+  UPDATE pm.case c
+  SET variant_id = v.variant_id,
+      updated_at = now()
+  FROM (
+    SELECT case_id, md5(array_to_string(seq, '→')) AS variant_id
+    FROM tmp_case_seq
+  ) v
+  WHERE c.case_id = v.case_id;
+
+  -- Recount variant case_count (process-wide)
+  UPDATE pm.variant pv
+  SET case_count = x.cnt,
+      updated_at = now()
+  FROM (
+    SELECT variant_id, COUNT(*)::bigint AS cnt
+    FROM pm.case
+    WHERE process = 'p2p'
+      AND variant_id IS NOT NULL
+    GROUP BY variant_id
+  ) x
+  WHERE pv.variant_id = x.variant_id;
+
+  -- 6) Recompute DFG edges (process-wide for simplicity)
+  -- For high volume, switch to incremental aggregation by impacted cases
+  DELETE FROM pm.edge WHERE process = 'p2p';
+
+  WITH ordered AS (
+    SELECT
+      case_id,
+      ts,
+      event_id,
+      activity,
+      LEAD(activity) OVER (PARTITION BY case_id ORDER BY ts, event_id) AS next_activity,
+      LEAD(ts)       OVER (PARTITION BY case_id ORDER BY ts, event_id) AS next_ts
+    FROM pm.event
+    WHERE process = 'p2p'
+  ),
+  edges AS (
+    SELECT
+      'p2p'::text AS process,
+      activity AS activity_from,
+      next_activity AS activity_to,
+      COUNT(*)::bigint AS edge_count,
+      percentile_cont(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (next_ts - ts))) AS p50,
+      percentile_cont(0.95) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (next_ts - ts))) AS p95
+    FROM ordered
+    WHERE next_activity IS NOT NULL AND next_ts IS NOT NULL
+    GROUP BY activity, next_activity
+  )
+  INSERT INTO pm.edge(process, activity_from, activity_to, edge_count, p50_s, p95_s, updated_at)
+  SELECT process, activity_from, activity_to, edge_count, p50::bigint, p95::bigint, now()
+  FROM edges;
+
+  -- 7) Recompute deviations for impacted cases (delete+insert)
+  DELETE FROM pm.deviation d
+  WHERE d.process = 'p2p'
+    AND d.case_id IN (SELECT 'p2p:po:' || po_id::text FROM tmp_impacted_po);
+
+  -- Rule: Bill before Receipt (if both exist and bill_ts < receipt_ts)
+  INSERT INTO pm.deviation(process, case_id, rule_id, severity, details_json)
+  WITH t AS (
+    SELECT
+      case_id,
+      MIN(ts) FILTER (WHERE activity='Goods Received') AS receipt_ts,
+      MIN(ts) FILTER (WHERE activity='Vendor Bill Posted') AS bill_ts
+    FROM pm.event
+    WHERE process='p2p'
+      AND case_id IN (SELECT 'p2p:po:' || po_id::text FROM tmp_impacted_po)
+    GROUP BY case_id
+  )
+  SELECT
+    'p2p',
+    case_id,
+    'BILL_BEFORE_RECEIPT',
+    'high',
+    jsonb_build_object('receipt_ts', receipt_ts, 'bill_ts', bill_ts)
+  FROM t
+  WHERE receipt_ts IS NOT NULL AND bill_ts IS NOT NULL AND bill_ts < receipt_ts;
+
+  -- Rule: Missing Receipt (bill posted but no receipt)
+  INSERT INTO pm.deviation(process, case_id, rule_id, severity, details_json)
+  WITH t AS (
+    SELECT
+      case_id,
+      COUNT(*) FILTER (WHERE activity='Goods Received') AS receipt_cnt,
+      COUNT(*) FILTER (WHERE activity='Vendor Bill Posted') AS bill_cnt
+    FROM pm.event
+    WHERE process='p2p'
+      AND case_id IN (SELECT 'p2p:po:' || po_id::text FROM tmp_impacted_po)
+    GROUP BY case_id
+  )
+  SELECT
+    'p2p',
+    case_id,
+    'MISSING_RECEIPT',
+    'medium',
+    jsonb_build_object('bill_cnt', bill_cnt, 'receipt_cnt', receipt_cnt)
+  FROM t
+  WHERE bill_cnt > 0 AND receipt_cnt = 0;
+
+  -- Rule: Missing Bill (receipt exists but no vendor bill posted)
+  INSERT INTO pm.deviation(process, case_id, rule_id, severity, details_json)
+  WITH t AS (
+    SELECT
+      case_id,
+      COUNT(*) FILTER (WHERE activity='Goods Received') AS receipt_cnt,
+      COUNT(*) FILTER (WHERE activity='Vendor Bill Posted') AS bill_cnt
+    FROM pm.event
+    WHERE process='p2p'
+      AND case_id IN (SELECT 'p2p:po:' || po_id::text FROM tmp_impacted_po)
+    GROUP BY case_id
+  )
+  SELECT
+    'p2p',
+    case_id,
+    'MISSING_VENDOR_BILL',
+    'medium',
+    jsonb_build_object('bill_cnt', bill_cnt, 'receipt_cnt', receipt_cnt)
+  FROM t
+  WHERE receipt_cnt > 0 AND bill_cnt = 0;
+
+  -- Count deviations
+  SELECT COUNT(*) INTO v_deviations_count
+  FROM pm.deviation
+  WHERE process = 'p2p'
+    AND case_id IN (SELECT 'p2p:po:' || po_id::text FROM tmp_impacted_po);
+
+  -- Finalize job state
+  UPDATE pm.job_state
+  SET last_run_ts = p_to,
+      updated_at = now()
+  WHERE job_name = v_job;
+
+  -- Return stats
+  RETURN QUERY SELECT v_cases_count, v_events_count, v_deviations_count;
+END;
+$$;
+
+COMMENT ON FUNCTION pm.run_p2p_etl IS 'Incremental P2P process mining ETL - extracts events from purchase/receiving/billing/payment flow';
+
+COMMIT;

--- a/services/pm_api/README.md
+++ b/services/pm_api/README.md
@@ -1,0 +1,90 @@
+# Process Mining API
+
+Local-first query service for Odoo Copilot process mining insights.
+
+## Overview
+
+This API provides endpoints to query process mining data from the `pm.*` schema in your Odoo PostgreSQL database. It's designed to run locally alongside your Odoo instance, keeping all sensitive process data within your infrastructure.
+
+## Prerequisites
+
+1. PostgreSQL with the `pm.*` schema applied:
+   ```bash
+   psql -d odoo_dev -f db/process_mining/001_pm_schema.sql
+   psql -d odoo_dev -f db/process_mining/010_p2p_etl.sql
+   ```
+
+2. Python 3.11+
+
+## Installation
+
+```bash
+cd services/pm_api
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Configuration
+
+Copy `.env.example` to `.env` and configure:
+
+```bash
+cp .env.example .env
+# Edit .env with your database connection
+```
+
+## Running
+
+```bash
+export PM_DB_DSN="postgres://odoo:odoo@localhost:5432/odoo_dev"
+uvicorn app.main:app --host 0.0.0.0 --port 8787
+```
+
+## API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/health` | GET | Health check |
+| `/pm/{process}/summary` | GET | Process summary (cases, duration, etc.) |
+| `/pm/{process}/bottlenecks` | GET | Top edges by latency |
+| `/pm/{process}/variants` | GET | Top variants by frequency |
+| `/pm/{process}/cases/{id}` | GET | Case detail with timeline |
+| `/pm/{process}/deviations` | GET | List deviations |
+| `/pm/{process}/etl/run` | POST | Trigger incremental ETL |
+
+## Example Queries
+
+```bash
+# Process summary
+curl http://localhost:8787/pm/p2p/summary
+
+# Top 5 bottlenecks
+curl "http://localhost:8787/pm/p2p/bottlenecks?limit=5"
+
+# Top variants
+curl "http://localhost:8787/pm/p2p/variants?limit=10"
+
+# Case detail
+curl http://localhost:8787/pm/p2p/cases/p2p:po:123
+
+# High severity deviations
+curl "http://localhost:8787/pm/p2p/deviations?severity=high&limit=20"
+
+# Run ETL
+curl -X POST http://localhost:8787/pm/p2p/etl/run
+```
+
+## Docker
+
+```bash
+docker build -t pm-api .
+docker run -e PM_DB_DSN="postgres://odoo:odoo@host.docker.internal:5432/odoo_dev" -p 8787:8787 pm-api
+```
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+pytest
+```

--- a/services/pm_api/app/__init__.py
+++ b/services/pm_api/app/__init__.py
@@ -1,0 +1,1 @@
+# Process Mining API for Odoo Copilot

--- a/services/pm_api/app/main.py
+++ b/services/pm_api/app/main.py
@@ -1,0 +1,391 @@
+"""
+Process Mining API for Odoo Copilot
+
+Local-first query service for process mining insights.
+Connects to the pm.* schema in Odoo's PostgreSQL database.
+
+Usage:
+    export PM_DB_DSN="postgres://odoo:odoo@localhost:5432/odoo_dev"
+    uvicorn app.main:app --host 0.0.0.0 --port 8787
+"""
+
+import os
+from contextlib import asynccontextmanager
+from datetime import datetime
+from typing import Any
+
+import asyncpg
+from fastapi import FastAPI, HTTPException, Query
+from pydantic import BaseModel
+
+DB_DSN = os.getenv("PM_DB_DSN")  # e.g. postgres://user:pass@host:5432/dbname
+
+_pool: asyncpg.Pool | None = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Manage database connection pool lifecycle."""
+    global _pool
+    if not DB_DSN:
+        raise RuntimeError("PM_DB_DSN environment variable is required")
+    _pool = await asyncpg.create_pool(dsn=DB_DSN, min_size=1, max_size=5)
+    yield
+    if _pool:
+        await _pool.close()
+
+
+app = FastAPI(
+    title="Odoo Process Mining API",
+    description="Local-first query service for process mining insights",
+    version="0.1.0",
+    lifespan=lifespan,
+)
+
+
+# --------------------------------------------------------------------------
+# Models
+# --------------------------------------------------------------------------
+
+
+class ProcessSummary(BaseModel):
+    """Summary statistics for a process."""
+
+    process: str
+    cases: int
+    median_duration_s: int | None
+    p95_duration_s: int | None
+    open_cases: int
+
+
+class Edge(BaseModel):
+    """DFG edge with latency stats."""
+
+    activity_from: str
+    activity_to: str
+    edge_count: int
+    p50_s: int | None
+    p95_s: int | None
+
+
+class Variant(BaseModel):
+    """Process variant (unique activity sequence)."""
+
+    variant_id: str
+    case_count: int
+    sequence: list[str]
+
+
+class Event(BaseModel):
+    """Single event in a case timeline."""
+
+    activity: str
+    ts: datetime
+    source_model: str | None
+    source_id: int | None
+    attrs_json: dict[str, Any]
+
+
+class Deviation(BaseModel):
+    """Conformance deviation detected by rule engine."""
+
+    rule_id: str
+    severity: str
+    details_json: dict[str, Any]
+    created_at: datetime
+
+
+class CaseDetail(BaseModel):
+    """Full case detail with timeline and deviations."""
+
+    case_id: str
+    process: str
+    source_model: str
+    source_id: int
+    company_id: int | None
+    start_ts: datetime | None
+    end_ts: datetime | None
+    duration_s: int | None
+    variant_id: str | None
+    attrs_json: dict[str, Any]
+    events: list[Event]
+    deviations: list[Deviation]
+
+
+class DeviationSummary(BaseModel):
+    """Deviation with case context."""
+
+    deviation_id: int
+    case_id: str
+    rule_id: str
+    severity: str
+    details_json: dict[str, Any]
+    created_at: datetime
+
+
+class HealthResponse(BaseModel):
+    """Health check response."""
+
+    status: str
+    database: str
+    pm_schema: bool
+
+
+# --------------------------------------------------------------------------
+# Endpoints
+# --------------------------------------------------------------------------
+
+
+@app.get("/health", response_model=HealthResponse)
+async def health_check():
+    """Check API and database connectivity."""
+    assert _pool is not None
+    try:
+        async with _pool.acquire() as conn:
+            # Check pm schema exists
+            result = await conn.fetchval(
+                "SELECT EXISTS(SELECT 1 FROM information_schema.schemata WHERE schema_name='pm')"
+            )
+            return HealthResponse(status="ok", database="connected", pm_schema=result)
+    except Exception as e:
+        return HealthResponse(status="error", database=str(e), pm_schema=False)
+
+
+@app.get("/pm/{process}/summary", response_model=ProcessSummary)
+async def get_process_summary(process: str, company_id: int | None = None):
+    """
+    Get summary statistics for a process.
+
+    Args:
+        process: Process name (e.g., 'p2p', 'o2c')
+        company_id: Optional filter by company
+    """
+    assert _pool is not None
+    q = """
+        WITH base AS (
+            SELECT duration_s, end_ts
+            FROM pm.case
+            WHERE process = $1
+              AND ($2::bigint IS NULL OR company_id = $2)
+        )
+        SELECT
+            COUNT(*)::int AS cases,
+            percentile_cont(0.5) WITHIN GROUP (ORDER BY duration_s) AS p50,
+            percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_s) AS p95,
+            COUNT(*) FILTER (WHERE end_ts IS NULL)::int AS open_cases
+        FROM base
+        WHERE duration_s IS NOT NULL;
+    """
+    async with _pool.acquire() as conn:
+        row = await conn.fetchrow(q, process, company_id)
+
+    return ProcessSummary(
+        process=process,
+        cases=row["cases"] or 0,
+        median_duration_s=int(row["p50"]) if row["p50"] is not None else None,
+        p95_duration_s=int(row["p95"]) if row["p95"] is not None else None,
+        open_cases=row["open_cases"] or 0,
+    )
+
+
+@app.get("/pm/{process}/bottlenecks", response_model=list[Edge])
+async def get_bottlenecks(process: str, limit: int = Query(10, ge=1, le=100)):
+    """
+    Get top edges sorted by latency (bottlenecks).
+
+    Args:
+        process: Process name
+        limit: Maximum number of edges to return
+    """
+    assert _pool is not None
+    q = """
+        SELECT activity_from, activity_to, edge_count, p50_s, p95_s
+        FROM pm.edge
+        WHERE process = $1
+        ORDER BY p95_s DESC NULLS LAST, edge_count DESC
+        LIMIT $2;
+    """
+    async with _pool.acquire() as conn:
+        rows = await conn.fetch(q, process, limit)
+
+    return [
+        Edge(
+            activity_from=r["activity_from"],
+            activity_to=r["activity_to"],
+            edge_count=r["edge_count"],
+            p50_s=r["p50_s"],
+            p95_s=r["p95_s"],
+        )
+        for r in rows
+    ]
+
+
+@app.get("/pm/{process}/variants", response_model=list[Variant])
+async def get_variants(process: str, limit: int = Query(10, ge=1, le=100)):
+    """
+    Get top variants sorted by case count.
+
+    Args:
+        process: Process name
+        limit: Maximum number of variants to return
+    """
+    assert _pool is not None
+    q = """
+        SELECT variant_id, case_count, sequence
+        FROM pm.variant
+        WHERE process = $1
+        ORDER BY case_count DESC
+        LIMIT $2;
+    """
+    async with _pool.acquire() as conn:
+        rows = await conn.fetch(q, process, limit)
+
+    return [
+        Variant(
+            variant_id=r["variant_id"],
+            case_count=r["case_count"],
+            sequence=list(r["sequence"]),
+        )
+        for r in rows
+    ]
+
+
+@app.get("/pm/{process}/cases/{case_id}", response_model=CaseDetail)
+async def get_case(process: str, case_id: str):
+    """
+    Get full case detail including timeline and deviations.
+
+    Args:
+        process: Process name
+        case_id: Case identifier
+    """
+    assert _pool is not None
+    async with _pool.acquire() as conn:
+        # Get case
+        c = await conn.fetchrow(
+            "SELECT * FROM pm.case WHERE case_id = $1 AND process = $2;",
+            case_id,
+            process,
+        )
+        if not c:
+            raise HTTPException(status_code=404, detail="Case not found")
+
+        # Get events
+        events = await conn.fetch(
+            """
+            SELECT activity, ts, source_model, source_id, attrs_json
+            FROM pm.event
+            WHERE case_id = $1
+            ORDER BY ts, event_id;
+            """,
+            case_id,
+        )
+
+        # Get deviations
+        deviations = await conn.fetch(
+            """
+            SELECT rule_id, severity, details_json, created_at
+            FROM pm.deviation
+            WHERE case_id = $1
+            ORDER BY created_at DESC;
+            """,
+            case_id,
+        )
+
+    return CaseDetail(
+        case_id=c["case_id"],
+        process=c["process"],
+        source_model=c["source_model"],
+        source_id=c["source_id"],
+        company_id=c["company_id"],
+        start_ts=c["start_ts"],
+        end_ts=c["end_ts"],
+        duration_s=c["duration_s"],
+        variant_id=c["variant_id"],
+        attrs_json=dict(c["attrs_json"]) if c["attrs_json"] else {},
+        events=[
+            Event(
+                activity=e["activity"],
+                ts=e["ts"],
+                source_model=e["source_model"],
+                source_id=e["source_id"],
+                attrs_json=dict(e["attrs_json"]) if e["attrs_json"] else {},
+            )
+            for e in events
+        ],
+        deviations=[
+            Deviation(
+                rule_id=d["rule_id"],
+                severity=d["severity"],
+                details_json=dict(d["details_json"]) if d["details_json"] else {},
+                created_at=d["created_at"],
+            )
+            for d in deviations
+        ],
+    )
+
+
+@app.get("/pm/{process}/deviations", response_model=list[DeviationSummary])
+async def get_deviations(
+    process: str,
+    rule_id: str | None = None,
+    severity: str | None = None,
+    limit: int = Query(50, ge=1, le=500),
+):
+    """
+    List deviations with optional filters.
+
+    Args:
+        process: Process name
+        rule_id: Optional filter by rule ID
+        severity: Optional filter by severity (low, medium, high)
+        limit: Maximum number of deviations to return
+    """
+    assert _pool is not None
+    q = """
+        SELECT deviation_id, case_id, rule_id, severity, details_json, created_at
+        FROM pm.deviation
+        WHERE process = $1
+          AND ($2::text IS NULL OR rule_id = $2)
+          AND ($3::text IS NULL OR severity = $3)
+        ORDER BY created_at DESC
+        LIMIT $4;
+    """
+    async with _pool.acquire() as conn:
+        rows = await conn.fetch(q, process, rule_id, severity, limit)
+
+    return [
+        DeviationSummary(
+            deviation_id=r["deviation_id"],
+            case_id=r["case_id"],
+            rule_id=r["rule_id"],
+            severity=r["severity"],
+            details_json=dict(r["details_json"]) if r["details_json"] else {},
+            created_at=r["created_at"],
+        )
+        for r in rows
+    ]
+
+
+@app.post("/pm/{process}/etl/run")
+async def trigger_etl(process: str):
+    """
+    Trigger incremental ETL for a process.
+
+    Args:
+        process: Process name (currently only 'p2p' supported)
+    """
+    assert _pool is not None
+    if process != "p2p":
+        raise HTTPException(status_code=400, detail=f"ETL not implemented for {process}")
+
+    async with _pool.acquire() as conn:
+        result = await conn.fetchrow("SELECT * FROM pm.run_p2p_etl();")
+
+    return {
+        "status": "completed",
+        "process": process,
+        "cases_processed": result["cases_processed"],
+        "events_created": result["events_created"],
+        "deviations_found": result["deviations_found"],
+    }

--- a/services/pm_api/pyproject.toml
+++ b/services/pm_api/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "pm_api"
+version = "0.1.0"
+description = "Process Mining API for Odoo Copilot - local-first query service"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi>=0.110",
+  "uvicorn[standard]>=0.27",
+  "asyncpg>=0.29",
+  "pydantic>=2.6",
+  "python-dotenv>=1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "pytest-asyncio>=0.23",
+  "httpx>=0.27",
+]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
+[tool.uvicorn]
+factory = false

--- a/spec/odoo-copilot-process-mining/constitution.md
+++ b/spec/odoo-copilot-process-mining/constitution.md
@@ -1,0 +1,27 @@
+# Constitution: Odoo Copilot – Process Mining (Local-First)
+
+## Principles
+
+1. **Local-first capture and analysis**: raw event logs can be collected and processed on-prem.
+2. **Minimal invasive instrumentation**: prefer existing Odoo models/logs, avoid UI scripts.
+3. **Deterministic pipelines**: idempotent extraction and transformation.
+4. **Explainable insights**: every recommendation links to evidence (case ids, timestamps, events).
+5. **Privacy and compliance**: configurable redaction and retention; PII-aware schemas.
+6. **Extensible connectors**: Odoo DB + logs + optional external systems.
+
+## Non-goals
+
+- Full "screen recording" RPA unless explicitly enabled later.
+- Replacing Odoo workflows; this is analytics + recommendations.
+
+## Data Sovereignty
+
+- All raw event data stays within the Odoo infrastructure boundary.
+- Only aggregated, anonymized metrics may optionally sync to external systems.
+- Sensitive fields (partner names, amounts, user IDs) must be redactable via configuration.
+
+## Conformance Rules
+
+- Rules engine must be declarative and auditable.
+- Every deviation must reference the specific rule and evidence that triggered it.
+- False positive rates should be tracked and rules tuned accordingly.

--- a/spec/odoo-copilot-process-mining/plan.md
+++ b/spec/odoo-copilot-process-mining/plan.md
@@ -1,0 +1,116 @@
+# Plan: Odoo Copilot – Process Mining
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                     Process Mining Architecture                      │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│   Odoo PostgreSQL                                                    │
+│   ├── purchase_order                                                 │
+│   ├── stock_picking         ──► Extractor (SQL Views/ETL Job)       │
+│   ├── account_move                      │                           │
+│   └── account_payment                   ▼                           │
+│                              ┌──────────────────────┐               │
+│                              │    pm.* Schema       │               │
+│                              │ ├── pm.case          │               │
+│                              │ ├── pm.event         │               │
+│                              │ ├── pm.variant       │               │
+│                              │ ├── pm.edge          │               │
+│                              │ └── pm.deviation     │               │
+│                              └──────────────────────┘               │
+│                                        │                            │
+│                                        ▼                            │
+│                              ┌──────────────────────┐               │
+│                              │   Miner Worker       │               │
+│                              │ (Odoo cron / Python) │               │
+│                              │ • Variant compute    │               │
+│                              │ • DFG edges          │               │
+│                              │ • Conformance rules  │               │
+│                              └──────────────────────┘               │
+│                                        │                            │
+│                                        ▼                            │
+│                              ┌──────────────────────┐               │
+│                              │   Copilot API        │               │
+│                              │   (FastAPI local)    │               │
+│                              │ • Summary            │               │
+│                              │ • Bottlenecks        │               │
+│                              │ • Variants           │               │
+│                              │ • Case timeline      │               │
+│                              └──────────────────────┘               │
+│                                        │                            │
+│                                        ▼                            │
+│                              ┌──────────────────────┐               │
+│                              │   Odoo Copilot UI    │               │
+│                              │   (ipai_ai_copilot)  │               │
+│                              │ • NLQ interface      │               │
+│                              │ • Evidence cards     │               │
+│                              │ • Action suggestions │               │
+│                              └──────────────────────┘               │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Components
+
+### 1. Extractor (SQL Views / ETL Job)
+
+- Runs as PostgreSQL function `pm.run_p2p_etl()`
+- Idempotent: safe to re-run
+- Incremental: processes only changed records since last run
+- Tracks state in `pm.job_state` table
+
+### 2. Miner (Python Worker or Scheduled Action)
+
+- Computes variants from event sequences
+- Calculates DFG edges with latency percentiles
+- Applies conformance rules to detect deviations
+
+### 3. Copilot API
+
+- FastAPI service running locally
+- Queries pm.* schema for insights
+- Returns JSON for Copilot UI consumption
+
+### 4. Optional: Supabase Sync
+
+- Push only aggregated metrics (no raw events)
+- Anonymize case IDs and sensitive attributes
+- Enable cross-app dashboards in Superset
+
+## Deliverables
+
+| Deliverable | Location |
+|-------------|----------|
+| Schema migrations | `db/process_mining/001_pm_schema.sql` |
+| P2P ETL function | `db/process_mining/010_p2p_etl.sql` |
+| Query API service | `services/pm_api/` |
+| Copilot prompts | `addons/ipai/ipai_ai_copilot/data/pm_prompts.xml` |
+| Evidence renderer | `addons/ipai/ipai_ai_copilot/static/src/pm_cards/` |
+
+## Milestones
+
+| Milestone | Deliverables |
+|-----------|--------------|
+| M1 | Schema + P2P extraction |
+| M2 | Discovery + bottleneck metrics |
+| M3 | Conformance rules + insights |
+| M4 | Copilot NLQ + action suggestions |
+
+## Conformance Rules (P2P)
+
+| Rule ID | Description | Severity |
+|---------|-------------|----------|
+| `BILL_BEFORE_RECEIPT` | Vendor bill posted before goods received | High |
+| `MISSING_RECEIPT` | Bill exists but no receipt recorded | Medium |
+| `MISSING_VENDOR_BILL` | Receipt exists but no bill posted | Medium |
+| `APPROVAL_BYPASSED` | PO moved to purchase state without approval | High |
+| `LATE_PAYMENT` | Payment posted >30 days after bill | Low |
+
+## Performance Considerations
+
+- Index on `pm.event(case_id, ts)` for timeline queries
+- Index on `pm.edge(process, p95_s)` for bottleneck sorting
+- Partition large tables by date if volume exceeds 10M events
+- Use SKIP LOCKED for concurrent ETL runs

--- a/spec/odoo-copilot-process-mining/prd.md
+++ b/spec/odoo-copilot-process-mining/prd.md
@@ -1,0 +1,106 @@
+# PRD: Odoo Copilot – Process Mining & Process Intelligence (Mindzie-style, Local-First)
+
+## 1. Problem
+
+Finance/Ops teams need Joule-like guidance: find bottlenecks, non-compliance, cycle time variance, and automation opportunities across Odoo processes (P2P, O2C, R2R, Inventory, HR), without sending sensitive operational data to third parties.
+
+Current pain points:
+- No visibility into actual process execution paths vs intended workflows
+- Manual analysis of cycle times and bottlenecks
+- Compliance deviations discovered only during audits
+- Lack of evidence-backed recommendations for process improvement
+
+## 2. Goals
+
+- Generate event logs (XES-like) from Odoo transactional data
+- Compute core process mining metrics: cycle time, rework, variant frequency, conformance
+- Provide Copilot answers and recommendations with evidence
+- Support "Done locally" mode; optionally sync derived aggregates to Supabase
+
+## 3. Users
+
+| User | Primary Use Cases |
+|------|-------------------|
+| Finance Director / Controllers | Cycle time KPIs, compliance dashboards |
+| Operations Manager | Bottleneck identification, process optimization |
+| Process Owner (AP, AR, Procurement, Warehouse) | Variant analysis, deviation alerts |
+| Admin/IT | ETL configuration, redaction policies |
+
+## 4. Key Features
+
+### A. Event Log Builder (ETL)
+
+- **Extract**: Odoo Postgres tables (account.move, stock.picking, purchase.order, sale.order, hr.expense, etc.)
+- **Transform**: map to (case_id, activity, ts, resource, attributes)
+- **Load**: local store (Postgres schema `pm_*` or parquet) + optional XES export
+
+### B. Process Discovery
+
+- Variant graph + top variants
+- DFG (directly-follows graph) metrics
+- Bottleneck hotspots (median/95p lead time by edge/activity)
+
+### C. Conformance & Compliance
+
+- Reference model per process (configurable)
+- Deviations: missing approvals, out-of-order steps, bypassed controls
+- Compliance score & explanation
+
+### D. Copilot Integration (SAP Joule-like)
+
+- **NLQ**: "Why is AP cycle time worse this month?"
+- **Drill-through**: "Show the top 5 variants causing delays"
+- **Action suggestions**: "Add approval rule", "Fix vendor master", "Automate 3-way match check"
+- **Evidence cards**: clickable case samples with timestamps
+
+### E. Local-first + Optional Cloud
+
+- Default: everything runs on Odoo host / internal network
+- Optional: push only aggregates + anonymized embeddings to Supabase for cross-app analytics
+
+## 5. KPIs
+
+| Metric | Target |
+|--------|--------|
+| Cycle time reduction | Measure baseline vs after optimization |
+| Rework rate reduction | Track % of cases with duplicate activities |
+| Compliance rate | % cases conforming to reference model |
+| Mean time-to-detect anomalies | < 24 hours for high-severity deviations |
+
+## 6. Data Model (minimal)
+
+```
+pm.case        (case_id, process, start_ts, end_ts, duration_s, variant_id, attrs_json)
+pm.event       (event_id, case_id, activity, ts, resource, attrs_json)
+pm.variant     (variant_id, process, sequence_hash, sequence, count)
+pm.edge        (process, activity_from, activity_to, count, p50_s, p95_s)
+pm.deviation   (case_id, rule_id, severity, details_json)
+pm.insight     (insight_id, process, created_ts, type, summary, evidence_json)
+```
+
+## 7. Security
+
+- Redact PII fields configurable per model/field
+- Retention policy per table (default: 2 years for events, 5 years for aggregates)
+- Row-level filtering by company + user roles
+- Audit log for all ETL runs and data access
+
+## 8. Rollout
+
+| Phase | Scope | Processes |
+|-------|-------|-----------|
+| 1 | AP + Procurement | P2P (Purchase → Receipt → Bill → Payment) |
+| 2 | AR + Sales | O2C (Quote → Order → Delivery → Invoice → Payment) |
+| 3 | Inventory | Stock moves, transfers, adjustments |
+| 4 | Record-to-Report | Month-end close, reconciliations |
+
+## 9. API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/pm/{process}/summary` | GET | Process-level KPIs |
+| `/pm/{process}/bottlenecks` | GET | Top edges by latency |
+| `/pm/{process}/variants` | GET | Top variants by frequency |
+| `/pm/{process}/cases/{id}` | GET | Case timeline + deviations |
+| `/pm/{process}/deviations` | GET | List deviations with filters |
+| `/pm/{process}/etl/run` | POST | Trigger incremental ETL |

--- a/spec/odoo-copilot-process-mining/tasks.md
+++ b/spec/odoo-copilot-process-mining/tasks.md
@@ -1,0 +1,69 @@
+# Tasks: Odoo Copilot – Process Mining
+
+## M1: Schema + P2P Extraction
+
+- [x] Create pm.* schema with tables (case, event, variant, edge, deviation)
+- [x] Add indexes for query patterns
+- [x] Implement pm.job_state for ETL tracking
+- [x] Implement P2P event mapping:
+  - [x] purchase.order → PO Created, PO Approved
+  - [x] stock.picking → Goods Received
+  - [x] account.move → Vendor Bill Posted
+  - [x] account.payment → Payment Posted (heuristic)
+- [x] Implement backfill job (full history)
+- [x] Implement incremental job (idempotent, window-based)
+
+## M2: Discovery + Bottleneck Metrics
+
+- [x] Compute variants from event sequences
+- [x] Assign variant_id to cases
+- [x] Calculate DFG edges with p50/p95 latency
+- [x] Build bottleneck ranking endpoint
+
+## M3: Conformance Rules + Insights
+
+- [x] Implement deviation detection:
+  - [x] BILL_BEFORE_RECEIPT rule
+  - [x] MISSING_RECEIPT rule
+  - [x] MISSING_VENDOR_BILL rule
+- [ ] Add APPROVAL_BYPASSED rule
+- [ ] Add LATE_PAYMENT rule
+- [ ] Implement pm.insight table for recommendations
+- [ ] Build deviation summary endpoint
+
+## M4: Copilot NLQ + Action Suggestions
+
+- [ ] Create prompt templates for process mining queries
+- [ ] Implement evidence card renderer (case timeline)
+- [ ] Build action suggestion engine
+- [ ] Integrate with ipai_ai_copilot module
+- [ ] Add drill-through for variant analysis
+
+## API Implementation
+
+- [x] `/pm/p2p/summary` - Process-level KPIs
+- [x] `/pm/p2p/bottlenecks` - Top edges by latency
+- [x] `/pm/p2p/variants` - Top variants by frequency
+- [x] `/pm/p2p/cases/{id}` - Case timeline with deviations
+- [ ] `/pm/p2p/deviations` - List deviations with filters
+- [ ] `/pm/p2p/etl/run` - Trigger incremental ETL
+
+## Security & Privacy
+
+- [ ] Add redaction configuration table
+- [ ] Implement PII field masking in event attrs
+- [ ] Add retention policy cleanup job
+- [ ] Row-level filtering by company_id
+
+## Future: O2C Process
+
+- [ ] Map sale.order → SO Created, SO Confirmed
+- [ ] Map stock.picking (outgoing) → Goods Shipped
+- [ ] Map account.move (out_invoice) → Invoice Posted
+- [ ] Map account.payment → Customer Payment Received
+
+## Future: Strict Payment Reconciliation
+
+- [ ] Replace heuristic payment mapping with account_partial_reconcile join
+- [ ] Handle partial payments and overpayments
+- [ ] Track reconciliation status in event attrs


### PR DESCRIPTION
Add Mindzie-style desktop process mining capability with:

- Spec bundle (spec/odoo-copilot-process-mining/)
  - constitution.md: local-first, deterministic, privacy-first principles
  - prd.md: P2P/O2C/R2R process mining requirements
  - plan.md: architecture and milestones
  - tasks.md: implementation checklist

- Database schema (db/process_mining/)
  - pm.case: process cases (one per business document)
  - pm.event: XES-like event log
  - pm.variant: unique activity sequences
  - pm.edge: DFG with latency percentiles
  - pm.deviation: conformance rule violations
  - pm.insight: generated recommendations

- P2P ETL function (pm.run_p2p_etl)
  - Incremental, idempotent extraction
  - Maps: purchase.order → stock.picking → account.move → payment
  - Computes variants, DFG edges, deviations
  - Rules: BILL_BEFORE_RECEIPT, MISSING_RECEIPT, MISSING_VENDOR_BILL

- FastAPI query service (services/pm_api/)
  - /pm/{process}/summary - process KPIs
  - /pm/{process}/bottlenecks - top latency edges
  - /pm/{process}/variants - frequent patterns
  - /pm/{process}/cases/{id} - case timeline
  - /pm/{process}/deviations - conformance violations
  - /pm/{process}/etl/run - trigger ETL

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Supabase security review | [View](https://hub.continue.dev/tasks/ea8b2be2-efaf-4ea2-a7a8-6b3451355432) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->