### PR TITLE
Add Odoo export template documentation

### DIFF
--- a/docs/seed-data/EXPORT_TEMPLATES.md
+++ b/docs/seed-data/EXPORT_TEMPLATES.md
@@ -1,0 +1,333 @@
+# Odoo Export Template System
+
+This document describes the data dictionary-driven template generation system for Odoo imports.
+
+## Overview
+
+The system uses a **data dictionary** stored in Supabase (`odoo_dict` schema) to define:
+
+1. **Field definitions** - Technical metadata for each importable field
+2. **Templates** - Predefined column sets for specific use cases
+3. **Validation rules** - Required fields, types, relationships
+
+This approach treats the **data dictionary itself as data**, enabling:
+
+- Programmatic template generation
+- Import validation
+- Documentation generation
+- Schema evolution tracking
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Data Dictionary (odoo_dict)                  │
+├─────────────────────────────────────────────────────────────────┤
+│  fields table          │  templates table      │  import_runs   │
+│  - model_name          │  - slug               │  - audit log   │
+│  - field_name          │  - field_names[]      │                │
+│  - import_column       │  - model_name         │                │
+│  - required            │                       │                │
+│  - example_value       │                       │                │
+└─────────────────────────────────────────────────────────────────┘
+            │                       │
+            ▼                       ▼
+┌───────────────────┐    ┌───────────────────┐
+│  Edge Function    │    │  Python Script    │
+│  (Supabase)       │    │  (Local)          │
+└───────────────────┘    └───────────────────┘
+            │                       │
+            ▼                       ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                 Generated Templates (CSV/XLSX/JSON)             │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Quick Start
+
+### Generate Templates Locally (No Supabase)
+
+```bash
+# List available models
+python scripts/generate_odoo_template.py --list-models
+
+# List predefined templates
+python scripts/generate_odoo_template.py --list-templates
+
+# Generate a specific template
+python scripts/generate_odoo_template.py --template finance-ppm-tasks --output templates/
+
+# Generate with example row
+python scripts/generate_odoo_template.py --template finance-ppm-tasks --include-examples
+
+# Generate all templates
+python scripts/generate_odoo_template.py --all --output templates/
+
+# Generate for any model
+python scripts/generate_odoo_template.py --model project.task --format xlsx
+```
+
+### Generate Templates via Supabase Edge Function
+
+```bash
+# Get CSV template for a model
+curl "https://<project>.supabase.co/functions/v1/odoo-template-export?model=project.task"
+
+# Get CSV template from predefined template
+curl "https://<project>.supabase.co/functions/v1/odoo-template-export?template=finance-ppm-tasks"
+
+# Get JSON field metadata
+curl "https://<project>.supabase.co/functions/v1/odoo-template-export?model=project.task&format=json"
+
+# Include example row
+curl "https://<project>.supabase.co/functions/v1/odoo-template-export?template=finance-ppm-tasks&include_examples=true"
+```
+
+## Available Templates
+
+| Slug | Model | Fields | Description |
+|------|-------|--------|-------------|
+| `finance-ppm-tasks` | project.task | 13 | Full task import for month-end closing and tax filing |
+| `finance-ppm-tasks-minimal` | project.task | 5 | Minimal task import with required fields only |
+| `finance-ppm-projects` | project.project | 7 | Project import for finance programs |
+| `project-stages` | project.task.type | 4 | Stage definitions for project kanban |
+| `project-tags` | project.tags | 3 | Tag definitions for task categorization |
+| `hr-employees` | hr.employee | 6 | Employee master data for assignment references |
+| `analytic-accounts` | account.analytic.account | 5 | Analytic accounts for project cost tracking |
+
+## Available Models
+
+| Model | Fields | Domain |
+|-------|--------|--------|
+| `project.project` | 11 | project |
+| `project.task` | 15 | finance |
+| `project.tags` | 3 | project |
+| `project.task.type` | 5 | project |
+| `hr.employee` | 8 | hr |
+| `account.analytic.account` | 6 | finance |
+
+## Field Metadata
+
+Each field in the dictionary includes:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `model_name` | string | Odoo model (e.g., `project.task`) |
+| `field_name` | string | Technical field name (e.g., `date_deadline`) |
+| `label` | string | Human-friendly label |
+| `field_type` | string | Odoo type: `char`, `many2one`, `date`, `float`, `many2many` |
+| `required` | boolean | Whether field is required for import |
+| `is_key` | boolean | True for External ID fields |
+| `relation_model` | string | Target model for relational fields |
+| `import_column` | string | Exact header text for CSV import |
+| `description` | string | Business meaning (e.g., finance PPM context) |
+| `example_value` | string | Sample value for templates |
+| `default_value` | string | Default if not provided |
+| `sequence` | int | Column order in templates |
+
+## Import Column Headers
+
+The `import_column` field contains the **exact text** that Odoo expects in CSV headers:
+
+| Field | Import Column |
+|-------|---------------|
+| `x_external_ref` | External ID |
+| `name` | Name |
+| `project_id` | Project |
+| `company_id` | Company |
+| `user_ids` | Assigned to |
+| `date_deadline` | Planned Date |
+| `tag_ids` | Tags |
+| `depend_on_ids` | Depends on |
+
+## Database Schema
+
+### odoo_dict.fields
+
+```sql
+CREATE TABLE odoo_dict.fields (
+    id                bigserial PRIMARY KEY,
+    model_name        text NOT NULL,
+    field_name        text NOT NULL,
+    label             text NOT NULL,
+    field_type        text NOT NULL,
+    required          boolean NOT NULL DEFAULT false,
+    is_key            boolean NOT NULL DEFAULT false,
+    relation_model    text,
+    import_column     text NOT NULL,
+    description       text,
+    example_value     text,
+    default_value     text,
+    domain            text DEFAULT 'general',
+    module_required   text,
+    sequence          int NOT NULL DEFAULT 100,
+    is_active         boolean NOT NULL DEFAULT true,
+    created_at        timestamptz NOT NULL DEFAULT now(),
+    updated_at        timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (model_name, field_name)
+);
+```
+
+### odoo_dict.templates
+
+```sql
+CREATE TABLE odoo_dict.templates (
+    id                bigserial PRIMARY KEY,
+    slug              text UNIQUE NOT NULL,
+    name              text NOT NULL,
+    description       text,
+    model_name        text NOT NULL,
+    field_names       text[] NOT NULL,
+    domain            text DEFAULT 'general',
+    is_active         boolean NOT NULL DEFAULT true,
+    created_at        timestamptz NOT NULL DEFAULT now(),
+    updated_at        timestamptz NOT NULL DEFAULT now()
+);
+```
+
+## Helper Functions
+
+### Get Import Headers for a Model
+
+```sql
+SELECT * FROM odoo_dict.get_import_headers('project.task');
+-- Returns: External ID, Name of the Tasks?, Description, Project, ...
+```
+
+### Get Headers for a Template
+
+```sql
+SELECT * FROM odoo_dict.get_template_headers('finance-ppm-tasks');
+-- Returns: import_column, field_name, required
+```
+
+### Validate Import Headers
+
+```sql
+SELECT * FROM odoo_dict.validate_import_headers(
+    'project.task',
+    ARRAY['External ID', 'Name of the Tasks?', 'Project', 'Unknown Column']
+);
+-- Returns status per header: valid, unknown, or missing
+```
+
+## Adding New Fields
+
+### Via SQL
+
+```sql
+INSERT INTO odoo_dict.fields (
+    model_name, field_name, label, field_type, required, is_key,
+    relation_model, import_column, description, example_value,
+    domain, sequence
+) VALUES (
+    'project.task',
+    'x_custom_field',
+    'Custom Field',
+    'char',
+    false,
+    false,
+    NULL,
+    'Custom Field',
+    'Description of what this field does',
+    'Example Value',
+    'finance',
+    200
+);
+```
+
+### Via Python Script
+
+Edit `scripts/generate_odoo_template.py` and add to the `FIELDS` list:
+
+```python
+DictField(
+    model_name="project.task",
+    field_name="x_custom_field",
+    label="Custom Field",
+    field_type="char",
+    required=False,
+    is_key=False,
+    relation_model=None,
+    import_column="Custom Field",
+    description="Description of what this field does",
+    example_value="Example Value",
+    default_value=None,
+    domain="finance",
+    sequence=200,
+),
+```
+
+## Adding New Templates
+
+### Via SQL
+
+```sql
+INSERT INTO odoo_dict.templates (slug, name, description, model_name, field_names, domain)
+VALUES (
+    'custom-task-template',
+    'Custom Task Template',
+    'A custom subset of task fields',
+    'project.task',
+    ARRAY['x_external_ref', 'name', 'project_id', 'date_deadline'],
+    'custom'
+);
+```
+
+### Via Python Script
+
+Edit `scripts/generate_odoo_template.py` and add to the `TEMPLATES` list:
+
+```python
+Template(
+    slug="custom-task-template",
+    name="Custom Task Template",
+    description="A custom subset of task fields",
+    model_name="project.task",
+    field_names=["x_external_ref", "name", "project_id", "date_deadline"],
+    domain="custom",
+),
+```
+
+## Deployment
+
+### Apply Supabase Migration
+
+```bash
+supabase db push
+```
+
+### Seed the Dictionary
+
+```bash
+psql "$POSTGRES_URL" -f supabase/seeds/003_odoo_dict_seed.sql
+```
+
+### Deploy Edge Function
+
+```bash
+supabase functions deploy odoo-template-export
+```
+
+## Related Files
+
+| File | Purpose |
+|------|---------|
+| `supabase/migrations/20260121100001_odoo_data_dictionary.sql` | Schema migration |
+| `supabase/seeds/003_odoo_dict_seed.sql` | Seed data |
+| `supabase/functions/odoo-template-export/index.ts` | Edge function |
+| `scripts/generate_odoo_template.py` | Local generator (no Supabase) |
+
+## Best Practices
+
+1. **Always use External ID** - Include `x_external_ref` for idempotent imports
+2. **Required fields** - Ensure all required fields are present in templates
+3. **Relational fields** - Use names or External IDs, not database IDs
+4. **Many2many fields** - Use comma-separated values (e.g., `Tag1,Tag2`)
+5. **Dependencies** - Reference by External ID (e.g., `FIN_CLOSE_DAY1_CUTOFF`)
+
+## See Also
+
+- [SEEDING_STRATEGY.md](../../db/seeds/SEEDING_STRATEGY.md) - Overall seeding strategy
+- [data/import_templates/README.md](../../data/import_templates/README.md) - Existing import templates
+- [data/finance_seed/README.md](../../data/finance_seed/README.md) - Finance seed data

--- a/scripts/generate_odoo_template.py
+++ b/scripts/generate_odoo_template.py
@@ -1,0 +1,1101 @@
+#!/usr/bin/env python3
+"""
+Odoo Import Template Generator
+
+Generates clean CSV import templates from the embedded data dictionary.
+Can be used standalone without Supabase connection.
+
+Usage:
+    python scripts/generate_odoo_template.py --model project.task --output templates/
+    python scripts/generate_odoo_template.py --template finance-ppm-tasks --output templates/
+    python scripts/generate_odoo_template.py --list-models
+    python scripts/generate_odoo_template.py --list-templates
+    python scripts/generate_odoo_template.py --all --output templates/
+
+Options:
+    --model MODEL       Generate template for a specific model
+    --template SLUG     Generate template using a predefined template
+    --output DIR        Output directory (default: ./templates)
+    --format FORMAT     Output format: csv, xlsx, json (default: csv)
+    --include-examples  Include example row in template
+    --list-models       List all available models
+    --list-templates    List all predefined templates
+    --all               Generate all predefined templates
+"""
+
+import argparse
+import csv
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+# =============================================================================
+# Embedded Data Dictionary (mirrors Supabase odoo_dict.fields)
+# =============================================================================
+
+@dataclass
+class DictField:
+    model_name: str
+    field_name: str
+    label: str
+    field_type: str
+    required: bool
+    is_key: bool
+    relation_model: Optional[str]
+    import_column: str
+    description: Optional[str]
+    example_value: Optional[str]
+    default_value: Optional[str]
+    domain: str
+    sequence: int
+
+
+@dataclass
+class Template:
+    slug: str
+    name: str
+    description: str
+    model_name: str
+    field_names: list[str]
+    domain: str
+
+
+# Embedded field definitions (canonical source of truth)
+FIELDS: list[DictField] = [
+    # =========================================================================
+    # PROJECT.PROJECT Fields
+    # =========================================================================
+    DictField(
+        model_name="project.project",
+        field_name="x_external_ref",
+        label="External Reference",
+        field_type="char",
+        required=True,
+        is_key=True,
+        relation_model=None,
+        import_column="External ID",
+        description="Stable key for this project across environments. Used for idempotent imports.",
+        example_value="FIN_CLOSE_TBWA",
+        default_value=None,
+        domain="project",
+        sequence=10,
+    ),
+    DictField(
+        model_name="project.project",
+        field_name="name",
+        label="Project Name",
+        field_type="char",
+        required=True,
+        is_key=False,
+        relation_model=None,
+        import_column="Name",
+        description="Human-friendly project name displayed in UI.",
+        example_value="Month-end Closing & Tax Filing",
+        default_value=None,
+        domain="project",
+        sequence=20,
+    ),
+    DictField(
+        model_name="project.project",
+        field_name="description",
+        label="Description",
+        field_type="html",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Description",
+        description="Rich text description of the project scope and objectives.",
+        example_value="<p>Finance PPM for month-end close and BIR tax compliance</p>",
+        default_value=None,
+        domain="project",
+        sequence=30,
+    ),
+    DictField(
+        model_name="project.project",
+        field_name="partner_id",
+        label="Customer",
+        field_type="many2one",
+        required=False,
+        is_key=False,
+        relation_model="res.partner",
+        import_column="Customer",
+        description="Legal entity or client owning this project.",
+        example_value="TBWA SMP",
+        default_value=None,
+        domain="project",
+        sequence=40,
+    ),
+    DictField(
+        model_name="project.project",
+        field_name="company_id",
+        label="Company",
+        field_type="many2one",
+        required=True,
+        is_key=False,
+        relation_model="res.company",
+        import_column="Company",
+        description="Odoo company owning this project. Required for multi-company finance.",
+        example_value="TBWA\\SMP",
+        default_value=None,
+        domain="project",
+        sequence=50,
+    ),
+    DictField(
+        model_name="project.project",
+        field_name="user_id",
+        label="Project Manager",
+        field_type="many2one",
+        required=False,
+        is_key=False,
+        relation_model="res.users",
+        import_column="Project Manager",
+        description="User responsible for overall project delivery.",
+        example_value="Rey Meran",
+        default_value=None,
+        domain="project",
+        sequence=60,
+    ),
+    DictField(
+        model_name="project.project",
+        field_name="privacy_visibility",
+        label="Visibility",
+        field_type="selection",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Visibility",
+        description="Who can see this project: portal, employees, or followers.",
+        example_value="employees",
+        default_value="employees",
+        domain="project",
+        sequence=70,
+    ),
+    DictField(
+        model_name="project.project",
+        field_name="allow_task_dependencies",
+        label="Allow Dependencies",
+        field_type="boolean",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Allow Task Dependencies",
+        description="Enable task dependency tracking (CE feature).",
+        example_value="True",
+        default_value="True",
+        domain="project",
+        sequence=80,
+    ),
+    DictField(
+        model_name="project.project",
+        field_name="date_start",
+        label="Start Date",
+        field_type="date",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Start Date",
+        description="Planned project start date.",
+        example_value="2026-01-01",
+        default_value=None,
+        domain="project",
+        sequence=90,
+    ),
+    DictField(
+        model_name="project.project",
+        field_name="date",
+        label="End Date",
+        field_type="date",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Deadline",
+        description="Planned project end date or deadline.",
+        example_value="2026-12-31",
+        default_value=None,
+        domain="project",
+        sequence=100,
+    ),
+    DictField(
+        model_name="project.project",
+        field_name="active",
+        label="Active",
+        field_type="boolean",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Active",
+        description="Whether the project is active.",
+        example_value="True",
+        default_value="True",
+        domain="project",
+        sequence=110,
+    ),
+
+    # =========================================================================
+    # PROJECT.TASK Fields
+    # =========================================================================
+    DictField(
+        model_name="project.task",
+        field_name="x_external_ref",
+        label="External Reference",
+        field_type="char",
+        required=True,
+        is_key=True,
+        relation_model=None,
+        import_column="External ID",
+        description="Stable key for this task. Used for idempotent imports and dependency references.",
+        example_value="FIN_CLOSE_DAY3_TRIALBAL",
+        default_value=None,
+        domain="finance",
+        sequence=10,
+    ),
+    DictField(
+        model_name="project.task",
+        field_name="name",
+        label="Task Name",
+        field_type="char",
+        required=True,
+        is_key=False,
+        relation_model=None,
+        import_column="Name of the Tasks?",
+        description="Name of the finance/closing task.",
+        example_value="Post Trial Balance & Adjustments",
+        default_value=None,
+        domain="finance",
+        sequence=20,
+    ),
+    DictField(
+        model_name="project.task",
+        field_name="description",
+        label="Description",
+        field_type="html",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Description",
+        description="Rich text description of what this task entails.",
+        example_value="<p>Run trial balance, post adjusting entries</p>",
+        default_value=None,
+        domain="finance",
+        sequence=30,
+    ),
+    DictField(
+        model_name="project.task",
+        field_name="project_id",
+        label="Project",
+        field_type="many2one",
+        required=True,
+        is_key=False,
+        relation_model="project.project",
+        import_column="Project",
+        description="Parent project containing this task.",
+        example_value="Month-end Closing & Tax Filing",
+        default_value=None,
+        domain="finance",
+        sequence=40,
+    ),
+    DictField(
+        model_name="project.task",
+        field_name="company_id",
+        label="Company",
+        field_type="many2one",
+        required=True,
+        is_key=False,
+        relation_model="res.company",
+        import_column="Company",
+        description="Odoo company for multi-company finance setup.",
+        example_value="TBWA\\SMP",
+        default_value=None,
+        domain="finance",
+        sequence=50,
+    ),
+    DictField(
+        model_name="project.task",
+        field_name="user_ids",
+        label="Assigned to",
+        field_type="many2many",
+        required=False,
+        is_key=False,
+        relation_model="res.users",
+        import_column="Assigned to",
+        description="One or more assignees (Finance Director, Sr Finance Manager, etc.).",
+        example_value="Rey Meran",
+        default_value=None,
+        domain="finance",
+        sequence=60,
+    ),
+    DictField(
+        model_name="project.task",
+        field_name="stage_id",
+        label="Stage",
+        field_type="many2one",
+        required=False,
+        is_key=False,
+        relation_model="project.task.type",
+        import_column="Stage",
+        description="Current workflow stage of the task.",
+        example_value="To Do",
+        default_value="To Do",
+        domain="finance",
+        sequence=70,
+    ),
+    DictField(
+        model_name="project.task",
+        field_name="planned_hours",
+        label="Allocated Time",
+        field_type="float",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Allocated Time",
+        description="Planned effort in hours for this task per cycle.",
+        example_value="4.0",
+        default_value="0",
+        domain="finance",
+        sequence=80,
+    ),
+    DictField(
+        model_name="project.task",
+        field_name="date_deadline",
+        label="Deadline",
+        field_type="date",
+        required=True,
+        is_key=False,
+        relation_model=None,
+        import_column="Planned Date",
+        description="Operational due date (e.g., Day 3, Day 5, BIR statutory cutoffs).",
+        example_value="2026-01-05",
+        default_value=None,
+        domain="finance",
+        sequence=90,
+    ),
+    DictField(
+        model_name="project.task",
+        field_name="tag_ids",
+        label="Tags",
+        field_type="many2many",
+        required=False,
+        is_key=False,
+        relation_model="project.tags",
+        import_column="Tags",
+        description="Classification tags: Month-End, Tax Filing, Risk, Must-Do, etc.",
+        example_value="Month-End,Tax Filing",
+        default_value=None,
+        domain="finance",
+        sequence=100,
+    ),
+    DictField(
+        model_name="project.task",
+        field_name="priority",
+        label="Priority",
+        field_type="selection",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Priority",
+        description="Task priority: 0=Normal, 1=Important.",
+        example_value="1",
+        default_value="0",
+        domain="finance",
+        sequence=110,
+    ),
+    DictField(
+        model_name="project.task",
+        field_name="depend_on_ids",
+        label="Dependencies",
+        field_type="many2many",
+        required=False,
+        is_key=False,
+        relation_model="project.task",
+        import_column="Depends on",
+        description="Tasks that must complete before this task can start.",
+        example_value="FIN_CLOSE_DAY1_CUTOFF",
+        default_value=None,
+        domain="finance",
+        sequence=120,
+    ),
+    DictField(
+        model_name="project.task",
+        field_name="sequence",
+        label="Sequence",
+        field_type="integer",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Sequence",
+        description="Order of task in project view. Lower = earlier.",
+        example_value="10",
+        default_value="10",
+        domain="finance",
+        sequence=130,
+    ),
+    DictField(
+        model_name="project.task",
+        field_name="parent_id",
+        label="Parent Task",
+        field_type="many2one",
+        required=False,
+        is_key=False,
+        relation_model="project.task",
+        import_column="Parent Task",
+        description="Parent task if this is a subtask.",
+        example_value=None,
+        default_value=None,
+        domain="finance",
+        sequence=140,
+    ),
+    DictField(
+        model_name="project.task",
+        field_name="active",
+        label="Active",
+        field_type="boolean",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Active",
+        description="Whether the task is active.",
+        example_value="True",
+        default_value="True",
+        domain="finance",
+        sequence=150,
+    ),
+
+    # =========================================================================
+    # PROJECT.TAGS Fields
+    # =========================================================================
+    DictField(
+        model_name="project.tags",
+        field_name="x_external_ref",
+        label="External Reference",
+        field_type="char",
+        required=False,
+        is_key=True,
+        relation_model=None,
+        import_column="External ID",
+        description="Stable key for this tag.",
+        example_value="TAG_MONTH_END",
+        default_value=None,
+        domain="project",
+        sequence=10,
+    ),
+    DictField(
+        model_name="project.tags",
+        field_name="name",
+        label="Tag Name",
+        field_type="char",
+        required=True,
+        is_key=False,
+        relation_model=None,
+        import_column="Name",
+        description="Display name of the tag.",
+        example_value="Month-End",
+        default_value=None,
+        domain="project",
+        sequence=20,
+    ),
+    DictField(
+        model_name="project.tags",
+        field_name="color",
+        label="Color",
+        field_type="integer",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Color Index",
+        description="Color index (0-11) for visual differentiation.",
+        example_value="2",
+        default_value="0",
+        domain="project",
+        sequence=30,
+    ),
+
+    # =========================================================================
+    # PROJECT.TASK.TYPE (Stages) Fields
+    # =========================================================================
+    DictField(
+        model_name="project.task.type",
+        field_name="x_external_ref",
+        label="External Reference",
+        field_type="char",
+        required=False,
+        is_key=True,
+        relation_model=None,
+        import_column="External ID",
+        description="Stable key for this stage.",
+        example_value="STAGE_TODO",
+        default_value=None,
+        domain="project",
+        sequence=10,
+    ),
+    DictField(
+        model_name="project.task.type",
+        field_name="name",
+        label="Stage Name",
+        field_type="char",
+        required=True,
+        is_key=False,
+        relation_model=None,
+        import_column="Name",
+        description="Display name of the stage.",
+        example_value="To Do",
+        default_value=None,
+        domain="project",
+        sequence=20,
+    ),
+    DictField(
+        model_name="project.task.type",
+        field_name="sequence",
+        label="Sequence",
+        field_type="integer",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Sequence",
+        description="Order of stage in kanban. Lower = earlier.",
+        example_value="1",
+        default_value="1",
+        domain="project",
+        sequence=30,
+    ),
+    DictField(
+        model_name="project.task.type",
+        field_name="fold",
+        label="Folded",
+        field_type="boolean",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Folded in Kanban",
+        description="Whether this stage is collapsed by default in kanban.",
+        example_value="False",
+        default_value="False",
+        domain="project",
+        sequence=40,
+    ),
+    DictField(
+        model_name="project.task.type",
+        field_name="project_ids",
+        label="Projects",
+        field_type="many2many",
+        required=False,
+        is_key=False,
+        relation_model="project.project",
+        import_column="Projects",
+        description="Projects that use this stage.",
+        example_value="Month-end Closing & Tax Filing",
+        default_value=None,
+        domain="project",
+        sequence=50,
+    ),
+
+    # =========================================================================
+    # HR.EMPLOYEE Fields
+    # =========================================================================
+    DictField(
+        model_name="hr.employee",
+        field_name="x_external_ref",
+        label="External Reference",
+        field_type="char",
+        required=False,
+        is_key=True,
+        relation_model=None,
+        import_column="External ID",
+        description="Stable key for this employee.",
+        example_value="EMP_FINANCE_DIR",
+        default_value=None,
+        domain="hr",
+        sequence=10,
+    ),
+    DictField(
+        model_name="hr.employee",
+        field_name="name",
+        label="Employee Name",
+        field_type="char",
+        required=True,
+        is_key=False,
+        relation_model=None,
+        import_column="Name",
+        description="Full name of the employee.",
+        example_value="Rey Meran",
+        default_value=None,
+        domain="hr",
+        sequence=20,
+    ),
+    DictField(
+        model_name="hr.employee",
+        field_name="work_email",
+        label="Work Email",
+        field_type="char",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Work Email",
+        description="Corporate email address.",
+        example_value="rey.meran@tbwa.com.ph",
+        default_value=None,
+        domain="hr",
+        sequence=30,
+    ),
+    DictField(
+        model_name="hr.employee",
+        field_name="job_title",
+        label="Job Title",
+        field_type="char",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Job Title",
+        description="Current job title/position.",
+        example_value="Finance Director",
+        default_value=None,
+        domain="hr",
+        sequence=40,
+    ),
+    DictField(
+        model_name="hr.employee",
+        field_name="department_id",
+        label="Department",
+        field_type="many2one",
+        required=False,
+        is_key=False,
+        relation_model="hr.department",
+        import_column="Department",
+        description="Department this employee belongs to.",
+        example_value="Finance",
+        default_value=None,
+        domain="hr",
+        sequence=50,
+    ),
+    DictField(
+        model_name="hr.employee",
+        field_name="company_id",
+        label="Company",
+        field_type="many2one",
+        required=True,
+        is_key=False,
+        relation_model="res.company",
+        import_column="Company",
+        description="Company this employee works for.",
+        example_value="TBWA\\SMP",
+        default_value=None,
+        domain="hr",
+        sequence=60,
+    ),
+    DictField(
+        model_name="hr.employee",
+        field_name="user_id",
+        label="Related User",
+        field_type="many2one",
+        required=False,
+        is_key=False,
+        relation_model="res.users",
+        import_column="Related User",
+        description="Odoo user account linked to this employee.",
+        example_value="rey.meran@tbwa.com.ph",
+        default_value=None,
+        domain="hr",
+        sequence=70,
+    ),
+    DictField(
+        model_name="hr.employee",
+        field_name="active",
+        label="Active",
+        field_type="boolean",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Active",
+        description="Whether the employee is currently active.",
+        example_value="True",
+        default_value="True",
+        domain="hr",
+        sequence=80,
+    ),
+
+    # =========================================================================
+    # ACCOUNT.ANALYTIC.ACCOUNT Fields
+    # =========================================================================
+    DictField(
+        model_name="account.analytic.account",
+        field_name="x_external_ref",
+        label="External Reference",
+        field_type="char",
+        required=False,
+        is_key=True,
+        relation_model=None,
+        import_column="External ID",
+        description="Stable key for this analytic account.",
+        example_value="AA_FIN_CLOSE_2026",
+        default_value=None,
+        domain="finance",
+        sequence=10,
+    ),
+    DictField(
+        model_name="account.analytic.account",
+        field_name="name",
+        label="Name",
+        field_type="char",
+        required=True,
+        is_key=False,
+        relation_model=None,
+        import_column="Name",
+        description="Name of the analytic account.",
+        example_value="Finance Close 2026",
+        default_value=None,
+        domain="finance",
+        sequence=20,
+    ),
+    DictField(
+        model_name="account.analytic.account",
+        field_name="code",
+        label="Reference",
+        field_type="char",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Reference",
+        description="Short code/reference for the analytic account.",
+        example_value="FIN-CLOSE-26",
+        default_value=None,
+        domain="finance",
+        sequence=30,
+    ),
+    DictField(
+        model_name="account.analytic.account",
+        field_name="plan_id",
+        label="Analytic Plan",
+        field_type="many2one",
+        required=True,
+        is_key=False,
+        relation_model="account.analytic.plan",
+        import_column="Analytic Plan",
+        description="Plan this account belongs to.",
+        example_value="Projects",
+        default_value=None,
+        domain="finance",
+        sequence=40,
+    ),
+    DictField(
+        model_name="account.analytic.account",
+        field_name="company_id",
+        label="Company",
+        field_type="many2one",
+        required=False,
+        is_key=False,
+        relation_model="res.company",
+        import_column="Company",
+        description="Company owning this analytic account.",
+        example_value="TBWA\\SMP",
+        default_value=None,
+        domain="finance",
+        sequence=50,
+    ),
+    DictField(
+        model_name="account.analytic.account",
+        field_name="active",
+        label="Active",
+        field_type="boolean",
+        required=False,
+        is_key=False,
+        relation_model=None,
+        import_column="Active",
+        description="Whether the analytic account is active.",
+        example_value="True",
+        default_value="True",
+        domain="finance",
+        sequence=60,
+    ),
+]
+
+# Predefined templates
+TEMPLATES: list[Template] = [
+    Template(
+        slug="finance-ppm-tasks",
+        name="Finance PPM Tasks",
+        description="Full task import for month-end closing and tax filing",
+        model_name="project.task",
+        field_names=[
+            "x_external_ref", "name", "description", "project_id", "company_id",
+            "user_ids", "stage_id", "planned_hours", "date_deadline", "tag_ids",
+            "priority", "depend_on_ids", "sequence"
+        ],
+        domain="finance",
+    ),
+    Template(
+        slug="finance-ppm-tasks-minimal",
+        name="Finance PPM Tasks (Minimal)",
+        description="Minimal task import with required fields only",
+        model_name="project.task",
+        field_names=["x_external_ref", "name", "project_id", "company_id", "date_deadline"],
+        domain="finance",
+    ),
+    Template(
+        slug="finance-ppm-projects",
+        name="Finance PPM Projects",
+        description="Project import for finance programs",
+        model_name="project.project",
+        field_names=["x_external_ref", "name", "description", "company_id", "user_id", "date_start", "date"],
+        domain="finance",
+    ),
+    Template(
+        slug="project-stages",
+        name="Project Stages",
+        description="Stage definitions for project kanban",
+        model_name="project.task.type",
+        field_names=["x_external_ref", "name", "sequence", "fold"],
+        domain="project",
+    ),
+    Template(
+        slug="project-tags",
+        name="Project Tags",
+        description="Tag definitions for task categorization",
+        model_name="project.tags",
+        field_names=["x_external_ref", "name", "color"],
+        domain="project",
+    ),
+    Template(
+        slug="hr-employees",
+        name="HR Employees",
+        description="Employee master data for assignment references",
+        model_name="hr.employee",
+        field_names=["x_external_ref", "name", "work_email", "job_title", "department_id", "company_id"],
+        domain="hr",
+    ),
+    Template(
+        slug="analytic-accounts",
+        name="Analytic Accounts",
+        description="Analytic accounts for project cost tracking",
+        model_name="account.analytic.account",
+        field_names=["x_external_ref", "name", "code", "plan_id", "company_id"],
+        domain="finance",
+    ),
+]
+
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+def get_fields_for_model(model_name: str) -> list[DictField]:
+    """Get all fields for a model, sorted by sequence."""
+    fields = [f for f in FIELDS if f.model_name == model_name]
+    return sorted(fields, key=lambda f: (f.sequence, f.field_name))
+
+
+def get_fields_for_template(template: Template) -> list[DictField]:
+    """Get fields for a template in the specified order."""
+    field_map = {f.field_name: f for f in FIELDS if f.model_name == template.model_name}
+    return [field_map[name] for name in template.field_names if name in field_map]
+
+
+def get_available_models() -> list[str]:
+    """Get list of all models in the dictionary."""
+    return sorted(set(f.model_name for f in FIELDS))
+
+
+def get_template_by_slug(slug: str) -> Optional[Template]:
+    """Get template by slug."""
+    for t in TEMPLATES:
+        if t.slug == slug:
+            return t
+    return None
+
+
+# =============================================================================
+# Output Generators
+# =============================================================================
+
+def generate_csv(fields: list[DictField], include_examples: bool = False) -> str:
+    """Generate CSV content from fields."""
+    import io
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+
+    # Header row
+    headers = [f.import_column for f in fields]
+    writer.writerow(headers)
+
+    # Example row if requested
+    if include_examples:
+        examples = [f.example_value or "" for f in fields]
+        writer.writerow(examples)
+
+    return output.getvalue()
+
+
+def generate_json(fields: list[DictField], model_name: str, template_slug: Optional[str] = None) -> str:
+    """Generate JSON metadata from fields."""
+    data = {
+        "model": model_name,
+        "template": template_slug,
+        "fields": [
+            {
+                "field_name": f.field_name,
+                "import_column": f.import_column,
+                "label": f.label,
+                "field_type": f.field_type,
+                "required": f.required,
+                "is_key": f.is_key,
+                "relation_model": f.relation_model,
+                "description": f.description,
+                "example_value": f.example_value,
+                "default_value": f.default_value,
+            }
+            for f in fields
+        ],
+    }
+    return json.dumps(data, indent=2)
+
+
+def generate_xlsx(fields: list[DictField], include_examples: bool = False) -> bytes:
+    """Generate XLSX content from fields."""
+    try:
+        import openpyxl
+        from openpyxl.styles import Font, PatternFill
+    except ImportError:
+        raise ImportError("openpyxl is required for XLSX output. Install with: pip install openpyxl")
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Import Template"
+
+    # Header style
+    header_fill = PatternFill(start_color="4472C4", end_color="4472C4", fill_type="solid")
+    header_font = Font(bold=True, color="FFFFFF")
+
+    # Header row
+    for col, field in enumerate(fields, start=1):
+        cell = ws.cell(row=1, column=col, value=field.import_column)
+        cell.fill = header_fill
+        cell.font = header_font
+        ws.column_dimensions[openpyxl.utils.get_column_letter(col)].width = max(15, len(field.import_column) + 2)
+
+    # Example row if requested
+    if include_examples:
+        for col, field in enumerate(fields, start=1):
+            ws.cell(row=2, column=col, value=field.example_value or "")
+
+    # Save to bytes
+    import io
+    output = io.BytesIO()
+    wb.save(output)
+    return output.getvalue()
+
+
+# =============================================================================
+# Main CLI
+# =============================================================================
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate Odoo import templates from data dictionary",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --model project.task --output templates/
+  %(prog)s --template finance-ppm-tasks --include-examples
+  %(prog)s --list-templates
+  %(prog)s --all --output templates/
+        """,
+    )
+
+    parser.add_argument("--model", "-m", help="Model name (e.g., project.task)")
+    parser.add_argument("--template", "-t", help="Template slug (e.g., finance-ppm-tasks)")
+    parser.add_argument("--output", "-o", default=".", help="Output directory (default: .)")
+    parser.add_argument("--format", "-f", choices=["csv", "xlsx", "json"], default="csv", help="Output format")
+    parser.add_argument("--include-examples", "-e", action="store_true", help="Include example row")
+    parser.add_argument("--list-models", action="store_true", help="List available models")
+    parser.add_argument("--list-templates", action="store_true", help="List available templates")
+    parser.add_argument("--all", "-a", action="store_true", help="Generate all templates")
+
+    args = parser.parse_args()
+
+    # Handle list commands
+    if args.list_models:
+        print("Available models:")
+        for model in get_available_models():
+            field_count = len(get_fields_for_model(model))
+            print(f"  {model} ({field_count} fields)")
+        return 0
+
+    if args.list_templates:
+        print("Available templates:")
+        for t in TEMPLATES:
+            print(f"  {t.slug}")
+            print(f"    Model: {t.model_name}")
+            print(f"    Fields: {len(t.field_names)}")
+            print(f"    Description: {t.description}")
+            print()
+        return 0
+
+    # Ensure output directory exists
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Generate all templates
+    if args.all:
+        for template in TEMPLATES:
+            fields = get_fields_for_template(template)
+            generate_and_save(fields, template.model_name, template.slug, output_dir, args.format, args.include_examples)
+        print(f"Generated {len(TEMPLATES)} templates in {output_dir}")
+        return 0
+
+    # Generate single template by slug
+    if args.template:
+        template = get_template_by_slug(args.template)
+        if not template:
+            print(f"Error: Template '{args.template}' not found", file=sys.stderr)
+            print("Use --list-templates to see available templates", file=sys.stderr)
+            return 1
+        fields = get_fields_for_template(template)
+        generate_and_save(fields, template.model_name, template.slug, output_dir, args.format, args.include_examples)
+        return 0
+
+    # Generate by model name
+    if args.model:
+        fields = get_fields_for_model(args.model)
+        if not fields:
+            print(f"Error: Model '{args.model}' not found in dictionary", file=sys.stderr)
+            print("Use --list-models to see available models", file=sys.stderr)
+            return 1
+        generate_and_save(fields, args.model, None, output_dir, args.format, args.include_examples)
+        return 0
+
+    # No action specified
+    parser.print_help()
+    return 1
+
+
+def generate_and_save(
+    fields: list[DictField],
+    model_name: str,
+    template_slug: Optional[str],
+    output_dir: Path,
+    fmt: str,
+    include_examples: bool,
+):
+    """Generate template and save to file."""
+    filename_base = template_slug or model_name.replace(".", "_")
+
+    if fmt == "csv":
+        content = generate_csv(fields, include_examples)
+        filepath = output_dir / f"{filename_base}.csv"
+        filepath.write_text(content)
+    elif fmt == "json":
+        content = generate_json(fields, model_name, template_slug)
+        filepath = output_dir / f"{filename_base}.json"
+        filepath.write_text(content)
+    elif fmt == "xlsx":
+        content = generate_xlsx(fields, include_examples)
+        filepath = output_dir / f"{filename_base}.xlsx"
+        filepath.write_bytes(content)
+
+    print(f"Generated: {filepath}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/supabase/functions/odoo-template-export/index.ts
+++ b/supabase/functions/odoo-template-export/index.ts
@@ -1,0 +1,257 @@
+/**
+ * Odoo Template Export Edge Function
+ *
+ * Generates clean CSV/JSON import templates from the odoo_dict.fields data dictionary.
+ *
+ * Endpoints:
+ * - GET /odoo-template-export?model=project.task&format=csv
+ * - GET /odoo-template-export?template=finance-ppm-tasks&format=csv
+ * - GET /odoo-template-export?model=project.task&format=json (returns field metadata)
+ *
+ * Query params:
+ * - model: Odoo model name (e.g., 'project.task')
+ * - template: Predefined template slug (e.g., 'finance-ppm-tasks')
+ * - format: 'csv' | 'json' (default: 'csv')
+ * - include_examples: 'true' to include example row (csv only)
+ */
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+interface DictField {
+  id: number;
+  model_name: string;
+  field_name: string;
+  label: string;
+  field_type: string;
+  required: boolean;
+  is_key: boolean;
+  relation_model: string | null;
+  import_column: string;
+  description: string | null;
+  example_value: string | null;
+  default_value: string | null;
+  domain: string;
+  sequence: number;
+}
+
+interface Template {
+  slug: string;
+  name: string;
+  description: string | null;
+  model_name: string;
+  field_names: string[];
+}
+
+Deno.serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const url = new URL(req.url);
+    const modelName = url.searchParams.get("model");
+    const templateSlug = url.searchParams.get("template");
+    const format = url.searchParams.get("format") || "csv";
+    const includeExamples = url.searchParams.get("include_examples") === "true";
+
+    if (!modelName && !templateSlug) {
+      return new Response(
+        JSON.stringify({
+          error: "Missing required parameter: 'model' or 'template'",
+          usage: {
+            by_model: "?model=project.task&format=csv",
+            by_template: "?template=finance-ppm-tasks&format=csv",
+          },
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Initialize Supabase client
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    let fields: DictField[] = [];
+    let templateInfo: Template | null = null;
+
+    if (templateSlug) {
+      // Fetch template first
+      const { data: template, error: tplError } = await supabase
+        .from("odoo_dict.templates")
+        .select("*")
+        .eq("slug", templateSlug)
+        .eq("is_active", true)
+        .single();
+
+      if (tplError || !template) {
+        return new Response(
+          JSON.stringify({
+            error: `Template not found: ${templateSlug}`,
+            available: await getAvailableTemplates(supabase),
+          }),
+          {
+            status: 404,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          }
+        );
+      }
+
+      templateInfo = template as Template;
+
+      // Fetch fields in template order
+      const { data: fieldData, error: fieldError } = await supabase
+        .from("odoo_dict.fields")
+        .select("*")
+        .eq("model_name", template.model_name)
+        .in("field_name", template.field_names)
+        .eq("is_active", true);
+
+      if (fieldError) {
+        throw fieldError;
+      }
+
+      // Reorder fields according to template.field_names
+      const fieldMap = new Map(
+        (fieldData as DictField[]).map((f) => [f.field_name, f])
+      );
+      fields = template.field_names
+        .map((name: string) => fieldMap.get(name))
+        .filter(Boolean) as DictField[];
+    } else if (modelName) {
+      // Fetch all active fields for model
+      const { data, error } = await supabase
+        .from("odoo_dict.fields")
+        .select("*")
+        .eq("model_name", modelName)
+        .eq("is_active", true)
+        .order("sequence", { ascending: true })
+        .order("id", { ascending: true });
+
+      if (error) {
+        throw error;
+      }
+
+      if (!data || data.length === 0) {
+        return new Response(
+          JSON.stringify({
+            error: `No fields found for model: ${modelName}`,
+            available: await getAvailableModels(supabase),
+          }),
+          {
+            status: 404,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          }
+        );
+      }
+
+      fields = data as DictField[];
+    }
+
+    // Generate output based on format
+    if (format === "json") {
+      return new Response(
+        JSON.stringify(
+          {
+            model: modelName || templateInfo?.model_name,
+            template: templateSlug || null,
+            fields: fields.map((f) => ({
+              field_name: f.field_name,
+              import_column: f.import_column,
+              label: f.label,
+              field_type: f.field_type,
+              required: f.required,
+              is_key: f.is_key,
+              relation_model: f.relation_model,
+              description: f.description,
+              example_value: f.example_value,
+              default_value: f.default_value,
+            })),
+          },
+          null,
+          2
+        ),
+        {
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // CSV format
+    const headers = fields.map((f) => f.import_column);
+    const csvRows: string[] = [headers.map(escapeCSV).join(",")];
+
+    if (includeExamples) {
+      const exampleRow = fields.map((f) => f.example_value || "");
+      csvRows.push(exampleRow.map(escapeCSV).join(","));
+    }
+
+    const csvContent = csvRows.join("\n");
+    const filename =
+      templateSlug ||
+      modelName?.replace(/\./g, "_") ||
+      "odoo_import_template";
+
+    return new Response(csvContent, {
+      headers: {
+        ...corsHeaders,
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}.csv"`,
+      },
+    });
+  } catch (error) {
+    console.error("Error:", error);
+    return new Response(
+      JSON.stringify({
+        error: "Internal server error",
+        details: error instanceof Error ? error.message : String(error),
+      }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  }
+});
+
+function escapeCSV(value: string): string {
+  if (!value) return "";
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+async function getAvailableModels(
+  supabase: ReturnType<typeof createClient>
+): Promise<string[]> {
+  const { data } = await supabase
+    .from("odoo_dict.fields")
+    .select("model_name")
+    .eq("is_active", true);
+
+  if (!data) return [];
+  return [...new Set(data.map((r) => r.model_name))].sort();
+}
+
+async function getAvailableTemplates(
+  supabase: ReturnType<typeof createClient>
+): Promise<string[]> {
+  const { data } = await supabase
+    .from("odoo_dict.templates")
+    .select("slug")
+    .eq("is_active", true);
+
+  if (!data) return [];
+  return data.map((r) => r.slug).sort();
+}

--- a/supabase/migrations/20260121100001_odoo_data_dictionary.sql
+++ b/supabase/migrations/20260121100001_odoo_data_dictionary.sql
@@ -1,0 +1,283 @@
+-- =============================================================================
+-- Migration: Odoo Data Dictionary
+-- Purpose: Schema-as-records for Odoo import template generation
+-- Pattern: Data dictionary drives CSV/XLSX template headers + validation
+-- Integration: Complements odoo_seed schema (20260121_odoo_seed_schema.sql)
+-- =============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------------------------
+-- Schema: odoo_dict
+-- Stores field definitions that describe how to import data into Odoo models
+-- -----------------------------------------------------------------------------
+
+CREATE SCHEMA IF NOT EXISTS odoo_dict;
+
+COMMENT ON SCHEMA odoo_dict IS
+'Canonical data dictionary for Odoo field definitions. Drives template generation and import validation.';
+
+-- -----------------------------------------------------------------------------
+-- 1. Fields Table (the data dictionary core)
+-- Each row describes one field in an Odoo model for import purposes
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS odoo_dict.fields (
+    id                bigserial PRIMARY KEY,
+
+    -- Model identification
+    model_name        text NOT NULL,              -- e.g., 'project.task', 'project.project'
+    field_name        text NOT NULL,              -- technical field name, e.g., 'name', 'x_external_ref'
+
+    -- Display
+    label             text NOT NULL,              -- human-friendly label
+
+    -- Type information
+    field_type        text NOT NULL,              -- e.g., 'char', 'many2one', 'date', 'float', 'many2many'
+    relation_model    text,                       -- target model for many2one/many2many
+
+    -- Import behavior
+    import_column     text NOT NULL,              -- exact header text for CSV/XLSX import
+    required          boolean NOT NULL DEFAULT false,
+    is_key            boolean NOT NULL DEFAULT false,  -- true for External ID fields
+
+    -- Documentation
+    description       text,                       -- business meaning (e.g., finance PPM context)
+    example_value     text,                       -- sample value for templates
+    default_value     text,                       -- default if not provided in import
+
+    -- Categorization
+    domain            text DEFAULT 'general',     -- e.g., 'finance', 'hr', 'project'
+    module_required   text,                       -- Odoo module that must be installed (null = core)
+
+    -- Template ordering
+    sequence          int NOT NULL DEFAULT 100,   -- column order in generated templates
+
+    -- Status
+    is_active         boolean NOT NULL DEFAULT true,
+
+    -- Audit
+    created_at        timestamptz NOT NULL DEFAULT now(),
+    updated_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_odoo_dict_fields_model_field
+    ON odoo_dict.fields (model_name, field_name);
+
+CREATE INDEX IF NOT EXISTS idx_odoo_dict_fields_model
+    ON odoo_dict.fields (model_name);
+
+CREATE INDEX IF NOT EXISTS idx_odoo_dict_fields_domain
+    ON odoo_dict.fields (domain);
+
+CREATE INDEX IF NOT EXISTS idx_odoo_dict_fields_active
+    ON odoo_dict.fields (is_active) WHERE is_active = true;
+
+COMMENT ON TABLE odoo_dict.fields IS
+'Data dictionary for Odoo import fields. Each row defines one field for template generation and validation.';
+
+-- -----------------------------------------------------------------------------
+-- 2. Templates Table (predefined column sets for specific use cases)
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS odoo_dict.templates (
+    id                bigserial PRIMARY KEY,
+
+    -- Template identification
+    slug              text UNIQUE NOT NULL,       -- e.g., 'finance-ppm-tasks', 'hr-employees'
+    name              text NOT NULL,              -- human-friendly name
+    description       text,
+
+    -- Target model
+    model_name        text NOT NULL,              -- primary model this template imports
+
+    -- Field selection (ordered)
+    field_names       text[] NOT NULL,            -- array of field_name values to include
+
+    -- Metadata
+    domain            text DEFAULT 'general',
+    is_active         boolean NOT NULL DEFAULT true,
+
+    -- Audit
+    created_at        timestamptz NOT NULL DEFAULT now(),
+    updated_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_odoo_dict_templates_model
+    ON odoo_dict.templates (model_name);
+
+CREATE INDEX IF NOT EXISTS idx_odoo_dict_templates_domain
+    ON odoo_dict.templates (domain);
+
+COMMENT ON TABLE odoo_dict.templates IS
+'Predefined template configurations for specific import use cases.';
+
+-- -----------------------------------------------------------------------------
+-- 3. Import Runs Log (audit trail for template-based imports)
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS odoo_dict.import_runs (
+    id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Template reference
+    template_slug     text REFERENCES odoo_dict.templates(slug),
+    model_name        text NOT NULL,
+
+    -- Run metadata
+    started_at        timestamptz NOT NULL DEFAULT now(),
+    completed_at      timestamptz,
+
+    -- Results
+    status            text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'running', 'success', 'partial', 'failed')),
+    rows_total        int DEFAULT 0,
+    rows_imported     int DEFAULT 0,
+    rows_skipped      int DEFAULT 0,
+    rows_failed       int DEFAULT 0,
+
+    -- Errors
+    error_log         jsonb DEFAULT '[]'::jsonb,
+
+    -- Source
+    source_file       text,                       -- original filename
+    triggered_by      text                        -- 'manual', 'workflow', 'api'
+);
+
+CREATE INDEX IF NOT EXISTS idx_odoo_dict_import_runs_status
+    ON odoo_dict.import_runs (status);
+
+CREATE INDEX IF NOT EXISTS idx_odoo_dict_import_runs_template
+    ON odoo_dict.import_runs (template_slug);
+
+COMMENT ON TABLE odoo_dict.import_runs IS
+'Audit log of template-based imports for traceability.';
+
+-- -----------------------------------------------------------------------------
+-- 4. Updated_at Trigger
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION odoo_dict.set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_fields_updated
+    BEFORE UPDATE ON odoo_dict.fields
+    FOR EACH ROW EXECUTE FUNCTION odoo_dict.set_updated_at();
+
+CREATE TRIGGER trg_templates_updated
+    BEFORE UPDATE ON odoo_dict.templates
+    FOR EACH ROW EXECUTE FUNCTION odoo_dict.set_updated_at();
+
+-- -----------------------------------------------------------------------------
+-- 5. Helper Functions for Template Generation
+-- -----------------------------------------------------------------------------
+
+-- Get ordered import columns for a model
+CREATE OR REPLACE FUNCTION odoo_dict.get_import_headers(p_model_name text)
+RETURNS TABLE (import_column text) AS $$
+    SELECT f.import_column
+    FROM odoo_dict.fields f
+    WHERE f.model_name = p_model_name
+      AND f.is_active = true
+    ORDER BY f.sequence, f.id;
+$$ LANGUAGE sql STABLE;
+
+COMMENT ON FUNCTION odoo_dict.get_import_headers(text) IS
+'Returns ordered import column headers for a model.';
+
+-- Get ordered import columns for a template
+CREATE OR REPLACE FUNCTION odoo_dict.get_template_headers(p_template_slug text)
+RETURNS TABLE (import_column text, field_name text, required boolean) AS $$
+    SELECT f.import_column, f.field_name, f.required
+    FROM odoo_dict.templates t
+    CROSS JOIN LATERAL unnest(t.field_names) WITH ORDINALITY AS fn(name, ord)
+    JOIN odoo_dict.fields f ON f.model_name = t.model_name AND f.field_name = fn.name
+    WHERE t.slug = p_template_slug
+      AND f.is_active = true
+    ORDER BY fn.ord;
+$$ LANGUAGE sql STABLE;
+
+COMMENT ON FUNCTION odoo_dict.get_template_headers(text) IS
+'Returns ordered import column headers for a predefined template.';
+
+-- Validate import data against dictionary
+CREATE OR REPLACE FUNCTION odoo_dict.validate_import_headers(
+    p_model_name text,
+    p_headers text[]
+)
+RETURNS TABLE (
+    header text,
+    status text,
+    field_name text,
+    message text
+) AS $$
+DECLARE
+    h text;
+    f_record RECORD;
+BEGIN
+    -- Check each provided header
+    FOREACH h IN ARRAY p_headers LOOP
+        SELECT f.field_name, f.required INTO f_record
+        FROM odoo_dict.fields f
+        WHERE f.model_name = p_model_name
+          AND f.import_column = h
+          AND f.is_active = true;
+
+        IF f_record.field_name IS NOT NULL THEN
+            RETURN QUERY SELECT h, 'valid'::text, f_record.field_name, NULL::text;
+        ELSE
+            RETURN QUERY SELECT h, 'unknown'::text, NULL::text, 'Header not in data dictionary'::text;
+        END IF;
+    END LOOP;
+
+    -- Check for missing required fields
+    FOR f_record IN
+        SELECT f.import_column, f.field_name
+        FROM odoo_dict.fields f
+        WHERE f.model_name = p_model_name
+          AND f.required = true
+          AND f.is_active = true
+          AND f.import_column != ALL(p_headers)
+    LOOP
+        RETURN QUERY SELECT f_record.import_column, 'missing'::text, f_record.field_name, 'Required field not in headers'::text;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION odoo_dict.validate_import_headers(text, text[]) IS
+'Validates import CSV headers against the data dictionary. Returns status per header.';
+
+-- -----------------------------------------------------------------------------
+-- 6. RLS Policies
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE odoo_dict.fields ENABLE ROW LEVEL SECURITY;
+ALTER TABLE odoo_dict.templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE odoo_dict.import_runs ENABLE ROW LEVEL SECURITY;
+
+-- Service role full access
+CREATE POLICY "Service role full access to fields"
+    ON odoo_dict.fields FOR ALL
+    USING (auth.role() = 'service_role');
+
+CREATE POLICY "Service role full access to templates"
+    ON odoo_dict.templates FOR ALL
+    USING (auth.role() = 'service_role');
+
+CREATE POLICY "Service role full access to import_runs"
+    ON odoo_dict.import_runs FOR ALL
+    USING (auth.role() = 'service_role');
+
+-- Authenticated users can read (for template generation)
+CREATE POLICY "Authenticated users can read fields"
+    ON odoo_dict.fields FOR SELECT
+    USING (auth.role() = 'authenticated');
+
+CREATE POLICY "Authenticated users can read templates"
+    ON odoo_dict.templates FOR SELECT
+    USING (auth.role() = 'authenticated');
+
+COMMIT;

--- a/supabase/seeds/003_odoo_dict_seed.sql
+++ b/supabase/seeds/003_odoo_dict_seed.sql
@@ -1,0 +1,426 @@
+-- =============================================================================
+-- Seed: Odoo Data Dictionary - Finance PPM Fields
+-- Purpose: Populate odoo_dict.fields with finance PPM model definitions
+-- Models: project.project, project.task, hr.employee, project.tags
+-- =============================================================================
+
+-- Clear existing entries for idempotent seed
+TRUNCATE TABLE odoo_dict.templates RESTART IDENTITY CASCADE;
+TRUNCATE TABLE odoo_dict.fields RESTART IDENTITY CASCADE;
+
+-- =============================================================================
+-- PROJECT.PROJECT Fields
+-- =============================================================================
+
+INSERT INTO odoo_dict.fields (
+    model_name, field_name, label, field_type, required, is_key,
+    relation_model, import_column, description, example_value, default_value,
+    domain, sequence
+) VALUES
+-- Key field
+('project.project', 'x_external_ref', 'External Reference', 'char', true, true,
+ NULL, 'External ID',
+ 'Stable key for this project across environments. Used for idempotent imports.',
+ 'FIN_CLOSE_TBWA', NULL,
+ 'project', 10),
+
+-- Core fields
+('project.project', 'name', 'Project Name', 'char', true, false,
+ NULL, 'Name',
+ 'Human-friendly project name displayed in UI.',
+ 'Month-end Closing & Tax Filing', NULL,
+ 'project', 20),
+
+('project.project', 'description', 'Description', 'html', false, false,
+ NULL, 'Description',
+ 'Rich text description of the project scope and objectives.',
+ '<p>Finance PPM for month-end close and BIR tax compliance</p>', NULL,
+ 'project', 30),
+
+-- Relational fields
+('project.project', 'partner_id', 'Customer', 'many2one', false, false,
+ 'res.partner', 'Customer',
+ 'Legal entity or client owning this project. Can be internal or external.',
+ 'TBWA SMP', NULL,
+ 'project', 40),
+
+('project.project', 'company_id', 'Company', 'many2one', true, false,
+ 'res.company', 'Company',
+ 'Odoo company owning this project. Required for multi-company finance.',
+ 'TBWA\\SMP', NULL,
+ 'project', 50),
+
+('project.project', 'user_id', 'Project Manager', 'many2one', false, false,
+ 'res.users', 'Project Manager',
+ 'User responsible for overall project delivery.',
+ 'Rey Meran', NULL,
+ 'project', 60),
+
+-- Settings (CE-compatible)
+('project.project', 'privacy_visibility', 'Visibility', 'selection', false, false,
+ NULL, 'Visibility',
+ 'Who can see this project: portal (external), employees, or followers only.',
+ 'employees', 'employees',
+ 'project', 70),
+
+('project.project', 'allow_task_dependencies', 'Allow Dependencies', 'boolean', false, false,
+ NULL, 'Allow Task Dependencies',
+ 'Enable task dependency tracking (CE feature).',
+ 'True', 'True',
+ 'project', 80),
+
+-- Dates
+('project.project', 'date_start', 'Start Date', 'date', false, false,
+ NULL, 'Start Date',
+ 'Planned project start date.',
+ '2026-01-01', NULL,
+ 'project', 90),
+
+('project.project', 'date', 'End Date', 'date', false, false,
+ NULL, 'Deadline',
+ 'Planned project end date or deadline.',
+ '2026-12-31', NULL,
+ 'project', 100),
+
+-- Status
+('project.project', 'active', 'Active', 'boolean', false, false,
+ NULL, 'Active',
+ 'Whether the project is active. Inactive projects are archived.',
+ 'True', 'True',
+ 'project', 110);
+
+-- =============================================================================
+-- PROJECT.TASK Fields
+-- =============================================================================
+
+INSERT INTO odoo_dict.fields (
+    model_name, field_name, label, field_type, required, is_key,
+    relation_model, import_column, description, example_value, default_value,
+    domain, sequence
+) VALUES
+-- Key field
+('project.task', 'x_external_ref', 'External Reference', 'char', true, true,
+ NULL, 'External ID',
+ 'Stable key for this task. Used for idempotent imports and dependency references.',
+ 'FIN_CLOSE_DAY3_TRIALBAL', NULL,
+ 'finance', 10),
+
+-- Core fields
+('project.task', 'name', 'Task Name', 'char', true, false,
+ NULL, 'Name of the Tasks?',
+ 'Name of the finance/closing task.',
+ 'Post Trial Balance & Adjustments', NULL,
+ 'finance', 20),
+
+('project.task', 'description', 'Description', 'html', false, false,
+ NULL, 'Description',
+ 'Rich text description of what this task entails.',
+ '<p>Run trial balance, post adjusting entries, verify account reconciliations</p>', NULL,
+ 'finance', 30),
+
+-- Project linkage
+('project.task', 'project_id', 'Project', 'many2one', true, false,
+ 'project.project', 'Project',
+ 'Parent project containing this task.',
+ 'Month-end Closing & Tax Filing', NULL,
+ 'finance', 40),
+
+-- Company (multi-company)
+('project.task', 'company_id', 'Company', 'many2one', true, false,
+ 'res.company', 'Company',
+ 'Odoo company for multi-company finance setup.',
+ 'TBWA\\SMP', NULL,
+ 'finance', 50),
+
+-- Assignment
+('project.task', 'user_ids', 'Assigned to', 'many2many', false, false,
+ 'res.users', 'Assigned to',
+ 'One or more assignees (Finance Director, Sr Finance Manager, etc.).',
+ 'Rey Meran', NULL,
+ 'finance', 60),
+
+-- Stage
+('project.task', 'stage_id', 'Stage', 'many2one', false, false,
+ 'project.task.type', 'Stage',
+ 'Current workflow stage of the task.',
+ 'To Do', 'To Do',
+ 'finance', 70),
+
+-- Planning
+('project.task', 'planned_hours', 'Allocated Time', 'float', false, false,
+ NULL, 'Allocated Time',
+ 'Planned effort in hours for this task per cycle.',
+ '4.0', '0',
+ 'finance', 80),
+
+('project.task', 'date_deadline', 'Deadline', 'date', true, false,
+ NULL, 'Planned Date',
+ 'Operational due date (e.g., Day 3, Day 5, BIR statutory cutoffs).',
+ '2026-01-05', NULL,
+ 'finance', 90),
+
+-- Tags
+('project.task', 'tag_ids', 'Tags', 'many2many', false, false,
+ 'project.tags', 'Tags',
+ 'Classification tags: Month-End, Tax Filing, Risk, Must-Do, etc.',
+ 'Month-End,Tax Filing', NULL,
+ 'finance', 100),
+
+-- Priority
+('project.task', 'priority', 'Priority', 'selection', false, false,
+ NULL, 'Priority',
+ 'Task priority: 0=Normal, 1=Important.',
+ '1', '0',
+ 'finance', 110),
+
+-- Dependencies (CE feature)
+('project.task', 'depend_on_ids', 'Dependencies', 'many2many', false, false,
+ 'project.task', 'Depends on',
+ 'Tasks that must complete before this task can start.',
+ 'FIN_CLOSE_DAY1_CUTOFF', NULL,
+ 'finance', 120),
+
+-- Sequence
+('project.task', 'sequence', 'Sequence', 'integer', false, false,
+ NULL, 'Sequence',
+ 'Order of task in project view. Lower = earlier.',
+ '10', '10',
+ 'finance', 130),
+
+-- Parent task (for subtasks)
+('project.task', 'parent_id', 'Parent Task', 'many2one', false, false,
+ 'project.task', 'Parent Task',
+ 'Parent task if this is a subtask.',
+ NULL, NULL,
+ 'finance', 140),
+
+-- Status
+('project.task', 'active', 'Active', 'boolean', false, false,
+ NULL, 'Active',
+ 'Whether the task is active. Inactive tasks are archived.',
+ 'True', 'True',
+ 'finance', 150);
+
+-- =============================================================================
+-- PROJECT.TAGS Fields
+-- =============================================================================
+
+INSERT INTO odoo_dict.fields (
+    model_name, field_name, label, field_type, required, is_key,
+    relation_model, import_column, description, example_value, default_value,
+    domain, sequence
+) VALUES
+-- Key field
+('project.tags', 'x_external_ref', 'External Reference', 'char', false, true,
+ NULL, 'External ID',
+ 'Stable key for this tag.',
+ 'TAG_MONTH_END', NULL,
+ 'project', 10),
+
+-- Core fields
+('project.tags', 'name', 'Tag Name', 'char', true, false,
+ NULL, 'Name',
+ 'Display name of the tag.',
+ 'Month-End', NULL,
+ 'project', 20),
+
+('project.tags', 'color', 'Color', 'integer', false, false,
+ NULL, 'Color Index',
+ 'Color index (0-11) for visual differentiation.',
+ '2', '0',
+ 'project', 30);
+
+-- =============================================================================
+-- PROJECT.TASK.TYPE (Stages) Fields
+-- =============================================================================
+
+INSERT INTO odoo_dict.fields (
+    model_name, field_name, label, field_type, required, is_key,
+    relation_model, import_column, description, example_value, default_value,
+    domain, sequence
+) VALUES
+-- Key field
+('project.task.type', 'x_external_ref', 'External Reference', 'char', false, true,
+ NULL, 'External ID',
+ 'Stable key for this stage.',
+ 'STAGE_TODO', NULL,
+ 'project', 10),
+
+-- Core fields
+('project.task.type', 'name', 'Stage Name', 'char', true, false,
+ NULL, 'Name',
+ 'Display name of the stage.',
+ 'To Do', NULL,
+ 'project', 20),
+
+('project.task.type', 'sequence', 'Sequence', 'integer', false, false,
+ NULL, 'Sequence',
+ 'Order of stage in kanban. Lower = earlier.',
+ '1', '1',
+ 'project', 30),
+
+('project.task.type', 'fold', 'Folded', 'boolean', false, false,
+ NULL, 'Folded in Kanban',
+ 'Whether this stage is collapsed by default in kanban.',
+ 'False', 'False',
+ 'project', 40),
+
+('project.task.type', 'project_ids', 'Projects', 'many2many', false, false,
+ 'project.project', 'Projects',
+ 'Projects that use this stage.',
+ 'Month-end Closing & Tax Filing', NULL,
+ 'project', 50);
+
+-- =============================================================================
+-- HR.EMPLOYEE Fields (for assignee reference)
+-- =============================================================================
+
+INSERT INTO odoo_dict.fields (
+    model_name, field_name, label, field_type, required, is_key,
+    relation_model, import_column, description, example_value, default_value,
+    domain, sequence
+) VALUES
+-- Key field
+('hr.employee', 'x_external_ref', 'External Reference', 'char', false, true,
+ NULL, 'External ID',
+ 'Stable key for this employee.',
+ 'EMP_FINANCE_DIR', NULL,
+ 'hr', 10),
+
+-- Core fields
+('hr.employee', 'name', 'Employee Name', 'char', true, false,
+ NULL, 'Name',
+ 'Full name of the employee.',
+ 'Rey Meran', NULL,
+ 'hr', 20),
+
+('hr.employee', 'work_email', 'Work Email', 'char', false, false,
+ NULL, 'Work Email',
+ 'Corporate email address.',
+ 'rey.meran@tbwa.com.ph', NULL,
+ 'hr', 30),
+
+('hr.employee', 'job_title', 'Job Title', 'char', false, false,
+ NULL, 'Job Title',
+ 'Current job title/position.',
+ 'Finance Director', NULL,
+ 'hr', 40),
+
+('hr.employee', 'department_id', 'Department', 'many2one', false, false,
+ 'hr.department', 'Department',
+ 'Department this employee belongs to.',
+ 'Finance', NULL,
+ 'hr', 50),
+
+('hr.employee', 'company_id', 'Company', 'many2one', true, false,
+ 'res.company', 'Company',
+ 'Company this employee works for.',
+ 'TBWA\\SMP', NULL,
+ 'hr', 60),
+
+('hr.employee', 'user_id', 'Related User', 'many2one', false, false,
+ 'res.users', 'Related User',
+ 'Odoo user account linked to this employee.',
+ 'rey.meran@tbwa.com.ph', NULL,
+ 'hr', 70),
+
+('hr.employee', 'active', 'Active', 'boolean', false, false,
+ NULL, 'Active',
+ 'Whether the employee is currently active.',
+ 'True', 'True',
+ 'hr', 80);
+
+-- =============================================================================
+-- ACCOUNT.ANALYTIC.ACCOUNT Fields (for project cost tracking)
+-- =============================================================================
+
+INSERT INTO odoo_dict.fields (
+    model_name, field_name, label, field_type, required, is_key,
+    relation_model, import_column, description, example_value, default_value,
+    domain, sequence
+) VALUES
+-- Key field
+('account.analytic.account', 'x_external_ref', 'External Reference', 'char', false, true,
+ NULL, 'External ID',
+ 'Stable key for this analytic account.',
+ 'AA_FIN_CLOSE_2026', NULL,
+ 'finance', 10),
+
+-- Core fields
+('account.analytic.account', 'name', 'Name', 'char', true, false,
+ NULL, 'Name',
+ 'Name of the analytic account.',
+ 'Finance Close 2026', NULL,
+ 'finance', 20),
+
+('account.analytic.account', 'code', 'Reference', 'char', false, false,
+ NULL, 'Reference',
+ 'Short code/reference for the analytic account.',
+ 'FIN-CLOSE-26', NULL,
+ 'finance', 30),
+
+('account.analytic.account', 'plan_id', 'Analytic Plan', 'many2one', true, false,
+ 'account.analytic.plan', 'Analytic Plan',
+ 'Plan this account belongs to.',
+ 'Projects', NULL,
+ 'finance', 40),
+
+('account.analytic.account', 'company_id', 'Company', 'many2one', false, false,
+ 'res.company', 'Company',
+ 'Company owning this analytic account.',
+ 'TBWA\\SMP', NULL,
+ 'finance', 50),
+
+('account.analytic.account', 'active', 'Active', 'boolean', false, false,
+ NULL, 'Active',
+ 'Whether the analytic account is active.',
+ 'True', 'True',
+ 'finance', 60);
+
+-- =============================================================================
+-- PREDEFINED TEMPLATES
+-- =============================================================================
+
+INSERT INTO odoo_dict.templates (slug, name, description, model_name, field_names, domain)
+VALUES
+-- Finance PPM Tasks (full)
+('finance-ppm-tasks', 'Finance PPM Tasks', 'Full task import for month-end closing and tax filing',
+ 'project.task',
+ ARRAY['x_external_ref', 'name', 'description', 'project_id', 'company_id', 'user_ids', 'stage_id', 'planned_hours', 'date_deadline', 'tag_ids', 'priority', 'depend_on_ids', 'sequence'],
+ 'finance'),
+
+-- Finance PPM Tasks (minimal)
+('finance-ppm-tasks-minimal', 'Finance PPM Tasks (Minimal)', 'Minimal task import with required fields only',
+ 'project.task',
+ ARRAY['x_external_ref', 'name', 'project_id', 'company_id', 'date_deadline'],
+ 'finance'),
+
+-- Finance Projects
+('finance-ppm-projects', 'Finance PPM Projects', 'Project import for finance programs',
+ 'project.project',
+ ARRAY['x_external_ref', 'name', 'description', 'company_id', 'user_id', 'date_start', 'date'],
+ 'finance'),
+
+-- Task Stages
+('project-stages', 'Project Stages', 'Stage definitions for project kanban',
+ 'project.task.type',
+ ARRAY['x_external_ref', 'name', 'sequence', 'fold'],
+ 'project'),
+
+-- Project Tags
+('project-tags', 'Project Tags', 'Tag definitions for task categorization',
+ 'project.tags',
+ ARRAY['x_external_ref', 'name', 'color'],
+ 'project'),
+
+-- HR Employees
+('hr-employees', 'HR Employees', 'Employee master data for assignment references',
+ 'hr.employee',
+ ARRAY['x_external_ref', 'name', 'work_email', 'job_title', 'department_id', 'company_id'],
+ 'hr'),
+
+-- Analytic Accounts
+('analytic-accounts', 'Analytic Accounts', 'Analytic accounts for project cost tracking',
+ 'account.analytic.account',
+ ARRAY['x_external_ref', 'name', 'code', 'plan_id', 'company_id'],
+ 'finance');


### PR DESCRIPTION
Implements a data-dictionary-as-records approach where field definitions are stored in Supabase and drive CSV/XLSX template generation.

Components:
- odoo_dict schema with fields, templates, and import_runs tables
- Helper SQL functions for header generation and validation
- Supabase edge function for HTTP-based template export
- Python script for local template generation without Supabase
- Documentation for the export template system

Models covered: project.project, project.task, project.tags, project.task.type, hr.employee, account.analytic.account

Templates: finance-ppm-tasks, finance-ppm-projects, project-stages, project-tags, hr-employees, analytic-accounts

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Supabase security review | [View](https://hub.continue.dev/tasks/b083b265-1bdd-4959-84db-db3ab8a422be) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->