### PR TITLE
feat(ci): add Docker image diff tooling

### DIFF
--- a/.github/workflows/image-diff.yml
+++ b/.github/workflows/image-diff.yml
@@ -1,0 +1,262 @@
+# =============================================================================
+# GitHub Actions: Docker Image Diff
+# =============================================================================
+# Compares production Odoo image against target/edge build.
+# Generates diff reports for:
+#   - Layer history
+#   - Pip packages
+#   - Odoo addons
+#   - Configuration
+#
+# Triggers:
+#   - Manual workflow dispatch
+#   - After successful build-unified-image runs
+#
+# Outputs:
+#   - Markdown diff report as workflow artifact
+#   - JSON summary for downstream automation
+#   - Optional PR comment with diff summary
+# =============================================================================
+
+name: Docker Image Diff
+
+on:
+  workflow_dispatch:
+    inputs:
+      live_image:
+        description: 'Production/live image to compare'
+        required: true
+        default: 'ghcr.io/jgtolentino/odoo-ce:latest'
+        type: string
+      target_image:
+        description: 'Target/new image to compare against'
+        required: true
+        default: 'ghcr.io/jgtolentino/odoo-ce:edge-standard'
+        type: string
+      add_pr_comment:
+        description: 'Add diff summary as PR comment'
+        required: false
+        default: 'false'
+        type: boolean
+      pr_number:
+        description: 'PR number for comment (if add_pr_comment is true)'
+        required: false
+        type: string
+
+  workflow_run:
+    workflows: ["Build IPAI Odoo Images"]
+    types:
+      - completed
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: jgtolentino/odoo-ce
+
+jobs:
+  # ===========================================================================
+  # Run Image Diff
+  # ===========================================================================
+  diff:
+    name: Compare Images
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+
+    outputs:
+      size_diff_mb: ${{ steps.diff.outputs.size_diff_mb }}
+      pip_added: ${{ steps.diff.outputs.pip_added }}
+      pip_removed: ${{ steps.diff.outputs.pip_removed }}
+
+    steps:
+      # -----------------------------------------------------------------------
+      # Checkout
+      # -----------------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # -----------------------------------------------------------------------
+      # Registry Login
+      # -----------------------------------------------------------------------
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # -----------------------------------------------------------------------
+      # Determine Images
+      # -----------------------------------------------------------------------
+      - name: Determine images to compare
+        id: images
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "live=${{ github.event.inputs.live_image }}" >> $GITHUB_OUTPUT
+            echo "target=${{ github.event.inputs.target_image }}" >> $GITHUB_OUTPUT
+          else
+            # Auto-triggered after build: compare latest vs edge
+            echo "live=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
+            echo "target=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:edge-standard" >> $GITHUB_OUTPUT
+          fi
+
+      # -----------------------------------------------------------------------
+      # Run Diff Script
+      # -----------------------------------------------------------------------
+      - name: Run image diff
+        id: diff
+        run: |
+          chmod +x ./scripts/ci/docker-image-diff.sh
+
+          OUTPUT_DIR="/tmp/image-diff-${{ github.run_id }}"
+
+          ./scripts/ci/docker-image-diff.sh \
+            "${{ steps.images.outputs.live }}" \
+            "${{ steps.images.outputs.target }}" \
+            "$OUTPUT_DIR"
+
+          # Export outputs for downstream steps
+          if [ -f "$OUTPUT_DIR/summary/diff_summary.json" ]; then
+            SIZE_DIFF=$(jq -r '.size_diff_mb' "$OUTPUT_DIR/summary/diff_summary.json")
+            PIP_ADDED=$(jq -r '.pip_added' "$OUTPUT_DIR/summary/diff_summary.json")
+            PIP_REMOVED=$(jq -r '.pip_removed' "$OUTPUT_DIR/summary/diff_summary.json")
+
+            echo "size_diff_mb=$SIZE_DIFF" >> $GITHUB_OUTPUT
+            echo "pip_added=$PIP_ADDED" >> $GITHUB_OUTPUT
+            echo "pip_removed=$PIP_REMOVED" >> $GITHUB_OUTPUT
+          fi
+
+          echo "output_dir=$OUTPUT_DIR" >> $GITHUB_OUTPUT
+
+      # -----------------------------------------------------------------------
+      # Upload Artifacts
+      # -----------------------------------------------------------------------
+      - name: Upload diff report
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-diff-report-${{ github.run_id }}
+          path: /tmp/image-diff-${{ github.run_id }}/
+          retention-days: 30
+
+      # -----------------------------------------------------------------------
+      # Job Summary
+      # -----------------------------------------------------------------------
+      - name: Write job summary
+        run: |
+          OUTPUT_DIR="/tmp/image-diff-${{ github.run_id }}"
+
+          echo "## Docker Image Diff Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Live Image:** \`${{ steps.images.outputs.live }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Target Image:** \`${{ steps.images.outputs.target }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ -f "$OUTPUT_DIR/summary/diff_summary.json" ]; then
+            echo "### Summary" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
+            echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+            echo "| Size Difference | ${{ steps.diff.outputs.size_diff_mb }} MB |" >> $GITHUB_STEP_SUMMARY
+            echo "| Pip Packages Added | ${{ steps.diff.outputs.pip_added }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| Pip Packages Removed | ${{ steps.diff.outputs.pip_removed }} |" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "### Full Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ -f "$OUTPUT_DIR/summary/DIFF_REPORT.md" ]; then
+            # Include report but limit to avoid huge summaries
+            head -100 "$OUTPUT_DIR/summary/DIFF_REPORT.md" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "_[Truncated - see full artifact for complete report]_" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      # -----------------------------------------------------------------------
+      # Optional: PR Comment
+      # -----------------------------------------------------------------------
+      - name: Add PR comment
+        if: |
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.add_pr_comment == 'true' &&
+          github.event.inputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const outputDir = '/tmp/image-diff-${{ github.run_id }}';
+            const summaryPath = `${outputDir}/summary/DIFF_REPORT.md`;
+
+            let body = '## Docker Image Diff Results\n\n';
+            body += `**Live Image:** \`${{ steps.images.outputs.live }}\`\n`;
+            body += `**Target Image:** \`${{ steps.images.outputs.target }}\`\n\n`;
+            body += `| Metric | Value |\n`;
+            body += `|--------|-------|\n`;
+            body += `| Size Difference | ${{ steps.diff.outputs.size_diff_mb }} MB |\n`;
+            body += `| Pip Packages Added | ${{ steps.diff.outputs.pip_added }} |\n`;
+            body += `| Pip Packages Removed | ${{ steps.diff.outputs.pip_removed }} |\n\n`;
+
+            if (fs.existsSync(summaryPath)) {
+              const report = fs.readFileSync(summaryPath, 'utf8');
+              // Truncate if too long
+              const maxLen = 4000;
+              if (report.length > maxLen) {
+                body += '<details><summary>Full Diff Report (click to expand)</summary>\n\n';
+                body += report.substring(0, maxLen);
+                body += '\n\n_[Truncated]_\n</details>';
+              } else {
+                body += '<details><summary>Full Diff Report (click to expand)</summary>\n\n';
+                body += report;
+                body += '\n</details>';
+              }
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: parseInt('${{ github.event.inputs.pr_number }}'),
+              body: body
+            });
+
+  # ===========================================================================
+  # Alert on Large Changes
+  # ===========================================================================
+  alert:
+    name: Check Thresholds
+    runs-on: ubuntu-latest
+    needs: diff
+    if: |
+      needs.diff.outputs.size_diff_mb != '' &&
+      (needs.diff.outputs.size_diff_mb > 100 || needs.diff.outputs.pip_removed > 10)
+
+    steps:
+      - name: Alert on large image changes
+        run: |
+          echo "## ⚠️ Large Image Changes Detected" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The following thresholds were exceeded:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          SIZE_DIFF="${{ needs.diff.outputs.size_diff_mb }}"
+          PIP_REMOVED="${{ needs.diff.outputs.pip_removed }}"
+
+          if [ "$SIZE_DIFF" -gt 100 ]; then
+            echo "- **Size increase:** ${SIZE_DIFF}MB (threshold: 100MB)" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ "$PIP_REMOVED" -gt 10 ]; then
+            echo "- **Pip packages removed:** ${PIP_REMOVED} (threshold: 10)" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Please review the diff report before deploying." >> $GITHUB_STEP_SUMMARY
+
+          # Optionally fail the workflow on large changes
+          # exit 1

--- a/docs/evidence/20260121-0000/docker-image-diff/README.md
+++ b/docs/evidence/20260121-0000/docker-image-diff/README.md
@@ -1,0 +1,119 @@
+# Docker Image Diff Evidence
+
+**Scope:** Docker Image Comparison Tooling
+**Date:** 2026-01-21
+**Status:** Tooling Shipped (awaiting runtime execution)
+
+## What Was Shipped
+
+### 1. Image Diff Script
+- **Path:** `scripts/ci/docker-image-diff.sh`
+- **Purpose:** Compare two Docker images at multiple levels:
+  - Layer history
+  - Filesystem (addons, config, python packages)
+  - Runtime (pip packages, odoo version, env vars)
+
+### 2. CI Workflow
+- **Path:** `.github/workflows/image-diff.yml`
+- **Triggers:**
+  - Manual dispatch with custom image inputs
+  - Auto-triggered after successful `build-unified-image` workflow
+- **Outputs:**
+  - Markdown diff report
+  - JSON summary for automation
+  - Optional PR comment
+
+## Usage
+
+### Manual Execution
+```bash
+# Compare production vs edge
+./scripts/ci/docker-image-diff.sh \
+  ghcr.io/jgtolentino/odoo-ce:latest \
+  ghcr.io/jgtolentino/odoo-ce:edge-standard \
+  /tmp/diff-output
+
+# Compare specific versions
+./scripts/ci/docker-image-diff.sh \
+  ghcr.io/jgtolentino/odoo-ce:prod-20260121-2317 \
+  ghcr.io/jgtolentino/odoo-ce:custom-target \
+  /tmp/diff-output
+```
+
+### CI Workflow
+```bash
+# Trigger via GitHub CLI
+gh workflow run image-diff.yml \
+  -f live_image="ghcr.io/jgtolentino/odoo-ce:latest" \
+  -f target_image="ghcr.io/jgtolentino/odoo-ce:edge-standard"
+```
+
+## Evidence Placeholders
+
+When the script runs in an environment with Docker access, the following files will be generated:
+
+```
+<output_dir>/
+├── history/
+│   ├── live.history.txt
+│   ├── target.history.txt
+│   └── history.diff
+├── runtime/
+│   ├── live.pip.txt
+│   ├── target.pip.txt
+│   ├── pip.diff
+│   ├── live.odoo-version.txt
+│   ├── target.odoo-version.txt
+│   ├── odoo-version.diff
+│   ├── live.env.txt
+│   ├── target.env.txt
+│   └── env.diff
+├── filesystem/
+│   ├── _mnt_extra-addons.diff
+│   ├── _etc_odoo.diff
+│   ├── odoo.conf.diff
+│   └── ...
+└── summary/
+    ├── DIFF_REPORT.md
+    ├── diff_summary.json
+    ├── live.id.txt
+    ├── target.id.txt
+    └── size.txt
+```
+
+## Verification Commands
+
+After running the diff, verify the target image:
+
+```bash
+# Smoke test
+docker run --rm <target_image> odoo --version
+
+# DB connection test
+docker run --rm \
+  -e DB_HOST="$DB_HOST" \
+  -e DB_PORT="$DB_PORT" \
+  -e DB_USER="$DB_USER" \
+  -e DB_PASSWORD="$DB_PASSWORD" \
+  <target_image> \
+  odoo -d $ODOO_DB --log-level=info --stop-after-init
+```
+
+## Deployment Flow
+
+1. Run image diff
+2. Review `DIFF_REPORT.md`
+3. Verify no unexpected changes
+4. Deploy target as new production:
+   ```bash
+   docker tag <target_image> ghcr.io/jgtolentino/odoo-ce:prod
+   docker push ghcr.io/jgtolentino/odoo-ce:prod
+   ```
+
+## Rollback
+
+```bash
+# Retag previous image as prod
+docker tag <previous_live_image> ghcr.io/jgtolentino/odoo-ce:prod
+docker push ghcr.io/jgtolentino/odoo-ce:prod
+```

--- a/scripts/ci/docker-image-diff.sh
+++ b/scripts/ci/docker-image-diff.sh
@@ -1,0 +1,338 @@
+#!/bin/bash
+# =============================================================================
+# Docker Image Diff Script
+# =============================================================================
+# Compares two Docker images at multiple levels:
+#   - Layer history
+#   - Filesystem (addons, config, python packages)
+#   - Runtime (pip packages, odoo version, env vars)
+#
+# Usage:
+#   ./scripts/ci/docker-image-diff.sh <live_image> <target_image> [output_dir]
+#
+# Examples:
+#   ./scripts/ci/docker-image-diff.sh \
+#     ghcr.io/jgtolentino/odoo-ce:prod \
+#     ghcr.io/jgtolentino/odoo-ce:edge-standard \
+#     /tmp/image-diff-output
+#
+# Exit codes:
+#   0 - Success (diff completed)
+#   1 - Error (missing args, docker failure)
+# =============================================================================
+set -euo pipefail
+
+# =============================================================================
+# Configuration
+# =============================================================================
+IMAGE_LIVE="${1:-}"
+IMAGE_TARGET="${2:-}"
+OUTPUT_DIR="${3:-/tmp/docker-image-diff}"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+log_info() {
+  echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+  echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+  echo -e "${RED}[ERROR]${NC} $1"
+}
+
+cleanup() {
+  log_info "Cleaning up temporary containers..."
+  docker rm -f diff_live_container diff_target_container 2>/dev/null || true
+  rm -f "$OUTPUT_DIR/live.tar" "$OUTPUT_DIR/target.tar" 2>/dev/null || true
+}
+
+trap cleanup EXIT
+
+# =============================================================================
+# Validation
+# =============================================================================
+if [ -z "$IMAGE_LIVE" ] || [ -z "$IMAGE_TARGET" ]; then
+  log_error "Usage: $0 <live_image> <target_image> [output_dir]"
+  exit 1
+fi
+
+if ! command -v docker &> /dev/null; then
+  log_error "Docker is not installed or not in PATH"
+  exit 1
+fi
+
+# =============================================================================
+# Setup
+# =============================================================================
+log_info "=== Docker Image Diff ==="
+log_info "Live image:   $IMAGE_LIVE"
+log_info "Target image: $IMAGE_TARGET"
+log_info "Output dir:   $OUTPUT_DIR"
+log_info "Timestamp:    $TIMESTAMP"
+echo ""
+
+mkdir -p "$OUTPUT_DIR"/{history,filesystem,runtime,summary}
+
+# =============================================================================
+# Step 1: Pull Images
+# =============================================================================
+log_info ">>> Step 1: Pulling images..."
+
+docker pull "$IMAGE_LIVE" || {
+  log_error "Failed to pull live image: $IMAGE_LIVE"
+  exit 1
+}
+
+docker pull "$IMAGE_TARGET" || {
+  log_error "Failed to pull target image: $IMAGE_TARGET"
+  exit 1
+}
+
+echo ""
+
+# =============================================================================
+# Step 2: Image Metadata
+# =============================================================================
+log_info ">>> Step 2: Extracting image metadata..."
+
+# Image IDs and digests
+docker inspect --format='{{.Id}}' "$IMAGE_LIVE" > "$OUTPUT_DIR/summary/live.id.txt"
+docker inspect --format='{{.Id}}' "$IMAGE_TARGET" > "$OUTPUT_DIR/summary/target.id.txt"
+
+docker inspect --format='{{json .RepoDigests}}' "$IMAGE_LIVE" > "$OUTPUT_DIR/summary/live.digest.json"
+docker inspect --format='{{json .RepoDigests}}' "$IMAGE_TARGET" > "$OUTPUT_DIR/summary/target.digest.json"
+
+# Full inspect
+docker inspect "$IMAGE_LIVE" > "$OUTPUT_DIR/summary/live.inspect.json"
+docker inspect "$IMAGE_TARGET" > "$OUTPUT_DIR/summary/target.inspect.json"
+
+# Size comparison
+LIVE_SIZE=$(docker inspect --format='{{.Size}}' "$IMAGE_LIVE")
+TARGET_SIZE=$(docker inspect --format='{{.Size}}' "$IMAGE_TARGET")
+LIVE_SIZE_MB=$((LIVE_SIZE / 1024 / 1024))
+TARGET_SIZE_MB=$((TARGET_SIZE / 1024 / 1024))
+SIZE_DIFF_MB=$((TARGET_SIZE_MB - LIVE_SIZE_MB))
+
+cat > "$OUTPUT_DIR/summary/size.txt" << EOF
+Live Image Size:   ${LIVE_SIZE_MB} MB
+Target Image Size: ${TARGET_SIZE_MB} MB
+Difference:        ${SIZE_DIFF_MB} MB
+EOF
+
+log_info "Live size: ${LIVE_SIZE_MB}MB, Target size: ${TARGET_SIZE_MB}MB (diff: ${SIZE_DIFF_MB}MB)"
+echo ""
+
+# =============================================================================
+# Step 3: Layer History Diff
+# =============================================================================
+log_info ">>> Step 3: Comparing layer history..."
+
+docker history --no-trunc "$IMAGE_LIVE" > "$OUTPUT_DIR/history/live.history.txt"
+docker history --no-trunc "$IMAGE_TARGET" > "$OUTPUT_DIR/history/target.history.txt"
+
+diff -u "$OUTPUT_DIR/history/live.history.txt" "$OUTPUT_DIR/history/target.history.txt" \
+  > "$OUTPUT_DIR/history/history.diff" 2>&1 || true
+
+LAYER_COUNT_LIVE=$(docker history -q "$IMAGE_LIVE" | wc -l)
+LAYER_COUNT_TARGET=$(docker history -q "$IMAGE_TARGET" | wc -l)
+
+log_info "Live layers: $LAYER_COUNT_LIVE, Target layers: $LAYER_COUNT_TARGET"
+echo ""
+
+# =============================================================================
+# Step 4: Runtime Diff (pip, odoo, env)
+# =============================================================================
+log_info ">>> Step 4: Comparing runtime environment..."
+
+# Pip packages
+docker run --rm "$IMAGE_LIVE" pip list --format=freeze 2>/dev/null | sort > "$OUTPUT_DIR/runtime/live.pip.txt" || true
+docker run --rm "$IMAGE_TARGET" pip list --format=freeze 2>/dev/null | sort > "$OUTPUT_DIR/runtime/target.pip.txt" || true
+
+diff -u "$OUTPUT_DIR/runtime/live.pip.txt" "$OUTPUT_DIR/runtime/target.pip.txt" \
+  > "$OUTPUT_DIR/runtime/pip.diff" 2>&1 || true
+
+# Count pip changes
+PIP_ADDED=$(diff "$OUTPUT_DIR/runtime/live.pip.txt" "$OUTPUT_DIR/runtime/target.pip.txt" | grep '^>' | wc -l || echo "0")
+PIP_REMOVED=$(diff "$OUTPUT_DIR/runtime/live.pip.txt" "$OUTPUT_DIR/runtime/target.pip.txt" | grep '^<' | wc -l || echo "0")
+
+log_info "Pip packages: +$PIP_ADDED added, -$PIP_REMOVED removed"
+
+# Odoo version
+docker run --rm "$IMAGE_LIVE" odoo --version 2>/dev/null > "$OUTPUT_DIR/runtime/live.odoo-version.txt" || echo "Unknown" > "$OUTPUT_DIR/runtime/live.odoo-version.txt"
+docker run --rm "$IMAGE_TARGET" odoo --version 2>/dev/null > "$OUTPUT_DIR/runtime/target.odoo-version.txt" || echo "Unknown" > "$OUTPUT_DIR/runtime/target.odoo-version.txt"
+
+diff -u "$OUTPUT_DIR/runtime/live.odoo-version.txt" "$OUTPUT_DIR/runtime/target.odoo-version.txt" \
+  > "$OUTPUT_DIR/runtime/odoo-version.diff" 2>&1 || true
+
+# Environment variables
+docker run --rm "$IMAGE_LIVE" env 2>/dev/null | sort > "$OUTPUT_DIR/runtime/live.env.txt" || true
+docker run --rm "$IMAGE_TARGET" env 2>/dev/null | sort > "$OUTPUT_DIR/runtime/target.env.txt" || true
+
+diff -u "$OUTPUT_DIR/runtime/live.env.txt" "$OUTPUT_DIR/runtime/target.env.txt" \
+  > "$OUTPUT_DIR/runtime/env.diff" 2>&1 || true
+
+echo ""
+
+# =============================================================================
+# Step 5: Filesystem Diff (targeted paths)
+# =============================================================================
+log_info ">>> Step 5: Comparing filesystem (targeted paths)..."
+
+# Create containers
+docker create --name diff_live_container "$IMAGE_LIVE" >/dev/null
+docker create --name diff_target_container "$IMAGE_TARGET" >/dev/null
+
+# Export specific directories instead of full filesystem (faster)
+mkdir -p "$OUTPUT_DIR/filesystem/live" "$OUTPUT_DIR/filesystem/target"
+
+# Copy key directories
+DIFF_PATHS=(
+  "/mnt/extra-addons"
+  "/etc/odoo"
+  "/usr/lib/python3/dist-packages/odoo"
+)
+
+for path in "${DIFF_PATHS[@]}"; do
+  path_safe=$(echo "$path" | tr '/' '_')
+
+  # Extract from live
+  docker cp "diff_live_container:$path" "$OUTPUT_DIR/filesystem/live/$path_safe" 2>/dev/null || {
+    log_warn "Path not found in live: $path"
+    mkdir -p "$OUTPUT_DIR/filesystem/live/$path_safe"
+  }
+
+  # Extract from target
+  docker cp "diff_target_container:$path" "$OUTPUT_DIR/filesystem/target/$path_safe" 2>/dev/null || {
+    log_warn "Path not found in target: $path"
+    mkdir -p "$OUTPUT_DIR/filesystem/target/$path_safe"
+  }
+done
+
+# Generate filesystem diffs
+for path in "${DIFF_PATHS[@]}"; do
+  path_safe=$(echo "$path" | tr '/' '_')
+
+  diff -ruN \
+    "$OUTPUT_DIR/filesystem/live/$path_safe" \
+    "$OUTPUT_DIR/filesystem/target/$path_safe" \
+    > "$OUTPUT_DIR/filesystem/${path_safe}.diff" 2>&1 || true
+
+  # Count changes
+  CHANGES=$(grep -c '^[+-]' "$OUTPUT_DIR/filesystem/${path_safe}.diff" 2>/dev/null || echo "0")
+  log_info "  $path: $CHANGES lines changed"
+done
+
+# Odoo config diff specifically
+if [ -f "$OUTPUT_DIR/filesystem/live/_etc_odoo/odoo.conf" ] && [ -f "$OUTPUT_DIR/filesystem/target/_etc_odoo/odoo.conf" ]; then
+  diff -u \
+    "$OUTPUT_DIR/filesystem/live/_etc_odoo/odoo.conf" \
+    "$OUTPUT_DIR/filesystem/target/_etc_odoo/odoo.conf" \
+    > "$OUTPUT_DIR/filesystem/odoo.conf.diff" 2>&1 || true
+fi
+
+echo ""
+
+# =============================================================================
+# Step 6: Generate Summary Report
+# =============================================================================
+log_info ">>> Step 6: Generating summary report..."
+
+cat > "$OUTPUT_DIR/summary/DIFF_REPORT.md" << EOF
+# Docker Image Diff Report
+
+**Generated:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+
+## Images Compared
+
+| Property | Live | Target |
+|----------|------|--------|
+| Image | \`$IMAGE_LIVE\` | \`$IMAGE_TARGET\` |
+| Size | ${LIVE_SIZE_MB} MB | ${TARGET_SIZE_MB} MB |
+| Layers | $LAYER_COUNT_LIVE | $LAYER_COUNT_TARGET |
+
+**Size Difference:** ${SIZE_DIFF_MB} MB
+
+## Summary
+
+### Pip Packages
+- **Added:** $PIP_ADDED packages
+- **Removed:** $PIP_REMOVED packages
+
+### Layer Changes
+\`\`\`
+$(head -30 "$OUTPUT_DIR/history/history.diff" 2>/dev/null || echo "No layer changes")
+\`\`\`
+
+### Pip Package Changes
+\`\`\`
+$(head -50 "$OUTPUT_DIR/runtime/pip.diff" 2>/dev/null || echo "No pip changes")
+\`\`\`
+
+### Odoo Version
+- **Live:** $(cat "$OUTPUT_DIR/runtime/live.odoo-version.txt")
+- **Target:** $(cat "$OUTPUT_DIR/runtime/target.odoo-version.txt")
+
+### Config Changes
+\`\`\`
+$(head -30 "$OUTPUT_DIR/filesystem/odoo.conf.diff" 2>/dev/null || echo "No config changes")
+\`\`\`
+
+## Files Generated
+
+- \`history/\` - Layer history comparison
+- \`runtime/\` - Pip, Odoo version, env diffs
+- \`filesystem/\` - Targeted path diffs
+- \`summary/\` - This report and metadata
+
+## Verification Commands
+
+\`\`\`bash
+# Smoke test target image
+docker run --rm $IMAGE_TARGET odoo --version
+
+# DB connection test (replace env vars)
+docker run --rm \\
+  -e DB_HOST="\$DB_HOST" \\
+  -e DB_PORT="\$DB_PORT" \\
+  -e DB_USER="\$DB_USER" \\
+  -e DB_PASSWORD="\$DB_PASSWORD" \\
+  $IMAGE_TARGET \\
+  odoo -d \$ODOO_DB --log-level=info --stop-after-init
+\`\`\`
+EOF
+
+# Generate JSON summary for machine consumption
+cat > "$OUTPUT_DIR/summary/diff_summary.json" << EOF
+{
+  "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "live_image": "$IMAGE_LIVE",
+  "target_image": "$IMAGE_TARGET",
+  "live_size_mb": $LIVE_SIZE_MB,
+  "target_size_mb": $TARGET_SIZE_MB,
+  "size_diff_mb": $SIZE_DIFF_MB,
+  "live_layers": $LAYER_COUNT_LIVE,
+  "target_layers": $LAYER_COUNT_TARGET,
+  "pip_added": $PIP_ADDED,
+  "pip_removed": $PIP_REMOVED
+}
+EOF
+
+echo ""
+log_info "=== Diff Complete ==="
+log_info "Report: $OUTPUT_DIR/summary/DIFF_REPORT.md"
+log_info "JSON:   $OUTPUT_DIR/summary/diff_summary.json"
+echo ""
+
+# Output summary to stdout
+cat "$OUTPUT_DIR/summary/DIFF_REPORT.md"


### PR DESCRIPTION
Add script and CI workflow to compare Docker images at multiple levels:
- Layer history comparison
- Pip package diffs
- Odoo addon filesystem diffs
- Configuration file diffs

Includes:
- scripts/ci/docker-image-diff.sh: Reusable diff script
- .github/workflows/image-diff.yml: CI workflow with auto/manual triggers
- docs/evidence/: Evidence placeholders for runtime execution

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fjgtolentino%2Fodoo-ce%2Fpull%2F261)
<!-- continue-task-summary-end -->