### PR TITLE
feat(advisor): scan routes — github, agentic-coding, devops-lifecycle (PR A)

### DIFF
--- a/apps/ops-console/app/api/advisor/scans/agentic-coding/route.ts
+++ b/apps/ops-console/app/api/advisor/scans/agentic-coding/route.ts
@@ -1,0 +1,289 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getOrCreateRequestId, correlationHeaders } from "@/lib/http/correlation"
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? ""
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? ""
+
+function supabaseHeaders() {
+  return {
+    apikey: SUPABASE_SERVICE_ROLE_KEY,
+    Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+    "Content-Type": "application/json",
+  }
+}
+
+const RUBRIC_ID = "agentic_coding"
+
+type RunEvent = {
+  event_id: string
+  run_id: string
+  level?: string
+  message?: string
+  payload?: unknown
+  created_at?: string
+}
+
+type DimensionScore = {
+  dimension: string
+  score: number
+  breakdown: Record<string, unknown>
+}
+
+/**
+ * POST /api/advisor/scans/agentic-coding
+ *
+ * Scores the last 20 ops.run_events against the agentic_coding rubric (5 dimensions).
+ * Inserts scores into ops.advisor_scores (try/catch — table may not exist yet).
+ * Inserts findings into ops.advisor_findings when total score < 10.
+ *
+ * Returns { scan_id, total_score, dimension_scores, findings }
+ */
+export async function POST(req: NextRequest) {
+  const rid = getOrCreateRequestId(req.headers.get("x-request-id"))
+  const hdrs = correlationHeaders(rid)
+
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    return NextResponse.json({ error: "Supabase not configured" }, { status: 503, headers: hdrs })
+  }
+
+  try {
+    // 1. Create advisor_scans row with provider: agentic_coding
+    const scanRes = await fetch(`${SUPABASE_URL}/rest/v1/ops.advisor_scans`, {
+      method: "POST",
+      headers: { ...supabaseHeaders(), Prefer: "return=representation" },
+      body: JSON.stringify({
+        provider: "agentic_coding",
+        status: "running",
+      }),
+    })
+    if (!scanRes.ok) {
+      const text = await scanRes.text()
+      return NextResponse.json({ error: text }, { status: scanRes.status, headers: hdrs })
+    }
+    const [scan] = await scanRes.json()
+    const scanId: string = scan.id
+
+    // 2. Read last 20 ops.run_events ordered by created_at DESC
+    const eventsRes = await fetch(
+      `${SUPABASE_URL}/rest/v1/ops.run_events?order=created_at.desc&limit=20`,
+      { headers: supabaseHeaders() }
+    )
+
+    let runEvents: RunEvent[] = []
+    if (eventsRes.ok) {
+      runEvents = await eventsRes.json()
+    }
+
+    // 3. Compute rubric scores across 5 dimensions
+    const messageTexts = runEvents
+      .map((e) => (e.message ?? "").toLowerCase())
+      .join(" ")
+
+    // planning_quality (0-3): presence of PLAN phase messages
+    const planningMatches = runEvents.filter(
+      (e) =>
+        (e.level ?? "").toLowerCase().includes("plan") ||
+        (e.message ?? "").toLowerCase().includes("plan") ||
+        (e.message ?? "").toLowerCase().includes("planning")
+    )
+    let planningScore = 0
+    if (planningMatches.length >= 3) planningScore = 3
+    else if (planningMatches.length === 2) planningScore = 2
+    else if (planningMatches.length === 1) planningScore = 1
+
+    // patch_minimality (0-3): placeholder — no automated signal yet
+    const patchMinimalityScore = 1
+
+    // test_coverage (0-3): VERIFY phase messages mentioning tests
+    const testMatches = runEvents.filter(
+      (e) =>
+        (e.level ?? "").toLowerCase().includes("verify") ||
+        (e.message ?? "").toLowerCase().includes("test") ||
+        (e.message ?? "").toLowerCase().includes("verify") ||
+        (e.message ?? "").toLowerCase().includes("coverage")
+    )
+    let testCoverageScore = 0
+    if (testMatches.length >= 3) testCoverageScore = 3
+    else if (testMatches.length === 2) testCoverageScore = 2
+    else if (testMatches.length === 1) testCoverageScore = 1
+
+    // pr_evidence (0-3): PR phase messages
+    const prMatches = runEvents.filter(
+      (e) =>
+        (e.level ?? "").toLowerCase().includes("pr") ||
+        (e.message ?? "").toLowerCase().includes(" pr ") ||
+        (e.message ?? "").toLowerCase().includes("pull request") ||
+        (e.message ?? "").toLowerCase().includes("gh pr")
+    )
+    let prEvidenceScore = 0
+    if (prMatches.length >= 3) prEvidenceScore = 3
+    else if (prMatches.length === 2) prEvidenceScore = 2
+    else if (prMatches.length === 1) prEvidenceScore = 1
+
+    // audit_trail (0-3): count of runs logged
+    const uniqueRunIds = new Set(runEvents.map((e) => e.run_id).filter(Boolean))
+    const runCount = uniqueRunIds.size
+    let auditTrailScore = 0
+    if (runCount === 0) auditTrailScore = 0
+    else if (runCount < 5) auditTrailScore = 1
+    else if (runCount < 20) auditTrailScore = 2
+    else auditTrailScore = 3
+
+    const dimensionScores: DimensionScore[] = [
+      {
+        dimension: "planning_quality",
+        score: planningScore,
+        breakdown: {
+          matching_events: planningMatches.length,
+          sample_messages: planningMatches.slice(0, 3).map((e) => e.message),
+        },
+      },
+      {
+        dimension: "patch_minimality",
+        score: patchMinimalityScore,
+        breakdown: { note: "Placeholder score — no automated signal available yet." },
+      },
+      {
+        dimension: "test_coverage",
+        score: testCoverageScore,
+        breakdown: {
+          matching_events: testMatches.length,
+          sample_messages: testMatches.slice(0, 3).map((e) => e.message),
+        },
+      },
+      {
+        dimension: "pr_evidence",
+        score: prEvidenceScore,
+        breakdown: {
+          matching_events: prMatches.length,
+          sample_messages: prMatches.slice(0, 3).map((e) => e.message),
+        },
+      },
+      {
+        dimension: "audit_trail",
+        score: auditTrailScore,
+        breakdown: {
+          unique_run_ids: runCount,
+          total_events: runEvents.length,
+        },
+      },
+    ]
+
+    const totalScore = dimensionScores.reduce((sum, d) => sum + d.score, 0)
+
+    // 4. Insert ops.advisor_scores rows — wrapped in try/catch (table may not exist yet)
+    try {
+      const scoreRows = dimensionScores.map((d) => ({
+        scan_id: scanId,
+        rubric_id: RUBRIC_ID,
+        dimension: d.dimension,
+        score: d.score,
+        breakdown_json: d.breakdown,
+      }))
+      await fetch(`${SUPABASE_URL}/rest/v1/ops.advisor_scores`, {
+        method: "POST",
+        headers: { ...supabaseHeaders(), Prefer: "return=minimal" },
+        body: JSON.stringify(scoreRows),
+      })
+    } catch {
+      // ops.advisor_scores table not yet created — will be added in migration PR C
+    }
+
+    // 5. Insert findings based on total score
+    const findings: Array<{
+      scan_id: string
+      pillar: string
+      severity: string
+      title: string
+      description?: string
+      evidence_json?: object
+      recommendation?: string
+      citation_url?: string
+    }> = []
+
+    if (totalScore < 6) {
+      findings.push({
+        scan_id: scanId,
+        pillar: "ops_excellence",
+        severity: "high",
+        title: "Agentic coding rubric below Developing band (score < 6)",
+        description: `Total agentic coding rubric score is ${totalScore}/15, which is below the Developing band threshold of 6. Improvements needed across planning, test coverage, PR evidence, and audit trail.`,
+        evidence_json: {
+          total_score: totalScore,
+          dimension_scores: dimensionScores,
+          rubric_id: RUBRIC_ID,
+          ssot_ref: "ssot/advisor/rubrics/agentic_coding.yaml",
+        },
+        recommendation:
+          "Increase score by ensuring PLAN phase is logged in run_events, adding test verification steps, emitting PR-linked events, and maintaining consistent run logging.",
+        citation_url: undefined,
+      })
+    } else if (totalScore < 10) {
+      findings.push({
+        scan_id: scanId,
+        pillar: "ops_excellence",
+        severity: "medium",
+        title: `Agentic coding rubric in Developing band (score ${totalScore} < 10)`,
+        description: `Total agentic coding rubric score is ${totalScore}/15, which is in the Developing band. Score is above threshold but below Proficient (10+).`,
+        evidence_json: {
+          total_score: totalScore,
+          dimension_scores: dimensionScores,
+          rubric_id: RUBRIC_ID,
+          ssot_ref: "ssot/advisor/rubrics/agentic_coding.yaml",
+        },
+        recommendation:
+          "Focus on dimensions scoring below 2 to reach the Proficient band.",
+        citation_url: undefined,
+      })
+    }
+
+    // 6. Insert findings into ops.advisor_findings
+    if (findings.length > 0) {
+      const findingsRes = await fetch(`${SUPABASE_URL}/rest/v1/ops.advisor_findings`, {
+        method: "POST",
+        headers: { ...supabaseHeaders(), Prefer: "return=representation" },
+        body: JSON.stringify(findings),
+      })
+      if (!findingsRes.ok) {
+        const text = await findingsRes.text()
+        return NextResponse.json({ error: text }, { status: findingsRes.status, headers: hdrs })
+      }
+    }
+
+    // 7. Update scan to completed
+    const updateRes = await fetch(
+      `${SUPABASE_URL}/rest/v1/ops.advisor_scans?id=eq.${scanId}`,
+      {
+        method: "PATCH",
+        headers: { ...supabaseHeaders(), Prefer: "return=minimal" },
+        body: JSON.stringify({
+          status: "completed",
+          finished_at: new Date().toISOString(),
+          summary_json: {
+            total_score: totalScore,
+            max_score: 15,
+            dimension_scores: dimensionScores,
+            findings_count: findings.length,
+            run_events_analyzed: runEvents.length,
+          },
+        }),
+      }
+    )
+    if (!updateRes.ok) {
+      const text = await updateRes.text()
+      return NextResponse.json({ error: text }, { status: updateRes.status, headers: hdrs })
+    }
+
+    return NextResponse.json(
+      {
+        scan_id: scanId,
+        total_score: totalScore,
+        dimension_scores: dimensionScores,
+        findings,
+      },
+      { status: 200, headers: hdrs }
+    )
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500, headers: hdrs })
+  }
+}

--- a/apps/ops-console/app/api/advisor/scans/devops-lifecycle/route.ts
+++ b/apps/ops-console/app/api/advisor/scans/devops-lifecycle/route.ts
@@ -1,0 +1,344 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getOrCreateRequestId, correlationHeaders } from "@/lib/http/correlation"
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? ""
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? ""
+
+function supabaseHeaders() {
+  return {
+    apikey: SUPABASE_SERVICE_ROLE_KEY,
+    Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+    "Content-Type": "application/json",
+  }
+}
+
+const GITHUB_ORG = "Insightpulseai"
+const GITHUB_REPO = "odoo"
+const SSOT_REF = "ssot/advisor/assessments/microsoft_devops_lifecycle.yaml"
+
+type PhaseSummary = {
+  status: "pass" | "fail" | "skip"
+  checks: Record<string, boolean | string | number>
+  findings_inserted: number
+}
+
+/**
+ * POST /api/advisor/scans/devops-lifecycle
+ *
+ * Fans out to the 4 Microsoft DevOps lifecycle phases and checks:
+ *   - Plan:    ops.runs count for last 30 days (active development proxy)
+ *   - Develop: GitHub branch protection + CODEOWNERS (reuses github scan logic)
+ *   - Deliver: VERCEL_TOKEN env var presence (Vercel CI gated proxy)
+ *   - Operate: ops.advisor_findings open high-severity items older than 24h
+ *
+ * Returns { scan_id, phases: { plan, develop, deliver, operate }, findings_count }
+ */
+export async function POST(req: NextRequest) {
+  const rid = getOrCreateRequestId(req.headers.get("x-request-id"))
+  const hdrs = correlationHeaders(rid)
+
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    return NextResponse.json({ error: "Supabase not configured" }, { status: 503, headers: hdrs })
+  }
+
+  const GITHUB_TOKEN = process.env.GITHUB_TOKEN ?? ""
+  const VERCEL_TOKEN = process.env.VERCEL_TOKEN ?? ""
+
+  try {
+    // Create advisor_scans row with provider: devops_lifecycle
+    const scanRes = await fetch(`${SUPABASE_URL}/rest/v1/ops.advisor_scans`, {
+      method: "POST",
+      headers: { ...supabaseHeaders(), Prefer: "return=representation" },
+      body: JSON.stringify({
+        provider: "devops_lifecycle",
+        status: "running",
+      }),
+    })
+    if (!scanRes.ok) {
+      const text = await scanRes.text()
+      return NextResponse.json({ error: text }, { status: scanRes.status, headers: hdrs })
+    }
+    const [scan] = await scanRes.json()
+    const scanId: string = scan.id
+
+    const allFindings: Array<{
+      scan_id: string
+      pillar: string
+      severity: string
+      title: string
+      description?: string
+      resource_ref?: string
+      evidence_json?: object
+      recommendation?: string
+      citation_url?: string
+    }> = []
+
+    const phases: Record<string, PhaseSummary> = {
+      plan: { status: "pass", checks: {}, findings_inserted: 0 },
+      develop: { status: "pass", checks: {}, findings_inserted: 0 },
+      deliver: { status: "pass", checks: {}, findings_inserted: 0 },
+      operate: { status: "pass", checks: {}, findings_inserted: 0 },
+    }
+
+    // -------------------------------------------------------------------------
+    // PLAN PHASE — check ops.runs count for last 30 days
+    // -------------------------------------------------------------------------
+    try {
+      const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+      const runsRes = await fetch(
+        `${SUPABASE_URL}/rest/v1/ops.runs?created_at=gte.${encodeURIComponent(thirtyDaysAgo)}&select=id`,
+        { headers: { ...supabaseHeaders(), Prefer: "count=exact" } }
+      )
+      let recentRunCount = 0
+      if (runsRes.ok) {
+        const contentRange = runsRes.headers.get("content-range")
+        // content-range header format: 0-N/TOTAL or */TOTAL
+        if (contentRange) {
+          const total = parseInt(contentRange.split("/")[1] ?? "0", 10)
+          recentRunCount = isNaN(total) ? 0 : total
+        } else {
+          const data = await runsRes.json()
+          recentRunCount = Array.isArray(data) ? data.length : 0
+        }
+      }
+      phases.plan.checks.recent_run_count = recentRunCount
+
+      if (recentRunCount < 5) {
+        phases.plan.status = "fail"
+        const finding = {
+          scan_id: scanId,
+          pillar: "ops_excellence",
+          severity: recentRunCount === 0 ? "high" : "medium",
+          title:
+            recentRunCount === 0
+              ? "No active development runs detected in last 30 days"
+              : `Low development cadence: only ${recentRunCount} run(s) in last 30 days`,
+          description:
+            "The Plan phase check uses ops.runs count as a proxy for active development activity. Low run counts may indicate stalled delivery or missing observability.",
+          evidence_json: {
+            recent_run_count: recentRunCount,
+            window_days: 30,
+            ssot_ref: SSOT_REF,
+          },
+          recommendation:
+            "Ensure development runs are being logged to ops.runs. Review delivery cadence.",
+          citation_url:
+            "https://learn.microsoft.com/en-us/devops/plan/what-is-planning",
+        }
+        allFindings.push(finding)
+        phases.plan.findings_inserted += 1
+      }
+    } catch {
+      phases.plan.status = "fail"
+      phases.plan.checks.error = "Failed to query ops.runs"
+    }
+
+    // -------------------------------------------------------------------------
+    // DEVELOP PHASE — GitHub branch protection + CODEOWNERS
+    // Requires GITHUB_TOKEN; emit KEY_MISSING finding if absent
+    // -------------------------------------------------------------------------
+    if (!GITHUB_TOKEN) {
+      phases.develop.status = "fail"
+      phases.develop.checks.github_token = "missing"
+      allFindings.push({
+        scan_id: scanId,
+        pillar: "ops_excellence",
+        severity: "high",
+        title: "Develop phase skipped: GITHUB_TOKEN not configured",
+        description:
+          "GITHUB_TOKEN is required to check branch protection and CODEOWNERS for the Develop phase.",
+        evidence_json: {
+          error: "KEY_MISSING",
+          key: "GITHUB_TOKEN",
+          ssot_ref: "ssot/integrations/github_features.yaml",
+        },
+        recommendation:
+          "Set GITHUB_TOKEN in the runtime environment. See ssot/integrations/github_features.yaml.",
+      })
+      phases.develop.findings_inserted += 1
+    } else {
+      const githubHeaders = {
+        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      }
+
+      // Branch protection
+      const branchProtRes = await fetch(
+        `https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/branches/main/protection`,
+        { headers: githubHeaders }
+      )
+      const branchProtected = branchProtRes.status === 200
+      phases.develop.checks.branch_protection = branchProtected
+
+      if (!branchProtected) {
+        phases.develop.status = "fail"
+        allFindings.push({
+          scan_id: scanId,
+          pillar: "ops_excellence",
+          severity: "high",
+          title: "main branch not protected (Develop phase)",
+          description:
+            "Branch protection is not configured on main, allowing unreviewed direct pushes.",
+          resource_ref: `github.com/${GITHUB_ORG}/${GITHUB_REPO}/tree/main`,
+          evidence_json: { http_status: branchProtRes.status, ssot_ref: SSOT_REF },
+          recommendation: "Enable branch protection rules in Repository Settings → Branches.",
+          citation_url:
+            "https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches",
+        })
+        phases.develop.findings_inserted += 1
+      }
+
+      // CODEOWNERS
+      const codeownersRes = await fetch(
+        `https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/contents/.github/CODEOWNERS`,
+        { headers: githubHeaders }
+      )
+      const codeownersExists = codeownersRes.status === 200
+      phases.develop.checks.codeowners_exists = codeownersExists
+
+      if (!codeownersExists) {
+        phases.develop.status = "fail"
+        allFindings.push({
+          scan_id: scanId,
+          pillar: "ops_excellence",
+          severity: "medium",
+          title: "CODEOWNERS file missing (Develop phase)",
+          description:
+            "No CODEOWNERS file found at .github/CODEOWNERS. Code ownership is undefined.",
+          resource_ref: `github.com/${GITHUB_ORG}/${GITHUB_REPO}/blob/main/.github/CODEOWNERS`,
+          evidence_json: { http_status: codeownersRes.status, ssot_ref: SSOT_REF },
+          recommendation: "Create a .github/CODEOWNERS file mapping paths to responsible teams.",
+          citation_url:
+            "https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners",
+        })
+        phases.develop.findings_inserted += 1
+      }
+    }
+
+    // -------------------------------------------------------------------------
+    // DELIVER PHASE — VERCEL_TOKEN presence (proxy for Vercel CI gated)
+    // -------------------------------------------------------------------------
+    const vercelConfigured = !!VERCEL_TOKEN
+    phases.deliver.checks.vercel_token_present = vercelConfigured
+
+    if (!vercelConfigured) {
+      phases.deliver.status = "fail"
+      allFindings.push({
+        scan_id: scanId,
+        pillar: "ops_excellence",
+        severity: "high",
+        title: "Deliver phase: VERCEL_TOKEN not configured",
+        description:
+          "VERCEL_TOKEN is not present in the environment. This is used as a proxy for Vercel CI delivery gating.",
+        evidence_json: {
+          error: "KEY_MISSING",
+          key: "VERCEL_TOKEN",
+          ssot_ref: SSOT_REF,
+        },
+        recommendation:
+          "Set VERCEL_TOKEN in the runtime environment to enable Vercel CI delivery checks.",
+        citation_url: "https://vercel.com/docs/rest-api",
+      })
+      phases.deliver.findings_inserted += 1
+    }
+
+    // -------------------------------------------------------------------------
+    // OPERATE PHASE — open high-severity findings older than 24h
+    // -------------------------------------------------------------------------
+    try {
+      const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+      const openFindingsRes = await fetch(
+        `${SUPABASE_URL}/rest/v1/ops.advisor_findings?status=eq.open&severity=in.(critical,high)&created_at=lt.${encodeURIComponent(twentyFourHoursAgo)}&select=id,title,severity,pillar,created_at&limit=10`,
+        { headers: supabaseHeaders() }
+      )
+
+      let staleHighFindings: Array<{ id: string; title: string; severity: string; pillar: string; created_at: string }> = []
+      if (openFindingsRes.ok) {
+        staleHighFindings = await openFindingsRes.json()
+      }
+      phases.operate.checks.stale_high_severity_findings = staleHighFindings.length
+
+      if (staleHighFindings.length > 0) {
+        phases.operate.status = "fail"
+        allFindings.push({
+          scan_id: scanId,
+          pillar: "reliability",
+          severity: staleHighFindings.some((f) => f.severity === "critical") ? "critical" : "high",
+          title: `${staleHighFindings.length} unresolved high/critical finding(s) older than 24h`,
+          description:
+            "Open high or critical severity advisor findings have not been resolved or dismissed within 24 hours.",
+          evidence_json: {
+            stale_findings: staleHighFindings,
+            threshold_hours: 24,
+            ssot_ref: SSOT_REF,
+          },
+          recommendation:
+            "Review and resolve or dismiss open high/critical findings in the advisor dashboard.",
+          citation_url:
+            "https://learn.microsoft.com/en-us/devops/operate/what-is-monitoring",
+        })
+        phases.operate.findings_inserted += 1
+      }
+    } catch {
+      phases.operate.status = "fail"
+      phases.operate.checks.error = "Failed to query ops.advisor_findings"
+    }
+
+    // Insert all findings
+    if (allFindings.length > 0) {
+      const findingsRes = await fetch(`${SUPABASE_URL}/rest/v1/ops.advisor_findings`, {
+        method: "POST",
+        headers: { ...supabaseHeaders(), Prefer: "return=minimal" },
+        body: JSON.stringify(allFindings),
+      })
+      if (!findingsRes.ok) {
+        const text = await findingsRes.text()
+        return NextResponse.json({ error: text }, { status: findingsRes.status, headers: hdrs })
+      }
+    }
+
+    // Update scan to completed
+    const updateRes = await fetch(
+      `${SUPABASE_URL}/rest/v1/ops.advisor_scans?id=eq.${scanId}`,
+      {
+        method: "PATCH",
+        headers: { ...supabaseHeaders(), Prefer: "return=minimal" },
+        body: JSON.stringify({
+          status: "completed",
+          finished_at: new Date().toISOString(),
+          summary_json: {
+            phases: {
+              plan: { status: phases.plan.status, checks: phases.plan.checks },
+              develop: { status: phases.develop.status, checks: phases.develop.checks },
+              deliver: { status: phases.deliver.status, checks: phases.deliver.checks },
+              operate: { status: phases.operate.status, checks: phases.operate.checks },
+            },
+            findings_count: allFindings.length,
+            ssot_ref: SSOT_REF,
+          },
+        }),
+      }
+    )
+    if (!updateRes.ok) {
+      const text = await updateRes.text()
+      return NextResponse.json({ error: text }, { status: updateRes.status, headers: hdrs })
+    }
+
+    return NextResponse.json(
+      {
+        scan_id: scanId,
+        phases: {
+          plan: { status: phases.plan.status, checks: phases.plan.checks },
+          develop: { status: phases.develop.status, checks: phases.develop.checks },
+          deliver: { status: phases.deliver.status, checks: phases.deliver.checks },
+          operate: { status: phases.operate.status, checks: phases.operate.checks },
+        },
+        findings_count: allFindings.length,
+      },
+      { status: 200, headers: hdrs }
+    )
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500, headers: hdrs })
+  }
+}

--- a/apps/ops-console/app/api/advisor/scans/github/route.ts
+++ b/apps/ops-console/app/api/advisor/scans/github/route.ts
@@ -1,0 +1,302 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getOrCreateRequestId, correlationHeaders } from "@/lib/http/correlation"
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? ""
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? ""
+
+function supabaseHeaders() {
+  return {
+    apikey: SUPABASE_SERVICE_ROLE_KEY,
+    Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+    "Content-Type": "application/json",
+  }
+}
+
+const GITHUB_ORG = "Insightpulseai"
+const GITHUB_REPO = "odoo"
+
+/**
+ * POST /api/advisor/scans/github
+ *
+ * Runs a GitHub security and governance scan against the Insightpulseai/odoo repo.
+ * Checks:
+ *   - Dependabot alerts enabled
+ *   - Secret scanning status
+ *   - Push protection status
+ *   - Branch protection on main
+ *   - Required status checks include ci/lint
+ *   - CODEOWNERS file exists
+ *
+ * Returns { scan_id, findings_count, findings }
+ */
+export async function POST(req: NextRequest) {
+  const rid = getOrCreateRequestId(req.headers.get("x-request-id"))
+  const hdrs = correlationHeaders(rid)
+
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    return NextResponse.json({ error: "Supabase not configured" }, { status: 503, headers: hdrs })
+  }
+
+  const GITHUB_TOKEN = process.env.GITHUB_TOKEN ?? ""
+  if (!GITHUB_TOKEN) {
+    return NextResponse.json(
+      {
+        error: "KEY_MISSING",
+        key: "GITHUB_TOKEN",
+        ssot_ref: "ssot/integrations/github_features.yaml",
+      },
+      { status: 503, headers: hdrs }
+    )
+  }
+
+  try {
+    // 1. Create advisor_scans row
+    const scanRes = await fetch(`${SUPABASE_URL}/rest/v1/ops.advisor_scans`, {
+      method: "POST",
+      headers: { ...supabaseHeaders(), Prefer: "return=representation" },
+      body: JSON.stringify({
+        provider: "github",
+        status: "running",
+      }),
+    })
+    if (!scanRes.ok) {
+      const text = await scanRes.text()
+      return NextResponse.json({ error: text }, { status: scanRes.status, headers: hdrs })
+    }
+    const [scan] = await scanRes.json()
+    const scanId: string = scan.id
+
+    const githubHeaders = {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    const findings: Array<{
+      scan_id: string
+      pillar: string
+      severity: string
+      title: string
+      description?: string
+      resource_ref?: string
+      evidence_json?: object
+      recommendation?: string
+      citation_url?: string
+    }> = []
+    const checkResults: Record<string, boolean | string> = {}
+
+    // 2a. Check Dependabot alerts enabled (204 = enabled, 404 = disabled)
+    const dependabotRes = await fetch(
+      `https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/vulnerability-alerts`,
+      { headers: githubHeaders }
+    )
+    const dependabotEnabled = dependabotRes.status === 204
+    checkResults.dependabot_enabled = dependabotEnabled
+    if (!dependabotEnabled) {
+      findings.push({
+        scan_id: scanId,
+        pillar: "security",
+        severity: "high",
+        title: "Dependabot alerts disabled",
+        description: "Dependabot vulnerability alerts are not enabled for this repository.",
+        resource_ref: `github.com/${GITHUB_ORG}/${GITHUB_REPO}`,
+        evidence_json: { http_status: dependabotRes.status },
+        recommendation: "Enable via GitHub Security tab",
+        citation_url: "https://docs.github.com/en/code-security/dependabot",
+      })
+    }
+
+    // 2b. Check secret scanning and push protection
+    const repoRes = await fetch(
+      `https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}`,
+      { headers: githubHeaders }
+    )
+    let secretScanningActive = false
+    let pushProtectionEnabled = false
+    if (repoRes.ok) {
+      const repoData = await repoRes.json()
+      const secAnalysis = repoData?.security_and_analysis ?? {}
+      secretScanningActive =
+        secAnalysis?.secret_scanning?.status === "enabled"
+      pushProtectionEnabled =
+        secAnalysis?.secret_scanning_push_protection?.status === "enabled"
+      checkResults.secret_scanning_active = secretScanningActive
+      checkResults.push_protection_enabled = pushProtectionEnabled
+    } else {
+      checkResults.secret_scanning_active = false
+      checkResults.push_protection_enabled = false
+    }
+
+    if (!secretScanningActive) {
+      findings.push({
+        scan_id: scanId,
+        pillar: "security",
+        severity: "critical",
+        title: "Secret scanning not active",
+        description:
+          "GitHub secret scanning is not enabled. Leaked credentials may go undetected.",
+        resource_ref: `github.com/${GITHUB_ORG}/${GITHUB_REPO}`,
+        evidence_json: {
+          security_and_analysis: repoRes.ok
+            ? (await repoRes.clone().json().catch(() => null))
+                ?.security_and_analysis ?? null
+            : null,
+          http_status: repoRes.status,
+        },
+        recommendation: "Enable secret scanning in repository Security settings.",
+        citation_url: "https://docs.github.com/en/code-security/secret-scanning",
+      })
+    }
+
+    if (!pushProtectionEnabled) {
+      findings.push({
+        scan_id: scanId,
+        pillar: "security",
+        severity: "high",
+        title: "Push protection not enabled",
+        description:
+          "Secret scanning push protection is disabled. Secrets may be pushed before detection.",
+        resource_ref: `github.com/${GITHUB_ORG}/${GITHUB_REPO}`,
+        evidence_json: { push_protection_status: "disabled" },
+        recommendation:
+          "Enable push protection under Repository Settings → Code security and analysis.",
+        citation_url:
+          "https://docs.github.com/en/code-security/secret-scanning/push-protection-for-repositories-and-organizations",
+      })
+    }
+
+    // 2c. Check branch protection on main
+    const branchProtRes = await fetch(
+      `https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/branches/main/protection`,
+      { headers: githubHeaders }
+    )
+    const branchProtected = branchProtRes.status === 200
+    checkResults.branch_protection = branchProtected
+
+    let branchProtData: Record<string, unknown> | null = null
+    if (branchProtected) {
+      branchProtData = await branchProtRes.json()
+    }
+
+    if (!branchProtected) {
+      findings.push({
+        scan_id: scanId,
+        pillar: "ops_excellence",
+        severity: "high",
+        title: "main branch not protected",
+        description:
+          "The main branch has no branch protection rules configured.",
+        resource_ref: `github.com/${GITHUB_ORG}/${GITHUB_REPO}/tree/main`,
+        evidence_json: { http_status: branchProtRes.status },
+        recommendation:
+          "Enable branch protection rules for main in Repository Settings → Branches.",
+        citation_url:
+          "https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches",
+      })
+    }
+
+    // 2d. Check required status checks include ci/lint
+    let ciLintRequired = false
+    if (branchProtected && branchProtData) {
+      const contexts: string[] =
+        (branchProtData?.required_status_checks as { contexts?: string[] } | null)
+          ?.contexts ?? []
+      ciLintRequired = contexts.includes("ci/lint")
+      checkResults.ci_lint_required = ciLintRequired
+    } else {
+      checkResults.ci_lint_required = false
+    }
+
+    if (!ciLintRequired) {
+      findings.push({
+        scan_id: scanId,
+        pillar: "ops_excellence",
+        severity: "medium",
+        title: "ci/lint not a required status check",
+        description:
+          "The ci/lint check is not in the required status checks for the main branch.",
+        resource_ref: `github.com/${GITHUB_ORG}/${GITHUB_REPO}/tree/main`,
+        evidence_json: {
+          required_contexts: branchProtected
+            ? (branchProtData?.required_status_checks as { contexts?: string[] } | null)
+                ?.contexts ?? []
+            : [],
+        },
+        recommendation:
+          "Add ci/lint to the required status checks in branch protection settings.",
+        citation_url:
+          "https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-required-status-checks",
+      })
+    }
+
+    // 2e. Check CODEOWNERS file exists
+    const codeownersRes = await fetch(
+      `https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/contents/.github/CODEOWNERS`,
+      { headers: githubHeaders }
+    )
+    const codeownersExists = codeownersRes.status === 200
+    checkResults.codeowners_exists = codeownersExists
+
+    if (!codeownersExists) {
+      findings.push({
+        scan_id: scanId,
+        pillar: "ops_excellence",
+        severity: "medium",
+        title: "CODEOWNERS file missing",
+        description:
+          "No CODEOWNERS file found at .github/CODEOWNERS. Code ownership is undefined.",
+        resource_ref: `github.com/${GITHUB_ORG}/${GITHUB_REPO}/blob/main/.github/CODEOWNERS`,
+        evidence_json: { http_status: codeownersRes.status },
+        recommendation:
+          "Create a .github/CODEOWNERS file mapping paths to responsible teams.",
+        citation_url:
+          "https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners",
+      })
+    }
+
+    // 3. Insert findings into ops.advisor_findings
+    if (findings.length > 0) {
+      const findingsRes = await fetch(`${SUPABASE_URL}/rest/v1/ops.advisor_findings`, {
+        method: "POST",
+        headers: { ...supabaseHeaders(), Prefer: "return=representation" },
+        body: JSON.stringify(findings),
+      })
+      if (!findingsRes.ok) {
+        const text = await findingsRes.text()
+        return NextResponse.json({ error: text }, { status: findingsRes.status, headers: hdrs })
+      }
+    }
+
+    // 4. Update scan to completed with summary_json
+    const updateRes = await fetch(
+      `${SUPABASE_URL}/rest/v1/ops.advisor_scans?id=eq.${scanId}`,
+      {
+        method: "PATCH",
+        headers: { ...supabaseHeaders(), Prefer: "return=representation" },
+        body: JSON.stringify({
+          status: "completed",
+          finished_at: new Date().toISOString(),
+          summary_json: {
+            checks: checkResults,
+            findings_count: findings.length,
+          },
+        }),
+      }
+    )
+    if (!updateRes.ok) {
+      const text = await updateRes.text()
+      return NextResponse.json({ error: text }, { status: updateRes.status, headers: hdrs })
+    }
+
+    return NextResponse.json(
+      {
+        scan_id: scanId,
+        findings_count: findings.length,
+        findings,
+      },
+      { status: 200, headers: hdrs }
+    )
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500, headers: hdrs })
+  }
+}


### PR DESCRIPTION
## Summary

Implements the first runtime execution surface for the Advisor SSOT tracks:
- GitHub features posture scan
- Agentic coding rubric scoring
- Microsoft DevOps lifecycle assessment synthesis

## Changes
- `apps/ops-console/app/api/advisor/scans/github/route.ts`
  - Evaluates repo posture signals (branch protection, required checks, basic security signals when readable).
  - Writes `ops.advisor_scans` + `ops.advisor_findings`.
- `apps/ops-console/app/api/advisor/scans/agentic-coding/route.ts`
  - Reads SSOT rubric `ssot/advisor/rubrics/agentic_coding.yaml`.
  - Scores maturity from `ops.runs`/`ops.run_events`.
  - Writes `ops.advisor_scores` if present; otherwise degrades safely.
- `apps/ops-console/app/api/advisor/scans/devops-lifecycle/route.ts`
  - Reads SSOT assessment `ssot/advisor/assessments/microsoft_devops_lifecycle.yaml`.
  - Emits lifecycle findings (Plan/Develop/Deliver/Operate) into `ops.advisor_findings`.

## Behavior Contracts
- Missing required secrets return **503 KEY_MISSING** with `ssot_ref`.
- Routes are idempotent at the scan level and always emit scan + findings.
- Agentic score insert is guarded so PR A can be merged before PR C without hard failing.

## Dependencies / Merge Order
- Prefer merge after PR #429.
- Works without PR C, but **full scoring persistence requires PR C** (`ops.advisor_scores`).