### PR TITLE
fix(ssot): quote YAML values with special characters (plane_slack_intake + microsoft_agent_framework)

### DIFF
--- a/ssot/integrations/microsoft_agent_framework.yaml
+++ b/ssot/integrations/microsoft_agent_framework.yaml
@@ -141,7 +141,7 @@ posture:
 
 allowed_egress:
   - api.openai.com                           # OpenAI API (if SK uses OpenAI connector)
-  - *.openai.azure.com                       # Azure OpenAI (if using Azure connector)
+  - "*.openai.azure.com"                     # Azure OpenAI (if using Azure connector)
   - api.anthropic.com                        # Anthropic API (if using Anthropic connector)
   - packages.nuget.org                       # NuGet for C# SK packages
   - pypi.org                                 # PyPI for Python SK/AutoGen packages

--- a/ssot/integrations/plane_slack_intake.yaml
+++ b/ssot/integrations/plane_slack_intake.yaml
@@ -28,7 +28,7 @@ components:
       /plane create <title> command to trigger Plane issue creation.
     path: "apps/slack-agent/"
     new_handlers:
-      - event: reaction_added (emoji: plane)
+      - event: "reaction_added (emoji: plane)"
         action: create_plane_issue_from_thread
       - command: /plane create
         action: create_plane_issue_interactive


### PR DESCRIPTION
## Summary

- **`ssot/integrations/plane_slack_intake.yaml` line 31**: `reaction_added (emoji: plane)` — the unquoted `:` inside parentheses was parsed as a YAML mapping key, causing `ScannerError: mapping values are not allowed here`.
- **`ssot/integrations/microsoft_agent_framework.yaml` line 144**: `*.openai.azure.com` — the bare `*` in a sequence item was parsed as a YAML alias anchor, causing `ScannerError: while scanning an alias`.

Both values are now wrapped in double quotes. Both files validate via `yaml.safe_load()`.

These syntax errors survived into `main` via PR #429 (merged Feb 28). This PR hotfixes them.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('ssot/integrations/plane_slack_intake.yaml'))"` → no error
- [x] `python3 -c "import yaml; yaml.safe_load(open('ssot/integrations/microsoft_agent_framework.yaml'))"` → no error
- [ ] CI P6 YAML/JSON syntax gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)