### PR TITLE
fix(ops-console): exclude tests/ from tsc + register webhook routes in vercel.json

### DIFF
--- a/apps/ops-console/playwright.config.ts
+++ b/apps/ops-console/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 30_000,
+  use: {
+    baseURL: process.env.TEST_BASE_URL ?? "http://localhost:3000",
+    extraHTTPHeaders: {
+      "Content-Type": "application/json",
+    },
+  },
+});

--- a/apps/ops-console/tsconfig.json
+++ b/apps/ops-console/tsconfig.json
@@ -19,5 +19,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "tests"]
 }

--- a/apps/ops-console/vercel.json
+++ b/apps/ops-console/vercel.json
@@ -34,6 +34,12 @@
     },
     "app/api/queues/consume/route.ts": {
       "maxDuration": 60
+    },
+    "app/api/webhooks/plane/route.ts": {
+      "maxDuration": 15
+    },
+    "app/api/webhooks/github/route.ts": {
+      "maxDuration": 15
     }
   },
   "headers": [


### PR DESCRIPTION
## Summary

- **\`tsconfig.json\`**: Add \`\"tests\"\` to \`exclude\` — prevents \`next build\` from type-checking Playwright test files, fixing ~27s preview build failures
- **\`playwright.config.ts\`**: Add root Playwright config pointing \`testDir\` to \`./tests\`
- **\`vercel.json\`**: Register webhook routes with \`maxDuration: 15\`

## Root Cause

\`tsconfig.json\` included \`**/*.ts\` with only \`node_modules\` excluded. \`next build\` compiled Playwright test files causing TypeScript errors — all preview deployments failed at ~27s.

## Test plan
- [ ] Vercel preview build for this branch succeeds
- [ ] Webhook routes in Vercel function list post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)