### PR TITLE
fix(ci): stop Syntax Check false positives (node_modules/worktrees/jsonc)

### DIFF
--- a/.github/workflows/all-green-gates.yml
+++ b/.github/workflows/all-green-gates.yml
@@ -159,6 +159,12 @@ jobs:
         run: pip install pyyaml
 
       - name: Validate JSON files
+        # Excludes:
+        #   - All nested node_modules (not just root-level)
+        #   - .claude/worktrees and .worktrees (local git worktrees, not CI artifacts)
+        #   - docs/evidence and .gemini/tmp (generated output, not source)
+        #   - JSONC files: tsconfig.json, devcontainer.json, .vscode/*.json
+        #     (these are JSON-with-comments by spec; strict JSON parsers reject them)
         run: |
           fail=0
           while IFS= read -r jsonfile; do
@@ -166,10 +172,24 @@ jobs:
               echo "::error file=$jsonfile::Invalid JSON"
               fail=1
             }
-          done < <(find . -name "*.json" -type f -not -path "./node_modules/*" -not -path "./.git/*" 2>/dev/null || true)
+          done < <(find . \
+            \( -path "*/node_modules/*" \
+               -o -path "*/.git/*" \
+               -o -path "*/.claude/worktrees/*" \
+               -o -path "*/.worktrees/*" \
+               -o -path "*/docs/evidence/*" \
+               -o -path "*/.gemini/tmp/*" \
+            \) -prune -o \
+            -type f -name "*.json" \
+            ! -name "tsconfig.json" \
+            ! -name "tsconfig.*.json" \
+            ! -name "devcontainer.json" \
+            ! -path "*/.vscode/*.json" \
+            -print 2>/dev/null || true)
           exit $fail
 
       - name: Validate YAML files
+        # Excludes node_modules, .git, worktrees, and generated output paths
         run: |
           fail=0
           while IFS= read -r yamlfile; do
@@ -177,7 +197,14 @@ jobs:
               echo "::error file=$yamlfile::Invalid YAML"
               fail=1
             }
-          done < <(find . -name "*.yaml" -o -name "*.yml" -type f -not -path "./node_modules/*" -not -path "./.git/*" 2>/dev/null || true)
+          done < <(find . \
+            \( -path "*/node_modules/*" \
+               -o -path "*/.git/*" \
+               -o -path "*/.claude/worktrees/*" \
+               -o -path "*/.worktrees/*" \
+            \) -prune -o \
+            \( -name "*.yaml" -o -name "*.yml" \) \
+            -type f -print 2>/dev/null || true)
           exit $fail
 
   # ==========================================================================

--- a/.github/workflows/ci-platform-gates.yml
+++ b/.github/workflows/ci-platform-gates.yml
@@ -99,18 +99,32 @@ jobs:
           PY
 
       - name: Validate JSON configs
+        # Excludes nested node_modules, worktrees, evidence output, and JSONC files
+        # (tsconfig.json / devcontainer.json / .vscode/*.json allow comments by spec)
         run: |
           python - <<'PY'
-          import glob, json, sys
+          import glob, json, sys, os
+          SKIP_DIRS = {"node_modules", ".git", "worktrees", "evidence", ".gemini"}
+          SKIP_NAMES = {"tsconfig.json", "devcontainer.json"}
           errors = []
-          for pattern in ["**/*.json", ".claude/*.json"]:
-              for f in glob.glob(pattern, recursive=True):
-                  if "node_modules" in f or ".git" in f:
-                      continue
-                  try:
-                      json.load(open(f))
-                  except Exception as e:
-                      errors.append(f"{f}: {e}")
+          for f in glob.glob("**/*.json", recursive=True):
+              parts = set(f.replace("\\", "/").split("/"))
+              # Skip any path component that is a known excluded directory
+              if parts & SKIP_DIRS:
+                  continue
+              # Skip .vscode JSON (JSONC)
+              if "/.vscode/" in f.replace("\\", "/") or f.startswith(".vscode/"):
+                  continue
+              # Skip .worktrees and .claude/worktrees (local git worktrees)
+              if ".worktrees/" in f or ".claude/worktrees/" in f:
+                  continue
+              # Skip known JSONC filenames
+              if os.path.basename(f) in SKIP_NAMES or os.path.basename(f).startswith("tsconfig."):
+                  continue
+              try:
+                  json.load(open(f))
+              except Exception as e:
+                  errors.append(f"{f}: {e}")
           if errors:
               print("JSON validation errors (first 10):")
               for e in errors[:10]:


### PR DESCRIPTION
## Summary

- **`all-green-gates.yml`** (Gate 4 - Syntax Check): Replace `find -not -path` with proper `prune` semantics that catches *nested* `node_modules` (e.g. `apps/ops-console/node_modules/`) instead of only root-level. Also prunes `.claude/worktrees/`, `.worktrees/`, `docs/evidence/`, `.gemini/tmp/`. Excludes JSONC files by name: `tsconfig.json`, `tsconfig.*.json`, `devcontainer.json`, `.vscode/*.json` — these allow JS comments by spec and fail strict `json.load()`.
- **`ci-platform-gates.yml`** (platform-syntax job): Replace `glob("**/*.json")` + string-contains check with set-based directory component exclusion so any depth of `node_modules` is skipped. Same JSONC exclusions by basename.

## Root cause

The old `find . -not -path "./node_modules/*"` pattern only excluded the *root-level* `node_modules/`. Sub-packages like `apps/ops-console/node_modules/` still matched, causing `json.load()` to fail on JSONC `tsconfig.json` files inside those trees.

## Test plan

- [ ] CI "Syntax Check" gate (Gate 4) passes with 0 errors on this PR
- [ ] CI "Platform Syntax Checks" job passes on this PR  
- [ ] Dry-run validated locally: `find . \( -path "*/node_modules/*" ... \) -prune -o -type f -name "*.json" ! -name "tsconfig.json" ... -print | wc -l` → 1235 files, all parse clean

## Related

Resolves pre-existing false positives surfaced during PR #437 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)