### PR TITLE
chore(ops): PR #436 rollout checklist + webhook secrets SSOT registry

### DIFF
--- a/docs/ops/release/2026-03-01_pr436_rollout.md
+++ b/docs/ops/release/2026-03-01_pr436_rollout.md
@@ -1,0 +1,70 @@
+# PR #436 + #438 Rollout Checklist — 2026-03-01
+
+## Context
+- PR #436 merged: mail catcher + DO ingest + ops.capabilities + work-items webhooks + processor + tests
+- PR #438 merged: fix(ops-console) exclude tests/ from tsc + playwright.config + webhook fn registration
+
+## Pre-deployment (DONE)
+- [x] `20260301000050_ops_digitalocean.sql` — committed
+- [x] `20260301000055_ops_mail_events.sql` — committed
+- [x] `20260301000060_ops_capabilities.sql` — committed
+- [x] `20260301000065_ops_workitems_webhooks.sql` — committed
+- [x] `ops-mailgun-ingest` Edge Function — committed
+- [x] `ops-do-ingest` Edge Function — committed
+- [x] `ops-workitems-processor` Edge Function — committed
+- [x] Webhook routes `/api/webhooks/plane` + `/api/webhooks/github` — committed
+- [x] SSOT sources: `ssot/sources/plane/work_items.yaml`, `ssot/sources/github/work_items.yaml`
+- [x] Contracts: `C-PLANE-02` (C-21), `C-GH-02` (C-22)
+
+## Deployment Steps
+
+### 1. Apply migrations (prod)
+```bash
+# Requires valid SUPABASE_ACCESS_TOKEN — refresh at supabase.com/dashboard/account/tokens
+supabase link --project-ref spdtwktxdalcfigzeqrz
+supabase db push
+```
+Verify: `ops.mail_events`, `ops.plane_webhook_deliveries`, `ops.github_webhook_deliveries`, `ops.work_queue`, `ops.work_items` tables exist with correct RLS.
+
+### 2. Deploy Edge Functions
+```bash
+supabase functions deploy ops-mailgun-ingest --project-ref spdtwktxdalcfigzeqrz
+supabase functions deploy ops-do-ingest --project-ref spdtwktxdalcfigzeqrz
+supabase functions deploy ops-workitems-processor --project-ref spdtwktxdalcfigzeqrz
+```
+
+### 3. Set Supabase Vault secret
+SSOT ref: `mailgun_signing_key` (see `ssot/secrets/registry.yaml`)
+```bash
+supabase secrets set MAILGUN_SIGNING_KEY=<value> --project-ref spdtwktxdalcfigzeqrz
+```
+
+### 4. Set Vercel env vars for ops-console
+Project: `odooops-console`
+```bash
+vercel env add PLANE_WEBHOOK_SECRET production --yes
+vercel env add GITHUB_WEBHOOK_SECRET production --yes
+```
+SSOT refs: `plane_webhook_secret`, `github_webhook_secret` (see `ssot/secrets/registry.yaml`)
+
+### 5. Activate ops.insightpulseai.com
+1. [MANUAL] Add `ops.insightpulseai.com` as custom domain in Vercel project `odooops-console`
+2. Update `infra/dns/subdomain-registry.yaml` line ~263:
+   - `lifecycle: planned` → `lifecycle: active`
+   - Add `provider_claim.status: claimed`, `claimed_at: <today>`, `claim_ref: vercel:prj_<project-id>`
+
+## Verification Checklist
+- [ ] `POST /api/webhooks/plane` → 200 JSON with valid sig, 403 JSON with invalid sig
+- [ ] `POST /api/webhooks/github` → same
+- [ ] `ops.plane_webhook_deliveries` rows populate on webhook delivery
+- [ ] `ops.work_items` updated after processor runs
+- [ ] `ops.mail_events` populated on Mailgun webhook delivery
+- [ ] `ops.do_droplets` / `ops.do_databases` / `ops.do_firewalls` have recent rows
+- [ ] `/platform/digitalocean` page renders with data
+- [ ] `ops.insightpulseai.com` resolves to Vercel ops-console deployment
+
+## Links
+- PR #436: https://github.com/Insightpulseai/odoo/pull/436 (merged)
+- PR #438: https://github.com/Insightpulseai/odoo/pull/438 (merged)
+- Supabase project: https://supabase.com/dashboard/project/spdtwktxdalcfigzeqrz
+- Vercel project: https://vercel.com/tbwa/odooops-console

--- a/ssot/secrets/registry.yaml
+++ b/ssot/secrets/registry.yaml
@@ -626,17 +626,21 @@ secrets:
     approved_stores:
       - supabase_vault
       - os_keychain
+      - vercel_env
     vault_secret_name: plane_webhook_secret
     prohibited_consumers:
       - github_actions
-      - vercel_env
     consumers:
       - supabase_vault:plane_webhook_secret
+      - vercel_env:apps/ops-console  # PLANE_WEBHOOK_SECRET for webhook signature verification
+      - platform:apps/ops-console/app/api/webhooks/plane/route.ts
     rotation_policy: "On team member offboarding or exposure"
     notes: >
       Embedded as X-Plane-Webhook-Secret header or in webhook URL path.
       Generate: python3 -c "import secrets; print(secrets.token_hex(32))"
       See: ssot/integrations/plane_webhooks.yaml §risk_flags.webhook_no_signature
+      Contract: docs/contracts/C-PLANE-02-workitems-webhooks.md
+      SSOT: ssot/sources/plane/work_items.yaml (secret_ref: plane_webhook_secret)
 
   # ---------------------------------------------------------------------------
   # n8n automation runner credentials
@@ -976,6 +980,7 @@ secrets:
     approved_stores:
       - supabase_vault
       - os_keychain
+      - vercel_env
     vault_secret_name: github_webhook_secret
     storage_policy:
       local: os_keychain
@@ -983,9 +988,9 @@ secrets:
       runtime: supabase_vault
     prohibited_consumers:
       - github_actions   # server-only; must not appear in CI env vars
-      - vercel_env       # must never reach browser
     consumers:
       - supabase_vault:github_webhook_secret   # consumed by ops-console webhook receiver
+      - vercel_env:apps/ops-console  # GITHUB_WEBHOOK_SECRET for server-side Next.js API route (not browser)
       - platform:apps/ops-console/app/api/webhooks/github/route.ts
     rotation_policy: "On team member offboarding or GitHub webhook endpoint compromise"
     notes: >
@@ -994,5 +999,6 @@ secrets:
       Minimum 32 random bytes. Generate with:
         python3 -c "import secrets; print(secrets.token_hex(32))"
       Set as the 'secret' field when registering the webhook in GitHub repository settings.
+      Vercel env var is server-side only (Next.js API route — never exposed to browser).
       Contract: docs/contracts/C-GH-02-workitems-webhooks.md
       SSOT: ssot/sources/github/work_items.yaml (secret_ref: github_webhook_secret)


### PR DESCRIPTION
## Summary

- **`docs/ops/release/2026-03-01_pr436_rollout.md`**: Machine-readable deployment checklist for PRs #436/#438 rollout — migrations, Edge Functions, Vault secrets, Vercel env vars, DNS activation, verification checklist
- **`ssot/secrets/registry.yaml`**: Updated `plane_webhook_secret` and `github_webhook_secret` — moved `vercel_env` from prohibited to approved stores (server-side-only note), added ops-console consumer entries and contract refs (C-21/C-22)

## Why

Prevents the "merged but inert" problem — ops secrets must be traceable in SSOT. The rollout doc gives a single canonical reference for post-merge deployment steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)