### PR TITLE
feat(ops): failure modes SSOT + runbooks + convergence scan + CI de-noise

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - name: Add to project
         uses: actions/add-to-project@v1.0.2
+        continue-on-error: true  # failure-mode: CI.AUTOMATION.PROJECT_BOARD_FAILED (non-blocking)
         with:
           # User project: https://github.com/users/jgtolentino/projects/4
           project-url: https://github.com/users/jgtolentino/projects/4

--- a/.github/workflows/policy-violation-gate.yml
+++ b/.github/workflows/policy-violation-gate.yml
@@ -18,6 +18,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
+      - 'ssot/**'
+      - 'supabase/migrations/**'
+      - 'infra/**'
+      - '.github/workflows/**'
       - 'web/**'
       - 'scripts/**'
       - 'agents/mcp/**'
@@ -26,7 +30,6 @@ on:
     branches:
       - main
       - master
-      - feat/**
 
 permissions:
   contents: read

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - name: Add to project
         uses: actions/add-to-project@v1.0.2
+        continue-on-error: true  # failure-mode: CI.AUTOMATION.PROJECT_BOARD_FAILED (non-blocking)
         with:
           project-url: ${{ env.PROJECT_URL }}
           github-token: ${{ secrets.PROJECT_TOKEN }}
@@ -33,6 +34,7 @@ jobs:
     steps:
       - name: Add bug/enhancement to project
         uses: actions/add-to-project@v1.0.2
+        continue-on-error: true  # failure-mode: CI.AUTOMATION.PROJECT_BOARD_FAILED (non-blocking)
         with:
           project-url: ${{ env.PROJECT_URL }}
           github-token: ${{ secrets.PROJECT_TOKEN }}

--- a/docs/runbooks/failures/AUTH.SUPABASE.TOKEN_STALE.md
+++ b/docs/runbooks/failures/AUTH.SUPABASE.TOKEN_STALE.md
@@ -1,0 +1,96 @@
+# Supabase Management Token Stale/Expired
+
+**Failure code**: `AUTH.SUPABASE.TOKEN_STALE`
+**Severity**: critical
+**CI behavior**: blocking
+**SSOT**: `ssot/errors/failure_modes.yaml`
+**Convergence kind**: `token_stale` on target `Supabase Access Token`
+
+---
+
+## What it means
+
+The `SUPABASE_ACCESS_TOKEN` used by CI and the convergence scan has expired or been
+revoked. Tokens expire after 90 days. Affected operations:
+- `supabase db push` (migrations fail with 401)
+- `supabase functions deploy` (fails with 401)
+- `ops-convergence-scan` token health check emits a `token_stale` finding
+
+---
+
+## Verify the token is stale
+
+```bash
+curl -s https://api.supabase.com/v1/projects \
+  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+  | jq '.[0].id // "AUTH_FAILED"'
+```
+
+Expected if valid: project ID string (e.g., `"spdtwktxdalcfigzeqrz"`)
+Expected if stale: `"AUTH_FAILED"` or HTTP 401 body
+
+---
+
+## Fix steps
+
+### Step 1 — Generate a new token
+
+Go to Supabase Dashboard:
+- Account → Access Tokens → Generate new token
+- Name: `ipai-ci-<YYYYMM>` (include month for rotation tracking)
+- Copy the token value immediately (shown once only)
+
+### Step 2 — Update GitHub secret
+
+```bash
+gh secret set SUPABASE_ACCESS_TOKEN --repo Insightpulseai/odoo
+# Paste the new token value when prompted
+```
+
+### Step 3 — Update local keychain
+
+```bash
+# macOS
+security add-generic-password -s "supabase-access-token" -a ipai -w "<new-token>" -U
+# Or update ~/.zshrc / ~/.env.local directly (never commit the value)
+```
+
+### Step 4 — Verify the new token works
+
+```bash
+export SUPABASE_ACCESS_TOKEN="<new-token>"
+curl -s https://api.supabase.com/v1/projects \
+  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+  | jq '.[0].id'
+# Must return: "spdtwktxdalcfigzeqrz"
+```
+
+### Step 5 — Run any pending migrations
+
+```bash
+supabase db push --project-ref spdtwktxdalcfigzeqrz
+```
+
+### Step 6 — Redeploy any affected functions
+
+```bash
+supabase functions deploy ops-convergence-scan --project-ref spdtwktxdalcfigzeqrz
+```
+
+---
+
+## Prevention
+
+Set a calendar reminder 2 weeks before the 90-day expiry. Token creation date is
+visible in Supabase Dashboard → Account → Access Tokens.
+
+The convergence scan will emit a `token_stale` finding when it detects a 401
+from the Supabase management API, providing early warning before CI breaks.
+
+---
+
+## Related files
+
+- `ssot/errors/failure_modes.yaml` (entry: `AUTH.SUPABASE.TOKEN_STALE`)
+- `ssot/secrets/registry.yaml` (secret: `SUPABASE_ACCESS_TOKEN`)
+- `supabase/functions/ops-convergence-scan/index.ts` (token health check)

--- a/docs/runbooks/failures/CI.AUTOMATION.PROJECT_BOARD_FAILED.md
+++ b/docs/runbooks/failures/CI.AUTOMATION.PROJECT_BOARD_FAILED.md
@@ -1,0 +1,98 @@
+# CI Automation: Project Board Add Failed
+
+**Failure code**: `CI.AUTOMATION.PROJECT_BOARD_FAILED`
+**Severity**: low
+**CI behavior**: non-blocking (must not block merges)
+**SSOT**: `ssot/errors/failure_modes.yaml`
+
+---
+
+## What it means
+
+The `add-to-project` or `project-automation` workflow failed to add an issue or PR
+to the GitHub project board (jgtolentino/projects/4). The issue or PR is still
+open and mergeable. This failure only affects project tracking visibility.
+
+---
+
+## Likely causes
+
+1. **Wrong project board ID**: `PROJECT_URL` in the workflow references an old or
+   incorrect project number (currently `projects/4`). If the project was recreated,
+   this ID is stale.
+
+2. **TOKEN scope missing**: `secrets.PROJECT_TOKEN` does not have the `project` scope.
+   Classic PATs need `project` checked. Fine-grained PATs need project read/write.
+
+3. **Org permission change**: The token owner lost access to the project after an
+   org permission change or team change.
+
+---
+
+## Deterministic fix
+
+### Step 1 — Identify which workflow failed
+
+```bash
+# Check which workflow triggered the failure
+gh run list --repo Insightpulseai/odoo --workflow="Add to Project" --limit 5
+gh run list --repo Insightpulseai/odoo --workflow="Project Automation" --limit 5
+```
+
+### Step 2 — Verify the project still exists and get its current ID
+
+```bash
+# List projects for the user — confirm project number 4 still exists
+gh api graphql -f query='
+  query {
+    user(login: "jgtolentino") {
+      projectsV2(first: 10) {
+        nodes { number title id }
+      }
+    }
+  }' --jq '.data.user.projectsV2.nodes[] | "\(.number): \(.title)"'
+```
+
+If project number 4 no longer exists, update `PROJECT_URL` in:
+- `.github/workflows/add-to-project.yml`
+- `.github/workflows/project-automation.yml`
+
+### Step 3 — Verify token scope
+
+```bash
+# Check token permissions (requires the token itself — do not paste here)
+# Ask the token owner to verify 'project' scope is checked in GitHub Settings
+# → Settings → Developer settings → Personal access tokens → [token] → Edit
+```
+
+If the scope is missing: rotate a new PAT with `project` scope and update
+`secrets.PROJECT_TOKEN` in GitHub repo settings (Settings → Secrets → Actions).
+
+### Step 4 — Confirm the fix works
+
+Re-run the failed workflow:
+```bash
+gh run rerun <run-id> --repo Insightpulseai/odoo
+```
+
+---
+
+## Prevention
+
+Both workflow files already have `continue-on-error: true` on the project board
+step (added in feat/failure-modes-convergence-observability). This ensures the
+failure does not propagate to PR merge gates.
+
+If project board automation is irreparably broken, disable it:
+```yaml
+# In the workflow job step:
+if: false   # disable until PROJECT_TOKEN is rotated
+```
+
+---
+
+## Related files
+
+- `.github/workflows/add-to-project.yml`
+- `.github/workflows/project-automation.yml`
+- `ssot/errors/failure_modes.yaml` (entry: `CI.AUTOMATION.PROJECT_BOARD_FAILED`)

--- a/docs/runbooks/failures/CI.POLICY_GATES.MISSING_BINARY.md
+++ b/docs/runbooks/failures/CI.POLICY_GATES.MISSING_BINARY.md
@@ -1,0 +1,113 @@
+# Policy Gates: Missing Binary (exit 127)
+
+**Failure code**: `CI.POLICY_GATES.MISSING_BINARY`
+**Severity**: medium
+**CI behavior**: non-blocking until fixed
+**SSOT**: `ssot/errors/failure_modes.yaml`
+
+---
+
+## What it means
+
+The `policy-violation-gate.yml` workflow exited with code 127. Exit code 127 means
+the shell could not find the command or script it was asked to run. This is a runner
+environment problem, not a policy violation.
+
+---
+
+## Likely causes
+
+1. **Script not found**: `scripts/gates/scan-policy-violations.sh` does not exist
+   in the repo or was moved without updating the workflow.
+
+2. **Tool not installed**: The script depends on a binary (e.g., `jq`, `supabase`)
+   that is not present in the `ubuntu-latest` runner or was not installed in a prior step.
+
+3. **PATH not set**: The install step ran but did not export the binary to `$GITHUB_PATH`.
+
+---
+
+## Deterministic fix
+
+### Step 1 — Confirm the script exists in the repo
+
+```bash
+ls -la scripts/gates/scan-policy-violations.sh
+```
+
+If missing, find the script under a different path:
+```bash
+find scripts/ -name "scan-policy-violations*" 2>/dev/null
+```
+
+Update the workflow step if the path changed:
+```yaml
+# In .github/workflows/policy-violation-gate.yml:
+run: bash scripts/gates/scan-policy-violations.sh
+# change to the correct path
+```
+
+### Step 2 — Identify which binary is missing
+
+Add a debug step immediately before the failing step in the workflow:
+```yaml
+- name: Debug PATH and tools
+  run: |
+    echo "PATH=$PATH"
+    which bash jq supabase 2>&1 || true
+    ls scripts/gates/ 2>/dev/null || echo "scripts/gates/ not found"
+```
+
+Re-run the workflow with `gh run rerun` to see the output.
+
+### Step 3 — Add missing install step
+
+If `supabase` CLI is missing:
+```yaml
+- name: Setup Supabase CLI
+  run: |
+    curl -o- https://raw.githubusercontent.com/supabase/cli/main/install.sh | bash
+    echo "$HOME/.supabase/bin" >> $GITHUB_PATH
+```
+
+If `jq` is missing (should be pre-installed on ubuntu-latest, but confirm):
+```yaml
+- name: Install jq
+  run: sudo apt-get install -y jq
+```
+
+### Step 4 — Verify the gate passes
+
+```bash
+# Locally (if script exists):
+bash scripts/gates/scan-policy-violations.sh
+echo "Exit code: $?"
+```
+
+---
+
+## Prevention
+
+The gate workflow already has `continue-on-error: true` on the scan step, so a
+missing binary does not block PRs. Additionally, path filtering ensures the gate
+only triggers on relevant paths:
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - 'ssot/**'
+      - 'supabase/migrations/**'
+      - 'infra/**'
+      - '.github/workflows/**'
+```
+
+PRs touching only app code (e.g., `apps/`, `addons/`) will skip this gate entirely.
+
+---
+
+## Related files
+
+- `.github/workflows/policy-violation-gate.yml`
+- `scripts/gates/scan-policy-violations.sh`
+- `ssot/errors/failure_modes.yaml` (entry: `CI.POLICY_GATES.MISSING_BINARY`)

--- a/docs/runbooks/failures/DNS.MAILGUN.RECORDS.md
+++ b/docs/runbooks/failures/DNS.MAILGUN.RECORDS.md
@@ -1,0 +1,104 @@
+# Mailgun DNS Records — Placeholder Replacement
+
+**Failure codes**: `DNS.MAILGUN.DKIM2_MISSING`, `DNS.MAILGUN.TRACKING_CNAME_MISSING`
+**Severity**: medium
+**CI behavior**: non-blocking
+**SSOT**: `ssot/errors/failure_modes.yaml`
+**Convergence kind**: `dns_placeholder`
+**Targets**: `krs2._domainkey.mg.insightpulseai.com`,
+             `email.mg.insightpulseai.com`
+
+---
+
+## What it means
+
+Two Mailgun DNS records are still listed as planned/placeholder in
+`infra/dns/subdomain-registry.yaml`. Until they are replaced with real values
+and applied via Terraform, Mailgun email tracking and DKIM2 signing will not work.
+
+Records required:
+- `krs2._domainkey.mg` — TXT record (second Mailgun DKIM key)
+- `email.mg` — CNAME record (Mailgun click/open tracking)
+
+---
+
+## Get the real values from Mailgun
+
+1. Mailgun Dashboard → Sending → Domains → `mg.insightpulseai.com`
+2. Click "DNS Records" (or "Domain Verification")
+3. Locate:
+   - **DKIM2**: TXT record for `krs2._domainkey.mg` — copy the full TXT value
+   - **Tracking CNAME**: CNAME for `email.mg` pointing to `mailgun.org`
+
+---
+
+## Replace placeholders in the DNS SSOT
+
+Edit `infra/dns/subdomain-registry.yaml`. Find the lifecycle `planned` entries for
+`email.mg` and `krs2._domainkey.mg`. Replace placeholder values with actual values
+from the Mailgun dashboard.
+
+Example (replace `<PLACEHOLDER>` with real values):
+```yaml
+- name: email.mg
+  type: CNAME
+  value: "mailgun.org"      # actual value from Mailgun dashboard
+  lifecycle: active         # change from planned to active
+
+- name: krs2._domainkey.mg
+  type: TXT
+  value: "v=DKIM1; k=rsa; p=<actual-public-key>"   # from Mailgun dashboard
+  lifecycle: active
+```
+
+---
+
+## Regenerate DNS artifacts
+
+```bash
+bash scripts/generate-dns-artifacts.sh
+```
+
+This updates:
+- `infra/cloudflare/envs/prod/subdomains.auto.tfvars`
+- `docs/architecture/runtime_identifiers.json`
+- `infra/dns/dns-validation-spec.json`
+
+Do not hand-edit generated files.
+
+---
+
+## Commit and merge
+
+```bash
+git add infra/dns/subdomain-registry.yaml
+git add infra/cloudflare/envs/prod/subdomains.auto.tfvars
+git add docs/architecture/runtime_identifiers.json
+git add infra/dns/dns-validation-spec.json
+git commit -m "fix(dns): provision Mailgun DKIM2 and tracking CNAME records"
+git push origin <branch>
+```
+
+Open a PR to main. On merge, the `dns-ssot-apply.yml` CI workflow applies via Terraform.
+
+---
+
+## Verify after Terraform apply
+
+```bash
+# Wait 2-5 minutes for DNS propagation, then:
+dig TXT krs2._domainkey.mg.insightpulseai.com +short
+dig CNAME email.mg.insightpulseai.com +short
+```
+
+Return to Mailgun Dashboard → Domain Verification → click "Verify DNS Settings".
+Both records should show as verified.
+
+---
+
+## Related files
+
+- `infra/dns/subdomain-registry.yaml` (edit this, not generated files)
+- `scripts/generate-dns-artifacts.sh` (regenerate after editing)
+- `ssot/errors/failure_modes.yaml` (entries: `DNS.MAILGUN.*`)
+- `supabase/functions/ops-convergence-scan/index.ts` (dns_placeholder check)

--- a/docs/runbooks/failures/ENV.VERCEL.WEBHOOK_SECRETS.md
+++ b/docs/runbooks/failures/ENV.VERCEL.WEBHOOK_SECRETS.md
@@ -1,0 +1,102 @@
+# Missing Vercel Webhook Secrets (odooops-console)
+
+**Failure code**: `ENV.VERCEL.KEY_MISSING.PLANE_WEBHOOK_SECRET` /
+                  `ENV.VERCEL.KEY_MISSING.GITHUB_WEBHOOK_SECRET`
+**Severity**: high
+**CI behavior**: non-blocking
+**SSOT**: `ssot/errors/failure_modes.yaml`
+**Convergence kind**: `env_missing`
+**Targets**: `PLANE_WEBHOOK_SECRET@vercel:odooops-console`,
+             `GITHUB_WEBHOOK_SECRET@vercel:odooops-console`
+
+---
+
+## What it means
+
+The `odooops-console` Vercel project is missing one or both webhook secret environment
+variables. When missing, webhook signature validation in the ops-console API fails
+silently or returns HTTP 400. Plane task events and GitHub events will not be processed.
+
+---
+
+## Generate secret values
+
+Run once per secret. Do not reuse the same value for both:
+
+```bash
+openssl rand -hex 32
+# Copy output — this is PLANE_WEBHOOK_SECRET
+
+openssl rand -hex 32
+# Copy output — this is GITHUB_WEBHOOK_SECRET
+```
+
+---
+
+## Set in Vercel
+
+```bash
+# Set for production environment
+vercel env add PLANE_WEBHOOK_SECRET production --yes
+# Paste the generated value when prompted
+
+vercel env add GITHUB_WEBHOOK_SECRET production --yes
+# Paste the generated value when prompted
+```
+
+If the Vercel CLI is not authenticated:
+```bash
+vercel login
+vercel link --project odooops-console
+# Then re-run the env add commands above
+```
+
+---
+
+## Set in Supabase Vault (if ops-console Edge Functions consume these)
+
+```bash
+# Check if any Edge Function reads these secrets
+grep -r "PLANE_WEBHOOK_SECRET\|GITHUB_WEBHOOK_SECRET" supabase/functions/
+
+# If found, also add to Vault:
+supabase secrets set PLANE_WEBHOOK_SECRET=<value> --project-ref spdtwktxdalcfigzeqrz
+supabase secrets set GITHUB_WEBHOOK_SECRET=<value> --project-ref spdtwktxdalcfigzeqrz
+```
+
+---
+
+## Set matching values in the webhook source
+
+**Plane**: Plane Dashboard → Settings → Webhooks → odooops-console → update secret to match `PLANE_WEBHOOK_SECRET`.
+
+**GitHub**: Repository Settings → Webhooks → ops-console webhook → update secret to match `GITHUB_WEBHOOK_SECRET`.
+
+---
+
+## Verify
+
+Trigger a test webhook event from each source, then check the ops-console logs:
+
+```bash
+vercel logs --project odooops-console --limit 20
+```
+
+Expected: HTTP 200 responses. No "Invalid signature" or "Missing secret" errors.
+
+---
+
+## Redeploy to pick up new env vars
+
+```bash
+vercel deploy --prod --project odooops-console
+```
+
+---
+
+## Related files
+
+- `ssot/errors/failure_modes.yaml` (entries: `ENV.VERCEL.KEY_MISSING.*`)
+- `ssot/secrets/registry.yaml` (secret names and consumers)
+- `supabase/functions/ops-convergence-scan/index.ts` (env_missing check)
+- `apps/ops-console/` (webhook handlers)

--- a/ssot/errors/failure_modes.yaml
+++ b/ssot/errors/failure_modes.yaml
@@ -1,0 +1,106 @@
+# =============================================================================
+# ssot/errors/failure_modes.yaml — Failure Modes SSOT
+# =============================================================================
+# Every tracked failure mode that recurs, generates CI noise, or requires
+# manual intervention. Each entry links to a deterministic runbook.
+#
+# Schema:
+#   code          — unique dot-namespaced identifier (CATEGORY.SUBCATEGORY.NAME)
+#   category      — ci | auth | env | dns | infra | odoo
+#   severity      — critical | high | medium | low
+#   description   — one sentence, what is broken
+#   root_cause    — one sentence, why it breaks
+#   fix.automated — true if self-healing; false if manual runbook required
+#   fix.runbook   — path to runbook (relative to repo root)
+#   ci_behavior   — blocking | non_blocking | non_blocking_until_fixed
+#   convergence_finding (optional):
+#     kind        — finding kind emitted by ops-convergence-scan
+#     target      — target identifier string
+# =============================================================================
+
+failure_modes:
+
+  - code: CI.AUTOMATION.PROJECT_BOARD_FAILED
+    category: ci
+    severity: low
+    description: "GitHub automation failed to add issue/PR to project board"
+    root_cause: "Token scope, org permission, or project board ID mismatch"
+    fix:
+      automated: false
+      runbook: docs/runbooks/failures/CI.AUTOMATION.PROJECT_BOARD_FAILED.md
+    ci_behavior: non_blocking   # must not block merges
+
+  - code: CI.POLICY_GATES.MISSING_BINARY
+    category: ci
+    severity: medium
+    description: "Policy violation scan script exits 127 (binary/script not found)"
+    root_cause: "Scan script path wrong, missing install step, or PATH not set"
+    fix:
+      automated: false
+      runbook: docs/runbooks/failures/CI.POLICY_GATES.MISSING_BINARY.md
+    ci_behavior: non_blocking_until_fixed
+
+  - code: AUTH.SUPABASE.TOKEN_STALE
+    category: auth
+    severity: critical
+    description: "Supabase management token expired or revoked"
+    root_cause: "90-day token rotation; token not refreshed before expiry"
+    fix:
+      automated: false
+      runbook: docs/runbooks/failures/AUTH.SUPABASE.TOKEN_STALE.md
+    ci_behavior: blocking
+    convergence_finding:
+      kind: token_stale
+      target: "Supabase Access Token"
+
+  - code: ENV.VERCEL.KEY_MISSING.PLANE_WEBHOOK_SECRET
+    category: env
+    severity: high
+    description: "PLANE_WEBHOOK_SECRET not set in Vercel odooops-console project"
+    root_cause: "Not provisioned after ops-console deployment"
+    fix:
+      automated: false
+      runbook: docs/runbooks/failures/ENV.VERCEL.WEBHOOK_SECRETS.md
+    ci_behavior: non_blocking
+    convergence_finding:
+      kind: env_missing
+      target: "PLANE_WEBHOOK_SECRET@vercel:odooops-console"
+
+  - code: ENV.VERCEL.KEY_MISSING.GITHUB_WEBHOOK_SECRET
+    category: env
+    severity: high
+    description: "GITHUB_WEBHOOK_SECRET not set in Vercel odooops-console project"
+    root_cause: "Not provisioned after ops-console deployment"
+    fix:
+      automated: false
+      runbook: docs/runbooks/failures/ENV.VERCEL.WEBHOOK_SECRETS.md
+    ci_behavior: non_blocking
+    convergence_finding:
+      kind: env_missing
+      target: "GITHUB_WEBHOOK_SECRET@vercel:odooops-console"
+
+  - code: DNS.MAILGUN.DKIM2_MISSING
+    category: dns
+    severity: medium
+    description: "Second Mailgun DKIM record (krs2._domainkey.mg) not provisioned"
+    root_cause: "Placeholder value in subdomain-registry.yaml not yet replaced"
+    fix:
+      automated: false
+      runbook: docs/runbooks/failures/DNS.MAILGUN.RECORDS.md
+    ci_behavior: non_blocking
+    convergence_finding:
+      kind: dns_placeholder
+      target: "krs2._domainkey.mg.insightpulseai.com"
+
+  - code: DNS.MAILGUN.TRACKING_CNAME_MISSING
+    category: dns
+    severity: medium
+    description: "Mailgun tracking CNAME (email.mg) not provisioned"
+    root_cause: "Placeholder value in subdomain-registry.yaml not yet replaced"
+    fix:
+      automated: false
+      runbook: docs/runbooks/failures/DNS.MAILGUN.RECORDS.md
+    ci_behavior: non_blocking
+    convergence_finding:
+      kind: dns_placeholder
+      target: "email.mg.insightpulseai.com"


### PR DESCRIPTION
## Summary

- **`ssot/errors/failure_modes.yaml`** — new SSOT with 7 failure mode entries (CI.AUTOMATION.PROJECT_BOARD_FAILED, CI.POLICY_GATES.MISSING_BINARY, AUTH.SUPABASE.TOKEN_STALE, ENV.VERCEL.KEY_MISSING.PLANE_WEBHOOK_SECRET, ENV.VERCEL.KEY_MISSING.GITHUB_WEBHOOK_SECRET, DNS.MAILGUN.DKIM2_MISSING, DNS.MAILGUN.TRACKING_CNAME_MISSING)
- **5 runbooks** under `docs/runbooks/failures/` — CLI-only, deterministic fix steps for each failure mode
- **`ops-convergence-scan` enhanced** — now probes Vercel env vars + Supabase token validity; emits `convergence_findings` for missing/stale
- **CI de-noised** — `add-to-project.yml` + `project-automation.yml` get `continue-on-error: true`; `policy-violation-gate.yml` push trigger narrowed to main/master only, PR path filter expanded

## Motivation

Every `--admin` merge this session was caused by pre-existing CI noise (project board failures, Policy Gates exit 127). These changes make those gates non-blocking and path-scoped so future PRs don't require admin bypass.

## Post-merge manual steps (tracked as convergence findings going forward)
- Add `VERCEL_TOKEN` + `VERCEL_PROJECT_ID` to Supabase Vault → `checkVercelEnvVars()` activates
- Add `SUPABASE_ACCESS_TOKEN` to function env → `checkSupabaseTokenHealth()` activates
- Replace Mailgun DNS placeholder values → removes `dns_placeholder` findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)