### PR TITLE
feat(ssot): secrets inventory — registry + migration + scanner + Ops Console page + CI guard

### DIFF
--- a/.github/workflows/secrets-registry-guard.yml
+++ b/.github/workflows/secrets-registry-guard.yml
@@ -1,0 +1,49 @@
+name: Secrets Registry Guard
+
+on:
+  pull_request:
+    paths:
+      - "ssot/secrets/registry.yaml"
+      - "scripts/ci/check_secrets_registry.py"
+      - ".github/workflows/secrets-registry-guard.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "ssot/secrets/registry.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: secrets-registry-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-registry:
+    name: Validate Secrets Registry SSOT
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Validate registry schema (hard fail on violations)
+        run: |
+          python scripts/ci/check_secrets_registry.py
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+
+      - name: Scan source files for unregistered secret refs (warn-only)
+        run: |
+          python scripts/ci/check_secrets_registry.py --warn-unregistered
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        continue-on-error: false

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ docker-compose.override.yml
 secrets/
 !ssot/secrets/
 !ssot/secrets/registry.yaml
+!apps/ops-console/app/platform/secrets/
 .secrets
 # Identifier-only registry (no values) — intentionally tracked
 !ssot/secrets/

--- a/apps/ops-console/app/api/secrets-inventory/route.ts
+++ b/apps/ops-console/app/api/secrets-inventory/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server"
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? ""
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? ""
+
+function supabaseHeaders() {
+  return {
+    apikey: SUPABASE_SERVICE_ROLE_KEY,
+    Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+    "Content-Type": "application/json",
+  }
+}
+
+/**
+ * GET /api/secrets-inventory
+ *
+ * Returns the current observed state of secrets from ops.secret_inventory.
+ * Ordered by severity_if_missing DESC (critical first), then status.
+ *
+ * Query params:
+ *   status  — filter by status (ok|missing|stale|unknown). Default: all.
+ *   limit   — max results (default 100)
+ */
+export async function GET(req: NextRequest) {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    return NextResponse.json(
+      { error: "Supabase not configured" },
+      { status: 503 }
+    )
+  }
+
+  const { searchParams } = req.nextUrl
+  const statusFilter = searchParams.get("status")
+  const limit = searchParams.get("limit") ?? "100"
+
+  try {
+    const params = new URLSearchParams()
+
+    // Severity ordering: critical > high > medium > low
+    params.set(
+      "order",
+      "severity_if_missing.asc,status.asc,key.asc"
+    )
+    params.set("limit", limit)
+
+    if (statusFilter) {
+      params.set("status", `eq.${statusFilter}`)
+    }
+
+    const res = await fetch(
+      `${SUPABASE_URL}/rest/v1/ops.secret_inventory?${params.toString()}`,
+      {
+        headers: supabaseHeaders(),
+        next: { revalidate: 60 },
+      }
+    )
+
+    if (!res.ok) {
+      const body = await res.text()
+      return NextResponse.json({ error: body }, { status: res.status })
+    }
+
+    const secrets = (await res.json()) as Array<Record<string, unknown>>
+
+    // Re-sort client-side so critical appears before low
+    const severityOrder: Record<string, number> = {
+      critical: 0,
+      high: 1,
+      medium: 2,
+      low: 3,
+    }
+    secrets.sort((a, b) => {
+      const aS = severityOrder[String(a.severity_if_missing ?? "")] ?? 99
+      const bS = severityOrder[String(b.severity_if_missing ?? "")] ?? 99
+      if (aS !== bS) return aS - bS
+      return String(a.status ?? "").localeCompare(String(b.status ?? ""))
+    })
+
+    return NextResponse.json({ secrets })
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
+}

--- a/apps/ops-console/app/platform/secrets/page.tsx
+++ b/apps/ops-console/app/platform/secrets/page.tsx
@@ -1,0 +1,429 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  KeyRound,
+  RefreshCw,
+  AlertCircle,
+  CheckCircle2,
+  Clock,
+  HelpCircle,
+  ShieldAlert,
+} from "lucide-react"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type SecretStatus = "ok" | "missing" | "stale" | "unknown"
+type SecretSeverity = "critical" | "high" | "medium" | "low"
+
+interface SecretInventoryRow {
+  id: string
+  key: string
+  purpose: string | null
+  severity_if_missing: SecretSeverity | null
+  desired_consumers: Array<{ kind: string; project?: string; name: string }> | null
+  observed: Record<string, string> | null
+  status: SecretStatus
+  probe_status_code: number | null
+  probe_error: string | null
+  last_checked_at: string | null
+  next_rotation_at: string | null
+  notes: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Status badge
+// ---------------------------------------------------------------------------
+
+const STATUS_CONFIG: Record<
+  SecretStatus,
+  { label: string; icon: React.ElementType; variant: string; className: string }
+> = {
+  ok: {
+    label: "ok",
+    icon: CheckCircle2,
+    variant: "outline",
+    className:
+      "border-green-500/40 bg-green-500/10 text-green-600 dark:text-green-400",
+  },
+  missing: {
+    label: "missing",
+    icon: AlertCircle,
+    variant: "outline",
+    className:
+      "border-red-500/40 bg-red-500/10 text-red-600 dark:text-red-400",
+  },
+  stale: {
+    label: "stale",
+    icon: Clock,
+    variant: "outline",
+    className:
+      "border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  },
+  unknown: {
+    label: "unknown",
+    icon: HelpCircle,
+    variant: "outline",
+    className:
+      "border-gray-400/40 bg-gray-500/10 text-gray-500 dark:text-gray-400",
+  },
+}
+
+function StatusBadge({ status }: { status: SecretStatus }) {
+  const cfg = STATUS_CONFIG[status] ?? STATUS_CONFIG.unknown
+  const Icon = cfg.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold border ${cfg.className}`}
+    >
+      <Icon className="h-3 w-3" />
+      {cfg.label}
+    </span>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Severity badge
+// ---------------------------------------------------------------------------
+
+const SEVERITY_CLASSES: Record<SecretSeverity, string> = {
+  critical: "border-red-600/40 bg-red-600/10 text-red-600 dark:text-red-400",
+  high: "border-orange-500/40 bg-orange-500/10 text-orange-600 dark:text-orange-400",
+  medium: "border-yellow-500/40 bg-yellow-500/10 text-yellow-600 dark:text-yellow-500",
+  low: "border-gray-400/40 bg-gray-500/10 text-gray-500",
+}
+
+function SeverityBadge({ severity }: { severity: SecretSeverity | null }) {
+  if (!severity) return <span className="text-muted-foreground text-xs">—</span>
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold border ${SEVERITY_CLASSES[severity]}`}
+    >
+      {severity}
+    </span>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Date formatter
+// ---------------------------------------------------------------------------
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return "—"
+  const d = new Date(iso)
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Consumer pills
+// ---------------------------------------------------------------------------
+
+function ConsumerPill({ consumer }: { consumer: { kind: string; name: string; project?: string } }) {
+  return (
+    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-muted text-[10px] font-mono text-muted-foreground border border-border">
+      {consumer.kind === "github_secret" && "GH"}
+      {consumer.kind === "vercel_env" && "VCL"}
+      {consumer.kind === "supabase_vault" && "SB"}
+      {consumer.kind === "keychain" && "KC"}
+      {consumer.kind === "odoo_config" && "OD"}
+      {!["github_secret", "vercel_env", "supabase_vault", "keychain", "odoo_config"].includes(
+        consumer.kind
+      ) && consumer.kind.slice(0, 2).toUpperCase()}
+      :{consumer.name}
+    </span>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Summary cards
+// ---------------------------------------------------------------------------
+
+function SummaryCard({
+  label,
+  count,
+  colorClass,
+}: {
+  label: string
+  count: number
+  colorClass: string
+}) {
+  return (
+    <div className={`rounded-lg border p-4 ${colorClass}`}>
+      <div className="text-2xl font-bold">{count}</div>
+      <div className="text-xs text-muted-foreground uppercase tracking-wider mt-0.5">
+        {label}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main page component
+// ---------------------------------------------------------------------------
+
+export default function SecretsPage() {
+  const [secrets, setSecrets] = useState<SecretInventoryRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
+
+  async function fetchSecrets() {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch("/api/secrets-inventory")
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: res.statusText }))
+        throw new Error(body.error ?? `HTTP ${res.status}`)
+      }
+      const data = await res.json()
+      setSecrets(data.secrets ?? [])
+      setLastRefresh(new Date())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchSecrets()
+  }, [])
+
+  const counts = {
+    ok: secrets.filter((s) => s.status === "ok").length,
+    missing: secrets.filter((s) => s.status === "missing").length,
+    stale: secrets.filter((s) => s.status === "stale").length,
+    unknown: secrets.filter((s) => s.status === "unknown").length,
+  }
+
+  const criticalMissing = secrets.filter(
+    (s) =>
+      (s.status === "missing" || s.status === "stale") &&
+      (s.severity_if_missing === "critical" || s.severity_if_missing === "high")
+  ).length
+
+  return (
+    <div className="space-y-6 animate-in zoom-in-95 duration-700">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight flex items-center gap-2">
+            <KeyRound className="h-7 w-7 text-primary" />
+            Secrets Inventory
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Observed state of registry-tracked secrets vs. desired state.
+            Sourced from{" "}
+            <code className="text-xs bg-muted rounded px-1">
+              ssot/secrets/registry.yaml
+            </code>
+          </p>
+          {lastRefresh && (
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Last refreshed: {lastRefresh.toLocaleTimeString()}
+            </p>
+          )}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={fetchSecrets}
+          disabled={loading}
+          className="h-8 gap-1.5"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Critical alert banner */}
+      {criticalMissing > 0 && (
+        <div className="flex items-center gap-3 rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-600 dark:text-red-400">
+          <ShieldAlert className="h-4 w-4 shrink-0" />
+          <span>
+            <strong>{criticalMissing}</strong> critical/high severity secret
+            {criticalMissing !== 1 ? "s" : ""} are missing or stale.
+            Check convergence findings for remediation steps.
+          </span>
+        </div>
+      )}
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <SummaryCard label="ok" count={counts.ok} colorClass="border-green-500/20" />
+        <SummaryCard
+          label="missing"
+          count={counts.missing}
+          colorClass="border-red-500/20"
+        />
+        <SummaryCard
+          label="stale"
+          count={counts.stale}
+          colorClass="border-amber-500/20"
+        />
+        <SummaryCard
+          label="unknown"
+          count={counts.unknown}
+          colorClass="border-muted"
+        />
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <Card className="border-red-500/30 bg-red-500/5">
+          <CardContent className="pt-4 text-sm text-red-600 dark:text-red-400">
+            Failed to load secrets inventory: {error}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Table */}
+      {!error && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Registry Entries</CardTitle>
+            <CardDescription className="text-xs">
+              {secrets.length} secret{secrets.length !== 1 ? "s" : ""} tracked
+              {loading ? " — refreshing..." : ""}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="p-0">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-muted/30">
+                    <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                      Key
+                    </th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                      Purpose
+                    </th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                      Consumers
+                    </th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                      Status
+                    </th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                      Last Checked
+                    </th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                      Next Rotation
+                    </th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                      Severity
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loading && secrets.length === 0 ? (
+                    <tr>
+                      <td
+                        colSpan={7}
+                        className="px-4 py-8 text-center text-muted-foreground text-xs"
+                      >
+                        Loading...
+                      </td>
+                    </tr>
+                  ) : secrets.length === 0 ? (
+                    <tr>
+                      <td
+                        colSpan={7}
+                        className="px-4 py-8 text-center text-muted-foreground text-xs"
+                      >
+                        No secrets found. Run the ops-secrets-scan Edge Function to populate.
+                      </td>
+                    </tr>
+                  ) : (
+                    secrets.map((secret) => (
+                      <tr
+                        key={secret.id}
+                        className="border-b border-border/50 hover:bg-muted/20 transition-colors"
+                      >
+                        {/* Key */}
+                        <td className="px-4 py-3 font-mono text-xs text-foreground font-medium whitespace-nowrap">
+                          {secret.key}
+                        </td>
+
+                        {/* Purpose */}
+                        <td className="px-4 py-3 text-xs text-muted-foreground max-w-[240px]">
+                          <span className="line-clamp-2">{secret.purpose ?? "—"}</span>
+                          {secret.probe_error && (
+                            <span className="block text-[10px] text-red-500 mt-0.5">
+                              {secret.probe_error.slice(0, 80)}
+                            </span>
+                          )}
+                        </td>
+
+                        {/* Consumers */}
+                        <td className="px-4 py-3">
+                          <div className="flex flex-wrap gap-1">
+                            {(secret.desired_consumers ?? []).slice(0, 3).map((c, i) => (
+                              <ConsumerPill key={i} consumer={c} />
+                            ))}
+                            {(secret.desired_consumers ?? []).length > 3 && (
+                              <span className="text-[10px] text-muted-foreground">
+                                +{(secret.desired_consumers ?? []).length - 3}
+                              </span>
+                            )}
+                          </div>
+                        </td>
+
+                        {/* Status */}
+                        <td className="px-4 py-3">
+                          <StatusBadge status={secret.status} />
+                        </td>
+
+                        {/* Last Checked */}
+                        <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap">
+                          {fmtDate(secret.last_checked_at)}
+                        </td>
+
+                        {/* Next Rotation */}
+                        <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap">
+                          {fmtDate(secret.next_rotation_at)}
+                        </td>
+
+                        {/* Severity */}
+                        <td className="px-4 py-3">
+                          <SeverityBadge severity={secret.severity_if_missing} />
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Footer note */}
+      <p className="text-[11px] text-muted-foreground">
+        Status is updated by the{" "}
+        <code className="bg-muted rounded px-0.5">ops-secrets-scan</code> Edge
+        Function (scheduled every 6 hours). Trigger manually via{" "}
+        <code className="bg-muted rounded px-0.5">
+          POST /functions/v1/ops-secrets-scan
+        </code>
+        .
+      </p>
+    </div>
+  )
+}

--- a/apps/ops-console/components/navigation/sidebar.tsx
+++ b/apps/ops-console/components/navigation/sidebar.tsx
@@ -31,6 +31,7 @@ import {
   SearchCode,
   HardHat,
   Paintbrush,
+  KeyRound,
 } from "lucide-react"
 import { useState, useCallback, useEffect } from "react"
 
@@ -64,6 +65,7 @@ const navSections: NavSection[] = [
       { href: "/database", icon: Database, label: "Database" },
       { href: "/backups", icon: HardDrive, label: "Backups", badge: "New" },
       { href: "/platform", icon: Cpu, label: "Control Plane" },
+      { href: "/platform/secrets", icon: KeyRound, label: "Secrets" },
       { href: "/modules", icon: Package, label: "Modules" },
     ],
   },

--- a/scripts/ci/check_secrets_registry.py
+++ b/scripts/ci/check_secrets_registry.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""
+check_secrets_registry.py — Secrets Registry SSOT compliance checker.
+
+Reads ssot/secrets/registry.yaml and:
+  1. Validates schema: every v2_entry must have purpose, consumers, status.severity_if_missing.
+  2. Scans .github/workflows/ and apps/ for secret references:
+       - ${{ secrets.NAME }}
+       - process.env.NAME  (where NAME is ALL_CAPS with optional underscores)
+       - Deno.env.get("NAME")
+  3. Warns if referenced secrets are not in the v2 registry (soft-fail).
+  4. Hard-fails (exit 1) on schema violations only.
+
+Exit codes:
+  0 — schema clean (warnings may have been emitted for unregistered references)
+  1 — schema violations found
+  2 — registry file missing or invalid YAML
+"""
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML not installed. Run: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_PATH = REPO_ROOT / "ssot" / "secrets" / "registry.yaml"
+SCAN_DIRS = [
+    REPO_ROOT / ".github" / "workflows",
+    REPO_ROOT / "apps",
+]
+
+# Patterns for secret references
+GH_ACTIONS_PATTERN = re.compile(r"\$\{\{\s*secrets\.([A-Z0-9_]+)\s*\}\}")
+NODE_ENV_PATTERN = re.compile(r"process\.env\.([A-Z][A-Z0-9_]{3,})")
+DENO_ENV_PATTERN = re.compile(r'Deno\.env\.get\(["\']([A-Z][A-Z0-9_]{3,})["\']\)')
+
+# File extensions to scan
+SCAN_EXTENSIONS = {".yml", ".yaml", ".ts", ".tsx", ".js", ".mjs", ".sh"}
+
+# Keys we expect to be ALL_CAPS that are NOT secrets (common false positives)
+ALLOWLISTED_REFS = {
+    "NODE_ENV",
+    "NEXT_PUBLIC_",  # prefix check handled separately
+    "CI",
+    "HOME",
+    "PATH",
+    "USER",
+    "SHELL",
+    "TERM",
+    "LANG",
+    "TZ",
+}
+
+# ---------------------------------------------------------------------------
+# Load registry
+# ---------------------------------------------------------------------------
+
+def load_registry(path: Path) -> dict:
+    if not path.exists():
+        print(f"ERROR: Registry not found at {path}", file=sys.stderr)
+        sys.exit(2)
+    try:
+        with path.open() as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, dict):
+            print(f"ERROR: Registry is not a valid YAML mapping: {path}", file=sys.stderr)
+            sys.exit(2)
+        return data
+    except yaml.YAMLError as e:
+        print(f"ERROR: Invalid YAML in registry: {e}", file=sys.stderr)
+        sys.exit(2)
+
+
+# ---------------------------------------------------------------------------
+# Extract v2 entry keys
+# ---------------------------------------------------------------------------
+
+def extract_v2_keys(registry: dict) -> set[str]:
+    """Return set of all secret keys from v2_entries section."""
+    v2 = registry.get("v2_entries", {})
+    if not isinstance(v2, dict):
+        return set()
+    return set(v2.keys())
+
+
+def extract_legacy_keys(registry: dict) -> set[str]:
+    """Return set of all secret keys from legacy (flat) secrets section."""
+    secrets = registry.get("secrets", {})
+    if not isinstance(secrets, dict):
+        return set()
+    return set(secrets.keys())
+
+
+# ---------------------------------------------------------------------------
+# Validate v2 entry schema
+# ---------------------------------------------------------------------------
+
+REQUIRED_V2_FIELDS = ["purpose", "consumers", "status"]
+
+def validate_v2_entries(registry: dict) -> list[str]:
+    """Return list of schema violation messages."""
+    violations = []
+    v2 = registry.get("v2_entries", {})
+    if not isinstance(v2, dict):
+        violations.append("v2_entries is missing or not a mapping")
+        return violations
+
+    for key, entry in v2.items():
+        if not isinstance(entry, dict):
+            violations.append(f"v2_entries.{key}: entry is not a mapping")
+            continue
+
+        # Check required fields
+        for field in REQUIRED_V2_FIELDS:
+            if field not in entry:
+                violations.append(
+                    f"v2_entries.{key}: missing required field '{field}'"
+                )
+
+        # Validate status.severity_if_missing
+        status = entry.get("status", {})
+        if isinstance(status, dict):
+            sev = status.get("severity_if_missing")
+            if sev not in ("critical", "high", "medium", "low"):
+                violations.append(
+                    f"v2_entries.{key}.status.severity_if_missing: invalid value '{sev}' "
+                    f"(must be critical|high|medium|low)"
+                )
+        else:
+            violations.append(
+                f"v2_entries.{key}.status: must be a mapping with severity_if_missing"
+            )
+
+        # Validate consumers is a list
+        consumers = entry.get("consumers", [])
+        if not isinstance(consumers, list) or len(consumers) == 0:
+            violations.append(
+                f"v2_entries.{key}.consumers: must be a non-empty list"
+            )
+        else:
+            for i, consumer in enumerate(consumers):
+                if not isinstance(consumer, dict):
+                    violations.append(
+                        f"v2_entries.{key}.consumers[{i}]: must be a mapping"
+                    )
+                    continue
+                if "kind" not in consumer:
+                    violations.append(
+                        f"v2_entries.{key}.consumers[{i}]: missing 'kind'"
+                    )
+                if "name" not in consumer:
+                    violations.append(
+                        f"v2_entries.{key}.consumers[{i}]: missing 'name'"
+                    )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Scan files for secret references
+# ---------------------------------------------------------------------------
+
+def scan_for_secret_refs(dirs: list[Path]) -> dict[str, list[str]]:
+    """
+    Scan directories for env/secret references.
+    Returns dict: secret_name -> list of "file:line" locations.
+    """
+    refs: dict[str, list[str]] = {}
+
+    for scan_dir in dirs:
+        if not scan_dir.exists():
+            continue
+        for fpath in scan_dir.rglob("*"):
+            if fpath.suffix not in SCAN_EXTENSIONS:
+                continue
+            if any(part.startswith(".") for part in fpath.parts):
+                # skip hidden dirs like .git, .next, .turbo
+                continue
+            try:
+                text = fpath.read_text(errors="ignore")
+            except OSError:
+                continue
+
+            for line_no, line in enumerate(text.splitlines(), 1):
+                location = f"{fpath.relative_to(REPO_ROOT)}:{line_no}"
+                for pattern in (GH_ACTIONS_PATTERN, NODE_ENV_PATTERN, DENO_ENV_PATTERN):
+                    for match in pattern.finditer(line):
+                        name = match.group(1)
+                        # Skip obvious non-secrets
+                        if name in ALLOWLISTED_REFS:
+                            continue
+                        if name.startswith("NEXT_PUBLIC_") and not name.endswith("KEY"):
+                            continue
+                        refs.setdefault(name, []).append(location)
+
+    return refs
+
+
+# ---------------------------------------------------------------------------
+# Map referenced names to registry keys (best-effort)
+# ---------------------------------------------------------------------------
+
+def map_ref_to_registry_key(ref_name: str, v2_keys: set[str], legacy_keys: set[str]) -> str | None:
+    """Try to find which registry key corresponds to a raw env var name."""
+    # Direct match (case-insensitive snake_case lookup)
+    lower = ref_name.lower()
+    if lower in v2_keys:
+        return lower
+    if lower in legacy_keys:
+        return f"(legacy){lower}"
+
+    # Common normalisations: strip leading NEXT_PUBLIC_
+    if lower.startswith("next_public_"):
+        stripped = lower[len("next_public_"):]
+        if stripped in v2_keys:
+            return stripped
+        if stripped in legacy_keys:
+            return f"(legacy){stripped}"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate secrets registry SSOT")
+    parser.add_argument("--warn-unregistered", action="store_true",
+                        help="Emit warnings for unregistered secret refs (default: always warn)")
+    parser.add_argument("--no-scan", action="store_true",
+                        help="Skip scanning source files for secret references")
+    args = parser.parse_args()
+
+    print(f"[check_secrets_registry] Registry: {REGISTRY_PATH.relative_to(REPO_ROOT)}")
+
+    registry = load_registry(REGISTRY_PATH)
+    v2_keys = extract_v2_keys(registry)
+    legacy_keys = extract_legacy_keys(registry)
+
+    print(f"[check_secrets_registry] v2 entries: {len(v2_keys)}, legacy entries: {len(legacy_keys)}")
+
+    # --- Schema validation (hard fail) ---
+    violations = validate_v2_entries(registry)
+    if violations:
+        print("\n[FAIL] Schema violations found in v2_entries:", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        return 1
+
+    print(f"[check_secrets_registry] Schema OK — {len(v2_keys)} v2 entries validated")
+
+    # --- Source file scan (soft warn) ---
+    if not args.no_scan:
+        print(f"[check_secrets_registry] Scanning {len(SCAN_DIRS)} directories for secret references...")
+        refs = scan_for_secret_refs(SCAN_DIRS)
+
+        unregistered = []
+        for ref_name, locations in refs.items():
+            key = map_ref_to_registry_key(ref_name, v2_keys, legacy_keys)
+            if key is None:
+                # Only warn for things that look like secrets (not generic env vars)
+                if len(ref_name) > 5 and not ref_name.endswith("_URL"):
+                    unregistered.append((ref_name, locations))
+
+        if unregistered:
+            print(
+                f"\n[WARN] {len(unregistered)} secret-like reference(s) not found in registry "
+                f"(informational only — not a hard failure):"
+            )
+            for ref_name, locations in sorted(unregistered):
+                sample = locations[:3]
+                print(f"  {ref_name}: {', '.join(sample)}"
+                      + (f" (+{len(locations)-3} more)" if len(locations) > 3 else ""))
+            print("  Suggestion: add these to ssot/secrets/registry.yaml#v2_entries if they are secrets.")
+        else:
+            print("[check_secrets_registry] All detected secret refs are in registry (or allowlisted)")
+
+    print("\n[check_secrets_registry] PASS — no schema violations")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ssot/secrets/registry.yaml
+++ b/ssot/secrets/registry.yaml
@@ -12,9 +12,9 @@
 #
 # Workflow: docs/runbooks/SECRETS_SSOT.md
 
-version: "1.0.0"
-schema: ssot.secrets.v1
-last_reviewed: "2026-02-27"
+version: "2.0.0"
+schema: ssot.secrets.v2
+last_reviewed: "2026-03-02"
 
 schema_rules:
   required_fields:
@@ -1049,3 +1049,281 @@ secrets:
       Vercel env var is server-side only (Next.js API route — never exposed to browser).
       Contract: docs/contracts/C-GH-02-workitems-webhooks.md
       SSOT: ssot/sources/github/work_items.yaml (secret_ref: github_webhook_secret)
+
+# =============================================================================
+# v2 extended entries — SSOT-driven secrets inventory with healthcheck probes
+# Schema: ssot.secrets.v2 (added: type, owner, consumers/storage lists, rotation, healthcheck, status)
+# Added: 2026-03-02 for ops-secrets-scan Edge Function + Ops Console secrets page
+# =============================================================================
+
+v2_entries:
+
+  supabase_access_token:
+    key: supabase_access_token
+    type: token
+    owner: platform
+    purpose: "Supabase Management API Personal Access Token used by Supabase CLI and CI deploy workflows"
+    consumers:
+      - kind: github_secret
+        name: SUPABASE_ACCESS_TOKEN
+      - kind: github_secret
+        name: SUPABASE_MANAGEMENT_TOKEN
+    storage:
+      - kind: github_secret
+        name: SUPABASE_ACCESS_TOKEN
+      - kind: keychain
+        name: supabase-access-token
+    rotation:
+      cadence: "90d"
+      signal: manual
+    healthcheck:
+      kind: http
+      probe:
+        system: supabase
+        endpoint: "/v1/projects"
+        auth: bearer
+    status:
+      desired: present
+      severity_if_missing: critical
+
+  supabase_service_role_key:
+    key: supabase_service_role_key
+    type: secret
+    owner: platform
+    purpose: "Supabase project service role key — bypasses RLS for Edge Functions and ops-console server-side API routes"
+    consumers:
+      - kind: github_secret
+        name: SUPABASE_SERVICE_ROLE_KEY
+      - kind: vercel_env
+        project: odooops-console
+        name: SUPABASE_SERVICE_ROLE_KEY
+    storage:
+      - kind: github_secret
+        name: SUPABASE_SERVICE_ROLE_KEY
+      - kind: keychain
+        name: supabase-service-role-key
+    rotation:
+      cadence: "90d"
+      signal: manual
+    healthcheck:
+      kind: presence
+      probe:
+        system: supabase
+        endpoint: "/rest/v1/ops.maintenance_runs"
+        auth: bearer
+    status:
+      desired: present
+      severity_if_missing: critical
+
+  supabase_anon_key:
+    key: supabase_anon_key
+    type: api_key
+    owner: platform
+    purpose: "Supabase project anon key (public-safe) used by ops-console for public queries with RLS enforced"
+    consumers:
+      - kind: vercel_env
+        project: odooops-console
+        name: NEXT_PUBLIC_SUPABASE_ANON_KEY
+    storage:
+      - kind: vercel_env
+        name: NEXT_PUBLIC_SUPABASE_ANON_KEY
+      - kind: keychain
+        name: supabase-anon-key
+    rotation:
+      cadence: "365d"
+      signal: revoked
+    healthcheck:
+      kind: presence
+      probe:
+        system: supabase
+        endpoint: "/rest/v1/"
+        auth: header
+    status:
+      desired: present
+      severity_if_missing: high
+
+  plane_webhook_secret:
+    key: plane_webhook_secret
+    type: secret
+    owner: ops
+    purpose: "Shared HMAC secret for verifying inbound Plane.so webhook payloads in ops-console"
+    consumers:
+      - kind: supabase_vault
+        name: plane_webhook_secret
+      - kind: vercel_env
+        project: odooops-console
+        name: PLANE_WEBHOOK_SECRET
+    storage:
+      - kind: supabase_vault
+        name: plane_webhook_secret
+      - kind: vercel_env
+        name: PLANE_WEBHOOK_SECRET
+    rotation:
+      cadence: "180d"
+      signal: manual
+    healthcheck:
+      kind: presence
+      probe:
+        system: supabase
+        endpoint: "/rest/v1/rpc/vault_secret_exists"
+        auth: bearer
+    status:
+      desired: present
+      severity_if_missing: high
+
+  github_webhook_secret:
+    key: github_webhook_secret
+    type: secret
+    owner: ops
+    purpose: "Shared HMAC-SHA256 secret for verifying inbound GitHub webhook payloads (X-Hub-Signature-256)"
+    consumers:
+      - kind: supabase_vault
+        name: github_webhook_secret
+      - kind: vercel_env
+        project: odooops-console
+        name: GITHUB_WEBHOOK_SECRET
+    storage:
+      - kind: supabase_vault
+        name: github_webhook_secret
+      - kind: vercel_env
+        name: GITHUB_WEBHOOK_SECRET
+    rotation:
+      cadence: "180d"
+      signal: manual
+    healthcheck:
+      kind: presence
+      probe:
+        system: supabase
+        endpoint: "/rest/v1/rpc/vault_secret_exists"
+        auth: bearer
+    status:
+      desired: present
+      severity_if_missing: high
+
+  vercel_token:
+    key: vercel_token
+    type: token
+    owner: infra
+    purpose: "Vercel API personal access token used by CI workflows to trigger and manage Vercel deployments programmatically"
+    consumers:
+      - kind: github_secret
+        name: VERCEL_TOKEN
+    storage:
+      - kind: github_secret
+        name: VERCEL_TOKEN
+      - kind: keychain
+        name: vercel-token
+    rotation:
+      cadence: "365d"
+      signal: manual
+    healthcheck:
+      kind: http
+      probe:
+        system: vercel
+        endpoint: "/v10/projects/odooops-console/env"
+        auth: bearer
+    status:
+      desired: present
+      severity_if_missing: medium
+
+  cloudflare_api_token:
+    key: cloudflare_api_token
+    type: token
+    owner: infra
+    purpose: "Cloudflare scoped API token for Terraform DNS apply via CI workflows"
+    consumers:
+      - kind: github_secret
+        name: CF_DNS_EDIT_TOKEN
+    storage:
+      - kind: github_secret
+        name: CF_DNS_EDIT_TOKEN
+      - kind: keychain
+        name: cloudflare-api-token
+    rotation:
+      cadence: "365d"
+      signal: manual
+    healthcheck:
+      kind: none
+      probe:
+        system: digitalocean
+        endpoint: "/v2/account"
+        auth: bearer
+    status:
+      desired: present
+      severity_if_missing: medium
+
+  digitalocean_access_token:
+    key: digitalocean_access_token
+    type: token
+    owner: infra
+    purpose: "DigitalOcean API token used by doctl and App Platform automation in CI and Ops Advisor DO scan adapter"
+    consumers:
+      - kind: github_secret
+        name: DO_ACCESS_TOKEN
+      - kind: supabase_vault
+        name: digitalocean_api_token
+    storage:
+      - kind: github_secret
+        name: DO_ACCESS_TOKEN
+      - kind: supabase_vault
+        name: digitalocean_api_token
+    rotation:
+      cadence: "365d"
+      signal: manual
+    healthcheck:
+      kind: http
+      probe:
+        system: digitalocean
+        endpoint: "/v2/account"
+        auth: bearer
+    status:
+      desired: present
+      severity_if_missing: high
+
+  mailgun_api_key:
+    key: mailgun_api_key
+    type: api_key
+    owner: mail
+    purpose: "Mailgun API key for webhook signature verification and optional management API queries (future Mailgun verification)"
+    consumers:
+      - kind: supabase_vault
+        name: mailgun_api_key
+    storage:
+      - kind: supabase_vault
+        name: mailgun_api_key
+    rotation:
+      cadence: "365d"
+      signal: manual
+    healthcheck:
+      kind: none
+      probe:
+        system: supabase
+        endpoint: "/rest/v1/rpc/vault_secret_exists"
+        auth: bearer
+    status:
+      desired: present
+      severity_if_missing: low
+
+  zoho_mail_smtp_password:
+    key: zoho_mail_smtp_password
+    type: secret
+    owner: mail
+    purpose: "Zoho Mail SMTP app-specific password for Odoo outbound email via ipai_mail_bridge_zoho"
+    consumers:
+      - kind: odoo_config
+        name: ir.mail_server.smtp_pass
+    storage:
+      - kind: keychain
+        name: zoho-smtp-app-password
+    rotation:
+      cadence: "365d"
+      signal: manual
+    healthcheck:
+      kind: none
+      probe:
+        system: supabase
+        endpoint: "/rest/v1/"
+        auth: bearer
+    status:
+      desired: present
+      severity_if_missing: medium

--- a/supabase/functions/ops-secrets-scan/index.ts
+++ b/supabase/functions/ops-secrets-scan/index.ts
@@ -1,0 +1,610 @@
+// =============================================================================
+// ops-secrets-scan — Secrets Inventory Scanner Edge Function
+// =============================================================================
+// SSOT:      ssot/secrets/registry.yaml (v2_entries)
+// Migration: supabase/migrations/20260302000010_ops_secret_inventory.sql
+// Schedule:  Every 6 hours via ops.schedules / Vercel cron.
+//
+// Purpose:
+//   1. For each registry entry, probe presence and validity via external APIs.
+//   2. Upsert status into ops.secret_inventory.
+//   3. Emit ops.convergence_findings for critical/high secrets that are missing/stale.
+//   4. Write ops.maintenance_runs + events row.
+//
+// Probe strategies by consumer kind:
+//   - github_secret   → GET /repos/Insightpulseai/odoo/actions/secrets/{name} with GITHUB_TOKEN
+//   - vercel_env      → GET /v10/projects/{project}/env with VERCEL_TOKEN, check if name exists
+//   - supabase_vault  → SELECT count(*) FROM vault.decrypted_secrets WHERE name = $1
+//   - supabase token  → GET /v1/projects with SUPABASE_ACCESS_TOKEN
+//   - other           → mark unknown (no probe available)
+// =============================================================================
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const GITHUB_TOKEN = Deno.env.get("GITHUB_TOKEN") ?? "";
+const VERCEL_TOKEN = Deno.env.get("VERCEL_TOKEN") ?? "";
+const SUPABASE_ACCESS_TOKEN = Deno.env.get("SUPABASE_ACCESS_TOKEN") ?? "";
+const CRON_SECRET = Deno.env.get("CRON_SECRET") ?? "";
+
+const GITHUB_REPO = "Insightpulseai/odoo";
+
+// ---------------------------------------------------------------------------
+// Registry snapshot — hardcoded since Edge Functions cannot read files.
+// Mirrors ssot/secrets/registry.yaml#v2_entries.
+// ---------------------------------------------------------------------------
+
+type HealthcheckKind = "http" | "jwt" | "presence" | "none";
+type ConsumerKind = "github_secret" | "vercel_env" | "supabase_vault" | "keychain" | "odoo_config";
+
+interface RegistryEntry {
+  key: string;
+  purpose: string;
+  severity: "critical" | "high" | "medium" | "low";
+  consumers: Array<{
+    kind: ConsumerKind;
+    project?: string;
+    name: string;
+  }>;
+  rotation_cadence: string;
+  healthcheck: {
+    kind: HealthcheckKind;
+    system: "supabase" | "vercel" | "github" | "digitalocean" | "mailgun" | "odoo";
+    endpoint?: string;
+    auth?: "bearer" | "basic" | "header";
+    envVar?: string;
+  };
+}
+
+const REGISTRY_SNAPSHOT: RegistryEntry[] = [
+  {
+    key: "supabase_access_token",
+    purpose: "Supabase Management API PAT used by Supabase CLI and CI deploy workflows",
+    severity: "critical",
+    consumers: [{ kind: "github_secret", name: "SUPABASE_ACCESS_TOKEN" }],
+    rotation_cadence: "90d",
+    healthcheck: {
+      kind: "http",
+      system: "supabase",
+      endpoint: "https://api.supabase.com/v1/projects",
+      auth: "bearer",
+      envVar: "SUPABASE_ACCESS_TOKEN",
+    },
+  },
+  {
+    key: "supabase_service_role_key",
+    purpose: "Supabase project service role key — bypasses RLS for Edge Functions and ops-console API routes",
+    severity: "critical",
+    consumers: [
+      { kind: "github_secret", name: "SUPABASE_SERVICE_ROLE_KEY" },
+      { kind: "vercel_env", project: "odooops-console", name: "SUPABASE_SERVICE_ROLE_KEY" },
+    ],
+    rotation_cadence: "90d",
+    healthcheck: {
+      kind: "presence",
+      system: "vercel",
+      envVar: "SUPABASE_SERVICE_ROLE_KEY",
+    },
+  },
+  {
+    key: "supabase_anon_key",
+    purpose: "Supabase project anon key (public-safe) for ops-console public queries with RLS enforced",
+    severity: "high",
+    consumers: [
+      { kind: "vercel_env", project: "odooops-console", name: "NEXT_PUBLIC_SUPABASE_ANON_KEY" },
+    ],
+    rotation_cadence: "365d",
+    healthcheck: {
+      kind: "presence",
+      system: "vercel",
+      envVar: "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+    },
+  },
+  {
+    key: "plane_webhook_secret",
+    purpose: "Shared HMAC secret for verifying inbound Plane.so webhook payloads in ops-console",
+    severity: "high",
+    consumers: [
+      { kind: "supabase_vault", name: "plane_webhook_secret" },
+      { kind: "vercel_env", project: "odooops-console", name: "PLANE_WEBHOOK_SECRET" },
+    ],
+    rotation_cadence: "180d",
+    healthcheck: {
+      kind: "presence",
+      system: "supabase",
+      envVar: "plane_webhook_secret",
+    },
+  },
+  {
+    key: "github_webhook_secret",
+    purpose: "Shared HMAC-SHA256 secret for verifying inbound GitHub webhook payloads",
+    severity: "high",
+    consumers: [
+      { kind: "supabase_vault", name: "github_webhook_secret" },
+      { kind: "vercel_env", project: "odooops-console", name: "GITHUB_WEBHOOK_SECRET" },
+    ],
+    rotation_cadence: "180d",
+    healthcheck: {
+      kind: "presence",
+      system: "supabase",
+      envVar: "github_webhook_secret",
+    },
+  },
+  {
+    key: "vercel_token",
+    purpose: "Vercel API PAT used by CI workflows to trigger and manage Vercel deployments",
+    severity: "medium",
+    consumers: [{ kind: "github_secret", name: "VERCEL_TOKEN" }],
+    rotation_cadence: "365d",
+    healthcheck: {
+      kind: "http",
+      system: "vercel",
+      endpoint: "https://api.vercel.com/v10/projects/odooops-console/env",
+      auth: "bearer",
+      envVar: "VERCEL_TOKEN",
+    },
+  },
+  {
+    key: "cloudflare_api_token",
+    purpose: "Cloudflare scoped API token for Terraform DNS apply via CI",
+    severity: "medium",
+    consumers: [{ kind: "github_secret", name: "CF_DNS_EDIT_TOKEN" }],
+    rotation_cadence: "365d",
+    healthcheck: {
+      kind: "none",
+      system: "github",
+      envVar: "CF_DNS_EDIT_TOKEN",
+    },
+  },
+  {
+    key: "digitalocean_access_token",
+    purpose: "DigitalOcean API token for doctl, App Platform and Ops Advisor DO scan adapter",
+    severity: "high",
+    consumers: [
+      { kind: "github_secret", name: "DO_ACCESS_TOKEN" },
+      { kind: "supabase_vault", name: "digitalocean_api_token" },
+    ],
+    rotation_cadence: "365d",
+    healthcheck: {
+      kind: "none",
+      system: "digitalocean",
+      envVar: "DO_ACCESS_TOKEN",
+    },
+  },
+  {
+    key: "mailgun_api_key",
+    purpose: "Mailgun API key for webhook verification and optional management API queries",
+    severity: "low",
+    consumers: [{ kind: "supabase_vault", name: "mailgun_api_key" }],
+    rotation_cadence: "365d",
+    healthcheck: {
+      kind: "none",
+      system: "mailgun",
+      envVar: "mailgun_api_key",
+    },
+  },
+  {
+    key: "zoho_mail_smtp_password",
+    purpose: "Zoho Mail SMTP app-specific password for Odoo outbound email",
+    severity: "medium",
+    consumers: [{ kind: "odoo_config", name: "ir.mail_server.smtp_pass" }],
+    rotation_cadence: "365d",
+    healthcheck: {
+      kind: "none",
+      system: "odoo",
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// PostgREST helper (raw fetch)
+// ---------------------------------------------------------------------------
+
+async function postgrest(
+  method: string,
+  path: string,
+  body?: unknown,
+  extraHeaders: Record<string, string> = {},
+): Promise<unknown> {
+  const headers: Record<string, string> = {
+    apikey: SERVICE_KEY,
+    Authorization: `Bearer ${SERVICE_KEY}`,
+    "Content-Type": "application/json",
+    ...extraHeaders,
+  };
+  if (method === "POST" || method === "PATCH") {
+    headers["Prefer"] = "resolution=merge-duplicates,return=representation";
+  }
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`PostgREST ${method} ${path}: ${res.status} ${text}`);
+  }
+  return text ? JSON.parse(text) : null;
+}
+
+// ---------------------------------------------------------------------------
+// Probe: check GitHub Actions secret presence
+// ---------------------------------------------------------------------------
+
+async function probeGithubSecret(secretName: string): Promise<{
+  status: "ok" | "missing" | "unknown";
+  statusCode: number;
+  error?: string;
+}> {
+  if (!GITHUB_TOKEN) {
+    return { status: "unknown", statusCode: 0, error: "GITHUB_TOKEN not available" };
+  }
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${GITHUB_REPO}/actions/secrets/${secretName}`,
+      {
+        headers: {
+          Authorization: `Bearer ${GITHUB_TOKEN}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+    );
+    if (res.status === 200) return { status: "ok", statusCode: 200 };
+    if (res.status === 404) return { status: "missing", statusCode: 404 };
+    const text = await res.text();
+    return { status: "unknown", statusCode: res.status, error: text.slice(0, 200) };
+  } catch (err) {
+    return { status: "unknown", statusCode: 0, error: String(err) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Probe: check Vercel environment variable presence
+// ---------------------------------------------------------------------------
+
+async function probeVercelEnv(envVarName: string, project = "odooops-console"): Promise<{
+  status: "ok" | "missing" | "unknown";
+  statusCode: number;
+  error?: string;
+}> {
+  if (!VERCEL_TOKEN) {
+    return { status: "unknown", statusCode: 0, error: "VERCEL_TOKEN not available" };
+  }
+  try {
+    const res = await fetch(
+      `https://api.vercel.com/v10/projects/${project}/env`,
+      {
+        headers: {
+          Authorization: `Bearer ${VERCEL_TOKEN}`,
+        },
+      },
+    );
+    if (!res.ok) {
+      const text = await res.text();
+      return { status: "unknown", statusCode: res.status, error: text.slice(0, 200) };
+    }
+    const data = await res.json() as { envs?: Array<{ key: string }> };
+    const envs = data.envs ?? [];
+    const found = envs.some((e) => e.key === envVarName);
+    return { status: found ? "ok" : "missing", statusCode: res.status };
+  } catch (err) {
+    return { status: "unknown", statusCode: 0, error: String(err) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Probe: check Supabase Management API token validity
+// ---------------------------------------------------------------------------
+
+async function probeSupabaseToken(): Promise<{
+  status: "ok" | "missing" | "stale" | "unknown";
+  statusCode: number;
+  error?: string;
+}> {
+  if (!SUPABASE_ACCESS_TOKEN) {
+    return { status: "missing", statusCode: 0, error: "SUPABASE_ACCESS_TOKEN env var absent" };
+  }
+  try {
+    const res = await fetch("https://api.supabase.com/v1/projects", {
+      headers: {
+        Authorization: `Bearer ${SUPABASE_ACCESS_TOKEN}`,
+      },
+    });
+    if (res.status === 200) return { status: "ok", statusCode: 200 };
+    if (res.status === 401) return { status: "stale", statusCode: 401, error: "Token invalid or expired" };
+    const text = await res.text();
+    return { status: "unknown", statusCode: res.status, error: text.slice(0, 200) };
+  } catch (err) {
+    return { status: "unknown", statusCode: 0, error: String(err) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Probe: check Supabase Vault secret presence
+// ---------------------------------------------------------------------------
+
+async function probeSupabaseVault(vaultSecretName: string): Promise<{
+  status: "ok" | "missing" | "unknown";
+  statusCode: number;
+  error?: string;
+}> {
+  try {
+    const result = await postgrest(
+      "GET",
+      `vault.decrypted_secrets?name=eq.${encodeURIComponent(vaultSecretName)}&select=id`,
+    ) as Array<{ id: string }>;
+    if (Array.isArray(result) && result.length > 0) {
+      return { status: "ok", statusCode: 200 };
+    }
+    return { status: "missing", statusCode: 200, error: `Vault secret '${vaultSecretName}' not found` };
+  } catch (err) {
+    return { status: "unknown", statusCode: 0, error: String(err) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Determine status for a single registry entry
+// ---------------------------------------------------------------------------
+
+interface ProbeResult {
+  status: "ok" | "missing" | "stale" | "unknown";
+  statusCode: number;
+  error?: string;
+  observed: Record<string, unknown>;
+}
+
+async function probeEntry(entry: RegistryEntry): Promise<ProbeResult> {
+  const observed: Record<string, unknown> = {};
+
+  // Special case: supabase_access_token — probe the Management API directly
+  if (entry.key === "supabase_access_token") {
+    const r = await probeSupabaseToken();
+    observed["supabase_management_api"] = r.status;
+    return { status: r.status, statusCode: r.statusCode, error: r.error, observed };
+  }
+
+  // For entries with Vercel env consumers, probe Vercel
+  const vercelConsumers = entry.consumers.filter((c) => c.kind === "vercel_env");
+  for (const vc of vercelConsumers) {
+    const r = await probeVercelEnv(vc.name, vc.project ?? "odooops-console");
+    observed[`vercel_env.${vc.name}`] = r.status;
+    if (r.status === "missing") {
+      return { status: "missing", statusCode: r.statusCode, error: r.error, observed };
+    }
+  }
+
+  // For entries with GitHub secret consumers, probe GitHub
+  const ghConsumers = entry.consumers.filter((c) => c.kind === "github_secret");
+  for (const gc of ghConsumers) {
+    const r = await probeGithubSecret(gc.name);
+    observed[`github_secret.${gc.name}`] = r.status;
+    if (r.status === "missing") {
+      return { status: "missing", statusCode: r.statusCode, error: r.error, observed };
+    }
+  }
+
+  // For entries with Supabase Vault consumers, probe Vault
+  const vaultConsumers = entry.consumers.filter((c) => c.kind === "supabase_vault");
+  for (const vc of vaultConsumers) {
+    const r = await probeSupabaseVault(vc.name);
+    observed[`supabase_vault.${vc.name}`] = r.status;
+    if (r.status === "missing") {
+      return { status: "missing", statusCode: r.statusCode, error: r.error, observed };
+    }
+  }
+
+  // If nothing actionable probed, mark unknown
+  if (Object.keys(observed).length === 0) {
+    return {
+      status: "unknown",
+      statusCode: 0,
+      error: "No probe configured for consumer kinds",
+      observed,
+    };
+  }
+
+  // All probed consumers are ok
+  const allOk = Object.values(observed).every((v) => v === "ok");
+  return {
+    status: allOk ? "ok" : "unknown",
+    statusCode: 200,
+    observed,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Compute next_rotation_at from cadence string
+// ---------------------------------------------------------------------------
+
+function nextRotationAt(cadence: string): string | null {
+  const now = new Date();
+  const match = cadence.match(/^(\d+)(d|y)$/);
+  if (!match) return null;
+  const n = parseInt(match[1], 10);
+  const unit = match[2];
+  if (unit === "d") now.setDate(now.getDate() + n);
+  else if (unit === "y") now.setFullYear(now.getFullYear() + n);
+  return now.toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Main scan logic
+// ---------------------------------------------------------------------------
+
+async function runSecretsScan(): Promise<{
+  run_id: string;
+  total: number;
+  missing: number;
+  stale: number;
+  ok: number;
+  unknown: number;
+}> {
+  const supabase = createClient(SUPABASE_URL, SERVICE_KEY);
+
+  // Create maintenance run
+  const { data: runRows, error: runErr } = await supabase
+    .from("ops.maintenance_runs")
+    .insert({
+      chore_id: "secrets_scan",
+      chore_name: "Secrets Inventory Scan",
+      status: "running",
+      started_at: new Date().toISOString(),
+    })
+    .select("id");
+
+  if (runErr || !runRows?.length) {
+    throw new Error(`Failed to create maintenance run: ${runErr?.message}`);
+  }
+
+  const runId = runRows[0].id as string;
+  let totalMissing = 0;
+  let totalStale = 0;
+  let totalOk = 0;
+  let totalUnknown = 0;
+
+  for (const entry of REGISTRY_SNAPSHOT) {
+    let probeResult: ProbeResult;
+    try {
+      probeResult = await probeEntry(entry);
+    } catch (err) {
+      probeResult = {
+        status: "unknown",
+        statusCode: 0,
+        error: String(err),
+        observed: {},
+      };
+    }
+
+    // Upsert into ops.secret_inventory
+    const { error: upsertErr } = await supabase
+      .from("ops.secret_inventory")
+      .upsert(
+        {
+          key: entry.key,
+          purpose: entry.purpose,
+          severity_if_missing: entry.severity,
+          desired_consumers: entry.consumers,
+          observed: probeResult.observed,
+          status: probeResult.status,
+          probe_status_code: probeResult.statusCode || null,
+          probe_error: probeResult.error ?? null,
+          last_checked_at: new Date().toISOString(),
+          next_rotation_at: nextRotationAt(entry.rotation_cadence),
+        },
+        { onConflict: "key" },
+      );
+
+    if (upsertErr) {
+      console.error(`Failed to upsert secret_inventory for ${entry.key}:`, upsertErr);
+    }
+
+    // Tally
+    if (probeResult.status === "ok") totalOk++;
+    else if (probeResult.status === "missing") totalMissing++;
+    else if (probeResult.status === "stale") totalStale++;
+    else totalUnknown++;
+
+    // Emit convergence finding for critical/high missing or stale secrets
+    if (
+      (probeResult.status === "missing" || probeResult.status === "stale") &&
+      (entry.severity === "critical" || entry.severity === "high")
+    ) {
+      try {
+        await postgrest(
+          "POST",
+          "ops.convergence_findings",
+          {
+            env: "prod",
+            kind: "vault_missing",
+            key: `secret:${entry.key}`,
+            status: "open",
+            evidence: {
+              secret_key: entry.key,
+              probe_status: probeResult.status,
+              probe_error: probeResult.error,
+              severity: entry.severity,
+            },
+            suggested_action: `Provision missing secret '${entry.key}' (severity: ${entry.severity}). See ssot/secrets/registry.yaml#v2_entries.`,
+          },
+          { Prefer: "resolution=merge-duplicates,return=representation" },
+        );
+      } catch (err) {
+        console.error(`Failed to emit convergence finding for ${entry.key}:`, err);
+      }
+    }
+
+    // Log event
+    await supabase.from("ops.maintenance_run_events").insert({
+      run_id: runId,
+      level: probeResult.status === "ok" ? "info" : probeResult.status === "unknown" ? "warn" : "error",
+      message: `Secret '${entry.key}': ${probeResult.status}`,
+      data: {
+        key: entry.key,
+        status: probeResult.status,
+        severity: entry.severity,
+        observed: probeResult.observed,
+      },
+    });
+  }
+
+  // Complete maintenance run
+  await supabase
+    .from("ops.maintenance_runs")
+    .update({
+      status: "completed",
+      completed_at: new Date().toISOString(),
+      findings_count: totalMissing + totalStale,
+      evidence: {
+        total: REGISTRY_SNAPSHOT.length,
+        ok: totalOk,
+        missing: totalMissing,
+        stale: totalStale,
+        unknown: totalUnknown,
+      },
+    })
+    .eq("id", runId);
+
+  return {
+    run_id: runId,
+    total: REGISTRY_SNAPSHOT.length,
+    missing: totalMissing,
+    stale: totalStale,
+    ok: totalOk,
+    unknown: totalUnknown,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Deno.serve entrypoint
+// ---------------------------------------------------------------------------
+
+Deno.serve(async (req: Request) => {
+  // Auth guard: require service role or CRON_SECRET
+  const authHeader = req.headers.get("authorization");
+
+  if (
+    authHeader !== `Bearer ${SERVICE_KEY}` &&
+    (CRON_SECRET === "" || authHeader !== `Bearer ${CRON_SECRET}`)
+  ) {
+    return new Response(JSON.stringify({ ok: false, error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const result = await runSecretsScan();
+    return new Response(
+      JSON.stringify({ ok: true, ...result }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return new Response(
+      JSON.stringify({ ok: false, error: message }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+});

--- a/supabase/migrations/20260302000010_ops_secret_inventory.sql
+++ b/supabase/migrations/20260302000010_ops_secret_inventory.sql
@@ -1,0 +1,141 @@
+-- =============================================================================
+-- Migration: ops.secret_inventory — observed state of secrets vs registry
+-- Owner: platform / ops-secrets-scan Edge Function
+-- SSOT: ssot/secrets/registry.yaml (v2 entries)
+-- See: supabase/functions/ops-secrets-scan/index.ts
+-- =============================================================================
+-- Extends ops schema (must run after convergence_maintenance migration)
+-- Append-only table design: status updates via UPDATE, never DROP/TRUNCATE.
+-- =============================================================================
+
+-- ops.secret_inventory — observed state of secrets vs registry desired state
+CREATE TABLE IF NOT EXISTS ops.secret_inventory (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  key                 text NOT NULL UNIQUE,
+  purpose             text,
+  severity_if_missing text CHECK (severity_if_missing IN ('critical', 'high', 'medium', 'low')),
+  desired_consumers   jsonb DEFAULT '[]'::jsonb,
+  observed            jsonb DEFAULT '{}'::jsonb,
+  -- status: ok | missing | stale | unknown
+  status              text NOT NULL DEFAULT 'unknown'
+                        CHECK (status IN ('ok', 'missing', 'stale', 'unknown')),
+  probe_status_code   int,
+  probe_error         text,
+  last_checked_at     timestamptz,
+  next_rotation_at    timestamptz,
+  notes               text,
+  created_at          timestamptz DEFAULT now(),
+  updated_at          timestamptz DEFAULT now()
+);
+
+-- Row-level security: only service_role can read/write
+ALTER TABLE ops.secret_inventory ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "service role full access" ON ops.secret_inventory
+  USING (auth.role() = 'service_role');
+
+-- Indexes for common query patterns
+CREATE INDEX IF NOT EXISTS secret_inventory_status_idx
+  ON ops.secret_inventory (status);
+
+CREATE INDEX IF NOT EXISTS secret_inventory_key_idx
+  ON ops.secret_inventory (key);
+
+CREATE INDEX IF NOT EXISTS secret_inventory_severity_idx
+  ON ops.secret_inventory (severity_if_missing);
+
+-- Auto-update updated_at on row modification
+CREATE OR REPLACE FUNCTION ops.set_secret_inventory_updated_at()
+  RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS secret_inventory_updated_at ON ops.secret_inventory;
+CREATE TRIGGER secret_inventory_updated_at
+  BEFORE UPDATE ON ops.secret_inventory
+  FOR EACH ROW EXECUTE FUNCTION ops.set_secret_inventory_updated_at();
+
+-- Grant access
+GRANT SELECT, INSERT, UPDATE ON ops.secret_inventory TO service_role;
+
+-- =============================================================================
+-- Seed: insert registry entries as 'unknown' status (initial scan populates them)
+-- This ensures the table has rows even before the first scanner run.
+-- =============================================================================
+
+INSERT INTO ops.secret_inventory (key, purpose, severity_if_missing, desired_consumers, status)
+VALUES
+  (
+    'supabase_access_token',
+    'Supabase Management API PAT used by Supabase CLI and CI deploy workflows',
+    'critical',
+    '[{"kind":"github_secret","name":"SUPABASE_ACCESS_TOKEN"}]'::jsonb,
+    'unknown'
+  ),
+  (
+    'supabase_service_role_key',
+    'Supabase project service role key — bypasses RLS for Edge Functions and ops-console API routes',
+    'critical',
+    '[{"kind":"github_secret","name":"SUPABASE_SERVICE_ROLE_KEY"},{"kind":"vercel_env","project":"odooops-console","name":"SUPABASE_SERVICE_ROLE_KEY"}]'::jsonb,
+    'unknown'
+  ),
+  (
+    'supabase_anon_key',
+    'Supabase project anon key (public-safe) for ops-console public queries with RLS enforced',
+    'high',
+    '[{"kind":"vercel_env","project":"odooops-console","name":"NEXT_PUBLIC_SUPABASE_ANON_KEY"}]'::jsonb,
+    'unknown'
+  ),
+  (
+    'plane_webhook_secret',
+    'Shared HMAC secret for verifying inbound Plane.so webhook payloads in ops-console',
+    'high',
+    '[{"kind":"supabase_vault","name":"plane_webhook_secret"},{"kind":"vercel_env","project":"odooops-console","name":"PLANE_WEBHOOK_SECRET"}]'::jsonb,
+    'unknown'
+  ),
+  (
+    'github_webhook_secret',
+    'Shared HMAC-SHA256 secret for verifying inbound GitHub webhook payloads (X-Hub-Signature-256)',
+    'high',
+    '[{"kind":"supabase_vault","name":"github_webhook_secret"},{"kind":"vercel_env","project":"odooops-console","name":"GITHUB_WEBHOOK_SECRET"}]'::jsonb,
+    'unknown'
+  ),
+  (
+    'vercel_token',
+    'Vercel API PAT used by CI workflows to trigger and manage Vercel deployments',
+    'medium',
+    '[{"kind":"github_secret","name":"VERCEL_TOKEN"}]'::jsonb,
+    'unknown'
+  ),
+  (
+    'cloudflare_api_token',
+    'Cloudflare scoped API token for Terraform DNS apply via CI',
+    'medium',
+    '[{"kind":"github_secret","name":"CF_DNS_EDIT_TOKEN"}]'::jsonb,
+    'unknown'
+  ),
+  (
+    'digitalocean_access_token',
+    'DigitalOcean API token for doctl, App Platform and Ops Advisor DO scan adapter',
+    'high',
+    '[{"kind":"github_secret","name":"DO_ACCESS_TOKEN"},{"kind":"supabase_vault","name":"digitalocean_api_token"}]'::jsonb,
+    'unknown'
+  ),
+  (
+    'mailgun_api_key',
+    'Mailgun API key for webhook verification and optional management API queries',
+    'low',
+    '[{"kind":"supabase_vault","name":"mailgun_api_key"}]'::jsonb,
+    'unknown'
+  ),
+  (
+    'zoho_mail_smtp_password',
+    'Zoho Mail SMTP app-specific password for Odoo outbound email',
+    'medium',
+    '[{"kind":"odoo_config","name":"ir.mail_server.smtp_pass"}]'::jsonb,
+    'unknown'
+  )
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Summary

- **SSOT registry** (`ssot/secrets/registry.yaml`): upgraded to v2.0.0 schema with new `v2_entries` block (keeps all existing entries). Adds 10 core secrets with full schema: `type`, `owner`, `purpose`, `consumers[]`, `storage[]`, `rotation.cadence`, `healthcheck.probe`, `status.severity_if_missing`.
- **Supabase migration** (`supabase/migrations/20260302000010_ops_secret_inventory.sql`): `ops.secret_inventory` table with RLS (service_role only), indexes on `status`/`key`/`severity_if_missing`, `updated_at` trigger, and seed rows for all 10 entries.
- **Edge Function** (`supabase/functions/ops-secrets-scan/index.ts`): probes secrets via GitHub secrets API, Vercel env API, Supabase Management API, Supabase Vault; upserts `ops.secret_inventory`; emits `ops.convergence_findings` for critical/high missing/stale; writes `ops.maintenance_runs` + events.
- **CI guard** (`scripts/ci/check_secrets_registry.py` + `.github/workflows/secrets-registry-guard.yml`): hard-fails (exit 1) on v2_entries schema violations; soft-warns on unregistered secret-like references in `.github/workflows/` and `apps/`.
- **Ops Console API** (`apps/ops-console/app/api/secrets-inventory/route.ts`): `GET /api/secrets-inventory` queries `ops.secret_inventory` sorted by severity.
- **Ops Console page** (`apps/ops-console/app/platform/secrets/page.tsx`): table: Key | Purpose | Consumers | Status | Last Checked | Next Rotation | Severity; status badges (ok/missing/stale/unknown); critical/high alert banner; summary cards.
- **Sidebar** (`apps/ops-console/components/navigation/sidebar.tsx`): Secrets nav item under Platform (KeyRound icon, `/platform/secrets`).

## Test plan

- [ ] `python scripts/ci/check_secrets_registry.py` → exit 0, "Schema OK — 10 v2 entries validated"
- [ ] Apply migration to dev Supabase branch; verify `ops.secret_inventory` with 10 `unknown` seed rows
- [ ] Deploy `ops-secrets-scan` Edge Function; invoke with Bearer service_role; verify rows updated + `ops.maintenance_runs` created
- [ ] Navigate to `/platform/secrets` in Ops Console; verify table loads and badges render
- [ ] `GET /api/secrets-inventory` returns `{ secrets: [...] }` sorted critical-first
- [ ] PR touching `ssot/secrets/registry.yaml` triggers `secrets-registry-guard` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)