### PR TITLE
ci(ios): iOS preview builds pipeline (split from #442)

### DIFF
--- a/.github/workflows/ios-appstore.yml
+++ b/.github/workflows/ios-appstore.yml
@@ -32,8 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_15.2.app
+      - name: Select Xcode 16.x
+        run: sudo bash scripts/mobile/verify_xcode.sh
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -62,8 +62,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_15.2.app
+      - name: Select Xcode 16.x
+        run: sudo bash scripts/mobile/verify_xcode.sh
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ios-preview-builds.yml
+++ b/.github/workflows/ios-preview-builds.yml
@@ -1,17 +1,16 @@
 name: iOS Preview Builds
 
-# Path A (every push/PR): build-for-testing on iOS Simulator target → validates iOS compilation
-# Path B (main push only): fastlane build_testflight → IPA upload to TestFlight
+# Path A (every push/PR): iOS compilation gate via xcodebuild build-for-testing
+# Path B (main push only): fastlane build_testflight -> IPA upload to TestFlight
 #
 # Package.swift defines OdooMobile as a library product (not an executable/app).
-# xcodebuild build-for-testing validates iOS compilation without a committed .xcodeproj —
+# xcodebuild build-for-testing validates iOS compilation without a committed .xcodeproj --
 # Xcode.app (selected by verify_xcode.sh) resolves the SPM package and its schemes directly.
-# A .app artifact requires adding an application target; tracked in follow-on work.
+# A .app artifact requires an application target; tracked as follow-on work.
 #
 # ops.artifacts is always posted with a truthful status:
-#   success  — iOS compilation succeeded (build-for-testing passed)
-#   failed   — iOS compilation failed
-# TestFlight job additionally posts success | failed based on fastlane exit code.
+#   success  -- iOS compilation succeeded (build-for-testing passed)
+#   failed   -- iOS compilation failed
 
 on:
   push:
@@ -34,14 +33,14 @@ permissions:
   contents: read
 
 jobs:
-  # ─── Path A: iOS compilation gate (PRs + main) ───────────────────────────────
+  # --- Path A: iOS compilation gate (PRs + main) --------------------------------
   simulator-build:
     name: iOS Compilation Gate
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
 
-      # Select Xcode.app 16.x — required for SPM scheme resolution (CLT alone is not enough).
+      # Select Xcode.app 16.x -- required for SPM scheme resolution (CLT alone is not enough).
       - name: Select Xcode 16.x
         run: sudo bash scripts/mobile/verify_xcode.sh
 
@@ -53,7 +52,7 @@ jobs:
             2>&1 | tee /tmp/spm-resolve.log
         working-directory: apps/odoo-mobile-ios
 
-      # Run the deterministic CLT test suite — gates on macOS target.
+      # Run the deterministic CLT test suite -- validates on macOS target.
       - name: Run unit tests (macOS / CLT)
         run: |
           swift test \
@@ -64,8 +63,8 @@ jobs:
         working-directory: apps/odoo-mobile-ios
 
       # Compile all targets for the iOS Simulator target.
-      # This validates iOS-specific code paths that swift test (macOS target) does not cover.
-      # Package.swift is a library — no .app produced; add an app target when needed.
+      # Validates iOS-specific code paths that swift test (macOS target) does not cover.
+      # Package.swift is a library -- no .app produced; add an app target when needed.
       - name: Build for iOS Simulator (compilation gate)
         id: ios-build
         run: |
@@ -100,11 +99,11 @@ jobs:
           RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
           case "${BUILD_OUTCOME}" in
-            success)  STATUS="success"; REASON="" ;;
-            failure)  STATUS="failed";  REASON="IOS_COMPILATION_FAILED" ;;
-            cancelled) STATUS="failed"; REASON="CANCELLED" ;;
-            skipped)  STATUS="skipped"; REASON="STEP_SKIPPED" ;;
-            *)         STATUS="failed"; REASON="UNKNOWN_${BUILD_OUTCOME}" ;;
+            success)   STATUS="success"; REASON="" ;;
+            failure)   STATUS="failed";  REASON="IOS_COMPILATION_FAILED" ;;
+            cancelled) STATUS="failed";  REASON="CANCELLED" ;;
+            skipped)   STATUS="skipped"; REASON="STEP_SKIPPED" ;;
+            *)         STATUS="failed";  REASON="UNKNOWN_${BUILD_OUTCOME}" ;;
           esac
 
           curl -sf -X POST "${SUPABASE_URL}/rest/v1/artifacts" \
@@ -140,7 +139,7 @@ jobs:
               "${GITHUB_SHA:0:8}")" \
           || echo "::warning::ops.artifacts POST failed (non-blocking)"
 
-  # ─── Path B: TestFlight (main pushes only, gated on Path A) ──────────────────
+  # --- Path B: TestFlight (main pushes only, gated on Path A) -------------------
   testflight:
     name: TestFlight Upload
     runs-on: macos-14


### PR DESCRIPTION
## Summary
iOS CI pipeline split from #442. Contains only workflow files — no schema changes.

- `ios-preview-builds.yml`: simulator build every PR + TestFlight on main merge
- `ios-appstore.yml`: Xcode 16.x alignment via `verify_xcode.sh`
- `all-green-gates.yml` / `ci-platform-gates.yml`: iOS gate registration

## Known failure
CI will fail until one of these is resolved:
1. **Commit a minimal `.xcodeproj`** for the Odoo mobile app
2. **Switch to SPM-native build** (`swift build` / `swift test` without Xcode project file)

## Removed
`continue-on-error: true` on the xcodebuild step was not present — CI fails clearly with `CI.XCODE_PROJECT_MISSING` when no `.xcodeproj` is found.

## What is NOT in this PR
Schema migrations (they're in `feat/ops-artifacts-registry` → #453).

## Iteration
This PR will stay open and be iterated until CI is green. Do not merge until green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)