### PR TITLE
feat(mail): enable Mailgun SMTP for prod via SSOT + idempotent Odoo seed

### DIFF
--- a/addons/ipai/ipai_mailgun_smtp/__manifest__.py
+++ b/addons/ipai/ipai_mailgun_smtp/__manifest__.py
@@ -3,27 +3,33 @@
 
 {
     "name": "IPAI Mailgun SMTP Transport",
-    "version": "19.0.1.0.0",
-    "summary": "DEPRECATED - Mailgun replaced by Zoho Mail (ipai_zoho_mail). Do not install.",
+    "version": "19.0.2.0.0",
+    "summary": "Authoritative production outgoing mail server via Mailgun SMTP (port 2525).",
     "description": """
 IPAI Mailgun SMTP Transport
 =============================
 
-Registers an Odoo outgoing mail server that sends via Mailgun SMTP on port 2525.
+Registers the production outgoing mail server that routes through Mailgun SMTP
+on port 2525 (not blocked on DigitalOcean droplets).
 
-Port 2525 is Mailgun's alternate submission port and is not blocked on DigitalOcean
-droplets (unlike ports 25/587/465 which may be blocked).
+This is the AUTHORITATIVE prod mail transport. sequence=5 ensures it is selected
+above all other active mail servers. SSOT: ssot/odoo/mail.yaml.
 
 Configuration:
   SMTP server : smtp.mailgun.org
   Port        : 2525 (STARTTLS)
   Username    : no-reply@mg.insightpulseai.com
-  Password    : set via scripts/setup_mailgun_smtp_password.sh (never commit)
+  Password    : injected at install by post_install_hook from ODOO_MAILGUN_SMTP_PASSWORD env var
   From        : no-reply@mg.insightpulseai.com
-  Reply-To    : support@insightpulseai.com (optional — Zoho inbound)
+
+Password management:
+  - Never commit smtp_pass to XML
+  - Set ODOO_MAILGUN_SMTP_PASSWORD before running Odoo in production
+  - See: ssot/secrets/registry.yaml#mailgun_smtp_password
 
 DNS auth records for mg.insightpulseai.com:
-  infra/dns/mailgun_mg_insightpulseai_com.yaml
+  infra/dns/subdomain-registry.yaml (mg subdomain)
+  PR #445: tracking CNAME + DKIM #2 still pending
 
 Sending domain: mg.insightpulseai.com (outbound-only, Zoho handles inbound).
     """,
@@ -35,7 +41,8 @@ Sending domain: mg.insightpulseai.com (outbound-only, Zoho handles inbound).
     "data": [
         "data/ir_mail_server.xml",
     ],
-    "installable": False,
+    "post_install": "hooks.post_install_hook",
+    "installable": True,
     "auto_install": False,
     "application": False,
 }

--- a/addons/ipai/ipai_mailgun_smtp/data/ir_mail_server.xml
+++ b/addons/ipai/ipai_mailgun_smtp/data/ir_mail_server.xml
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <!--
-        Mailgun SMTP outbound server for mg.insightpulseai.com.
-        sequence=2 → second priority (after Zoho API at sequence=1).
-        Port 2525: Mailgun alternate submission port, not blocked on DigitalOcean.
-        smtp_pass intentionally empty — set via scripts/setup_mailgun_smtp_password.sh.
-    -->
-    <record id="mail_server_mailgun_smtp" model="ir.mail_server">
-        <field name="name">Mailgun SMTP (mg.insightpulseai.com)</field>
-        <field name="sequence">2</field>
-        <field name="smtp_host">smtp.mailgun.org</field>
-        <field name="smtp_port">2525</field>
-        <field name="smtp_encryption">starttls</field>
-        <field name="smtp_user">no-reply@mg.insightpulseai.com</field>
-    </record>
+    <data noupdate="1">
+        <!--
+            Mailgun SMTP — authoritative prod outgoing mail server.
+            sequence=1 → absolute first priority (all other servers must have sequence > 1).
+            Port 2525: Mailgun alternate submission port; not blocked on DigitalOcean.
+            smtp_pass intentionally empty — injected at install time by post_install_hook
+            from ODOO_MAILGUN_SMTP_PASSWORD env var (never committed to git).
+            SSOT: ssot/odoo/mail.yaml
+        -->
+        <record id="mail_server_mailgun_smtp" model="ir.mail_server">
+            <field name="name">Mailgun SMTP (mg.insightpulseai.com)</field>
+            <field name="sequence">1</field>
+            <field name="smtp_host">smtp.mailgun.org</field>
+            <field name="smtp_port">2525</field>
+            <field name="smtp_encryption">starttls</field>
+            <field name="smtp_user">no-reply@mg.insightpulseai.com</field>
+            <field name="active">True</field>
+        </record>
+    </data>
 </odoo>

--- a/addons/ipai/ipai_mailgun_smtp/hooks.py
+++ b/addons/ipai/ipai_mailgun_smtp/hooks.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 InsightPulseAI
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+"""
+post_install_hook: inject ODOO_MAILGUN_SMTP_PASSWORD into the ir.mail_server record.
+
+The XML seed (data/ir_mail_server.xml) intentionally leaves smtp_pass empty.
+This hook reads the env var and writes it once — idempotently — after install.
+
+Secret management:
+  - Local dev : set ODOO_MAILGUN_SMTP_PASSWORD in .env (gitignored)
+  - Production: set via systemd EnvironmentFile or Docker --env-file (never committed)
+  - Vault      : stored as mailgun_smtp_password in Supabase Vault
+                 SSOT: ssot/secrets/registry.yaml#mailgun_smtp_password
+"""
+import logging
+import os
+
+_logger = logging.getLogger(__name__)
+
+_SERVER_XMLID = "ipai_mailgun_smtp.mail_server_mailgun_smtp"
+_ENV_VAR = "ODOO_MAILGUN_SMTP_PASSWORD"
+
+
+def post_install_hook(env):
+    """Idempotently set smtp_pass on the Mailgun ir.mail_server record.
+
+    Called automatically by Odoo after ``ipai_mailgun_smtp`` is installed
+    or upgraded (via the manifest ``post_install`` key).
+
+    Does nothing if the env var is absent — this allows the module to install
+    cleanly in CI/test environments where the password is not required.
+    """
+    password = os.environ.get(_ENV_VAR, "").strip()
+    if not password:
+        _logger.warning(
+            "ipai_mailgun_smtp: %s not set — smtp_pass left empty. "
+            "Set this env var before running Odoo in production.",
+            _ENV_VAR,
+        )
+        return
+
+    server = env.ref(_SERVER_XMLID, raise_if_not_found=False)
+    if not server:
+        _logger.error(
+            "ipai_mailgun_smtp: mail server xmlid %r not found — "
+            "password injection skipped.",
+            _SERVER_XMLID,
+        )
+        return
+
+    if server.smtp_pass == password:
+        _logger.info(
+            "ipai_mailgun_smtp: smtp_pass already up to date for %r, skipping.",
+            server.name,
+        )
+        return
+
+    server.sudo().write({"smtp_pass": password})
+    _logger.info(
+        "ipai_mailgun_smtp: smtp_pass injected for mail server %r (id=%s).",
+        server.name,
+        server.id,
+    )

--- a/ssot/agents/prod_policy.yaml
+++ b/ssot/agents/prod_policy.yaml
@@ -1,0 +1,141 @@
+# schema: ssot.agents.prod_policy.v1
+# Production Agent Governance — SSOT
+# Defines the guardrails that apply to ALL agents running against the production stack.
+# Per-agent policies (e.g. FixBot) are in ssot/agents/fixbot_policy.yaml and must
+# conform to (and never exceed) the permissions granted here.
+#
+# See: spec/agent/constitution.md
+#      ssot/agents/fixbot_policy.yaml
+#      ssot/mcp/registry.yaml
+
+version: "1.0.0"
+schema: ssot.agents.prod_policy.v1
+last_reviewed: "2026-03-02"
+
+# ── Global defaults ───────────────────────────────────────────────────────────
+defaults:
+  # All agents default to read-only unless explicitly promoted
+  default_mode: read_only
+
+  # Which agent action kinds are permitted in production
+  allowed_kinds:
+    - read_ops_tables          # SELECT on ops.* (convergence findings, builds, deployments, etc.)
+    - read_artifacts           # GET from Supabase Storage (log artifacts, snapshots)
+    - read_git_history         # git log, git diff — no writes
+    - read_github_api          # GitHub REST: issues, PRs, workflow runs (read scopes only)
+    - write_ops_runs           # INSERT into ops.runs (evidence trail — mandatory for all jobs)
+    - write_maintenance_runs   # INSERT into ops.maintenance_runs (chore evidence)
+    - write_work_items         # INSERT/UPSERT into ops.work_items (task creation from signals)
+    - send_slack_notification  # POST to #ops-alerts via ops-slack-notify
+
+  # What agents must NEVER do in production (regardless of caller)
+  forbidden_actions:
+    - push_to_main_branch      # production changes go through PR review
+    - drop_database_table      # destructive schema ops require human + migration
+    - truncate_ops_table       # ops.* tables are append-only
+    - direct_sql_ddl           # ALTER TABLE / CREATE INDEX outside migrations
+    - modify_supabase_rls      # RLS changes require migration PR
+    - access_vault_secrets     # agents read secret names, never values (except approved bridge)
+    - call_external_api_unauthenticated  # every outbound call must have auth header
+
+# ── Forbidden paths (file writes / git operations) ───────────────────────────
+forbidden_paths:
+  # Agents must never write to these paths via git or file system
+  - "ssot/secrets/**"          # secrets SSOT — human-only
+  - ".env*"                    # env files — human-only
+  - "supabase/config.toml"     # Supabase project config — human-only
+  - "supabase/migrations/**"   # migrations require PR review
+  - "infra/**"                 # IaC changes require PR review
+  - ".github/workflows/**"     # CI changes require PR review
+
+# Paths where agent writes are allowed but must be audited in ops.runs
+audited_write_paths:
+  - "addons/ipai/**"           # FixBot can propose Odoo module fixes
+  - "apps/**"                  # FixBot can propose frontend fixes
+  - "packages/**"              # FixBot can propose shared package fixes
+  - "scripts/**"               # FixBot can propose script fixes
+
+# ── Per-agent overrides ───────────────────────────────────────────────────────
+agents:
+  fixbot:
+    # Inherits defaults; additional constraints from fixbot_policy.yaml
+    pr_only: true              # must open a PR; never push to main
+    max_files_changed: 40
+    max_lines_changed: 1200
+    require_tests: true
+    require_gates: true
+    escalate_after_failures: 3
+    reference: ssot/agents/fixbot_policy.yaml
+
+  ops_convergence_scan:
+    # Convergence scanner runs read-only + writes findings
+    default_mode: read_only
+    allowed_kinds:
+      - read_ops_tables
+      - read_github_api
+      - read_git_history
+      - write_ops_runs
+      - write_maintenance_runs
+      # Extended: convergence scan may also write findings
+      - write_convergence_findings
+    forbidden_paths: []        # inherits global forbidden_paths
+
+  ops_do_ingest:
+    # DigitalOcean inventory ingester
+    default_mode: read_only
+    allowed_kinds:
+      - read_ops_tables
+      - write_ops_runs
+      - write_do_inventory      # INSERT into ops.do_droplets/databases/firewalls
+    forbidden_paths: []
+
+  ops_mailgun_ingest:
+    # Mailgun webhook ingest Edge Function
+    default_mode: write_restricted
+    allowed_kinds:
+      - write_ops_runs
+      - write_mail_events       # INSERT into ops.mail_events
+      - write_artifacts         # Upload raw webhook payload to Storage
+    forbidden_paths: []
+    notes: "Receives signed Mailgun webhooks; verifies HMAC before insert"
+
+  ops_slack_notify:
+    # Outbound Slack notification sender
+    default_mode: write_restricted
+    allowed_kinds:
+      - read_ops_tables         # reads alerts from ops.platform_events
+      - write_ops_runs          # logs notification sends
+      - send_slack_notification
+    forbidden_paths: []
+
+# ── Evidence requirements ─────────────────────────────────────────────────────
+evidence:
+  # Every agent run MUST write a row before starting any side effects
+  mandatory_pre_run_write: true
+  ops_table: ops.runs
+  required_fields:
+    - run_id           # UUID, generated before run
+    - agent_kind       # e.g. "fixbot", "ops_convergence_scan"
+    - triggered_by     # e.g. "schedule", "webhook", "manual"
+    - started_at       # UTC timestamp
+    - status           # "running" at write time; updated to "completed" / "failed"
+
+# ── MCP tool access ───────────────────────────────────────────────────────────
+# Agents may only use MCP servers registered in ssot/mcp/registry.yaml.
+# Unregistered MCP servers must not be used in production runs.
+mcp_policy:
+  allowed_servers_registry: ssot/mcp/registry.yaml
+  disallow_unregistered: true
+
+# ── Boundary rules ────────────────────────────────────────────────────────────
+boundary_rules:
+  - rule: "Agents are read-only by default; write access is explicitly enumerated per agent"
+    rationale: "Principle of least privilege in production"
+  - rule: "FixBot must always open a PR; never push directly to main"
+    rationale: "Human review gate for all production code changes"
+  - rule: "ops.* tables are append-only; agents may INSERT but not UPDATE/DELETE"
+    rationale: "Immutable audit trail required for compliance and debugging"
+  - rule: "Every agent run writes ops.runs BEFORE any side effect"
+    rationale: "Evidence-first invariant — all runs are auditable from creation"
+  - rule: "Agents never read secret values; they reference secret names from ssot/secrets/registry.yaml"
+    rationale: "Credential isolation — agents operate on secret names, not values"

--- a/ssot/maintenance/schedules.yaml
+++ b/ssot/maintenance/schedules.yaml
@@ -74,7 +74,89 @@ chores:
       - ops.platform_events
     alert_on_failure: false
 
+  - id: daily_mailgun_smtp_smoke
+    name: Mailgun SMTP E2E Smoke Test + Convergence Checks
+    cadence: daily
+    cron: "0 6 * * *"  # 06:00 UTC daily
+    runner: ops-convergence-scan
+    description: >
+      Phase 1 — Odoo mail convergence checks (run first; failures block send step):
+        - mailgun server exists + active in ir.mail_server
+        - mailgun has lowest sequence among active mail servers
+        - mailgun smtp_pass is non-empty
+        - running_env != 'test' in prod instance
+        - PR #445 DNS placeholders absent for lifecycle=active records
+      Phase 2 — E2E smoke send:
+        Send a stamped mail via smtp.mailgun.org:2525 (Odoo prod transport).
+        Subject: "E2E-MAILGUN-ODOO-TEXT <ISO8601-UTC-STAMP>".
+      Phase 3 — Evidence capture:
+        Mailgun webhook → ops-mailgun-ingest → ops.mail_events row.
+        Fallback: Mailgun Events API poll confirms delivery within 5 min.
+        Write run record + raw payload artifact to ops.artifacts.
+    outputs:
+      - ops.maintenance_runs
+      - ops.mail_events
+      - ops.artifacts
+      - ops.convergence_findings
+    alert_on_failure: true
+    success_criteria: "All convergence checks PASS + ops.mail_events row created within 5 minutes of send"
+    secrets_required:
+      - odoo_mailgun_smtp_password  # ssot/secrets/registry.yaml (prod Odoo SMTP, via ODOO_MAILGUN_SMTP_PASSWORD)
+      - mailgun_api_key             # ssot/secrets/registry.yaml (Events API poll fallback)
+    convergence_checks:
+      - id: mailgun_server_exists
+        query: "SELECT count(*) FROM ir_mail_server WHERE smtp_host='smtp.mailgun.org' AND active=true"
+        expected: ">= 1"
+        severity: high
+      - id: mailgun_server_selected_by_sequence
+        query: "SELECT smtp_host FROM ir_mail_server WHERE active=true ORDER BY sequence ASC LIMIT 1"
+        expected: "smtp.mailgun.org"
+        severity: high
+      - id: mailgun_password_present
+        query: "SELECT count(*) FROM ir_mail_server WHERE smtp_host='smtp.mailgun.org' AND smtp_pass IS NOT NULL AND smtp_pass != ''"
+        expected: ">= 1"
+        severity: high
+      - id: running_env_not_test
+        query: "SELECT value FROM ir_config_parameter WHERE key='running_env'"
+        expected_not: "test"
+        severity: medium
+      - id: mail_auth_incomplete
+        check: "DNS active-record placeholder scan (infra/dns/subdomain-registry.yaml)"
+        severity: medium
+        notes: "Fails if PR #445 tracking CNAME or DKIM #2 placeholder values remain in lifecycle=active DNS records"
+    reference: ssot/odoo/mail.yaml
+
   # ── Weekly ─────────────────────────────────────────────────────────────────
+  - id: weekly_agentstack_boot
+    name: AgentStack Compose Boot Verification
+    cadence: weekly
+    cron: "0 5 * * 1"  # Monday 05:00 UTC (before dependency window)
+    runner: ci
+    description: >
+      docker compose -f infra/agentstack/compose.yml up --wait --timeout 60;
+      health-check all services (mcp-gateway, mcp-postgres, agent-runner).
+      Record PASS/FAIL artifact to ops.maintenance_runs.
+      Uses default profile only (no local-model).
+    outputs:
+      - ops.maintenance_runs
+      - ops.agent_artifacts
+    alert_on_failure: true
+    reference: ssot/runtimes/agentstack.yaml
+
+  - id: monthly_model_inventory_refresh
+    name: Model Inventory Refresh (DMR + Gradient)
+    cadence: monthly
+    cron: "0 6 1 * *"  # 1st of month 06:00 UTC
+    runner: ops-convergence-scan
+    description: >
+      Re-ingest available model IDs and digests from Docker Model Runner
+      and DO Gradient into ops.ai_models. Alert on new deprecations.
+    outputs:
+      - ops.ai_models
+      - ops.maintenance_runs
+    alert_on_failure: false
+    reference: ssot/sources/digitalocean/gradient_models.yaml
+
   - id: dependency_upgrade_window
     name: Dependency Upgrade PR Window
     cadence: weekly

--- a/ssot/odoo/mail.yaml
+++ b/ssot/odoo/mail.yaml
@@ -1,0 +1,146 @@
+# schema: ssot.odoo.mail.v1
+# Odoo Outbound Mail — SSOT
+# Defines the canonical SMTP transport per environment and the mail catcher policy.
+#
+# DECISION (2026-03-02):
+#   Prod SMTP  → Mailgun SMTP (smtp.mailgun.org:2525) via ipai_mailgun_smtp module
+#   Non-prod   → Mailgun SMTP catcher (same host:port, separate credential + routing)
+#
+# Rationale:
+#   - E2E Mailgun SMTP proven working (evidence: ops.mail_events subject E2E-MAILGUN-ODOO-TEXT)
+#   - ops-mailgun-ingest provides webhook-driven audit trail (ops.mail_events rows)
+#   - Mailgun Events API enables delivery confirmation without manual polling
+#   - Zoho Mail handles INBOUND mail (MX records) and OAuth API; not outbound SMTP
+#
+# Odoo module: addons/ipai/ipai_mailgun_smtp/ (sequence=1, authoritative)
+# Password injection: post_install_hook reads ODOO_MAILGUN_SMTP_PASSWORD env var
+#
+# See: docs/runbooks/mail/MAIL_TRANSPORT.md
+#      ssot/integrations/mailgun.yaml
+#      ssot/maintenance/schedules.yaml § daily_mailgun_smtp_smoke
+
+version: "2.0.0"
+schema: ssot.odoo.mail.v1
+last_reviewed: "2026-03-02"
+
+# ── Production transport ──────────────────────────────────────────────────────
+production:
+  provider: mailgun_smtp
+  smtp_server: smtp.mailgun.org
+  smtp_port: 2525                       # Mailgun alternate port; not blocked on DO
+  smtp_ssl: starttls
+  smtp_user: no-reply@mg.insightpulseai.com
+  email_from: no-reply@mg.insightpulseai.com
+  smtp_password_secret: odoo_mailgun_smtp_password  # registry: ssot/secrets/registry.yaml
+  odoo_module: ipai_mailgun_smtp
+  ir_mail_server_xmlid: ipai_mailgun_smtp.mail_server_mailgun_smtp
+  sequence: 1                           # lowest sequence = highest Odoo priority
+
+  odoo_params:
+    - key: mail.catchall.domain
+      value: insightpulseai.com
+    - key: mail.default.from
+      value: no-reply@mg.insightpulseai.com
+
+  policy:
+    block_port_25: true
+    require_auth: true
+    max_retry: 3
+    evidence_required: true             # every prod send creates ops.mail_events row
+
+# ── Inbound mail (Zoho — unchanged) ──────────────────────────────────────────
+inbound:
+  provider: zoho
+  mx_domain: insightpulseai.com
+  notes: >
+    Zoho Mail handles inbound MX. The Zoho API module (ipai_zoho_mail_api, sequence=1)
+    must be deactivated in prod if installed — Mailgun SMTP at sequence=1 wins only
+    when no other active ir.mail_server has sequence <= 1. Verify via convergence check
+    mailgun_server_selected_by_sequence (see convergence_checks below).
+
+# ── Non-production transport (mail catcher) ──────────────────────────────────
+non_production:
+  # Environments: staging, dev, CI
+  provider: mailgun_catcher
+  smtp_server: smtp.mailgun.org
+  smtp_port: 2525
+  smtp_ssl: starttls
+  smtp_user: postmaster@mg.insightpulseai.com
+  email_from: noreply@mg.insightpulseai.com
+  smtp_password_secret: mailgun_smtp_password     # registry: ssot/secrets/registry.yaml
+
+  policy:
+    block_port_25: true
+    never_use_prod_credentials: true
+    enforce_catcher_routing: true
+    evidence_required: true
+
+# ── CI gate rules ─────────────────────────────────────────────────────────────
+ci_gates:
+  - id: no_port_25
+    check: "SMTP_PORT != 25 in all environments"
+    severity: error
+
+  - id: no_prod_creds_in_non_prod
+    check: "SMTP_USER != no-reply@mg.insightpulseai.com when ENV in [staging, dev] AND using prod password"
+    severity: error
+
+# ── Convergence checks (enforced by ops-convergence-scan) ────────────────────
+convergence_checks:
+  - id: mailgun_server_exists
+    check: >
+      SELECT count(*) FROM ir_mail_server
+      WHERE smtp_host = 'smtp.mailgun.org' AND active = true
+    expected: ">= 1"
+    severity: high
+    remediation: "Install ipai_mailgun_smtp module: odoo -i ipai_mailgun_smtp"
+
+  - id: mailgun_server_selected_by_sequence
+    check: >
+      SELECT smtp_host FROM ir_mail_server
+      WHERE active = true ORDER BY sequence ASC LIMIT 1
+    expected: "smtp.mailgun.org"
+    severity: high
+    remediation: >
+      Ensure no other active ir.mail_server has sequence <= 1 besides Mailgun.
+      Deactivate ipai_zoho_mail_api record if present (also sequence=1).
+
+  - id: mailgun_password_present
+    check: >
+      SELECT count(*) FROM ir_mail_server
+      WHERE smtp_host = 'smtp.mailgun.org' AND (smtp_pass IS NOT NULL AND smtp_pass != '')
+    expected: ">= 1"
+    severity: high
+    remediation: >
+      Set ODOO_MAILGUN_SMTP_PASSWORD env var and run:
+        odoo -u ipai_mailgun_smtp --stop-after-init
+
+  - id: running_env_matches_prod
+    check: >
+      SELECT value FROM ir_config_parameter
+      WHERE key = 'web.base.url'
+    expected_contains: "insightpulseai.com"
+    additional_check: >
+      Verify running_env != 'test' in odoo.conf for production instance.
+    severity: medium
+    remediation: "Set running_env = prod in /etc/odoo/odoo.conf and restart Odoo"
+
+# ── Evidence anchor ───────────────────────────────────────────────────────────
+evidence_anchor:
+  kind: e2e_mail_smoke
+  from: no-reply@mg.insightpulseai.com
+  transport: smtp.mailgun.org:2525
+  subject_prefix: "E2E-MAILGUN-ODOO-TEXT "
+  ops_table: ops.mail_events
+  artifact_table: ops.artifacts
+
+# ── Boundary rules ────────────────────────────────────────────────────────────
+boundary_rules:
+  - rule: "Prod Odoo MUST use odoo_mailgun_smtp_password via ODOO_MAILGUN_SMTP_PASSWORD env var"
+    rationale: "Secret injected by post_install_hook; never seeded in XML"
+  - rule: "Mailgun SMTP must have the lowest sequence among active ir.mail_server records"
+    rationale: "Odoo selects the server with the lowest sequence; determinism requires no lower-sequence competitor"
+  - rule: "ops-mailgun-ingest Edge Function is the sole writer to ops.mail_events"
+    rationale: "Single writer maintains SSOT for mail audit trail"
+  - rule: "smtp_pass values are never committed to git or XML data files"
+    rationale: "Secrets in env vars / keychain only; hooks.py is the injection point"

--- a/ssot/providers/ai/selection.yaml
+++ b/ssot/providers/ai/selection.yaml
@@ -1,0 +1,132 @@
+# schema: ssot.providers.ai.selection.v1
+# AI Provider Selection — Environment Routing SSOT
+# Maps each runtime environment to the correct AI inference lane.
+# Agent code MUST use MODEL_BASE_URL only — never hardcode provider URLs.
+#
+# Execution lanes:
+#   1. Vercel AI Gateway  — baseline; all production agent runs
+#   2. Docker Model Runner — optional; local dev, cost-zero evals
+#   3. Docker Offload (GPU) — optional; embedding backfills, fine-tunes
+#
+# See: ssot/providers/ai/provider.yaml           (Vercel AI Gateway details)
+#      ssot/providers/ai/docker_model_runner.yaml (DMR details)
+#      ssot/providers/exec/docker_offload.yaml    (GPU offload details)
+#      spec/odooops-console/plan.md § "Execution Lanes"
+
+version: "1.0.0"
+schema: ssot.providers.ai.selection.v1
+last_reviewed: "2026-03-02"
+
+# ── Environment routing table ────────────────────────────────────────────────
+environments:
+  production:
+    lane: vercel_ai_gateway
+    model_base_url_env: VERCEL_AI_GATEWAY_URL
+    default_model: google/gemini-2.0-flash
+    fallback_model: openai/gpt-4.1
+    rationale: "Vercel AI Gateway provides rate limiting, caching, and observability for all prod runs"
+    required_secrets:
+      - vercel_token           # ssot/secrets/registry.yaml#vercel_token
+      - gemini_api_key         # ssot/secrets/registry.yaml#gemini_api_key
+    optional_secrets:
+      - openai_api_key         # fallback model
+      - anthropic_api_key      # optional Claude route
+
+  staging:
+    lane: vercel_ai_gateway
+    model_base_url_env: VERCEL_AI_GATEWAY_URL
+    default_model: google/gemini-2.0-flash
+    fallback_model: openai/gpt-4.1
+    rationale: "Staging uses same Gateway as prod for parity; may use cheaper models via Gateway config"
+    required_secrets:
+      - vercel_token
+      - gemini_api_key
+    notes: "Use a separate Vercel AI Gateway project/team for staging to isolate rate limits"
+
+  development:
+    lane: docker_model_runner     # preferred; falls back to vercel_ai_gateway
+    model_base_url_env: MODEL_BASE_URL
+    default_model: ai/gemma3:4b   # local model via Docker Model Runner
+    fallback_lane: vercel_ai_gateway
+    fallback_model: google/gemini-2.0-flash
+    rationale: "DMR enables cost-zero local evals; fallback to Gateway when DMR not running"
+    required_secrets: []          # DMR is credential-free locally
+    optional_secrets:
+      - gemini_api_key            # for fallback lane
+    notes: >
+      Start DMR with: docker compose --profile local-model up model -d
+      MODEL_BASE_URL is auto-set by infra/agentstack/compose.yml
+
+  ci:
+    lane: vercel_ai_gateway
+    model_base_url_env: VERCEL_AI_GATEWAY_URL
+    default_model: google/gemini-2.0-flash
+    rationale: "CI must use Gateway for traceability and cost attribution"
+    required_secrets:
+      - vercel_token
+      - gemini_api_key
+
+# ── Model selection policy ────────────────────────────────────────────────────
+model_policy:
+  # All model selection goes through this SSOT; no ad-hoc model selection in agent code
+  ssot_authoritative: true
+
+  task_overrides:
+    # Tasks that require a specific model capability
+    - task: embedding_backfill
+      lane: docker_offload
+      model: nomic-embed-text    # GPU offload for large batch
+      env: [development]
+      notes: "Only in dev; prod embeddings via OpenAI text-embedding-3-small"
+
+    - task: code_review_assistance
+      lane: docker_model_runner
+      model: ai/gemma3:4b
+      env: [development]
+      notes: "Low-risk eval task; cost-zero via DMR"
+
+    - task: agent_run_production
+      lane: vercel_ai_gateway
+      model: google/gemini-2.0-flash
+      env: [production, staging, ci]
+      notes: "All production agent runs must use Gateway for observability"
+
+# ── Fallback chain ────────────────────────────────────────────────────────────
+fallback_chain:
+  # Ordered fallback when primary lane is unavailable
+  production:
+    - vercel_ai_gateway         # primary
+    - gemini_direct             # direct API (no gateway overhead) — last resort
+  development:
+    - docker_model_runner       # preferred
+    - vercel_ai_gateway         # fallback
+  ci:
+    - vercel_ai_gateway         # only lane for CI
+
+# ── Convergence requirements ──────────────────────────────────────────────────
+convergence_checks:
+  - id: model_base_url_set_in_prod
+    check: "MODEL_BASE_URL or VERCEL_AI_GATEWAY_URL env var present in prod runtime"
+    severity: high
+    remediation: "Set VERCEL_AI_GATEWAY_URL in Vercel project env vars"
+
+  - id: no_hardcoded_provider_urls
+    check: "No https://generativelanguage.googleapis.com or https://api.openai.com in agent code"
+    severity: medium
+    remediation: "Replace direct provider URLs with MODEL_BASE_URL reference"
+
+  - id: dmr_not_used_in_prod
+    check: "docker_model_runner lane is absent from prod runtime config"
+    severity: high
+    remediation: "DMR is local-only; prod must use vercel_ai_gateway"
+
+# ── Boundary rules ────────────────────────────────────────────────────────────
+boundary_rules:
+  - rule: "Agent code MUST use MODEL_BASE_URL; never hardcode provider endpoint URLs"
+    rationale: "Env-var-driven provider selection allows lane switching without code changes"
+  - rule: "Docker Model Runner is dev-only (local-model profile); never deploy to prod"
+    rationale: "DMR has no auth, rate limiting, or observability — not prod-grade"
+  - rule: "Model selection changes go through this SSOT; no ad-hoc model strings in handlers"
+    rationale: "Prevents model sprawl; all changes are auditable"
+  - rule: "CI must always use Vercel AI Gateway for cost attribution and traceability"
+    rationale: "CI runs are production-adjacent; must have same observability as prod"

--- a/ssot/secrets/registry.yaml
+++ b/ssot/secrets/registry.yaml
@@ -1008,17 +1008,42 @@ secrets:
       Required for webhook signature verification in ops-mailgun-ingest Edge Function.
 
   mailgun_smtp_password:
-    purpose: "Mailgun SMTP credential — used by Odoo runtime for outbound mail."
+    purpose: "Mailgun SMTP credential — used by NON-PROD environments (mail catcher on port 2525) and the daily smtp smoke chore."
     approved_stores:
       - supabase_vault
       - os_keychain
     vault_secret_name: mailgun_smtp_password
     consumers:
-      - odoo:runtime
+      - platform:ops-mailgun-ingest          # mail catcher ingest
+      - platform:daily_mailgun_smtp_smoke    # maintenance chore — sends stamped E2E test mail
     rotation_policy: "Annually or on team member offboarding."
     notes: >
-      Non-prod environments must use catcher routing (port 2525, not 25).
-      Never reference prod credentials in STAGE/DEV (CI gate enforced).
+      PROD Odoo uses zoho_mail_smtp_password (Zoho SMTP). This secret is
+      ONLY for non-prod mail catcher (smtp.mailgun.org:2525) and E2E smoke tests.
+      Never inject into prod Odoo ir.mail_server config.
+      SSOT: ssot/odoo/mail.yaml § non_production
+
+  odoo_mailgun_smtp_password:
+    purpose: >
+      Mailgun SMTP password for the production Odoo ir.mail_server record
+      (ipai_mailgun_smtp module, smtp.mailgun.org:2525).
+      Injected at Odoo install/upgrade by post_install_hook via
+      ODOO_MAILGUN_SMTP_PASSWORD env var. Never seeded in XML data files.
+    approved_stores:
+      - os_keychain
+      - supabase_vault
+    vault_secret_name: odoo_mailgun_smtp_password
+    env_var_name: ODOO_MAILGUN_SMTP_PASSWORD
+    consumers:
+      - odoo:addons/ipai/ipai_mailgun_smtp/hooks.py    # injected at install time
+    rotation_policy: "Annually or on Mailgun account credential reset."
+    notes: >
+      Distinct from mailgun_smtp_password (non-prod catcher) — same Mailgun
+      account but separate secret entry to enforce prod/non-prod isolation.
+      Set in the Odoo server environment before running:
+        odoo -i ipai_mailgun_smtp   (first install)
+        odoo -u ipai_mailgun_smtp   (after rotation)
+      SSOT: ssot/odoo/mail.yaml § production
 
 # ── GitHub webhook receiver secret ────────────────────────────────────────────
   github_webhook_secret:


### PR DESCRIPTION
## Summary

Control-plane changes that establish **Mailgun SMTP as the authoritative outbound mail transport** for prod Odoo. Decision locked in \`ssot/odoo/mail.yaml\` (v2.0.0).

- E2E proof already exists: \`ops.mail_events\` row with subject \`E2E-MAILGUN-ODOO-TEXT\` confirms smtp.mailgun.org:2525 works end-to-end
- Zoho Mail remains inbound-only (MX records); not outbound SMTP
- \`ipai_zoho_mail_api\` (sequence=1) must be **deactivated** in prod; Mailgun now holds sequence=1

---

## Changes

| File | What changed |
|------|-------------|
| \`ssot/odoo/mail.yaml\` (**NEW** v2.0.0) | Prod SSOT: mailgun_smtp, port 2525, sequence=1; 4 convergence checks; boundary rules |
| \`ssot/agents/prod_policy.yaml\` (**NEW**) | Agent access policy: default read_only, per-agent allowed_kinds, forbidden_paths |
| \`ssot/providers/ai/selection.yaml\` (**NEW**) | AI provider routing: prod/CI→Gateway, dev→DMR→gateway; MODEL_BASE_URL switch |
| \`ssot/secrets/registry.yaml\` | Added \`odoo_mailgun_smtp_password\` (prod); scoped \`mailgun_smtp_password\` to non-prod |
| \`ssot/maintenance/schedules.yaml\` | Added \`daily_mailgun_smtp_smoke\` chore: 5 convergence checks → send → evidence |
| \`addons/ipai/ipai_mailgun_smtp/__manifest__.py\` | Reinstated: installable=True, version=2.0.0, \`post_install_hook\` wired |
| \`addons/ipai/ipai_mailgun_smtp/data/ir_mail_server.xml\` | \`noupdate="1"\`, \`active=True\`, **sequence=1** |
| \`addons/ipai/ipai_mailgun_smtp/hooks.py\` (**NEW**) | Idempotent \`post_install_hook\`: reads \`ODOO_MAILGUN_SMTP_PASSWORD\`, writes \`smtp_pass\`; CI-safe |

---

## Correctness notes

**Sequence=1 rationale**: \`ipai_zoho_mail_api\` also has \`sequence=1\`. Mailgun must match or beat it. Convergence check \`mailgun_server_selected_by_sequence\` flags if any other server wins; remediation is to deactivate the Zoho API record.

**Password injection**: \`smtp_pass\` is intentionally absent from XML (\`noupdate="1"\` prevents overwrites on upgrade). The \`post_install_hook\` reads \`ODOO_MAILGUN_SMTP_PASSWORD\` env var and writes it once, idempotently.

---

## Activation (prod)

\`\`\`bash
# On prod droplet
export ODOO_MAILGUN_SMTP_PASSWORD=<from Supabase Vault: odoo_mailgun_smtp_password>
odoo -d odoo_prod -i ipai_mailgun_smtp --stop-after-init

# Verify selection
psql odoo_prod -c "SELECT smtp_host, sequence, active FROM ir_mail_server ORDER BY sequence ASC;"
# Expected: smtp.mailgun.org | 1 | t
\`\`\`

---

## Convergence checks (run by ops-convergence-scan)

| Check | Expected |
|-------|----------|
| \`mailgun_server_exists\` | count >= 1 (active Mailgun server) |
| \`mailgun_server_selected_by_sequence\` | smtp.mailgun.org is lowest-sequence active server |
| \`mailgun_password_present\` | smtp_pass not empty |
| \`running_env_matches_prod\` | web.base.url contains insightpulseai.com |

---

## Open items (NOT in this PR)

- [ ] **PR #445** (follow-up): CNAME + DKIM #2 DNS records — waiting on Mailgun dashboard values
- [ ] **\`[MANUAL_REQUIRED]\`**: Set \`running_env = prod\` in \`/etc/odoo/odoo.conf\` (SSH to prod droplet)
- [ ] **Zoho deactivation**: Set \`ipai_zoho_mail_api\` record \`active=False\`; convergence check will flag until done

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)