### PR TITLE
docs(repo): add Docker Reference links to runtime sanity check section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,11 @@ code .   # VS Code picks it up via initializeCommand
 
 The default (`desktop-linux`) is used when the variable is unset.
 
+#### Relevant Docker references
+
+- [dockerd CLI reference](https://docs.docker.com/reference/cli/dockerd/) — `--host`/`-H` socket flags, `DOCKER_HOST` env var behavior, and why `Server: null` appears when the client targets a stopped or wrong daemon.
+- [Docker Reference overview](https://docs.docker.com/reference/) — canonical flag, file-format, and API specs for the full Docker CLI toolchain.
+
 ### Quick Setup
 
 ```bash


### PR DESCRIPTION
**[CONTEXT]**
- repo: Insightpulseai/odoo
- branch: docs/contributing-docker-refs → main
- goal: Add canonical Docker Reference links (dockerd + overview) next to the existing Docker runtime sanity check block
- stamp: 2026-03-02T09:00+0800

**[CHANGES]**
- `CONTRIBUTING.md`: +5 lines — `#### Relevant Docker references` subsection with two official Docker Docs links

**[EVIDENCE]**
- command: `git diff CONTRIBUTING.md`
  result: PASS — 1 file changed, 5 insertions(+), 0 deletions(-); no reformatting elsewhere

**[DIFF SUMMARY]**
- `CONTRIBUTING.md`: Adds two reference links (dockerd CLI, Docker Reference overview) directly below the Colima context-override block, inside the existing "Docker runtime sanity check" section. No other lines touched.

**[CITATIONS]**
- https://docs.docker.com/reference/cli/dockerd/ — Docker daemon CLI reference; `--host`/`-H` flags and `DOCKER_HOST` env var control which socket the client targets (ASSUMPTION: paraphrase — verbatim pull not confirmed)
- https://docs.docker.com/reference/ — Docker Reference index; canonical specs for all CLI tools and file formats (ASSUMPTION: paraphrase — verbatim pull not confirmed)