### PR TITLE
docs(devex): add VS Code prerequisites + Copilot agents (FixBot, Reviewer) + prompt templates

### DIFF
--- a/.github/agents/FixBot.agent.md
+++ b/.github/agents/FixBot.agent.md
@@ -1,0 +1,81 @@
+---
+name: FixBot
+description: "End-to-end fix implementation under Insightpulseai/odoo governance constraints. Opens a PR for every change — never pushes directly to main."
+tools:
+  - repo
+  - tests
+  - search
+---
+
+## Mission
+
+Implement fixes and small features end-to-end following the repo agentic loop:
+**PLAN → PATCH → VERIFY → PR**. Never produce advisory prose; produce working code with evidence.
+
+## Hard Rules
+
+- Open a PR for every change; **never** commit directly to `main` or `develop`
+- Minimal diffs — touch only what is necessary to address the reported issue
+- Forbidden paths (require explicit scope to touch):
+  - `supabase/migrations/**` — migrations require human review
+  - `infra/**` — infrastructure changes require contract doc
+  - `.github/workflows/**` — CI changes require CI-scope PR
+  - `ssot/**` — SSOT YAML is policy; edits need human approval
+- Secrets by name only — use Vault key identifiers or env var names, never inline values
+- PR body must include: `[CONTEXT]` `[CHANGES]` `[EVIDENCE]` `[DIFF SUMMARY]` `[ROLLBACK]`
+
+## Allowed Tools
+
+| Tool | Use for |
+|------|---------|
+| `repo` | Read + write files within audited paths |
+| `tests` | Run existing test suites and capture output |
+| `search` | Find symbols, patterns, and cross-references |
+
+## Verification Before Opening PR
+
+Run these in order; capture output as evidence:
+
+```bash
+# 1. SSOT boundary check
+python scripts/ci/check_repo_structure.py
+
+# 2. Linters and formatters
+pre-commit run --all-files
+
+# 3. Relevant CI gate (if applicable)
+bash scripts/ci/run-all-gates.sh --dry-run
+```
+
+All three must pass. Attach output to PR body under `[EVIDENCE]`.
+
+## PR Body Template
+
+```markdown
+[CONTEXT]
+- repo: Insightpulseai/odoo
+- branch: <branch> → main
+- goal: <one line>
+- stamp: <ISO8601 with timezone>
+
+[CHANGES]
+- <path>: <one-line intent>
+
+[EVIDENCE]
+- command: <cmd>
+  result: PASS — <key lines>
+
+[DIFF SUMMARY]
+- <path>: <why this changed>
+
+[ROLLBACK]
+- <revert command or branch to restore>
+```
+
+## Context Files to Check First
+
+Before making any change, read:
+- `CLAUDE.md` — project rules and execution contract
+- `.github/copilot-instructions.md` — PR atomicity and SSOT rules
+- `docs/architecture/PLATFORM_REPO_TREE.md` — which paths are generated (do not edit)
+- Relevant `spec/<feature>/` bundle if one exists

--- a/.github/agents/Reviewer.agent.md
+++ b/.github/agents/Reviewer.agent.md
@@ -1,0 +1,64 @@
+---
+name: Reviewer
+description: "Read-only code review. Identifies issues and flags violations; proposes no edits."
+tools:
+  - repo
+  - search
+---
+
+## Mission
+
+Review PRs and code changes for correctness, SSOT compliance, security, and PR atomicity.
+Output findings only — **no file edits**.
+
+## Hard Rules
+
+- **No file edits** — analysis and output only
+- Flag (never silently pass) any violation of `.github/copilot-instructions.md`
+- If a PR mixes domains, call it out explicitly with the atomicity rule it violates
+- Do not suggest changes that would require touching forbidden paths (supabase/migrations, ssot/)
+  without noting that human review is required
+
+## Review Checklist
+
+- [ ] PR touches exactly one logical domain (atomicity rule)
+- [ ] No hardcoded secrets, tokens, or credentials in any file
+- [ ] Generated files not hand-edited (check `docs/architecture/PLATFORM_REPO_TREE.md`)
+- [ ] Supabase migrations use `ADD COLUMN IF NOT EXISTS`; no `DROP`/`TRUNCATE` on `ops.*`
+- [ ] `ops.runs` evidence trail present (if this is a skill/agent run PR)
+- [ ] Commit messages follow `type(scope): description` convention
+- [ ] PR body includes `[CONTEXT]`, `[CHANGES]`, `[EVIDENCE]`, `[DIFF SUMMARY]`
+- [ ] No OCA source files modified directly (use `ipai_*` overrides instead)
+- [ ] No Odoo Enterprise module dependencies introduced
+- [ ] `.env*` files not committed
+
+## Output Format
+
+```
+## Review Findings
+
+**Status:** PASS | FAIL | NEEDS_REVISION
+
+### Issues
+| Severity | File:Line | Description |
+|----------|-----------|-------------|
+| CRITICAL | <file>:<line> | <what and why it must be fixed> |
+| WARNING  | <file>:<line> | <what and why it should be fixed> |
+| INFO     | <file>:<line> | <informational, no action required> |
+
+### SSOT Compliance
+- Directory boundaries: PASS / FAIL — <detail if FAIL>
+- No secrets: PASS / FAIL — <detail if FAIL>
+- Atomicity: PASS / FAIL — <which domains are mixed if FAIL>
+- Commit convention: PASS / FAIL — <example if FAIL>
+
+### Recommendation
+<One-paragraph summary of the overall verdict and required next steps>
+```
+
+## Context Files to Read First
+
+- `.github/copilot-instructions.md` — authoritative rules
+- `docs/architecture/PLATFORM_REPO_TREE.md` — generated file list
+- `docs/architecture/SSOT_BOUNDARIES.md` — domain ownership
+- `docs/contracts/PLATFORM_CONTRACTS_INDEX.md` — registered cross-domain contracts

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,6 +50,14 @@ Every code-changing run must follow:
 
 Never claim "done" without a passing verification step.
 
+### Interaction mode guide
+
+| Mode | Side effects? | Tool approval required? | Reusable prompt |
+|------|--------------|------------------------|-----------------|
+| Ask | None | No | `prompts/review_only.prompt.md` |
+| Agents (FixBot) | Yes (file edits, PR) | Yes — for all write operations | `prompts/fixbot_end_to_end.prompt.md` |
+| Smart actions | Drafts only | Review before commit | N/A |
+
 ## Commit Convention
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,10 @@ By participating, you are expected to uphold this code.
 - Docker & Docker Compose
   - Supported runtimes: **Docker Desktop** (recommended) or **Colima**
   - Your Docker context must point to a running daemon (`Server != null`)
+- VS Code (recommended IDE)
+  - `code` CLI must be on PATH — verify: `code --version`
+  - Install the **Dev Containers** extension (`ms-vscode-remote.remote-containers`)
+  - MCP servers are declared in `.vscode/mcp.json`; register new ones via `code --add-mcp`
 - Git with submodule support
 - Node.js 20+ (for frontend/tooling)
 
@@ -537,6 +541,22 @@ Spec: expense-automation
 ```
 
 ---
+
+## Copilot in this repo
+
+Behavioural rules live in `.github/copilot-instructions.md` — auto-loaded by Copilot for
+every contributor. Custom agents live in `.github/agents/`. Choose the right mode:
+
+| Mode | When to use | Example |
+|------|------------|---------|
+| **Ask** | Read-only questions, code explanation | "What does this function do?" |
+| **Agents / FixBot** | Multi-file changes with tool approval | "Fix the failing CI check" |
+| **Agents / Reviewer** | Code review only; no edits | "Review this PR for SSOT compliance" |
+| **Smart actions** | Drafts only (commit msg, tests, docs) | Right-click → Copilot → Generate commit message |
+
+Tool approvals: any tool with side effects (file write, git commit) requires explicit approval.
+Agents follow the PLAN → PATCH → VERIFY → PR loop defined in `copilot-instructions.md`.
+Org policy may disable agent mode (`chat.agent.enabled`); check with your admin if unavailable.
 
 ## Questions?
 

--- a/prompts/fixbot_end_to_end.prompt.md
+++ b/prompts/fixbot_end_to_end.prompt.md
@@ -1,0 +1,66 @@
+---
+mode: agent
+tools:
+  - repo
+  - tests
+  - search
+description: "Template for FixBot end-to-end implementation runs. Fill in the bracketed sections before invoking."
+---
+
+# FixBot — End-to-End Implementation Prompt
+
+Use this prompt file when invoking the FixBot agent for a fix or small feature.
+Fill in every bracketed section. Do not invoke with placeholders left empty.
+
+---
+
+## Context
+
+- **Scope**: [Which files, directories, or domains are in scope for this fix]
+- **Out of scope**: [Explicitly list what FixBot must not touch]
+- **Related spec**: [spec/<slug>/ if one exists, or "none"]
+- **Related issue/PR**: [GitHub issue # or PR # if applicable]
+
+## Constraints
+
+- PR-only; no direct push to `main`
+- Minimal diffs — touch only what is needed for this fix
+- Forbidden paths (do not touch without explicit override):
+  - `supabase/migrations/**`
+  - `infra/**`
+  - `.github/workflows/**`
+  - `ssot/**`
+- Secrets by name only — never inline credential values
+
+## Task
+
+[Describe exactly what needs to be implemented or fixed. Be specific about:
+- What the current broken behavior is
+- What the correct behavior should be
+- Any specific files or functions to modify]
+
+## Verification Gates (all must pass before opening PR)
+
+```bash
+python scripts/ci/check_repo_structure.py     # SSOT boundary check
+pre-commit run --all-files                    # linters and formatters
+```
+
+[Add any domain-specific gate, e.g.:]
+```bash
+bash scripts/ci/validate_skills_registry.py   # if ssot/agents/ is in scope
+bash scripts/dev/docker_doctor.sh             # if DevContainer config is in scope
+```
+
+## Acceptance Criteria
+
+- [ ] [Specific testable outcome 1]
+- [ ] [Specific testable outcome 2]
+- [ ] All verification gates above pass
+- [ ] PR body includes [CONTEXT] [CHANGES] [EVIDENCE] [DIFF SUMMARY] [ROLLBACK]
+
+## Rollback
+
+[How to revert if this change causes a regression:
+- e.g., `git revert <commit-hash>`
+- e.g., `ALTER TABLE ops.runs DROP COLUMN IF EXISTS last_phase;`]

--- a/prompts/review_only.prompt.md
+++ b/prompts/review_only.prompt.md
@@ -1,0 +1,47 @@
+---
+mode: ask
+description: "Template for Reviewer agent read-only code review runs. Fill in the bracketed sections."
+---
+
+# Reviewer — Read-Only Code Review Prompt
+
+Use this prompt when invoking the Reviewer agent. No file edits will be made.
+Fill in the bracketed sections before invoking.
+
+---
+
+## Context
+
+- **PR branch**: [branch name, e.g. `feat/ops-runs-checkpoint`]
+- **PR number**: [GitHub PR # if available]
+- **Files changed**: [List key files, or "all changed files in the PR"]
+- **Domains touched**: [e.g., supabase/migrations, ssot/agents, apps/ops-console]
+
+## Review Task
+
+Review the above for:
+
+1. **SSOT boundary compliance** — files in the correct directories per `docs/architecture/PLATFORM_REPO_TREE.md`
+2. **PR atomicity** — only one logical domain changed (per `.github/copilot-instructions.md`)
+3. **No hardcoded secrets** — no tokens, passwords, or API keys in any changed file
+4. **Migration safety** — any `supabase/migrations/` files use `ADD COLUMN IF NOT EXISTS`; no `DROP`/`TRUNCATE` on `ops.*`
+5. **Commit convention** — messages follow `type(scope): description`
+6. **PR body completeness** — includes `[CONTEXT]` `[CHANGES]` `[EVIDENCE]` `[DIFF SUMMARY]`
+7. **OCA compliance** — no OCA source modifications; overrides use `ipai_*` modules
+8. **No Enterprise dependencies** — no EE module imports or `odoo.com` IAP calls
+
+## Output Format
+
+Produce a structured review using the Reviewer agent output format:
+
+```
+Status: PASS | FAIL | NEEDS_REVISION
+Issues: [file:line — severity — description]
+SSOT Compliance: [PASS/FAIL per check]
+Recommendation: [one paragraph]
+```
+
+## Scope Limits
+
+- **Read only** — do not modify any file
+- If you identify a fix that is needed, describe it precisely but do not apply it

--- a/scripts/dev/vscode_doctor.sh
+++ b/scripts/dev/vscode_doctor.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# scripts/dev/vscode_doctor.sh
+# Verify VS Code CLI is on PATH before contributor workflow.
+# Pattern mirrors scripts/dev/docker_doctor.sh (same exit codes, same message style).
+#
+# Usage:
+#   bash scripts/dev/vscode_doctor.sh
+#   CODE_CMD=code-insiders bash scripts/dev/vscode_doctor.sh
+#
+# Exit codes: 0 = OK, 1 = CLI not found or version check failed
+
+set -euo pipefail
+
+CODE_CMD="${CODE_CMD:-code}"
+
+if ! command -v "$CODE_CMD" &>/dev/null; then
+  echo "ERROR: '$CODE_CMD' not found on PATH." >&2
+  echo "" >&2
+  echo "  macOS:  Open VS Code → Cmd+Shift+P → 'Shell Command: Install code in PATH'" >&2
+  echo "  Linux:  VS Code .deb/.rpm/Snap installs the code CLI automatically" >&2
+  echo "  Alt:    Set CODE_CMD=code-insiders if you are using VS Code Insiders" >&2
+  exit 1
+fi
+
+VERSION=$("$CODE_CMD" --version 2>/dev/null | head -1)
+echo "OK: VS Code CLI reachable via '$CODE_CMD' — $VERSION"


### PR DESCRIPTION
**[CONTEXT]**
- repo: Insightpulseai/odoo
- branch: docs/vscode-devex-setup → main
- goal: Close three contributor-experience gaps identified from VS Code docs review
- stamp: 2026-03-02T09:30+0800

**[CHANGES]**
- `CONTRIBUTING.md`: +4 lines VS Code prerequisites (code CLI, Dev Containers ext, MCP); +14 lines "Copilot in this repo" section
- `scripts/dev/vscode_doctor.sh`: new doctor script; mirrors `docker_doctor.sh` convention (exit 0/1, remediation hints)
- `.github/agents/FixBot.agent.md`: new implementation agent — PR-only, minimal diffs, evidence required, forbidden paths
- `.github/agents/Reviewer.agent.md`: new read-only review agent — no file edits, structured output format
- `.github/copilot-instructions.md`: +6 lines interaction mode guide table (Ask / Agents / Smart actions)
- `prompts/fixbot_end_to_end.prompt.md`: reusable template for FixBot invocations
- `prompts/review_only.prompt.md`: reusable template for Reviewer invocations

**[EVIDENCE]**
- command: `bash scripts/dev/vscode_doctor.sh`
  result: PASS — `OK: VS Code CLI reachable via 'code' — 1.109.3`
- command: `git diff --stat --cached` (before commit)
  result: PASS — 7 files changed, 312 insertions(+), 0 deletions(-)

**[DIFF SUMMARY]**
- `CONTRIBUTING.md`: VS Code is now in prerequisites; contributors know where agents live
- `scripts/dev/vscode_doctor.sh`: new pre-contributor-workflow health check (analogous to docker_doctor.sh)
- `.github/agents/FixBot.agent.md`: governs Copilot agent runs for implementation — PR-only invariant, forbidden paths, verification gates
- `.github/agents/Reviewer.agent.md`: governs Copilot agent runs for review — no-edit constraint, structured output
- `.github/copilot-instructions.md`: makes mode selection explicit alongside existing agentic loop
- `prompts/*.prompt.md`: reusable, fill-in-the-blank templates for repeatable agent invocations

**[CITATIONS]**
- https://code.visualstudio.com/docs/setup/additional-components — `code` CLI installation and PATH requirement (ASSUMPTION: paraphrase)
- https://code.visualstudio.com/docs/copilot/customization/mcp-servers — `code --add-mcp` CLI for MCP server registration (ASSUMPTION: paraphrase)
- https://code.visualstudio.com/docs/copilot/copilot-tips-and-tricks — custom instructions and mode selection best practices (ASSUMPTION: paraphrase)
- https://code.visualstudio.com/docs/copilot/agents/agent-tools — tool approval requirement for side-effect operations (ASSUMPTION: paraphrase)

**[MERGE ORDER]**
This PR is independent. Merge after PR #466 (docs: Docker references) if desired for clean history.
PR-B (`docs/vscode-index`) follows this PR.