### PR TITLE
fix(ssot): mark github_push_protection_enabled as verified

### DIFF
--- a/ssot/maintenance/convergence.yaml
+++ b/ssot/maintenance/convergence.yaml
@@ -75,7 +75,8 @@ security_settings:
   - id: github_push_protection_enabled
     description: "GitHub secret scanning Push Protection must be enabled to block committed secrets at push time"
     kind: security_setting_disabled
-    status: unverified
+    status: verified
+    verified_at: "2026-03-02"
     verify_cmd: "gh api repos/Insightpulseai/odoo --jq '.security_and_analysis.secret_scanning_push_protection.status'"
     expected_value: "enabled"
     enable_ref: "https://docs.github.com/en/get-started/learning-to-code/storing-your-secrets-safely"


### PR DESCRIPTION
## Summary

- Updates `ssot/maintenance/convergence.yaml`: `github_push_protection_enabled` status `unverified → verified`, adds `verified_at: "2026-03-02"`.

## Evidence

```
$ gh api repos/Insightpulseai/odoo \
    --jq '.security_and_analysis.secret_scanning_push_protection.status'
"enabled"
```

Push Protection was confirmed enabled immediately after PR #472 merged. This closes the convergence finding opened in that PR.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('ssot/maintenance/convergence.yaml')); print('YAML OK')"` → `YAML OK`
- [x] Status field updated from `unverified` to `verified`
- [x] `verified_at` date recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)