### PR TITLE
docs(devex): add tooling inventory SSOT + index + CI validator

### DIFF
--- a/.github/workflows/tooling-inventory-check.yml
+++ b/.github/workflows/tooling-inventory-check.yml
@@ -1,0 +1,33 @@
+name: Tooling Inventory Validator
+
+on:
+  pull_request:
+    paths:
+      - "ssot/devex/**"
+      - "docs/dev/devex/**"
+      - "scripts/ci/check_tooling_inventory.py"
+  push:
+    branches: [main]
+    paths:
+      - "ssot/devex/**"
+      - "docs/dev/devex/**"
+      - "scripts/ci/check_tooling_inventory.py"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Validate tooling inventory
+        run: python scripts/ci/check_tooling_inventory.py

--- a/docs/dev/devex/TOOLING_INDEX.md
+++ b/docs/dev/devex/TOOLING_INDEX.md
@@ -1,0 +1,65 @@
+# Developer Tooling Index
+
+> SSOT: [`ssot/devex/tooling_inventory.yaml`](../../../ssot/devex/tooling_inventory.yaml)
+> Validator: `scripts/ci/check_tooling_inventory.py`
+> CI guard: `.github/workflows/tooling-inventory-check.yml`
+
+This document is the human-readable index of standardized developer tooling
+for the `Insightpulseai/odoo` repository. Edit the SSOT YAML, not this file.
+
+---
+
+## VS Code Extensions
+
+| ID | Name | Status | Purpose |
+|----|------|--------|---------|
+| `ms-vscode-remote.remote-containers` | Dev Containers | **required** | Standardized devcontainer workflow |
+| `GitHub.vscode-pull-request-github` | GitHub PRs & Issues | **required** | In-editor PR review and issue triage |
+| `ms-python.python` | Python | **required** | Odoo development, linting, testing |
+| `ms-python.vscode-pylance` | Pylance | **required** | Type checking and IntelliSense |
+| `redhat.vscode-yaml` | YAML | **required** | SSOT YAML schema validation |
+| `editorconfig.editorconfig` | EditorConfig | **required** | Consistent formatting rules |
+| `dbaeumer.vscode-eslint` | ESLint | recommended | JS/TS linting (MCP servers, apps) |
+| `mhutchie.git-graph` | Git Graph | recommended | Branch/merge visualization |
+| `dotjoshjohnson.xml` | XML Tools | optional | Odoo view XML editing |
+| `ms-edgedevtools.vscode-edge-devtools` | Edge Tools | optional | Browser debugging (when needed) |
+| `*.odoo-snippets` | Odoo Snippets packs | **avoid** | Inconsistent patterns across contributors |
+
+## Docker Desktop Extensions
+
+| Name | Status | Purpose |
+|------|--------|---------|
+| Logs Explorer | **required** | Container log triage without ID guessing |
+| Resource Usage | **required** | Memory/CPU spike detection |
+| Aqua Trivy | recommended | Image vulnerability scanning |
+| Copacetic | optional | Patch images from scanner results |
+| Remote Docker | optional | SSH tunnel to remote Docker hosts |
+| Docker MCP Toolkit (Deprecated) | **avoid** | Deprecated; native integration exists |
+
+## MCP Servers
+
+| ID | Source | Status | Integration Surface | Approval Required |
+|----|--------|--------|---------------------|-------------------|
+| `github-mcp` | external | **active** | GitHub repo/PR/issues/actions | no |
+| `supabase-mcp` | external | **active** | Supabase DB/Auth/Edge/Vault | no |
+| `context7-mcp` | external | **active** | Library docs injection | no |
+| `playwright-mcp` | external | **active** | E2E testing + regression | no |
+| `sentry-mcp` | external | **active** | Error tracking/alerting | no |
+| `netdata-mcp` | external | **active** | Server observability | no |
+| `markitdown-mcp` | external | **active** | Document-to-Markdown conversion | no |
+| `chrome-devtools-mcp` | external | **active** | Frontend perf/debug | no |
+| `vercel-mcp` | external | planned | Vercel deployments | yes |
+| `terraform-mcp` | external | planned | IaC enforcement (Cloudflare) | yes |
+| `figma-mcp` | external | planned | Design token sync | yes |
+| `stripe-mcp` | external | planned | Payment processing | yes |
+| `docker-mcp-toolkit-deprecated` | external | **rejected** | Docker Hub (deprecated toolkit) | no |
+
+### What we explicitly avoid
+
+- **Docker MCP Toolkit**: Deprecated upstream. Docker Desktop ships native MCP integration.
+- **Random Odoo Snippets packs**: No repo-wide standard; creates inconsistent patterns.
+- **Any MCP server not listed above**: Must be proposed via PR to `ssot/devex/tooling_inventory.yaml` before adoption.
+
+---
+
+*Last updated: 2026-03-02*

--- a/scripts/ci/check_tooling_inventory.py
+++ b/scripts/ci/check_tooling_inventory.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Validate ssot/devex/tooling_inventory.yaml for structural correctness.
+
+Checks:
+  1. YAML parses without errors
+  2. All entries use allowed statuses
+  3. No duplicate IDs within each section
+  4. MCP server secret_refs exist in ssot/secrets/registry.yaml
+
+Exit 0 on success, 1 on any violation.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("FAIL: pyyaml not installed. Run: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INVENTORY_PATH = REPO_ROOT / "ssot" / "devex" / "tooling_inventory.yaml"
+SECRETS_REGISTRY_PATH = REPO_ROOT / "ssot" / "secrets" / "registry.yaml"
+
+
+def load_yaml(path: Path) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def get_allowed_statuses(data: dict) -> set[str]:
+    return set(data.get("meta", {}).get("allowed_statuses", []))
+
+
+def check_statuses(data: dict, allowed: set[str]) -> list[str]:
+    errors: list[str] = []
+
+    for ext in data.get("vscode_extensions", []):
+        if ext.get("status") not in allowed:
+            errors.append(
+                f"vscode_extensions: '{ext.get('id')}' has invalid status "
+                f"'{ext.get('status')}' (allowed: {sorted(allowed)})"
+            )
+
+    for ext in data.get("docker_desktop_extensions", []):
+        if ext.get("status") not in allowed:
+            errors.append(
+                f"docker_desktop_extensions: '{ext.get('name')}' has invalid status "
+                f"'{ext.get('status')}' (allowed: {sorted(allowed)})"
+            )
+
+    mcp_statuses = allowed | {"active", "planned", "rejected"}
+    for srv in data.get("mcp_servers", []):
+        if srv.get("status") not in mcp_statuses:
+            errors.append(
+                f"mcp_servers: '{srv.get('id')}' has invalid status "
+                f"'{srv.get('status')}' (allowed: {sorted(mcp_statuses)})"
+            )
+
+    return errors
+
+
+def check_duplicate_ids(data: dict) -> list[str]:
+    errors: list[str] = []
+
+    vscode_ids = [e.get("id") for e in data.get("vscode_extensions", []) if e.get("id")]
+    seen = set()
+    for vid in vscode_ids:
+        if vid in seen:
+            errors.append(f"vscode_extensions: duplicate id '{vid}'")
+        seen.add(vid)
+
+    docker_names = [e.get("name") for e in data.get("docker_desktop_extensions", []) if e.get("name")]
+    seen = set()
+    for dn in docker_names:
+        if dn in seen:
+            errors.append(f"docker_desktop_extensions: duplicate name '{dn}'")
+        seen.add(dn)
+
+    mcp_ids = [s.get("id") for s in data.get("mcp_servers", []) if s.get("id")]
+    seen = set()
+    for mid in mcp_ids:
+        if mid in seen:
+            errors.append(f"mcp_servers: duplicate id '{mid}'")
+        seen.add(mid)
+
+    return errors
+
+
+def check_secret_refs(data: dict) -> list[str]:
+    errors: list[str] = []
+
+    if not SECRETS_REGISTRY_PATH.exists():
+        errors.append(f"secrets registry not found: {SECRETS_REGISTRY_PATH}")
+        return errors
+
+    secrets_data = load_yaml(SECRETS_REGISTRY_PATH)
+    known_secrets = set(secrets_data.get("secrets", {}).keys())
+    known_secrets |= set(secrets_data.get("v2_entries", {}).keys())
+
+    for srv in data.get("mcp_servers", []):
+        for ref in srv.get("secret_refs", []):
+            if ref not in known_secrets:
+                errors.append(
+                    f"mcp_servers: '{srv.get('id')}' references secret '{ref}' "
+                    f"not found in ssot/secrets/registry.yaml"
+                )
+
+    return errors
+
+
+def main() -> int:
+    if not INVENTORY_PATH.exists():
+        print(f"FAIL: inventory file not found: {INVENTORY_PATH}", file=sys.stderr)
+        return 1
+
+    try:
+        data = load_yaml(INVENTORY_PATH)
+    except yaml.YAMLError as exc:
+        print(f"FAIL: YAML parse error: {exc}", file=sys.stderr)
+        return 1
+
+    if not isinstance(data, dict):
+        print("FAIL: top-level YAML must be a mapping", file=sys.stderr)
+        return 1
+
+    allowed = get_allowed_statuses(data)
+    if not allowed:
+        print("FAIL: meta.allowed_statuses is empty or missing", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    errors.extend(check_statuses(data, allowed))
+    errors.extend(check_duplicate_ids(data))
+    errors.extend(check_secret_refs(data))
+
+    if errors:
+        print(f"FAIL: {len(errors)} violation(s):", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    print(
+        f"OK: tooling_inventory.yaml — "
+        f"{len(data.get('vscode_extensions', []))} VS Code extensions, "
+        f"{len(data.get('docker_desktop_extensions', []))} Docker extensions, "
+        f"{len(data.get('mcp_servers', []))} MCP servers"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ssot/devex/tooling_inventory.yaml
+++ b/ssot/devex/tooling_inventory.yaml
@@ -1,0 +1,322 @@
+# schema: ssot.devex.tooling_inventory.v1
+# ---
+# SSOT: Unified tooling inventory for Insightpulseai/odoo contributors
+# Covers VS Code extensions, Docker Desktop extensions, and MCP servers.
+# Companion files:
+#   - ssot/devex/vscode.yaml (VS Code workspace config)
+#   - docs/dev/devex/TOOLING_INDEX.md (human-readable index)
+# Validator: scripts/ci/check_tooling_inventory.py
+# CI guard: .github/workflows/tooling-inventory-check.yml
+# Last updated: 2026-03-02
+
+id: tooling_inventory
+name: "Unified tooling inventory — Insightpulseai/odoo"
+category: developer_tooling
+version: "1.0.0"
+
+meta:
+  schema_version: "1.0"
+  updated_at: "2026-03-02"
+  repo: "Insightpulseai/odoo"
+  allowed_statuses:
+    - required
+    - recommended
+    - optional
+    - avoid
+
+# ─────────────────────────────────────────────────────────────────────────────
+# VS Code Extensions
+# ─────────────────────────────────────────────────────────────────────────────
+vscode_extensions:
+
+  # --- Required ---
+  - id: ms-vscode-remote.remote-containers
+    name: Dev Containers
+    status: required
+    purpose: "Open repo in standardized devcontainer (Docker Desktop desktop-linux)"
+    evidence: ".devcontainer/devcontainer.json"
+
+  - id: GitHub.vscode-pull-request-github
+    name: GitHub Pull Requests and Issues
+    status: required
+    purpose: "Review/checkout PRs and issue comments inside VS Code"
+    evidence: "ssot/devex/vscode.yaml → vscode.required_extensions"
+
+  - id: ms-python.python
+    name: Python
+    status: required
+    purpose: "Odoo module development, scripts, linting, testing"
+    evidence: "ssot/devex/vscode.yaml → vscode.required_extensions"
+
+  - id: ms-python.vscode-pylance
+    name: Pylance
+    status: required
+    purpose: "Type checking and IntelliSense for Python/Odoo codebase"
+    evidence: "requirements.txt includes type stubs"
+
+  - id: redhat.vscode-yaml
+    name: YAML
+    status: required
+    purpose: "SSOT YAML authoring with schema validation"
+    evidence: "62+ SSOT YAML files in ssot/"
+
+  - id: editorconfig.editorconfig
+    name: EditorConfig
+    status: required
+    purpose: "Consistent whitespace and indent rules across contributors"
+    evidence: ".editorconfig"
+
+  # --- Recommended ---
+  - id: dbaeumer.vscode-eslint
+    name: ESLint
+    status: recommended
+    purpose: "JS/TS linting for MCP servers, web apps, and scripts"
+    evidence: "mcp/servers/ and apps/ contain JS/TS code"
+
+  - id: mhutchie.git-graph
+    name: Git Graph
+    status: recommended
+    purpose: "Fast branch and merge visualization"
+    evidence: "153 workflows produce complex branch activity"
+
+  # --- Optional ---
+  - id: dotjoshjohnson.xml
+    name: XML Tools
+    status: optional
+    purpose: "Odoo view XML editing and formatting"
+    evidence: "addons/ipai/**/views/*.xml"
+
+  - id: ms-edgedevtools.vscode-edge-devtools
+    name: Microsoft Edge Tools
+    status: optional
+    purpose: "Browser-side debugging for web apps (only when doing UI debug)"
+    evidence: "apps/ web frontends"
+
+  # --- Avoid ---
+  - id: "*.odoo-snippets"
+    name: "Random Odoo Snippets packs"
+    status: avoid
+    purpose: "Creates inconsistent code patterns across contributors"
+    evidence: "No repo-wide snippet standard established"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Docker Desktop Extensions
+# ─────────────────────────────────────────────────────────────────────────────
+docker_desktop_extensions:
+
+  # --- Required ---
+  - name: Logs Explorer
+    status: required
+    purpose: "Quick container log triage without guessing container IDs"
+    evidence: "docker-compose.devcontainer.yml runs multi-container stacks"
+
+  - name: Resource Usage
+    status: required
+    purpose: "Detect runaway containers and memory spikes during Odoo/devcontainers"
+    evidence: "Odoo + PostgreSQL + devcontainer resource pressure"
+
+  # --- Recommended ---
+  - name: Aqua Trivy
+    status: recommended
+    purpose: "Image vulnerability scanning (pre-merge signal, complements GitHub Dependabot)"
+    evidence: ".github/workflows/dependency-scan.yml"
+
+  - name: Copacetic
+    status: optional
+    purpose: "Patch container images based on scanner results (only if shipping images)"
+    evidence: "Only relevant for DO App Platform image builds"
+
+  - name: Remote Docker
+    status: optional
+    purpose: "Manage remote Docker hosts via SSH tunnels (DO droplet workflows)"
+    evidence: "infra/ contains DO deployment configs"
+
+  # --- Avoid ---
+  - name: Docker MCP Toolkit (Deprecated)
+    status: avoid
+    purpose: "Deprecated — Docker Desktop has integrated MCP Toolkit in newer versions"
+    evidence: "Docker Hub deprecation notice"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MCP Servers
+# ─────────────────────────────────────────────────────────────────────────────
+mcp_servers:
+
+  # --- Active (core platform control plane) ---
+  - id: github-mcp
+    source: external
+    status: active
+    integration_surface: "GitHub repo/PR/issues/actions"
+    runner: npx
+    tools:
+      - repo_management
+      - pr_review
+      - issue_triage
+      - actions_dispatch
+    secret_refs:
+      - github_token
+    requires_approval: false
+    evidence: "mcp/servers/ and .vscode/mcp.json"
+
+  - id: supabase-mcp
+    source: external
+    status: active
+    integration_surface: "Supabase DB/Auth/Edge Functions/Vault"
+    runner: npx
+    tools:
+      - database_query
+      - edge_function_deploy
+      - vault_read
+      - auth_management
+    secret_refs:
+      - supabase_management_token
+      - supabase_service_role_key
+    requires_approval: false
+    evidence: "supabase/ directory, 42 Edge Functions"
+
+  - id: context7-mcp
+    source: external
+    status: active
+    integration_surface: "Library docs injection for up-to-date patterns"
+    runner: npx
+    tools:
+      - resolve_library_id
+      - get_library_docs
+    secret_refs: []
+    requires_approval: false
+    evidence: "Referenced in ~/.claude/MCP.md"
+
+  - id: playwright-mcp
+    source: external
+    status: active
+    integration_surface: "E2E testing + regression reproduction"
+    runner: npx
+    tools:
+      - browser_navigate
+      - browser_click
+      - browser_screenshot
+      - browser_evaluate
+    secret_refs: []
+    requires_approval: false
+    evidence: "Referenced in ~/.claude/MCP.md"
+
+  # --- Active (ops / observability) ---
+  - id: sentry-mcp
+    source: external
+    status: active
+    integration_surface: "Error tracking and alerting"
+    runner: npx
+    tools:
+      - list_issues
+      - get_issue
+      - resolve_issue
+    secret_refs:
+      - sentry_auth_token
+    requires_approval: false
+    evidence: "ssot/observability/ references Sentry"
+
+  - id: netdata-mcp
+    source: external
+    status: active
+    integration_surface: "Server observability and metrics"
+    runner: npx
+    tools:
+      - get_metrics
+      - list_alerts
+    secret_refs: []
+    requires_approval: false
+    evidence: "ssot/observability/ references Netdata (secret TBD — register before activation)"
+
+  # --- Active (docs / context) ---
+  - id: markitdown-mcp
+    source: external
+    status: active
+    integration_surface: "Convert PDF/Word/Excel/images to Markdown for agent ingestion"
+    runner: npx
+    tools:
+      - convert_document
+    secret_refs: []
+    requires_approval: false
+    evidence: "Agent workflows ingest external documents"
+
+  # --- Active (devex / testing) ---
+  - id: chrome-devtools-mcp
+    source: external
+    status: active
+    integration_surface: "Frontend perf/debug via Chrome DevTools Protocol"
+    runner: npx
+    tools:
+      - get_performance_metrics
+      - get_console_logs
+      - get_network_requests
+    secret_refs: []
+    requires_approval: false
+    evidence: "apps/ web frontends need perf profiling"
+
+  # --- Planned ---
+  - id: vercel-mcp
+    source: external
+    status: planned
+    integration_surface: "Vercel deployments and edge functions"
+    runner: npx
+    tools:
+      - list_deployments
+      - get_deployment
+      - trigger_deploy
+    secret_refs:
+      - vercel_token
+    requires_approval: true
+    evidence: "apps/ deployed on Vercel, docs/dev/vercel/"
+
+  - id: terraform-mcp
+    source: external
+    status: planned
+    integration_surface: "IaC enforcement for Cloudflare DNS and infra"
+    runner: npx
+    tools:
+      - plan
+      - apply
+      - state_list
+    secret_refs:
+      - cf_dns_edit_token
+    requires_approval: true
+    evidence: "infra/cloudflare/ Terraform configs"
+
+  # --- Optional ---
+  - id: figma-mcp
+    source: external
+    status: planned
+    integration_surface: "Design token sync from Figma"
+    runner: npx
+    tools:
+      - get_file
+      - get_styles
+      - export_tokens
+    secret_refs:
+      - figma_personal_access_token
+    requires_approval: true
+    evidence: "packages/design-tokens/"
+
+  - id: stripe-mcp
+    source: external
+    status: planned
+    integration_surface: "Payment processing integration"
+    runner: npx
+    tools:
+      - list_charges
+      - create_checkout
+    secret_refs:
+      - stripe_secret_key
+    requires_approval: true
+    evidence: "Future payment module planning"
+
+  # --- Rejected ---
+  - id: docker-mcp-toolkit-deprecated
+    source: external
+    status: rejected
+    integration_surface: "Docker Hub (deprecated toolkit)"
+    runner: npx
+    tools: []
+    secret_refs: []
+    requires_approval: false
+    evidence: "Deprecated — Docker Desktop now has native MCP integration"


### PR DESCRIPTION
## Summary
- Adds `ssot/devex/tooling_inventory.yaml` — unified SSOT for VS Code extensions (11), Docker Desktop extensions (6), and MCP servers (13)
- Adds `docs/dev/devex/TOOLING_INDEX.md` — human-readable index referencing the SSOT
- Adds `scripts/ci/check_tooling_inventory.py` — validates YAML parse, allowed statuses, no duplicate IDs, and cross-checks `secret_refs` against `ssot/secrets/registry.yaml`
- Adds `.github/workflows/tooling-inventory-check.yml` — CI guard on PRs touching `ssot/devex/**`, `docs/dev/devex/**`, or the validator script

## Curated inventory
- **VS Code**: 6 required, 2 recommended, 2 optional, 1 avoid
- **Docker Desktop**: 2 required, 1 recommended, 2 optional, 1 avoid
- **MCP servers**: 8 active, 4 planned, 1 rejected — all secret_refs validated against secrets registry

## Rollback
Delete branch and revert commit. No runtime dependencies introduced.

## Test plan
- [x] `python3 scripts/ci/check_tooling_inventory.py` passes locally
- [ ] CI workflow triggers on this PR and validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)