### PR TITLE
ssot(roadmap): roadmap index + crosswalk for multi-track plans

### DIFF
--- a/.github/workflows/roadmap-crosswalk-contract.yml
+++ b/.github/workflows/roadmap-crosswalk-contract.yml
@@ -1,0 +1,30 @@
+name: Roadmap Crosswalk Contract Gate
+
+on:
+  pull_request:
+    paths: ['ssot/roadmap/**']
+  push:
+    branches: [main]
+    paths: ['ssot/roadmap/**']
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-roadmap-crosswalk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Validate roadmap crosswalk
+        run: python scripts/check_roadmap_crosswalk.py

--- a/scripts/check_roadmap_crosswalk.py
+++ b/scripts/check_roadmap_crosswalk.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Roadmap Crosswalk Contract Gate
+
+Validates ssot/roadmap/roadmap_crosswalk.yaml against
+ssot/roadmap/product_roadmap.yaml:
+  1. Every product_quarters reference matching YYYY-Qn:E-XXX-NN
+     must point to an existing epic ID in product_roadmap.yaml.
+  2. [NEEDS_CLARIFICATION: epic id] placeholders are allowed.
+  3. All capability entries have required fields.
+
+Exit 0 = PASS, exit 1 = validation error, exit 2 = file/parse error.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML is required. pip install pyyaml")
+    sys.exit(2)
+
+CROSSWALK_PATH = Path("ssot/roadmap/roadmap_crosswalk.yaml")
+ROADMAP_PATH = Path("ssot/roadmap/product_roadmap.yaml")
+
+EPIC_REF_RE = re.compile(r"^\d{4}-Q[1-4]:E-[A-Z]+-\d+$")
+
+
+def main() -> int:
+    for p in (CROSSWALK_PATH, ROADMAP_PATH):
+        if not p.exists():
+            print(f"FAIL: {p} not found")
+            return 2
+
+    try:
+        crosswalk = yaml.safe_load(CROSSWALK_PATH.read_text(encoding="utf-8"))
+        roadmap = yaml.safe_load(ROADMAP_PATH.read_text(encoding="utf-8"))
+    except yaml.YAMLError as e:
+        print(f"FAIL: YAML parse error: {e}")
+        return 2
+
+    # Build set of known epic IDs from product_roadmap.yaml
+    known_epics: set[str] = set()
+    for quarter in roadmap.get("quarters", []):
+        qid = quarter.get("id", "")
+        for epic in quarter.get("epics", []):
+            eid = epic.get("id", "")
+            if qid and eid:
+                known_epics.add(f"{qid}:{eid}")
+
+    capabilities = crosswalk.get("capabilities", [])
+    if not isinstance(capabilities, list) or not capabilities:
+        print("FAIL: No capabilities found in crosswalk")
+        return 2
+
+    errors: list[str] = []
+
+    for i, cap in enumerate(capabilities):
+        cid = cap.get("capability_id", f"<entry {i}>")
+
+        # Required fields
+        if not cap.get("capability_id"):
+            errors.append(f"Entry {i}: missing capability_id")
+        if not cap.get("tracks"):
+            errors.append(f"{cid}: missing tracks")
+            continue
+
+        tracks = cap["tracks"]
+        pq_refs = tracks.get("product_quarters", [])
+
+        for ref in pq_refs:
+            ref_str = str(ref)
+            # Allow placeholders
+            if ref_str.startswith("[NEEDS_CLARIFICATION"):
+                continue
+            # Validate epic reference format and existence
+            if EPIC_REF_RE.match(ref_str):
+                if ref_str not in known_epics:
+                    errors.append(f"{cid}: product_quarters ref '{ref_str}' not found in product_roadmap.yaml")
+            else:
+                errors.append(f"{cid}: product_quarters ref '{ref_str}' does not match expected format YYYY-Qn:E-XXX-NN")
+
+    if errors:
+        print(f"FAIL: {len(errors)} validation error(s):")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+
+    print(f"Roadmap crosswalk gate PASS ({len(capabilities)} capabilities, {len(known_epics)} known epics)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ssot/roadmap/roadmap_crosswalk.yaml
+++ b/ssot/roadmap/roadmap_crosswalk.yaml
@@ -1,0 +1,341 @@
+version: 1
+meta:
+  owner: platform
+  purpose: "Crosswalk between roadmaps (quarters/phases) using stable capability IDs. Uncertain links are explicitly marked."
+
+capabilities:
+  # ---------------------------
+  # FOUNDATION / GOVERNANCE
+  # ---------------------------
+  - capability_id: spec_kit_ssot_mechanics
+    aliases: ["Spec Kit mechanics", "SSOT bundles", "constitution/prd/plan/tasks"]
+    tracks:
+      product_quarters: ["2026-Q2:E-FND-01"]
+      ai_first_erp_engine: ["Phase 0"]
+      ai_marketing_canvas: ["Phase 0"]
+      di_ph: ["Phase -1"]
+
+  - capability_id: rollout_policy_audit_envelope
+    aliases: ["rollout policy", "audit envelope", "traceability", "evidence packs"]
+    tracks:
+      product_quarters: ["2026-Q2:E-FND-01", "2026-Q2:E-FND-02"]
+      ai_first_erp_engine: ["Phase 0", "Phase 1"]
+      ai_marketing_canvas: ["Phase 0"]
+      di_ph: ["Phase -1"]
+
+  - capability_id: minimal_tool_surface_tool_contract_v1
+    aliases: ["minimal tool surface", "Tool Contract v1", "preview->approval->commit", "idempotency"]
+    tracks:
+      product_quarters: ["2026-Q2:E-FND-02", "2026-Q4:E-COP-01"]
+      ai_first_erp_engine: ["Phase 1", "Phase 3"]
+      ai_marketing_canvas: ["Phase 0", "Phase 4", "Phase 5"]
+      di_ph: ["Phase -1", "Phase 6"]
+
+  - capability_id: eval_harnesses_knowledge_action
+    aliases: ["knowledge eval", "action eval", "harness-first development", "feature ledger failing->green"]
+    tracks:
+      product_quarters: ["2026-Q2:E-FND-02"]
+      ai_first_erp_engine: ["Phase 0", "Phase 1"]
+      ai_marketing_canvas: ["Phase 0"]
+      di_ph: ["Phase -1"]
+
+  # ---------------------------
+  # KNOWLEDGE / WORKSPACE / AGENTS (Notion/Kapa-like)
+  # ---------------------------
+  - capability_id: citation_first_knowledge_copilot
+    aliases: ["Kapa-like knowledge copilot", "citation-first answers", "docs-gap artifacts"]
+    tracks:
+      product_quarters: ["2026-Q3:E-KAPA-01"]
+      ai_first_erp_engine: ["Phase 1", "Phase 3"]
+      ai_marketing_canvas: ["Phase 0", "Phase 1"]
+      di_ph: ["Phase 1", "Phase 6"]
+
+  - capability_id: agent_registry_scoped_permissions
+    aliases: ["agent registry", "scoped tools", "deny-by-default", "role-based permissions"]
+    tracks:
+      product_quarters: ["2026-Q3:E-AGT-01"]
+      ai_first_erp_engine: ["Phase 1", "Phase 4"]
+      ai_marketing_canvas: ["Phase 0"]
+      di_ph: ["Phase -1", "Phase 6"]
+
+  - capability_id: notion_like_agentic_workspace
+    aliases: ["Notion-like workspace", "plan->preview->approval->execute", "auditable history"]
+    tracks:
+      product_quarters: ["2026-Q3:E-AGT-01"]
+      ai_first_erp_engine: ["Phase 4"]
+      ai_marketing_canvas: ["Phase 2", "Phase 4"]
+      di_ph: ["Phase 5", "Phase 6"]
+
+  - capability_id: workspace_embed_live_erp_views
+    aliases: ["embed live Odoo views", "block-based pages with live ERP widgets"]
+    tracks:
+      product_quarters: ["[NEEDS_CLARIFICATION: epic id]"]
+      ai_first_erp_engine: ["Phase 4"]
+      ai_marketing_canvas: []
+      di_ph: []
+
+  # ---------------------------
+  # ENTERPRISE COPILOT (M365/Joule-like)
+  # ---------------------------
+  - capability_id: enterprise_copilot_cross_surface
+    aliases: ["M365/Joule-like copilot", "Odoo + Ops Console + Dev surface"]
+    tracks:
+      product_quarters: ["2026-Q4:E-COP-01"]
+      ai_first_erp_engine: ["Phase 1", "Phase 3"]
+      ai_marketing_canvas: ["Phase 4"]
+      di_ph: ["Phase 6"]
+
+  - capability_id: natural_language_query_nlq
+    aliases: ["NLQ", "plain English queries", "strict access rights enforcement"]
+    tracks:
+      product_quarters: ["[NEEDS_CLARIFICATION: epic id]"]
+      ai_first_erp_engine: ["Phase 3"]
+      ai_marketing_canvas: ["Phase 2"]
+      di_ph: ["Phase 4"]
+
+  - capability_id: multi_provider_ai_routing
+    aliases: ["multi-provider router", "Gemini/OpenAI/Anthropic/Ollama routing"]
+    tracks:
+      product_quarters: ["[NEEDS_CLARIFICATION: epic id]"]
+      ai_first_erp_engine: ["Phase 1"]
+      ai_marketing_canvas: []
+      di_ph: []
+
+  # ---------------------------
+  # FINANCE OPS: CONCUR-LIKE EXPENSE + CASH ADVANCE + OCR
+  # ---------------------------
+  - capability_id: expense_cash_advance_monitoring
+    aliases: ["Concur-like cash advance", "liquidation", "expense monitoring"]
+    tracks:
+      product_quarters: ["2026-Q4:E-EXP-01"]
+      ai_first_erp_engine: ["Phase 0", "Phase 2"]
+      ai_marketing_canvas: []
+      di_ph: []
+
+  - capability_id: receipt_ocr_digitalization_bridge
+    aliases: ["OCR bridge", "receipt digitization", "evidence packs", "human correction loop"]
+    tracks:
+      product_quarters: ["2026-Q4:E-OCR-01"]
+      ai_first_erp_engine: ["Phase 1"]
+      ai_marketing_canvas: []
+      di_ph: []
+
+  # ---------------------------
+  # PREDICTIVE INTELLIGENCE (ERP)
+  # ---------------------------
+  - capability_id: predictive_cash_flow
+    aliases: ["cash flow projections", "forecasting"]
+    tracks:
+      product_quarters: ["[NEEDS_CLARIFICATION: epic id]"]
+      ai_first_erp_engine: ["Phase 2"]
+      ai_marketing_canvas: ["Phase 3", "Phase 4"]
+      di_ph: []
+
+  - capability_id: predictive_inventory_demand
+    aliases: ["inventory demand forecasting"]
+    tracks:
+      product_quarters: ["[NEEDS_CLARIFICATION: epic id]"]
+      ai_first_erp_engine: ["Phase 2"]
+      ai_marketing_canvas: []
+      di_ph: []
+
+  - capability_id: predictive_lead_scoring
+    aliases: ["lead scoring", "sales prioritization"]
+    tracks:
+      product_quarters: ["[NEEDS_CLARIFICATION: epic id]"]
+      ai_first_erp_engine: ["Phase 2"]
+      ai_marketing_canvas: ["Phase 3"]
+      di_ph: []
+
+  - capability_id: predictive_payment_delays
+    aliases: ["payment delay risk", "collections prioritization"]
+    tracks:
+      product_quarters: ["[NEEDS_CLARIFICATION: epic id]"]
+      ai_first_erp_engine: ["Phase 2"]
+      ai_marketing_canvas: []
+      di_ph: []
+
+  - capability_id: predictive_churn_risk
+    aliases: ["churn risk", "customer retention models"]
+    tracks:
+      product_quarters: ["[NEEDS_CLARIFICATION: epic id]"]
+      ai_first_erp_engine: ["Phase 2"]
+      ai_marketing_canvas: ["Phase 3", "Phase 4"]
+      di_ph: []
+
+  # ---------------------------
+  # MARKETING CANVAS (12-MONTH OPS)
+  # ---------------------------
+  - capability_id: marketing_kpi_baselines_governance
+    aliases: ["KPI baselines", "data mapping", "RLS boundaries", "audit logging"]
+    tracks:
+      product_quarters: ["2026-Q2:E-FND-01"]
+      ai_first_erp_engine: ["Phase 0"]
+      ai_marketing_canvas: ["Phase 0"]
+      di_ph: ["Phase -1"]
+
+  - capability_id: identity_resolution_consent_preferences
+    aliases: ["identity resolution", "consent sync", "preferences"]
+    tracks:
+      product_quarters: ["[NEEDS_CLARIFICATION: epic id]"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: ["Phase 1"]
+      di_ph: []
+
+  - capability_id: canonical_event_schema_tracking
+    aliases: ["canonical schemas", "web/app event tracking"]
+    tracks:
+      product_quarters: ["[NEEDS_CLARIFICATION: epic id]"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: ["Phase 1"]
+      di_ph: []
+
+  - capability_id: segment_engine_rfm_cohorts
+    aliases: ["segment engine", "RFM", "cohorts"]
+    tracks:
+      product_quarters: ["[NEEDS_CLARIFICATION: epic id]"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: ["Phase 2"]
+      di_ph: ["Phase 4"]
+
+  - capability_id: ab_testing_harness_reporting
+    aliases: ["A/B testing harness", "automated reporting", "channel playbooks"]
+    tracks:
+      product_quarters: ["[NEEDS_CLARIFICATION: epic id]"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: ["Phase 2"]
+      di_ph: []
+
+  - capability_id: next_best_action_rules_guardrails
+    aliases: ["Next Best Action", "audience fatigue guardrails", "frequency caps"]
+    tracks:
+      product_quarters: ["[NEEDS_CLARIFICATION: epic id]"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: ["Phase 3", "Phase 4"]
+      di_ph: []
+
+  - capability_id: closed_loop_learning_model_feedback
+    aliases: ["closed-loop learning", "outcomes -> model feedback"]
+    tracks:
+      product_quarters: ["[NEEDS_CLARIFICATION: epic id]"]
+      ai_first_erp_engine: ["Phase 2"]
+      ai_marketing_canvas: ["Phase 4"]
+      di_ph: []
+
+  - capability_id: ai_creative_brief_generator
+    aliases: ["AI creative brief generator"]
+    tracks:
+      product_quarters: ["2027-Q1:E-SMT-01", "2027-Q1:E-QLT-01"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: ["Phase 4"]
+      di_ph: []
+
+  - capability_id: canvas_in_a_box_sla_ops
+    aliases: ["Canvas in a Box", "SLAs", "incident playbooks", "usage-based auditing"]
+    tracks:
+      product_quarters: ["[NEEDS_CLARIFICATION: epic id]"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: ["Phase 5"]
+      di_ph: []
+
+  # ---------------------------
+  # MARKETING OS TRACKS (LIONS / SMARTLY / QUILT)
+  # ---------------------------
+  - capability_id: lions_like_evidence_workspace_modes
+    aliases: ["Inspire/Research/Validate modes", "evidence-backed marketing OS"]
+    tracks:
+      product_quarters: ["2027-Q1:E-LIO-01"]
+      ai_first_erp_engine: ["Phase 4"]
+      ai_marketing_canvas: ["Phase 4"]
+      di_ph: ["Phase 5"]
+
+  - capability_id: deterministic_pptx_export
+    aliases: ["deterministic PPTX export", "editable deck export with citations"]
+    tracks:
+      product_quarters: ["2027-Q1:E-LIO-01"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: ["Phase 5"]
+      di_ph: ["Phase 5"]
+
+  - capability_id: smartly_like_creative_ops_experiments
+    aliases: ["creative templates", "variant production", "experiment orchestration", "performance feedback"]
+    tracks:
+      product_quarters: ["2027-Q1:E-SMT-01"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: ["Phase 2", "Phase 4"]
+      di_ph: []
+
+  - capability_id: quilt_like_consumer_cultural_intelligence
+    aliases: ["consumer intelligence", "cultural signals", "brand health", "creative testing", "LLM visibility"]
+    tracks:
+      product_quarters: ["2027-Q1:E-QLT-01"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: ["Phase 2", "Phase 4"]
+      di_ph: ["Phase 4"]
+
+  # ---------------------------
+  # DI-PH (REGIONAL INTELLIGENCE)
+  # ---------------------------
+  - capability_id: di_ph_corpora_taxonomy_ingestion
+    aliases: ["PH corpora", "category taxonomy", "ingestion connectors"]
+    tracks:
+      product_quarters: ["2027-Q1:E-DI-01"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: ["Phase 0", "Phase 1"]
+      di_ph: ["Phase 1"]
+
+  - capability_id: di_ph_digital_competitive_monitoring
+    aliases: ["digital competitive monitoring", "channels/messages/themes"]
+    tracks:
+      product_quarters: ["2027-Q1:E-DI-01"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: ["Phase 2"]
+      di_ph: ["Phase 2"]
+
+  - capability_id: di_ph_tiktok_intelligence
+    aliases: ["TikTok index", "short-form video intelligence", "creator sets"]
+    tracks:
+      product_quarters: ["2027-Q1:E-DI-01"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: []
+      di_ph: ["Phase 2"]
+
+  - capability_id: di_ph_brand_reputation_radar
+    aliases: ["Brand Reputation Radar", "geo-sliced sentiment alerts", "playbooks"]
+    tracks:
+      product_quarters: ["2027-Q1:E-DI-01"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: ["Phase 2", "Phase 4"]
+      di_ph: ["Phase 3"]
+
+  - capability_id: di_ph_touchpoints_poe_benchmarks
+    aliases: ["POE touchpoints", "benchmarks", "mix hypotheses"]
+    tracks:
+      product_quarters: ["2027-Q1:E-DI-01"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: ["Phase 3"]
+      di_ph: ["Phase 3"]
+
+  - capability_id: di_ph_consumer_report_barometer
+    aliases: ["Consumer Report PH", "quarterly barometers", "drift detection"]
+    tracks:
+      product_quarters: ["2027-Q1:E-DI-01"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: ["Phase 2", "Phase 4"]
+      di_ph: ["Phase 4"]
+
+  - capability_id: di_ph_netnography_protocols
+    aliases: ["netnography protocols", "coding schemas", "reproducible synthesis"]
+    tracks:
+      product_quarters: ["2027-Q1:E-DI-01"]
+      ai_first_erp_engine: []
+      ai_marketing_canvas: []
+      di_ph: ["Phase 4"]
+
+  - capability_id: di_ph_workspace_modes_deck_export_copilot
+    aliases: ["DI-PH workspace modes", "deck export", "enterprise copilot layer"]
+    tracks:
+      product_quarters: ["2027-Q1:E-DI-01", "2027-Q1:E-LIO-01"]
+      ai_first_erp_engine: ["Phase 4"]
+      ai_marketing_canvas: ["Phase 5"]
+      di_ph: ["Phase 5", "Phase 6"]

--- a/ssot/roadmap/roadmaps_index.yaml
+++ b/ssot/roadmap/roadmaps_index.yaml
@@ -1,0 +1,32 @@
+version: 1
+meta:
+  owner: platform
+  purpose: "Index of interrelated roadmaps (quarters, phases, 12-month ops, DI-PH). Provides join keys for epics, gates, and ledgers."
+
+tracks:
+  - id: product_quarters
+    name: "Consolidated Product Development Roadmap (2026-Q2..2027-Q1)"
+    ssot: "ssot/roadmap/product_roadmap.yaml"
+    join_key: "roadmap_epic_id"
+
+  - id: ai_first_erp_engine
+    name: "AI-First ERP Core Engine Plan (Phase 0..5)"
+    ssot: "spec/ai-copilot/plan.md"
+    join_key: "engine_phase_id"
+
+  - id: ai_marketing_canvas
+    name: "AI Marketing Canvas (12-month ops plan)"
+    ssot: "spec/ai-marketing-canvas/plan.md"
+    join_key: "canvas_phase_id"
+
+  - id: di_ph
+    name: "Data Intelligence Philippines (DI-PH)"
+    ssot: "spec/di-ph/plan.md"
+    join_key: "di_phase_id"
+
+crosscutting_gates:
+  feature_ledger: "ssot/agent/feature_ledger.yaml"
+  tool_spec_contract_gate: "scripts/check_tool_spec_contract.py"
+  knowledge_eval: "eval/knowledge_copilot_eval.yaml"
+  action_eval: "eval/action_eval.yaml"
+  audit_envelope_contract: "contracts/tools/TOOL_SPEC_TEMPLATE.md"


### PR DESCRIPTION
## Summary
- Adds `ssot/roadmap/roadmaps_index.yaml` — single index of 4 roadmap tracks (product quarters, AI-first ERP engine, AI marketing canvas, DI-PH) with join keys and crosscutting gates
- Adds `ssot/roadmap/roadmap_crosswalk.yaml` — 39 capabilities mapped across all 4 tracks via stable `capability_id` join keys, with `[NEEDS_CLARIFICATION]` placeholders for unknown epic IDs
- Adds `scripts/check_roadmap_crosswalk.py` — CI validator ensuring crosswalk `product_quarters` refs point to existing epics in `product_roadmap.yaml`
- Adds `.github/workflows/roadmap-crosswalk-contract.yml` — path-filtered CI gate on `ssot/roadmap/**`

## Test plan
- [x] All 3 YAML files parse cleanly
- [x] `python scripts/check_roadmap_crosswalk.py` exits 0: "PASS (39 capabilities, 12 known epics)"
- [ ] CI workflow triggers on PR and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)