### PR TITLE
ssot(evals): SWE-bench harness policy for coding agent

### DIFF
--- a/spec/ai-copilot/prd.md
+++ b/spec/ai-copilot/prd.md
@@ -125,6 +125,14 @@ third-party AI subscriptions beyond a single Gemini API key.
 
 ---
 
+## Coding Agent Harness (SWE-bench Style)
+
+Our coding-agent parity follows a SWE-bench-style harness: explore→plan→implement→verify,
+tests-first where feasible, tools-heavy iteration, minimal diffs, and evidence attached to PRs.
+SSOT: `ssot/evals/swebench_harness_policy.yaml`.
+
+---
+
 ## Success Criteria
 
 1. `ipai_ai_copilot` module installs cleanly on Odoo 19 CE with `depends = ["mail","web","base"]`

--- a/ssot/ai/copilot_parity_priorities.yaml
+++ b/ssot/ai/copilot_parity_priorities.yaml
@@ -120,17 +120,23 @@ priorities:
   P1:
     - id: coding-agent-issue-to-pr
       reference: github_copilot
+      harness_policy: "ssot/evals/swebench_harness_policy.yaml"
       description: >
         Autonomous agent that reads a GitHub issue, generates implementation,
         runs tests, and opens a PR. Sandboxed execution with human approval gate.
+        Follows SWE-bench-style harness: explore→plan→implement→verify loop.
       acceptance:
         - "Agent creates branch from issue"
         - "Generated code passes lint + existing tests"
         - "PR opened with structured description"
         - "Human approval required before merge"
+        - "Tests-first: test written/strengthened before code change when feasible"
+        - "Verify loop enforced: agent runs tests before marking complete"
+        - "Evidence pack emitted: docs/evidence/agent_runs/<run_id>/"
       depends_on:
         - "addons/ipai/ipai_agent (agent runtime)"
         - "GitHub Actions CI"
+        - "ssot/evals/swebench_harness_policy.yaml"
       owner: platform
       status: planned
 

--- a/ssot/evals/swebench_harness_policy.yaml
+++ b/ssot/evals/swebench_harness_policy.yaml
@@ -1,0 +1,33 @@
+version: 1
+meta:
+  owner: platform
+  purpose: "Harness policy for agentic coding (SWE-bench style): verify-first, tools-heavy, tests-first, evidence-backed PRs."
+  references:
+    - "https://www.anthropic.com/research/swe-bench-sonnet"
+
+principles:
+  - id: explore_plan_implement_verify
+    rule: "Agent must follow explore -> plan -> implement -> verify loop before completion."
+  - id: tests_first
+    rule: "Prefer writing/strengthening tests before code changes when feasible."
+  - id: tool_heavy
+    rule: "Use tools iteratively (grep/read/test) rather than relying on long prompts."
+  - id: patch_minimization
+    rule: "Prefer minimal diffs; avoid refactors unless required by the issue."
+  - id: evidence_in_pr
+    rule: "PR must include evidence: tests run, key logs, and rationale tied to spec/SSOT."
+
+required_artifacts:
+  - "docs/evidence/agent_runs/<run_id>/"
+  - "docs/evidence/agent_runs/<run_id>/tests.log"
+  - "docs/evidence/agent_runs/<run_id>/diff.patch"
+
+gates:
+  - name: "install_smoke"
+    required: true
+  - name: "upgrade_smoke"
+    required: true
+  - name: "unit_tests"
+    required: true
+  - name: "tool_spec_contract"
+    required: true


### PR DESCRIPTION
## Summary
- Adds `ssot/evals/swebench_harness_policy.yaml` encoding SWE-bench-style agent discipline: explore→plan→implement→verify, tests-first, tools-heavy iteration, minimal diffs, evidence in PRs
- Patches `spec/ai-copilot/prd.md` with "Coding Agent Harness (SWE-bench Style)" section pointing to the SSOT policy
- Patches `ssot/ai/copilot_parity_priorities.yaml` so `coding-agent-issue-to-pr` (P1) references the harness policy with acceptance: tests-first, verify loop enforced, evidence pack emitted

Reference: [Anthropic SWE-bench Sonnet](https://www.anthropic.com/research/swe-bench-sonnet)

## Test plan
- [x] All YAML files parse cleanly
- [x] Harness policy defines 5 principles + 4 required gates
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)