### PR TITLE
feat(p0): governed tool specs + corpus indexer (turn ledger green)

### DIFF
--- a/contracts/tools/create_record.md
+++ b/contracts/tools/create_record.md
@@ -1,0 +1,155 @@
+# Tool Spec: create_record
+
+**Tool ID**: `create_record`
+**Category**: write
+**Requires Confirmation**: Yes
+**Copilot XML ID**: `tool_create_record`
+**Registry Ref**: `ssot/tools/registry.yaml` (copilot domain)
+
+---
+
+## Description
+
+Create a new Odoo record. **Always requires explicit user confirmation** before execution (constitution rule 1). The copilot first shows a preview of what will be created, then blocks until the user clicks Confirm or Cancel.
+
+---
+
+## Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "model": {
+      "type": "string",
+      "description": "Odoo model technical name (e.g. sale.order, res.partner)"
+    },
+    "values": {
+      "type": "object",
+      "description": "Field name to value mapping for the new record"
+    }
+  },
+  "required": ["model", "values"]
+}
+```
+
+### Validation Rules
+
+- `model` must be a valid Odoo model accessible via `request.env[model]`
+- `values` must be a non-empty object
+- Field names must exist on the model
+- Values must be type-compatible with field definitions
+- Required fields on the model must be present in `values`
+
+---
+
+## Preview Output Schema
+
+Before execution, the tool returns a preview for user confirmation:
+
+```json
+{
+  "preview": {
+    "action": "create",
+    "model": "res.partner",
+    "model_display": "Contact",
+    "values": {
+      "name": "John Doe",
+      "email": "john@example.com"
+    },
+    "warnings": []
+  },
+  "requires_confirmation": true
+}
+```
+
+### Preview Rules
+
+- All field values are shown with human-readable labels
+- Many2one fields show display_name, not raw ID
+- Computed/default fields that will be auto-filled are listed separately
+- Warnings include: required fields missing defaults, unusual field values
+
+---
+
+## Approval Requirements
+
+**Mandatory**. Write tools always require user confirmation.
+
+Flow:
+1. AI returns `tool_calls` with `create_record` args
+2. Controller calls `_dispatch_tool("create_record", args)` — returns preview (read-only)
+3. Frontend shows preview with Confirm / Cancel buttons
+4. **User clicks Confirm** → Controller calls `_execute_tool_confirmed("create_record", args)`
+5. **User clicks Cancel** → No record created; audit envelope records `cancelled_by_user`
+
+---
+
+## Response Schema (after confirmation)
+
+```json
+{
+  "created": true,
+  "record_id": 123,
+  "model": "res.partner",
+  "display_name": "John Doe"
+}
+```
+
+---
+
+## Access Control
+
+- Tool executes in `request.env` context (current user's access rights)
+- If user lacks create access to model, returns `ACCESS_DENIED` **before** showing preview
+- No `sudo()` escalation permitted
+- ir.rule record rules are enforced
+
+---
+
+## Audit Envelope
+
+Every invocation emits (including cancelled and failed attempts):
+
+```json
+{
+  "trace_id": "uuid",
+  "user_id": 2,
+  "timestamp": "2026-03-03T10:00:00Z",
+  "tool_name": "create_record",
+  "tool_args": { "model": "res.partner", "values": { "name": "John Doe" } },
+  "result_status": "success | cancelled_by_user | access_denied | validation_error",
+  "duration_ms": 120
+}
+```
+
+---
+
+## Failure Modes
+
+| Error Code | Condition | HTTP Status |
+|------------|-----------|-------------|
+| `ACCESS_DENIED` | User lacks create access to model | 403 |
+| `MODEL_NOT_FOUND` | Invalid model name | 400 |
+| `VALIDATION_ERROR` | Required fields missing or invalid values | 422 |
+| `TOOL_EXECUTION_FAILED` | ORM error during record creation | 500 |
+
+---
+
+## Idempotency
+
+**Not naturally idempotent** — each confirmed call creates a new record. Callers should use the `trace_id` to detect duplicate submissions. The audit envelope records every attempt.
+
+---
+
+## Side Effects
+
+- New record created in target model
+- Odoo ORM triggers fire (mail.thread, compute fields, etc.)
+- Chatter log entry if model inherits `mail.thread`
+
+---
+
+## Evidence Path
+
+`docs/evidence/action_eval/<run_id>/create_record/`

--- a/contracts/tools/navigate_to.md
+++ b/contracts/tools/navigate_to.md
@@ -1,0 +1,117 @@
+# Tool Spec: navigate_to
+
+**Tool ID**: `navigate_to`
+**Category**: navigation
+**Requires Confirmation**: No
+**Copilot XML ID**: `tool_navigate_to`
+**Registry Ref**: `ssot/tools/registry.yaml` (copilot domain)
+
+---
+
+## Description
+
+Open a specific Odoo record in the main view. Returns a client action that the OWL frontend executes to navigate the browser. No data mutation.
+
+---
+
+## Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "model": {
+      "type": "string",
+      "description": "Odoo model technical name (e.g. sale.order, res.partner)"
+    },
+    "record_id": {
+      "type": "integer",
+      "description": "Record ID to navigate to"
+    }
+  },
+  "required": ["model", "record_id"]
+}
+```
+
+### Validation Rules
+
+- `model` must be a valid Odoo model accessible via `request.env[model]`
+- `record_id` must be a positive integer
+- Record must exist and be readable by current user
+
+---
+
+## Preview Output Schema
+
+Not applicable — navigation tools execute immediately without preview.
+
+---
+
+## Approval Requirements
+
+None. Navigation tools do not mutate data per constitution rule 1.
+
+---
+
+## Response Schema
+
+```json
+{
+  "action": {
+    "type": "ir.actions.act_window",
+    "res_model": "sale.order",
+    "res_id": 42,
+    "views": [[false, "form"]]
+  }
+}
+```
+
+The frontend interprets this as a standard Odoo window action.
+
+---
+
+## Access Control
+
+- Tool executes in `request.env` context (current user's access rights)
+- If user lacks read access to model or record, returns `ACCESS_DENIED`
+- No `sudo()` escalation permitted
+
+---
+
+## Audit Envelope
+
+Every invocation emits:
+
+```json
+{
+  "trace_id": "uuid",
+  "user_id": 2,
+  "timestamp": "2026-03-03T10:00:00Z",
+  "tool_name": "navigate_to",
+  "tool_args": { "model": "sale.order", "record_id": 42 },
+  "result_status": "success",
+  "duration_ms": 12
+}
+```
+
+---
+
+## Failure Modes
+
+| Error Code | Condition | HTTP Status |
+|------------|-----------|-------------|
+| `ACCESS_DENIED` | User lacks read access to model/record | 403 |
+| `MODEL_NOT_FOUND` | Invalid model name | 400 |
+| `RECORD_NOT_FOUND` | Record does not exist | 404 |
+
+---
+
+## Idempotency
+
+Navigation is inherently idempotent — repeated calls produce the same client action.
+
+---
+
+## Evidence Path
+
+`docs/evidence/action_eval/<run_id>/navigate_to/`

--- a/contracts/tools/search_records.md
+++ b/contracts/tools/search_records.md
@@ -1,0 +1,125 @@
+# Tool Spec: search_records
+
+**Tool ID**: `search_records`
+**Category**: read
+**Requires Confirmation**: No
+**Copilot XML ID**: `tool_search_records`
+**Registry Ref**: `ssot/tools/registry.yaml` (copilot domain)
+
+---
+
+## Description
+
+Search any Odoo model using natural language. Returns matching records with ID and display name. Read-only — no side effects on Odoo data.
+
+---
+
+## Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "model": {
+      "type": "string",
+      "description": "Odoo model technical name (e.g. sale.order, res.partner)"
+    },
+    "query": {
+      "type": "string",
+      "description": "Natural language search query"
+    },
+    "limit": {
+      "type": "integer",
+      "description": "Maximum number of results to return",
+      "default": 5,
+      "maximum": 50
+    }
+  },
+  "required": ["model", "query"]
+}
+```
+
+### Validation Rules
+
+- `model` must be a valid Odoo model accessible via `request.env[model]`
+- `query` must be non-empty string, max 500 characters
+- `limit` clamped to 1–50
+
+---
+
+## Preview Output Schema
+
+Not applicable — read tools execute immediately without preview.
+
+---
+
+## Approval Requirements
+
+None. Read-only tools do not require user confirmation per constitution rule 1.
+
+---
+
+## Response Schema
+
+```json
+{
+  "results": [
+    { "id": 42, "display_name": "SO001 — Acme Corp" }
+  ],
+  "model": "sale.order",
+  "count": 1,
+  "total": 15
+}
+```
+
+- `count`: number of results returned
+- `total`: total matching records (before limit)
+
+---
+
+## Access Control
+
+- Tool executes in `request.env` context (current user's access rights)
+- If user lacks read access to `model`, returns `ACCESS_DENIED` error
+- No `sudo()` escalation permitted
+
+---
+
+## Audit Envelope
+
+Every invocation emits:
+
+```json
+{
+  "trace_id": "uuid",
+  "user_id": 2,
+  "timestamp": "2026-03-03T10:00:00Z",
+  "tool_name": "search_records",
+  "tool_args": { "model": "sale.order", "query": "Acme", "limit": 5 },
+  "result_status": "success",
+  "duration_ms": 45
+}
+```
+
+---
+
+## Failure Modes
+
+| Error Code | Condition | HTTP Status |
+|------------|-----------|-------------|
+| `ACCESS_DENIED` | User lacks read access to model | 403 |
+| `MODEL_NOT_FOUND` | Invalid model name | 400 |
+| `MESSAGE_REQUIRED` | Empty query string | 400 |
+| `BRIDGE_TIMEOUT` | AI bridge unreachable | 504 |
+
+---
+
+## Idempotency
+
+Read-only. Naturally idempotent — repeated calls with same args return same results (modulo concurrent data changes).
+
+---
+
+## Evidence Path
+
+`docs/evidence/action_eval/<run_id>/search_records/`

--- a/contracts/tools/send_chatter_message.md
+++ b/contracts/tools/send_chatter_message.md
@@ -1,0 +1,156 @@
+# Tool Spec: send_chatter_message
+
+**Tool ID**: `send_chatter_message`
+**Category**: write
+**Requires Confirmation**: Yes
+**Copilot XML ID**: `tool_send_chatter_message`
+**Registry Ref**: `ssot/tools/registry.yaml` (copilot domain)
+
+---
+
+## Description
+
+Post a message in a record's chatter (message log) via `mail.thread`. **Always requires explicit user confirmation** before execution (constitution rule 1). Messages are visible to followers and may trigger email notifications.
+
+---
+
+## Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "model": {
+      "type": "string",
+      "description": "Odoo model technical name (must inherit mail.thread)"
+    },
+    "record_id": {
+      "type": "integer",
+      "description": "Record ID to post the message on"
+    },
+    "message": {
+      "type": "string",
+      "description": "Message content to post in the chatter"
+    }
+  },
+  "required": ["model", "record_id", "message"]
+}
+```
+
+### Validation Rules
+
+- `model` must inherit `mail.thread`
+- `record_id` must reference an existing, accessible record
+- `message` must be non-empty, max 10,000 characters
+- HTML content is sanitized by Odoo's `mail` module
+
+---
+
+## Preview Output Schema
+
+Before execution, the tool returns a preview:
+
+```json
+{
+  "preview": {
+    "action": "send_chatter_message",
+    "model": "sale.order",
+    "model_display": "Sales Order",
+    "record_id": 42,
+    "record_display": "SO001",
+    "message": "Shipment delayed by 2 days",
+    "followers_count": 3,
+    "will_notify": true
+  },
+  "requires_confirmation": true
+}
+```
+
+### Preview Rules
+
+- Shows target record display name
+- Indicates follower count and whether notifications will fire
+- Message content displayed as-is for user review
+
+---
+
+## Approval Requirements
+
+**Mandatory**. Messages are visible to external parties (followers).
+
+Flow:
+1. AI returns `tool_calls` with `send_chatter_message` args
+2. Controller calls `_dispatch_tool` — returns preview with follower info
+3. Frontend shows preview with Confirm / Cancel buttons
+4. **User clicks Confirm** → `record.message_post(body=message, message_type='comment')`
+5. **User clicks Cancel** → No message posted; audit envelope records `cancelled_by_user`
+
+---
+
+## Response Schema (after confirmation)
+
+```json
+{
+  "posted": true,
+  "message_id": 456,
+  "model": "sale.order",
+  "record_id": 42,
+  "record_display": "SO001"
+}
+```
+
+---
+
+## Access Control
+
+- User must have read access to the record
+- User must have access to `mail.message` create
+- If model does not inherit `mail.thread`, returns `VALIDATION_ERROR`
+- No `sudo()` escalation permitted
+
+---
+
+## Audit Envelope
+
+```json
+{
+  "trace_id": "uuid",
+  "user_id": 2,
+  "timestamp": "2026-03-03T10:00:00Z",
+  "tool_name": "send_chatter_message",
+  "tool_args": { "model": "sale.order", "record_id": 42, "message": "..." },
+  "result_status": "success | cancelled_by_user | access_denied",
+  "duration_ms": 85
+}
+```
+
+---
+
+## Failure Modes
+
+| Error Code | Condition | HTTP Status |
+|------------|-----------|-------------|
+| `ACCESS_DENIED` | User lacks access to record or mail.message | 403 |
+| `RECORD_NOT_FOUND` | Record does not exist | 404 |
+| `VALIDATION_ERROR` | Model does not inherit mail.thread | 422 |
+| `TOOL_EXECUTION_FAILED` | ORM error during message_post | 500 |
+
+---
+
+## Idempotency
+
+**Not naturally idempotent** — each confirmed call posts a new message. Use `trace_id` to detect duplicate submissions.
+
+---
+
+## Side Effects
+
+- New `mail.message` record created
+- Email notifications sent to followers (if configured)
+- Activity stream updated for record followers
+
+---
+
+## Evidence Path
+
+`docs/evidence/action_eval/<run_id>/send_chatter_message/`

--- a/contracts/tools/trigger_workflow.md
+++ b/contracts/tools/trigger_workflow.md
@@ -1,0 +1,175 @@
+# Tool Spec: trigger_workflow
+
+**Tool ID**: `trigger_workflow`
+**Category**: automation
+**Requires Confirmation**: Yes
+**Copilot XML ID**: `tool_trigger_workflow`
+**Registry Ref**: `ssot/tools/registry.yaml` (copilot domain)
+
+---
+
+## Description
+
+Trigger a configured n8n automation workflow via webhook. **Always requires explicit user confirmation** (constitution rule 1). The workflow must be allowlisted in `ssot/bridges/catalog.yaml` and configured via `ir.config_parameter` (constitution rule 10).
+
+---
+
+## Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "workflow_id": {
+      "type": "string",
+      "description": "n8n workflow ID from the allowlist (matches ir.config_parameter key suffix)"
+    },
+    "data": {
+      "type": "object",
+      "description": "Data payload to pass to the n8n webhook"
+    }
+  },
+  "required": ["workflow_id"]
+}
+```
+
+### Validation Rules
+
+- `workflow_id` must exist in `ssot/bridges/catalog.yaml` allowlist
+- `workflow_id` must have a corresponding `ir.config_parameter` webhook URL
+- `data` payload must be JSON-serializable, max 100KB
+- No secrets permitted in `data` payload
+
+---
+
+## Preview Output Schema
+
+Before execution, the tool returns a preview:
+
+```json
+{
+  "preview": {
+    "action": "trigger_workflow",
+    "workflow_id": "expense_report_sync",
+    "workflow_display": "Expense Report Sync",
+    "webhook_url_masked": "https://n8n.insightpulseai.com/webhook/****",
+    "data_summary": { "keys": ["report_id", "user_id"], "size_bytes": 256 },
+    "allowlisted": true
+  },
+  "requires_confirmation": true
+}
+```
+
+### Preview Rules
+
+- Webhook URL is masked (last 4 chars of path shown)
+- Data payload summarized by keys and size (not full values)
+- `allowlisted` field confirms the workflow is in the catalog
+
+---
+
+## Approval Requirements
+
+**Mandatory**. Automation tools trigger external systems.
+
+Flow:
+1. AI returns `tool_calls` with `trigger_workflow` args
+2. Controller validates `workflow_id` against allowlist
+3. If not allowlisted → immediate `ACCESS_DENIED` (no preview)
+4. Controller calls `_dispatch_tool` — returns preview
+5. Frontend shows preview with Confirm / Cancel
+6. **User clicks Confirm** → POST to n8n webhook with HMAC signature
+7. **User clicks Cancel** → No webhook called; audit records `cancelled_by_user`
+
+---
+
+## Response Schema (after confirmation)
+
+```json
+{
+  "triggered": true,
+  "workflow_id": "expense_report_sync",
+  "webhook_status": 200,
+  "webhook_response": { "success": true },
+  "duration_ms": 450
+}
+```
+
+---
+
+## Access Control
+
+- Workflow must be in `ssot/bridges/catalog.yaml` allowlist
+- Webhook URL retrieved from `ir.config_parameter` (not user-supplied)
+- Request signed with HMAC using `ir.config_parameter` secret
+- Non-allowlisted workflows are rejected before preview
+
+---
+
+## Audit Envelope
+
+```json
+{
+  "trace_id": "uuid",
+  "user_id": 2,
+  "timestamp": "2026-03-03T10:00:00Z",
+  "tool_name": "trigger_workflow",
+  "tool_args": { "workflow_id": "expense_report_sync", "data": { "report_id": 7 } },
+  "result_status": "success | cancelled_by_user | access_denied | webhook_error",
+  "duration_ms": 450
+}
+```
+
+For rejected (non-allowlisted) workflows:
+
+```json
+{
+  "trace_id": "uuid",
+  "user_id": 2,
+  "timestamp": "2026-03-03T10:00:00Z",
+  "tool_name": "trigger_workflow",
+  "tool_args": { "workflow_id": "unknown_workflow" },
+  "result_status": "access_denied",
+  "duration_ms": 5
+}
+```
+
+---
+
+## Failure Modes
+
+| Error Code | Condition | HTTP Status |
+|------------|-----------|-------------|
+| `ACCESS_DENIED` | Workflow not in allowlist | 403 |
+| `BRIDGE_URL_NOT_CONFIGURED` | Webhook URL missing from ir.config_parameter | 503 |
+| `BRIDGE_TIMEOUT` | n8n webhook did not respond within 30s | 504 |
+| `TOOL_EXECUTION_FAILED` | n8n returned non-2xx status | 502 |
+
+---
+
+## Idempotency
+
+**Depends on the n8n workflow**. The copilot does not guarantee idempotency — it is the workflow's responsibility. The `trace_id` is passed in the webhook payload for deduplication.
+
+---
+
+## Side Effects
+
+- HTTP POST to external n8n webhook
+- n8n workflow execution (varies per workflow)
+- Potential downstream effects: email, Slack, record updates
+
+---
+
+## Security Notes
+
+- Webhook URLs never exposed to the frontend or AI model
+- HMAC signature prevents unauthorized webhook invocation
+- Payload size limited to 100KB
+- No secrets in `data` payload (enforced at validation)
+
+---
+
+## Evidence Path
+
+`docs/evidence/action_eval/<run_id>/trigger_workflow/`

--- a/docs/contracts/PLATFORM_CONTRACTS_INDEX.md
+++ b/docs/contracts/PLATFORM_CONTRACTS_INDEX.md
@@ -36,6 +36,7 @@
 | C-22 | [GitHub Issues Webhooks](C-GH-02-workitems-webhooks.md)       | `ssot/sources/github/work_items.yaml` | `ops.work_items`, ops-console Boards view | 🔲 Planned | `apps/ops-console/app/api/webhooks/github/route.ts` |
 | C-23 | [Agent Workflows](C-AGENT-WORKFLOWS-01.md)                    | `ssot/agents/interface_schema.yaml`   | All IPAI agent skills, executor runtimes  | ✅ Active  | `scripts/ci/validate_skills_registry.py` |
 | C-24 | [Tool Permissions](C-TOOLS-PERMISSIONS-01.md)                 | `ssot/tools/registry.yaml`            | All IPAI agent skills (`ssot/agents/skills.yaml`) | ✅ Active | `scripts/ci/validate_skills_registry.py` |
+| C-25 | [Governed Tool Specs](../contracts/tools/)                    | `contracts/tools/*.md`                | `ipai_ai_copilot` tool dispatch                   | ✅ Active | `scripts/index_corpus_registry.py --check` |
 
 ---
 

--- a/docs/evidence/action_eval/audit_envelope_sample.json
+++ b/docs/evidence/action_eval/audit_envelope_sample.json
@@ -1,0 +1,79 @@
+{
+  "_comment": "Sample audit envelope for governed tool use. All 7 required fields are present and non-null. This sample validates the schema defined in eval/action_eval.yaml (AEVAL-016).",
+  "envelopes": [
+    {
+      "trace_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "user_id": 2,
+      "timestamp": "2026-03-03T10:15:30.123Z",
+      "tool_name": "search_records",
+      "tool_args": {
+        "model": "sale.order",
+        "query": "Acme Corp",
+        "limit": 5
+      },
+      "result_status": "success",
+      "duration_ms": 45
+    },
+    {
+      "trace_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+      "user_id": 2,
+      "timestamp": "2026-03-03T10:16:00.456Z",
+      "tool_name": "create_record",
+      "tool_args": {
+        "model": "res.partner",
+        "values": {
+          "name": "John Doe",
+          "email": "john@example.com"
+        }
+      },
+      "result_status": "success",
+      "duration_ms": 120
+    },
+    {
+      "trace_id": "c3d4e5f6-a7b8-9012-cdef-012345678902",
+      "user_id": 2,
+      "timestamp": "2026-03-03T10:16:30.789Z",
+      "tool_name": "create_record",
+      "tool_args": {
+        "model": "res.partner",
+        "values": {
+          "name": "Cancelled Contact"
+        }
+      },
+      "result_status": "cancelled_by_user",
+      "duration_ms": 0
+    },
+    {
+      "trace_id": "d4e5f6a7-b8c9-0123-defa-123456789003",
+      "user_id": 2,
+      "timestamp": "2026-03-03T10:17:00.000Z",
+      "tool_name": "trigger_workflow",
+      "tool_args": {
+        "workflow_id": "expense_report_sync",
+        "data": {
+          "report_id": 7
+        }
+      },
+      "result_status": "success",
+      "duration_ms": 450
+    },
+    {
+      "trace_id": "e5f6a7b8-c9d0-1234-efab-234567890004",
+      "user_id": 5,
+      "timestamp": "2026-03-03T10:18:00.000Z",
+      "tool_name": "create_record",
+      "tool_args": {
+        "model": "account.move",
+        "values": {}
+      },
+      "result_status": "access_denied",
+      "duration_ms": 3
+    }
+  ],
+  "schema_validation": {
+    "required_fields": ["trace_id", "user_id", "timestamp", "tool_name", "tool_args", "result_status", "duration_ms"],
+    "all_non_null": true,
+    "envelope_count": 5,
+    "status_values_seen": ["success", "cancelled_by_user", "access_denied"]
+  }
+}

--- a/scripts/index_corpus_registry.py
+++ b/scripts/index_corpus_registry.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Populate file_count in ssot/knowledge/corpus_registry.yaml.
+
+Scans each corpus path, counts matching files, and updates the YAML in-place.
+Designed to be run locally or in CI (T-KAPA-01).
+
+Usage:
+    python scripts/index_corpus_registry.py          # update in-place
+    python scripts/index_corpus_registry.py --check   # exit 1 if any file_count == 0
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import glob
+import os
+import sys
+
+import yaml
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(SCRIPT_DIR)  # scripts/ -> repo root
+REGISTRY_PATH = os.path.join(REPO_ROOT, "ssot", "knowledge", "corpus_registry.yaml")
+
+
+def count_files(path_glob: str, include: list[str], exclude: list[str]) -> int:
+    """Count files matching the corpus glob patterns relative to repo root."""
+    matched: set[str] = set()
+
+    # Use include_patterns if provided, else fall back to path glob
+    patterns = include if include else [path_glob]
+
+    for pattern in patterns:
+        full_pattern = os.path.join(REPO_ROOT, pattern)
+        for fpath in glob.glob(full_pattern, recursive=True):
+            if os.path.isfile(fpath):
+                rel = os.path.relpath(fpath, REPO_ROOT)
+                # Check exclude patterns
+                excluded = False
+                for exc in exclude:
+                    if fnmatch.fnmatch(rel, exc):
+                        excluded = True
+                        break
+                if not excluded:
+                    matched.add(rel)
+
+    return len(matched)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Index corpus registry file counts")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check mode: exit 1 if any corpus has file_count == 0",
+    )
+    args = parser.parse_args()
+
+    # Parse YAML to get corpus definitions
+    with open(REGISTRY_PATH) as f:
+        data = yaml.safe_load(f)
+
+    # Count files for each corpus
+    count_map: dict[str, int] = {}
+    all_populated = True
+
+    for corpus in data.get("corpora", []):
+        cid = corpus["id"]
+        path_glob = corpus["path"]
+        include = corpus.get("include_patterns", [])
+        exclude = corpus.get("exclude_patterns", [])
+
+        count = count_files(path_glob, include, exclude)
+        count_map[cid] = count
+
+        status = "OK" if count > 0 else "EMPTY"
+        if count == 0:
+            all_populated = False
+        print(f"  {cid}: {count} files [{status}]")
+
+    if args.check:
+        if not all_populated:
+            print("\nFAIL: one or more corpora have file_count == 0")
+            return 1
+        print(f"\nPASS: all {len(data['corpora'])} corpora populated")
+        return 0
+
+    # Update file_count lines in-place, preserving comments
+    with open(REGISTRY_PATH) as f:
+        original_lines = f.readlines()
+
+    current_corpus_id = None
+    updated_lines: list[str] = []
+
+    for line in original_lines:
+        stripped = line.strip()
+
+        # Track which corpus we're in
+        if stripped.startswith("- id:"):
+            current_corpus_id = stripped.split(":", 1)[1].strip()
+
+        # Replace file_count line
+        if stripped.startswith("file_count:") and current_corpus_id in count_map:
+            indent = line[: len(line) - len(line.lstrip())]
+            new_count = count_map[current_corpus_id]
+            # Preserve inline comment if present
+            comment_part = ""
+            if "#" in stripped:
+                comment_idx = stripped.index("#")
+                comment_part = "  " + stripped[comment_idx:]
+            updated_lines.append(f"{indent}file_count: {new_count}{comment_part}\n")
+        else:
+            updated_lines.append(line)
+
+    with open(REGISTRY_PATH, "w") as f:
+        f.writelines(updated_lines)
+
+    print(f"\nUpdated {REGISTRY_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ssot/agent/feature_ledger.yaml
+++ b/ssot/agent/feature_ledger.yaml
@@ -29,7 +29,7 @@ capabilities:
       - gate: corpus_registry_populated
         description: "corpus_registry.yaml has >= 3 corpus sources with file counts > 0"
         evidence: "ssot/knowledge/corpus_registry.yaml"
-        passing: false
+        passing: true
       - gate: knowledge_eval_threshold
         description: "eval/knowledge_copilot_eval.yaml: >= 80% of cases pass citation_present check"
         evidence: "docs/evidence/knowledge_copilot_eval/"
@@ -65,7 +65,7 @@ capabilities:
       - gate: tool_spec_contracts_exist
         description: "Each governed tool has a spec in contracts/tools/<tool>.md"
         evidence: "contracts/tools/"
-        passing: false
+        passing: true
       - gate: action_eval_threshold
         description: "eval/action_eval.yaml: 100% approval compliance for write/automation tools"
         evidence: "docs/evidence/action_eval/"

--- a/ssot/knowledge/corpus_registry.yaml
+++ b/ssot/knowledge/corpus_registry.yaml
@@ -23,7 +23,7 @@ corpora:
     chunk_params:
       max_chunk_tokens: 512
       overlap_tokens: 64
-    file_count: 0  # populated by indexer
+    file_count: 200  # populated by indexer
     priority: high
     include_patterns:
       - "spec/*/constitution.md"
@@ -40,7 +40,7 @@ corpora:
     chunk_params:
       max_chunk_tokens: 256
       overlap_tokens: 32
-    file_count: 0  # populated by indexer
+    file_count: 106  # populated by indexer
     priority: high
     include_patterns:
       - "ssot/**/*.yaml"
@@ -53,7 +53,7 @@ corpora:
     chunk_params:
       max_chunk_tokens: 512
       overlap_tokens: 64
-    file_count: 0  # populated by indexer
+    file_count: 38  # populated by indexer
     priority: medium
     include_patterns:
       - "docs/ai/*.md"
@@ -66,7 +66,7 @@ corpora:
     chunk_params:
       max_chunk_tokens: 512
       overlap_tokens: 64
-    file_count: 0  # populated by indexer
+    file_count: 22  # populated by indexer
     priority: medium
     include_patterns:
       - "docs/contracts/*.md"
@@ -79,7 +79,7 @@ corpora:
     chunk_params:
       max_chunk_tokens: 512
       overlap_tokens: 64
-    file_count: 0  # populated by indexer
+    file_count: 57  # populated by indexer
     priority: low
     include_patterns:
       - "docs/runbooks/**/*.md"


### PR DESCRIPTION
## Summary

Turn P0 capability ledger items from `failing` toward `passing` by shipping the first concrete artifacts: governed tool spec contracts, corpus indexer, and audit envelope evidence.

### Ledger gates flipped to GREEN

| Gate | Capability | Evidence |
|------|-----------|----------|
| `corpus_registry_populated` | Citation-first Knowledge Copilot | `ssot/knowledge/corpus_registry.yaml` — 5 corpora, 423 files total |
| `tool_spec_contracts_exist` | Governed Tool Use | `contracts/tools/*.md` — 5 tool specs |

### What shipped

- **5 governed tool spec contracts** (`contracts/tools/*.md`):
  - `search_records` — read, no confirmation
  - `navigate_to` — navigation, no confirmation
  - `create_record` — write, requires confirmation
  - `send_chatter_message` — write, requires confirmation
  - `trigger_workflow` — automation, requires confirmation
- **Corpus indexer** (`scripts/index_corpus_registry.py`):
  - Populates `file_count` in `ssot/knowledge/corpus_registry.yaml`
  - `--check` mode for CI validation (exit 1 if any corpus empty)
  - Comment-preserving YAML update (no `yaml.dump` rewrite)
- **Audit envelope sample** (`docs/evidence/action_eval/audit_envelope_sample.json`):
  - 5 sample envelopes covering success, cancelled_by_user, access_denied
  - All 7 required fields present and non-null
- **Platform contract C-25** registered in `PLATFORM_CONTRACTS_INDEX.md`

### Gates still failing (next tasks)

| Gate | Blocker | Next step |
|------|---------|-----------|
| `knowledge_eval_threshold` | RAG pipeline not wired | T-KAPA-02/03: wire `ipai_ai_rag` retrieval |
| `rag_retrieval_wired` | No retrieval endpoint | T-KAPA-03: implement corpus chunk retrieval |
| `action_eval_threshold` | Tool dispatch not running evals | T-TOOLS-03: wire preview→approval→commit flow |
| `audit_envelope_emitted` | Schema defined, emission not coded | T-TOOLS-04: add envelope emit to tool executor |

### Verification

```
python -c "import yaml; yaml.safe_load(open('ssot/agent/feature_ledger.yaml'))"  # PASS
python -c "import yaml; yaml.safe_load(open('ssot/knowledge/corpus_registry.yaml'))"  # PASS
python scripts/index_corpus_registry.py --check  # PASS (5/5 corpora populated)
ls contracts/tools/*.md | wc -l  # 5
python -c "import json; d=json.load(open('docs/evidence/action_eval/audit_envelope_sample.json')); assert len(d['envelopes'])==5"  # PASS
```

## Test plan

- [ ] All 5 corpus `file_count` values > 0 after indexer run
- [ ] `scripts/index_corpus_registry.py --check` exits 0
- [ ] Each tool spec in `contracts/tools/` has: Input Schema, Preview Output, Approval Requirements, Audit Envelope sections
- [ ] Feature ledger parses without errors
- [ ] Audit envelope sample has all 7 required fields non-null

🤖 Generated with [Claude Code](https://claude.com/claude-code)