### PR TITLE
fix(devcontainer): colima context + deterministic postgres env

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,9 @@
 {
   "name": "ipai-devcontainer",
-  // Use Docker Desktop context. Run scripts/dev/docker_doctor.sh to verify.
-  // To switch runtime without editing this file:
-  //   export DOCKER_CONTEXT_OVERRIDE=colima  (then rebuild Dev Container)
-  "dockerContext": "desktop-linux",
-  "initializeCommand": "bash scripts/dev/docker_doctor.sh ${DOCKER_CONTEXT_OVERRIDE:-desktop-linux}",
+  // Docker context: uses whatever `docker context` is active on the host.
+  // No hardcoded dockerContext — works with Docker Desktop, Colima, or OrbStack.
+  // Run scripts/dev/docker_doctor.sh to verify connectivity before rebuild.
+  "initializeCommand": "bash scripts/dev/docker_doctor.sh ${DOCKER_CONTEXT_OVERRIDE:-default}",
   // Compose SSOT + overlay(s). Later files override earlier ones.
   "dockerComposeFile": [
     "../docker-compose.yml",
@@ -78,8 +77,8 @@
   "containerEnv": {
     "ODOO_DB": "${localEnv:ODOO_DB:odoo_dev}",
     "ODOO_LOG_LEVEL": "${localEnv:ODOO_LOG_LEVEL:debug}",
-    "POSTGRES_USER": "${localEnv:POSTGRES_USER:odoo}",
-    "POSTGRES_PASSWORD": "${localEnv:POSTGRES_PASSWORD:odoo}"
+    "POSTGRES_USER": "odoo",
+    "POSTGRES_PASSWORD": "odoo"
   },
   "containerUser": "devcontainer",
   "updateRemoteUserUID": true,


### PR DESCRIPTION
## Summary
- Removes hardcoded `dockerContext: "desktop-linux"` — DevContainer now uses whatever `docker context` is active on the host (Colima, Docker Desktop, OrbStack)
- Hardcodes `POSTGRES_USER`/`POSTGRES_PASSWORD` to `"odoo"` in `containerEnv` instead of `${localEnv:...}` which leaks shell vars from Supabase setup (`postgres`/`SHWYXDMFAwXI1drT`)
- No changes to debugpy setup — `IPAI_DEBUGPY=1` + port 5678 remains controlled by `.env`

## Problem
1. `dockerContext: "desktop-linux"` fails on Colima (context name is `colima`)
2. `${localEnv:POSTGRES_USER:odoo}` picks up `POSTGRES_USER=postgres` from `~/.zshrc` (set for Supabase), causing Odoo to either fail auth or hit the "postgres superuser is a security risk" block

## Test plan
- [ ] `docker context ls` shows active context (any runtime)
- [ ] Rebuild DevContainer in VS Code — compose starts without context errors
- [ ] Odoo connects to PostgreSQL as `odoo` user, not `postgres`
- [ ] `IPAI_DEBUGPY=1` enables debugpy attach on :5678

🤖 Generated with [Claude Code](https://claude.com/claude-code)