### PR TITLE
ci(auth): enforce zero-PAT GitHub auth surface (App + GITHUB_TOKEN)

### DIFF
--- a/.github/workflows/github-auth-surface-contract.yml
+++ b/.github/workflows/github-auth-surface-contract.yml
@@ -1,0 +1,56 @@
+name: GitHub Auth Surface Contract
+
+# Enforces the zero-PAT policy defined in ssot/auth/github_auth_surface.yaml.
+#
+# Scans workflows, scripts, SSOT, and Edge Functions for references to
+# deprecated Personal Access Tokens. Fails if any non-allowlisted PAT
+# reference is found.
+#
+# SSOT:    ssot/auth/github_auth_surface.yaml
+# Scanner: scripts/check_github_pat_usage.py
+# Related: .github/workflows/github-auth-surface-guard.yml (existing bash guard)
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - "scripts/**/*.py"
+      - "scripts/**/*.sh"
+      - "ssot/**"
+      - "supabase/functions/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - "scripts/**/*.py"
+      - "scripts/**/*.sh"
+      - "ssot/**"
+      - "supabase/functions/**"
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  pat-surface-scan:
+    name: Zero-PAT auth surface contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run PAT usage scanner
+        run: python3 scripts/check_github_pat_usage.py
+
+      - name: Upload evidence report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pat-usage-report
+          path: docs/evidence/auth_surface/*/pat_usage_report.json
+          retention-days: 90
+          if-no-files-found: warn

--- a/scripts/check_github_pat_usage.py
+++ b/scripts/check_github_pat_usage.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""GitHub PAT usage scanner — enforces zero-PAT auth surface policy.
+
+Scans workflows, scripts, SSOT files, and Edge Functions for references
+to deprecated Personal Access Tokens. Fails if any non-allowlisted PAT
+reference is found.
+
+SSOT:   ssot/auth/github_auth_surface.yaml
+Guard:  .github/workflows/github-auth-surface-contract.yml
+"""
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ── Configuration ────────────────────────────────────────────────────────────
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SCAN_PATHS = [
+    ".github/workflows/**/*.yml",
+    "scripts/**/*.py",
+    "scripts/**/*.sh",
+    "ssot/**/*.yaml",
+    "ssot/**/*.yml",
+    "supabase/functions/**/*.ts",
+    "supabase/functions/**/*.js",
+]
+
+# Patterns that signal PAT-backed secret usage in GitHub Actions
+SECRET_PATTERNS = [
+    # PAT-backed secrets (secrets.XYZ in workflow YAML)
+    # GH_PAT_SUPERSET is matched here too — allowlist logic handles it
+    (
+        r"secrets\.(GH_PAT\w*)",
+        "PAT-backed secret",
+    ),
+    (
+        r"secrets\.(GITHUB_PAT\w+)",
+        "PAT-backed secret",
+    ),
+    (
+        r"secrets\.(ADMIN_PAT\w*)",
+        "Deprecated admin PAT secret",
+    ),
+    (
+        r"secrets\.(ORG_TOKEN)\b",
+        "Deprecated org token secret",
+    ),
+    (
+        r"secrets\.(CR_PAT)\b",
+        "Deprecated container registry PAT secret",
+    ),
+    (
+        r"secrets\.(PROJECTS_TOKEN)\b",
+        "Deprecated projects token secret",
+    ),
+]
+
+# Patterns that signal hardcoded PATs in source
+HARDCODED_PATTERNS = [
+    (
+        r'Authorization["\s:]*(?:Bearer\s+|token\s+)?ghp_[A-Za-z0-9_]+',
+        "Hardcoded classic PAT in Authorization header",
+    ),
+    (
+        r'Authorization["\s:]*(?:Bearer\s+|token\s+)?github_pat_[A-Za-z0-9_]+',
+        "Hardcoded fine-grained PAT in Authorization header",
+    ),
+]
+
+# Allowlisted patterns — these are approved exceptions
+ALLOWLIST = {
+    "GH_PAT_SUPERSET": {
+        "reason": "Cross-repo dispatch to jgtolentino/superset",
+        "expires": "2026-06-30",
+        "consumer": ".github/workflows/notify-superset.yml",
+    },
+}
+
+# Files that are part of the auth enforcement infra itself (self-references OK)
+INFRA_FILES = {
+    "github-auth-surface-guard.yml",
+    "github-auth-surface-contract.yml",
+    "check_github_pat_usage.py",
+    "github_auth_surface.yaml",
+    "registry.yaml",
+}
+
+
+# ── Scanner ──────────────────────────────────────────────────────────────────
+
+
+def gather_files() -> list[Path]:
+    """Collect all files matching scan paths."""
+    files: list[Path] = []
+    for glob_pattern in SCAN_PATHS:
+        files.extend(REPO_ROOT.glob(glob_pattern))
+    return sorted(set(files))
+
+
+def is_infra_file(path: Path) -> bool:
+    """Check if file is part of auth enforcement infrastructure."""
+    return path.name in INFRA_FILES
+
+
+def is_comment_or_doc_line(line: str, path: Path) -> bool:
+    """Check if a line is a comment or documentation (not executable)."""
+    stripped = line.strip()
+    suffix = path.suffix
+
+    if suffix in (".yml", ".yaml"):
+        return stripped.startswith("#")
+    if suffix == ".py":
+        return stripped.startswith("#") or stripped.startswith('"""') or stripped.startswith("'''")
+    if suffix == ".sh":
+        return stripped.startswith("#")
+    if suffix in (".ts", ".js"):
+        return stripped.startswith("//") or stripped.startswith("/*") or stripped.startswith("*")
+    return False
+
+
+def check_allowlist(secret_name: str) -> bool:
+    """Check if a secret is on the allowlist and not expired."""
+    entry = ALLOWLIST.get(secret_name)
+    if not entry:
+        return False
+    expires = datetime.strptime(entry["expires"], "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    if now > expires:
+        return False  # Allowlist entry expired
+    return True
+
+
+def scan_file(path: Path) -> list[dict]:
+    """Scan a single file for PAT references. Returns list of findings."""
+    findings = []
+    rel_path = path.relative_to(REPO_ROOT)
+
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, UnicodeDecodeError):
+        return findings
+
+    for line_num, line in enumerate(content.splitlines(), start=1):
+        # Skip infra self-references (the guard/scanner files themselves)
+        if is_infra_file(path):
+            continue
+
+        # Check secret patterns
+        for pattern, description in SECRET_PATTERNS:
+            match = re.search(pattern, line)
+            if match:
+                secret_name = match.group(1)
+                if check_allowlist(secret_name):
+                    findings.append({
+                        "file": str(rel_path),
+                        "line": line_num,
+                        "secret": secret_name,
+                        "description": f"ALLOWLISTED: {description}",
+                        "content": line.strip(),
+                        "severity": "info",
+                        "allowlisted": True,
+                    })
+                else:
+                    findings.append({
+                        "file": str(rel_path),
+                        "line": line_num,
+                        "secret": secret_name,
+                        "description": description,
+                        "content": line.strip(),
+                        "severity": "error",
+                        "allowlisted": False,
+                    })
+
+        # Check hardcoded patterns (always an error, never allowlisted)
+        for pattern, description in HARDCODED_PATTERNS:
+            if re.search(pattern, line):
+                findings.append({
+                    "file": str(rel_path),
+                    "line": line_num,
+                    "secret": "HARDCODED_TOKEN",
+                    "description": description,
+                    "content": line.strip()[:120] + ("..." if len(line.strip()) > 120 else ""),
+                    "severity": "critical",
+                    "allowlisted": False,
+                })
+
+    return findings
+
+
+def write_report(findings: list[dict], report_path: Path) -> None:
+    """Write JSON report to evidence directory."""
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+
+    errors = [f for f in findings if f["severity"] in ("error", "critical")]
+    warnings = [f for f in findings if f["severity"] == "info"]
+
+    report = {
+        "schema": "ssot.auth.pat_usage_report.v1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "policy": "zero-pat",
+        "ssot": "ssot/auth/github_auth_surface.yaml",
+        "summary": {
+            "total_findings": len(findings),
+            "errors": len(errors),
+            "allowlisted": len(warnings),
+            "pass": len(errors) == 0,
+        },
+        "findings": findings,
+    }
+
+    report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    files = gather_files()
+    all_findings: list[dict] = []
+
+    for f in files:
+        all_findings.extend(scan_file(f))
+
+    errors = [f for f in all_findings if f["severity"] in ("error", "critical")]
+    allowlisted = [f for f in all_findings if f["allowlisted"]]
+
+    # Write report
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    report_path = REPO_ROOT / f"docs/evidence/auth_surface/{run_id}/pat_usage_report.json"
+    write_report(all_findings, report_path)
+
+    # Console output
+    print(f"GitHub PAT Usage Scanner")
+    print(f"========================")
+    print(f"Policy:      Zero-PAT (App + GITHUB_TOKEN only)")
+    print(f"SSOT:        ssot/auth/github_auth_surface.yaml")
+    print(f"Files:       {len(files)} scanned")
+    print(f"Findings:    {len(all_findings)} total")
+    print(f"Errors:      {len(errors)}")
+    print(f"Allowlisted: {len(allowlisted)}")
+    print(f"Report:      {report_path.relative_to(REPO_ROOT)}")
+    print()
+
+    if allowlisted:
+        print("Allowlisted (temporary exceptions):")
+        for f in allowlisted:
+            entry = ALLOWLIST.get(f["secret"], {})
+            print(f"  {f['file']}:{f['line']} — {f['secret']} (expires {entry.get('expires', '?')})")
+        print()
+
+    if errors:
+        print("VIOLATIONS:")
+        for f in errors:
+            print(f"  {f['severity'].upper()} {f['file']}:{f['line']}")
+            print(f"    Secret: {f['secret']}")
+            print(f"    Reason: {f['description']}")
+            print(f"    Line:   {f['content']}")
+            print(f"    Fix:    Use secrets.GITHUB_TOKEN or github_app_ipai_integrations")
+            print()
+        print(f"FAIL  {len(errors)} PAT reference(s) violate zero-PAT policy")
+        return 1
+
+    print("PASS  No unauthorized PAT references found")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ssot/auth/github_auth_surface.yaml
+++ b/ssot/auth/github_auth_surface.yaml
@@ -1,0 +1,157 @@
+# ssot/auth/github_auth_surface.yaml
+# Single Source of Truth for GitHub authentication surface.
+#
+# Policy: Zero PATs. All automation uses GITHUB_TOKEN (built-in) or
+# the ipai-integrations GitHub App (installation tokens).
+#
+# Guard workflow:  .github/workflows/github-auth-surface-contract.yml
+# Scanner script:  scripts/check_github_pat_usage.py
+# Secrets SSOT:    ssot/secrets/registry.yaml §github_auth
+# Runbook:         docs/runbooks/GITHUB_APP_PROVISIONING.md
+
+schema: ssot.auth.github_surface.v1
+last_reviewed: "2026-03-03"
+
+# ─── Policy ──────────────────────────────────────────────────────────────────
+policy:
+  name: "Zero-PAT GitHub Auth Surface"
+  description: >
+    Personal Access Tokens (classic and fine-grained) are deprecated for all
+    automated workflows, scripts, Edge Functions, and CI/CD pipelines.
+    The canonical auth methods are the GitHub Actions built-in GITHUB_TOKEN
+    and the ipai-integrations GitHub App installation tokens.
+  enforcement:
+    ci_guard: ".github/workflows/github-auth-surface-contract.yml"
+    scanner: "scripts/check_github_pat_usage.py"
+    existing_guard: ".github/workflows/github-auth-surface-guard.yml"
+  effective_date: "2026-03-03"
+
+# ─── Canonical Auth Methods ──────────────────────────────────────────────────
+canonical_methods:
+  github_actions_token:
+    type: "built-in"
+    description: >
+      Ephemeral token auto-injected by GitHub Actions into every workflow run.
+      Scoped to the current repository. Cannot cross repo boundaries.
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      packages: write
+      actions: read
+    consumers:
+      - ".github/workflows/**"
+    limitations:
+      - "Cannot trigger workflows in other repositories"
+      - "Cannot access GitHub Projects v2 in organizations (org-level scope)"
+      - "Cannot create repository_dispatch events cross-repo"
+    notes: >
+      Preferred for all in-repo operations. ship-on-deploy.yml, release
+      workflows, and all standard CI/CD use this exclusively.
+
+  github_app_ipai_integrations:
+    type: "github_app"
+    app_name: "ipai-integrations"
+    description: >
+      GitHub App that generates short-lived installation tokens for
+      server-side, cross-org, and Edge Function operations.
+    credentials:
+      app_id:
+        vault_key: "github_app_id"
+        github_secret: "GITHUB_APP_ID"
+      private_key:
+        vault_key: "github_app_private_key"
+        github_secret: "GITHUB_APP_PRIVATE_KEY"
+      client_id:
+        vault_key: "github_app_client_id"
+      client_secret:
+        vault_key: "github_app_client_secret"
+      webhook_secret:
+        vault_key: "github_app_webhook_secret"
+    consumers:
+      - "supabase/functions/github-app-auth/"
+      - "supabase/functions/ops-github-webhook-ingest/"
+      - ".github/workflows/github-apps-ssot-guard.yml"
+    provisioning:
+      script: "scripts/github/create-app-from-manifest.sh ipai-integrations"
+      ssot: "ssot/integrations/github_apps.yaml"
+      runbook: "docs/runbooks/GITHUB_APP_PROVISIONING.md"
+    notes: >
+      Installation tokens are generated on-demand by the github-app-auth
+      Edge Function. They expire after 1 hour. No static token stored.
+
+# ─── Deprecated Auth Methods ─────────────────────────────────────────────────
+deprecated_methods:
+  pat_classic:
+    type: "personal_access_token"
+    variant: "classic"
+    status: "deprecated"
+    description: "Classic PATs with broad org-level scopes. All deleted."
+    deleted_tokens:
+      - name: "admin-pat"
+        expired: "2026-03-16"
+        status: "deleted"
+        reason: "Broad admin scopes, no automation consumer."
+      - name: "PROJECTS_TOKEN"
+        expired: "2026-04-08"
+        status: "deleted"
+        reason: "ship-on-deploy.yml already uses built-in GITHUB_TOKEN."
+
+  pat_fine_grained:
+    type: "personal_access_token"
+    variant: "fine-grained"
+    status: "deprecated"
+    description: "Fine-grained PATs. All deleted except allowlisted exceptions."
+    deleted_tokens:
+      - name: "CR_PAT"
+        expired: "2026-03-19"
+        status: "deleted"
+        reason: "Dead token (401). No automation consumer."
+      - name: "ORG_TOKEN"
+        expired: "2026-04-26"
+        status: "deleted"
+        reason: "Not referenced in any workflow or script."
+
+# ─── Temporary Allowlist ─────────────────────────────────────────────────────
+# Tokens here are approved exceptions pending migration to App or GITHUB_TOKEN.
+# Each entry MUST have an expiry_date and migration_plan.
+allowlist:
+  - secret_name: "GH_PAT_SUPERSET"
+    github_secret_name: "GH_PAT_SUPERSET"
+    type: "fine-grained"
+    status: "allowlisted_temp"
+    expiry_date: "2026-06-30"
+    consumer: ".github/workflows/notify-superset.yml"
+    justification: >
+      Cross-repo repository_dispatch to jgtolentino/superset.
+      Built-in GITHUB_TOKEN cannot cross repository boundaries.
+    required_scopes:
+      - "Contents:read on jgtolentino/superset"
+      - "Actions:write on jgtolentino/superset"
+    migration_plan: >
+      Evaluate GitHub App cross-repo dispatch (ipai-integrations installed
+      on jgtolentino/superset) to eliminate this PAT entirely.
+    review_date: "2026-06-01"
+
+# ─── Scanner Configuration ───────────────────────────────────────────────────
+scanner:
+  scan_paths:
+    - ".github/workflows/**/*.yml"
+    - "scripts/**/*.py"
+    - "scripts/**/*.sh"
+    - "ssot/**/*"
+    - "supabase/functions/**/*"
+  blocked_patterns:
+    # Secret references that signal PAT usage
+    - pattern: 'secrets\.(GH_PAT(?!_SUPERSET)\w*|GITHUB_PAT\w*|ADMIN_PAT\w*|ORG_TOKEN|CR_PAT|PROJECTS_TOKEN)'
+      description: "PAT-backed GitHub Actions secret (not allowlisted)"
+    # Raw Authorization headers with tokens
+    - pattern: 'Authorization.*ghp_'
+      description: "Hardcoded classic PAT in Authorization header"
+    - pattern: 'Authorization.*github_pat_'
+      description: "Hardcoded fine-grained PAT in Authorization header"
+  allowlisted_patterns:
+    - pattern: 'secrets\.GH_PAT_SUPERSET'
+      reason: "Temporary allowlist — cross-repo dispatch"
+      expires: "2026-06-30"
+  report_path: "docs/evidence/auth_surface/{run_id}/pat_usage_report.json"

--- a/ssot/secrets/registry.yaml
+++ b/ssot/secrets/registry.yaml
@@ -1722,11 +1722,12 @@ v2_entries:
   # automation auth surface. Personal Access Tokens are deprecated for all
   # automated workflows. CI guard: .github/workflows/github-auth-surface-guard.yml
   #
-  # PAT inventory (live tokens, expires noted — rotate to App or delete):
-  #   admin-pat       classic  broad admin scopes  expires 2026-03-16  → DELETE
-  #   PROJECTS_TOKEN  classic  project/read:org/repo  expires 2026-04-08  → REVIEW
-  #   CR_PAT          fine-grained  expires 2026-03-19  → REVIEW
-  #   ORG_TOKEN       fine-grained  expires 2026-04-26  → REVIEW
+  # PAT inventory (all deleted per zero-PAT policy — 2026-03-03):
+  #   admin-pat       classic  broad admin scopes  expires 2026-03-16  → DELETED
+  #   PROJECTS_TOKEN  classic  project/read:org/repo  expires 2026-04-08  → DELETED
+  #   CR_PAT          fine-grained  expires 2026-03-19  → DELETED
+  #   ORG_TOKEN       fine-grained  expires 2026-04-26  → DELETED
+  # Auth surface SSOT: ssot/auth/github_auth_surface.yaml
   # ---------------------------------------------------------------------------
 
   github_cli_auth:
@@ -1745,56 +1746,84 @@ v2_entries:
       severity_if_missing: low
 
   github_pat_admin:
-    purpose: "DEPRECATED — broad classic PAT (admin-pat). Pending deletion."
+    purpose: "DELETED — broad classic PAT (admin-pat). Removed per zero-PAT policy."
     approved_stores: []
     consumers: []
-    rotation_policy: "Delete before 2026-03-16 expiry"
+    rotation_policy: "N/A — deleted 2026-03-03"
     notes: >
       Classic PAT with org hooks, repo hooks, audit log, workflow, admin scopes.
-      No automation should consume this. Delete from github.com/settings/tokens.
+      Deleted from github.com/settings/tokens per zero-PAT policy.
       Replacement: github_app_ipai_integrations (App installation token).
+      Auth surface SSOT: ssot/auth/github_auth_surface.yaml
     prohibited_consumers:
       - github_actions
       - vercel_env
       - supabase_vault
       - scripts
     status:
-      desired: deprecated
-      severity_if_missing: none   # deletion is the goal
+      desired: deleted
+      severity_if_missing: none
 
   github_pat_projects_token:
-    purpose: "REVIEW — classic PAT (PROJECTS_TOKEN) for GitHub Projects API"
-    approved_stores:
-      - os_keychain             # human CLI only until replaced
-    consumers:
-      - os_keychain:PROJECTS_TOKEN
-    rotation_policy: "Replace with fine-grained token or App before 2026-04-08"
+    purpose: "DELETED — classic PAT (PROJECTS_TOKEN). ship-on-deploy.yml uses built-in GITHUB_TOKEN."
+    approved_stores: []
+    consumers: []
+    rotation_policy: "N/A — deleted 2026-03-03"
     notes: >
-      Scopes: project, read:org, repo. Used by ship-on-deploy.yml via
-      GH_PROJECT_ID / GH_PROJECT_STATUS_FIELD_ID secrets (not the PAT directly —
-      those are non-secret IDs). Review whether GITHUB_TOKEN suffices for
-      Projects automation before next renewal.
+      Scopes: project, read:org, repo. ship-on-deploy.yml was confirmed to use
+      secrets.GITHUB_TOKEN (built-in), not this PAT. Deleted from
+      github.com/settings/tokens per zero-PAT policy.
+      Auth surface SSOT: ssot/auth/github_auth_surface.yaml
     status:
-      desired: review
-      severity_if_missing: low
+      desired: deleted
+      severity_if_missing: none
+
+  github_pat_cr_pat:
+    purpose: "DELETED — fine-grained PAT (CR_PAT). Dead token (401), no consumers."
+    approved_stores: []
+    consumers: []
+    rotation_policy: "N/A — deleted 2026-03-03"
+    notes: >
+      Fine-grained PAT that was already dead (HTTP 401). No workflow, script,
+      or Edge Function referenced it. Deleted per zero-PAT policy.
+      Auth surface SSOT: ssot/auth/github_auth_surface.yaml
+    status:
+      desired: deleted
+      severity_if_missing: none
+
+  github_pat_org_token:
+    purpose: "DELETED — fine-grained PAT (ORG_TOKEN). No consumers found."
+    approved_stores: []
+    consumers: []
+    rotation_policy: "N/A — deleted 2026-03-03"
+    notes: >
+      Fine-grained PAT with org-level scopes. Not referenced in any workflow,
+      script, or Edge Function. Deleted per zero-PAT policy.
+      Auth surface SSOT: ssot/auth/github_auth_surface.yaml
+    status:
+      desired: deleted
+      severity_if_missing: none
 
   github_pat_superset:
-    purpose: "Fine-grained PAT for cross-repo dispatch to jgtolentino/superset"
+    purpose: "ALLOWLISTED (temp) — fine-grained PAT for cross-repo dispatch to jgtolentino/superset"
     approved_stores:
       - github_actions
     github_secret_name: GH_PAT_SUPERSET
     consumers:
       - github_actions:.github/workflows/notify-superset.yml
     rotation_policy: "Annually or on personnel change. Fine-grained, repo-scoped."
+    expiry_date: "2026-06-30"
+    review_date: "2026-06-01"
     notes: >
       notify-superset.yml dispatches a repository_dispatch event to the external
       repo jgtolentino/superset. The built-in GITHUB_TOKEN cannot cross repo
       boundaries, so a fine-grained PAT with workflow:write on jgtolentino/superset
       is the correct (and only) pattern here.
       Scope: minimum — Contents:read + Actions:write on jgtolentino/superset only.
-      Rotate annually. Replace classic PAT with fine-grained token on next rotation.
+      Migration plan: evaluate ipai-integrations App installed on jgtolentino/superset.
+      Auth surface SSOT: ssot/auth/github_auth_surface.yaml
     status:
-      desired: active
+      desired: allowlisted_temp
       severity_if_missing: low   # Superset rebuild is non-critical path
 
   github_token_vercel_diff:


### PR DESCRIPTION
## Summary

Codifies and enforces the zero-PAT GitHub auth policy:
- **Canonical auth**: Built-in `GITHUB_TOKEN` (workflows) + `ipai-integrations` GitHub App (server-side/Edge Functions)
- **All PATs deprecated**: `admin-pat`, `PROJECTS_TOKEN`, `CR_PAT`, `ORG_TOKEN` marked as `status: deleted`
- **One temporary exception**: `GH_PAT_SUPERSET` allowlisted until 2026-06-30 (cross-repo dispatch)

## Deliverables

| File | Type | Purpose |
|------|------|---------|
| `ssot/auth/github_auth_surface.yaml` | NEW | Policy SSOT — canonical auth methods, deprecated methods, allowlist |
| `scripts/check_github_pat_usage.py` | NEW | Scanner — finds PAT references across 1371 files, emits JSON report |
| `.github/workflows/github-auth-surface-contract.yml` | NEW | CI gate — runs scanner on PR/push/merge_group, uploads evidence |
| `ssot/secrets/registry.yaml` | PATCH | 4 PATs → `deleted`, `GH_PAT_SUPERSET` → `allowlisted_temp` with expiry |

## Scanner Results (local)

```
Files:       1371 scanned
Findings:    1 total
Errors:      0
Allowlisted: 1 (GH_PAT_SUPERSET in notify-superset.yml:37, expires 2026-06-30)
Result:      PASS
```

## Test plan

- [ ] CI passes on this PR (new contract workflow runs green)
- [ ] Introducing a `secrets.PROJECTS_TOKEN` reference in a test workflow file fails the scanner
- [ ] `GH_PAT_SUPERSET` in `notify-superset.yml` shows as allowlisted (not error)
- [ ] Evidence report uploaded as artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)