### PR TITLE
feat(ops): CRM deployment + OIDC SSOT + ChatGPT Apps SDK spec

### DIFF
--- a/infra/deploy/nginx/crm.insightpulseai.com.conf
+++ b/infra/deploy/nginx/crm.insightpulseai.com.conf
@@ -1,0 +1,56 @@
+# Nginx Configuration - crm.insightpulseai.com
+# Status: PRODUCTION
+# Last Updated: 2026-03-05
+#
+# Purpose: Reverse proxy to Atomic CRM (marmelab/atomic-crm)
+# Container: atomic-crm binds 127.0.0.1:3004 → 80/tcp
+
+upstream atomic_crm {
+    server 127.0.0.1:3004;
+}
+
+# HTTP -> HTTPS redirect
+server {
+    listen 80;
+    server_name crm.insightpulseai.com;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS -- reverse proxy to Atomic CRM
+server {
+    listen 443 ssl http2;
+    server_name crm.insightpulseai.com;
+
+    ssl_certificate /etc/letsencrypt/live/insightpulseai.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/insightpulseai.com/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+
+    client_max_body_size 50M;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    location / {
+        proxy_pass http://atomic_crm;
+        proxy_redirect off;
+    }
+
+    access_log /var/log/nginx/crm.insightpulseai.com.access.log combined;
+    error_log /var/log/nginx/crm.insightpulseai.com.error.log warn;
+}

--- a/infra/dns/subdomain-registry.yaml
+++ b/infra/dns/subdomain-registry.yaml
@@ -167,6 +167,23 @@ subdomains:
       claimed_at: "2026-03-05"
       claim_ref: "ssot:cloudflare"
 
+  - name: crm
+    type: A
+    service: atomic_crm
+    port: 3004
+    health_check: /
+    owner_system: "Atomic CRM (marmelab/atomic-crm, Supabase-backed)"
+    cloudflare_proxied: true
+    tls_mode: "Full (strict)"
+    lifecycle: active
+    status: active
+    notes: "Atomic CRM SPA (React/Vite). Container atomic-crm on 127.0.0.1:3004. Supabase backend (spdtwktxdalcfigzeqrz). Deployed 2026-03-05."
+    provider_claim:
+      provider: cloudflare
+      status: claimed
+      claimed_at: "2026-03-05"
+      claim_ref: "ssot:cloudflare"
+
   - name: ocr
     type: A
     service: paddleocr_microservice

--- a/spec/chatgpt-ops-assistant/constitution.md
+++ b/spec/chatgpt-ops-assistant/constitution.md
@@ -1,0 +1,92 @@
+# Constitution — ChatGPT Ops Assistant
+
+> Non-negotiable rules for the `ops-assistant` MCP server and ChatGPT App.
+> These constraints are enforced at the tool-execution layer, not advisory.
+
+## 1. Deny-by-Default Execution
+
+All tool calls are **denied unless explicitly allowlisted** in
+`ssot/integrations/chatgpt_app_tool_allowlist.yaml`.
+
+- Unknown tool names: rejected with error, logged to audit sink.
+- Known tools with disallowed fields: rejected, field violation logged.
+- No implicit tool discovery from Odoo model introspection at runtime.
+
+## 2. Approval-Gated Odoo Writes
+
+Any tool that **writes to Odoo in production** requires prior Slack approval:
+
+- `slack.request_approval` is called automatically before execution.
+- The approval message includes: tool name, target record, field changes, requesting user.
+- Timeout: 60 minutes. If not approved, the action is cancelled and logged.
+- Stage environment: approval is bypassed (configurable per environment).
+
+## 3. Audit Trail
+
+Every tool invocation — successful, denied, or errored — is written to
+`supabase.ops.run_events` with:
+
+- `event_id` (UUID v4)
+- `tool_name`
+- `input_params` (secrets redacted)
+- `output_summary`
+- `status` (success | denied | error | approval_pending | approval_timeout)
+- `user_id` (OpenAI user identity from OAuth)
+- `idempotency_key`
+- `timestamp`
+
+Audit records are **append-only**. No deletions.
+
+## 4. No Secrets in Code
+
+- All secrets referenced by name only (vault key or env var name).
+- MCP server reads secrets from Supabase Vault or environment variables at runtime.
+- No secret values in: source code, YAML configs, MCP tool responses, audit logs.
+- Secret names are documented in `ssot/secrets/registry.yaml`.
+
+## 5. Idempotency
+
+Every external write (Odoo, Plane, Slack) must include an **idempotency key**:
+
+- Format: `{tool_name}:{entity_id}:{timestamp_ms}`
+- Duplicate keys within a 5-minute window are rejected (HTTP 409).
+- Idempotency keys are stored in `ops.idempotency_keys` (Supabase).
+
+## 6. Rate Limiting
+
+- Global: 60 requests/minute per user session.
+- Plane API: 60 requests/minute (upstream constraint, enforce client-side).
+- Odoo XML-RPC: no upstream limit, but self-imposed 30 writes/minute.
+- Slack: standard tier limits apply (chat.postMessage: 1/sec per channel).
+
+## 7. Field-Level Access Control
+
+- Each Odoo write tool declares `allowed_fields` and `blocked_fields`.
+- Fields not in `allowed_fields` are silently dropped (not errored).
+- Fields in `blocked_fields` cause the entire request to be rejected.
+- Financial fields (account_*, bank_*, vat) are always blocked.
+
+## 8. Cross-System Integrity
+
+- When a tool creates a linked entity (e.g., Odoo lead + Plane work item),
+  both IDs must be written to `ops.external_identities` atomically.
+- If one system write succeeds and the other fails, the successful write
+  is logged but the link is marked `status: partial`.
+- Partial links trigger a Slack notification for manual resolution.
+
+## 9. No Destructive Operations
+
+The following operations are permanently forbidden:
+
+- `unlink` / `delete` on any Odoo model
+- Deleting Plane work items or pages
+- Deleting Slack messages
+- Dropping or truncating any database table
+- Modifying Odoo `ir.config_parameter` values
+
+## 10. Transport Security
+
+- MCP server communicates over HTTPS only (TLS 1.2+).
+- SSE transport with proper CORS headers.
+- OAuth 2.1 with PKCE for all user authentication.
+- No API keys in URL query parameters.

--- a/spec/chatgpt-ops-assistant/plan.md
+++ b/spec/chatgpt-ops-assistant/plan.md
@@ -1,0 +1,147 @@
+# Implementation Plan — ChatGPT Ops Assistant
+
+> Phased plan for building the `ops-assistant` MCP server and registering it
+> as a ChatGPT App via the OpenAI Apps SDK.
+
+## Architecture Overview
+
+```
+ChatGPT (OpenAI)
+    │
+    │ SSE (MCP protocol)
+    ▼
+┌─────────────────────────┐
+│  ops-assistant           │
+│  (Supabase Edge Function │
+│   or DO droplet)         │
+│                          │
+│  ┌─────────────────────┐ │
+│  │ Tool Router          │ │
+│  │ (allowlist enforcer) │ │
+│  └──────┬──────┬───────┘ │
+│         │      │    │     │
+│    odoo.*  plane.*  slack.*│
+└─────┬──────┬────────┬────┘
+      │      │        │
+      ▼      ▼        ▼
+   Odoo    Plane    Slack
+  XML-RPC  REST     Web API
+```
+
+## Phase 1: MCP Server Scaffold
+
+**Goal**: Empty MCP server with SSE transport, health check, tool discovery.
+
+**Deliverables**:
+- `supabase/functions/ops-assistant/index.ts` (Deno, SSE handler)
+- MCP protocol compliance: `initialize`, `tools/list`, `tools/call`
+- Health endpoint: `GET /health` returns `{ status: "ok", version: "1.0.0" }`
+- Tool discovery: returns empty tool list initially
+- Allowlist loader: reads `chatgpt_app_tool_allowlist.yaml` at startup
+
+**Validation**: `curl /health` returns 200. MCP inspector connects via SSE.
+
+## Phase 2: Odoo Tools
+
+**Goal**: `odoo.search_read`, `odoo.update_partner`, `odoo.update_opportunity`, `odoo.create_activity`.
+
+**Deliverables**:
+- Odoo XML-RPC client wrapper (`lib/odoo-rpc.ts`)
+- Service user authentication (uid cached per session)
+- Field-level allowlist enforcement per tool
+- `odoo.search_read`: domain filter, fields, limit, offset
+- `odoo.update_partner`: validate fields against allowlist, execute `write()`
+- `odoo.update_opportunity`: same pattern for crm.lead
+- `odoo.create_activity`: validate model against allowed_models
+
+**Validation**: MCP inspector can call each tool. Audit rows appear in `ops.run_events`.
+
+## Phase 3: Plane Tools
+
+**Goal**: `plane.list_work_items`, `plane.create_work_item`, `plane.update_work_item`, `plane.create_page`, `plane.add_comment`.
+
+**Deliverables**:
+- Plane REST client wrapper (`lib/plane-api.ts`)
+- Bot Token auth (X-API-Key header)
+- Rate limiter: token bucket at 60 req/min
+- Request batching for list operations
+- All five Plane tools registered and functional
+
+**Validation**: Create work item via MCP, verify in Plane UI.
+
+## Phase 4: Slack Tools
+
+**Goal**: `slack.post_message`, `slack.request_approval`.
+
+**Deliverables**:
+- Slack Web API client (`lib/slack-api.ts`)
+- `slack.post_message`: channel validation against allowed list
+- `slack.request_approval`: interactive message with Block Kit buttons
+- Approval callback handler (Slack interactivity endpoint)
+- Signing secret verification for inbound Slack payloads
+
+**Validation**: Post message appears in Slack. Approval flow completes end-to-end.
+
+## Phase 5: Auth (OAuth 2.1)
+
+**Goal**: OpenAI Apps SDK OAuth 2.1 with PKCE.
+
+**Deliverables**:
+- `/oauth/authorize` endpoint (authorization code flow)
+- `/oauth/token` endpoint (code exchange + PKCE verification)
+- Token storage in Supabase (encrypted, per-user)
+- Refresh token rotation
+- Apps SDK manifest registration (app.json or equivalent)
+
+**Validation**: ChatGPT can connect to the app, authenticate, and call tools.
+
+## Phase 6: Approval Workflow Integration
+
+**Goal**: Odoo prod writes blocked until Slack approval received.
+
+**Deliverables**:
+- Pre-execution hook in tool router: check `requires_approval`
+- Approval request builder: formats change details for Slack message
+- Blocking wait with 60-minute timeout
+- Approval/rejection callback updates `ops.run_events`
+- Timeout handling: cancel action, notify user in ChatGPT
+
+**Validation**: Update partner in prod triggers Slack approval. Approve -> write succeeds. Reject -> write cancelled.
+
+## Phase 7: Cross-System Linking & Audit
+
+**Goal**: `ops.external_identities` population, audit dashboard.
+
+**Deliverables**:
+- Link writer: after cross-system operations, write to `ops.external_identities`
+- Partial link handling: mark `status: partial` on single-system failure
+- Superset dashboard for `ops.run_events` (or Supabase Studio view)
+- Error alerting: Slack notification on tool errors
+
+**Validation**: Cross-system operation creates identity link. Dashboard shows tool usage.
+
+## Phase 8: Deploy & Register
+
+**Goal**: Live ChatGPT App in OpenAI marketplace (or team-scoped).
+
+**Deliverables**:
+- Deploy MCP server to Supabase Edge Function (prod)
+- Register app in OpenAI Apps SDK developer portal
+- Configure OAuth redirect URIs
+- Team-scoped access (not public marketplace initially)
+- Monitoring: uptime check on `/health`
+
+**Validation**: Team member opens ChatGPT, adds Ops Assistant app, authenticates, executes a cross-system query.
+
+## Dependencies
+
+| Dependency | Status | Blocker? |
+|------------|--------|----------|
+| Supabase Edge Functions (Deno) | Available | No |
+| Odoo XML-RPC access | Available (prod) | No |
+| Plane API key | Available (vault) | No |
+| Slack bot token | Available (vault) | No |
+| OpenAI Apps SDK access | Requires signup | Yes (Phase 5+) |
+| `ops.external_identities` table | Needs creation | No (Phase 7) |
+| `ops.run_events` table | Needs creation | No (Phase 2) |
+| `ops.idempotency_keys` table | Needs creation | No (Phase 2) |

--- a/spec/chatgpt-ops-assistant/prd.md
+++ b/spec/chatgpt-ops-assistant/prd.md
@@ -1,0 +1,114 @@
+# PRD — ChatGPT Ops Assistant
+
+> Product requirements for the `ops-assistant` ChatGPT App.
+> Platform: OpenAI Apps SDK. Backend: MCP server with SSE transport.
+
+## Problem Statement
+
+Operations teams context-switch between Odoo (CRM, projects), Plane (work items),
+and Slack (communication) throughout the day. There is no unified interface to
+query, update, and coordinate across these systems without opening each tool separately.
+
+## Solution
+
+A ChatGPT App named **Ops Assistant** that exposes three tool families
+(`odoo.*`, `plane.*`, `slack.*`) via an MCP server. Users interact through
+ChatGPT's natural language interface and the app executes actions on their behalf
+with appropriate guardrails.
+
+## Target Users
+
+- Operations managers
+- Project coordinators
+- Sales team leads
+- Engineering leads tracking work items
+
+## Core Capabilities
+
+### Tool Family: `odoo.*`
+
+| Tool | Description | Approval |
+|------|-------------|----------|
+| `odoo.search_read` | Read-only search across CRM, partners, tasks, sales | No |
+| `odoo.update_partner` | Update contact info on res.partner | Yes (prod) |
+| `odoo.update_opportunity` | Update stage, revenue, probability on crm.lead | Yes (prod) |
+| `odoo.create_activity` | Schedule activities on allowed models | No |
+
+**Backend**: XML-RPC (`/xmlrpc/2/object`) with dedicated service user `odoo_chatgpt_rpc`.
+**Auth**: Service user with restricted access rights group.
+
+### Tool Family: `plane.*`
+
+| Tool | Description | Approval |
+|------|-------------|----------|
+| `plane.list_work_items` | Search/list work items in a project | No |
+| `plane.create_work_item` | Create new work item (issue) | No |
+| `plane.update_work_item` | Update existing work item fields | No |
+| `plane.create_page` | Create wiki/doc page | No |
+| `plane.add_comment` | Comment on a work item | No |
+
+**Backend**: Plane REST API v1 (`/api/v1/workspaces/{slug}/...`).
+**Auth**: Bot Token (`X-API-Key` header).
+**Rate limit**: 60 req/min (upstream Plane constraint).
+
+### Tool Family: `slack.*`
+
+| Tool | Description | Approval |
+|------|-------------|----------|
+| `slack.post_message` | Post message to allowed channels | No |
+| `slack.request_approval` | Interactive approval request (blocks until response) | No |
+
+**Backend**: Slack Web API.
+**Auth**: Bot token (`xoxb-`), signing secret for inbound verification.
+
+## Authentication
+
+- **User auth**: OAuth 2.1 with PKCE per OpenAI Apps SDK spec.
+- **Odoo backend**: Dedicated XML-RPC service user (not user's credentials).
+- **Plane backend**: Bot Token (workspace-level, not user-scoped).
+- **Slack backend**: Bot token with `chat:write`, `chat:write.public` scopes.
+
+## Approval Workflow
+
+1. User asks ChatGPT to update an Odoo record in production.
+2. MCP server checks allowlist: tool requires approval.
+3. MCP server calls `slack.request_approval` with change details.
+4. Slack message includes Approve/Reject buttons.
+5. On approval: MCP server executes the Odoo write, logs result.
+6. On rejection or timeout (60 min): action cancelled, logged.
+
+## Cross-System Linking
+
+When an action spans systems (e.g., "create a Plane work item for this Odoo lead"),
+the MCP server writes both IDs to `ops.external_identities`:
+
+```sql
+INSERT INTO ops.external_identities
+  (entity_type, source_system, source_id, target_system, target_id, created_by)
+VALUES
+  ('crm.lead', 'odoo', 42, 'plane', 'uuid-here', 'chatgpt_ops_assistant');
+```
+
+## Audit & Observability
+
+- All tool calls logged to `ops.run_events` (Supabase).
+- Dashboard: Superset or Supabase Studio for ops team.
+- Alerts: Slack notification on tool errors or approval timeouts.
+
+## Non-Functional Requirements
+
+| Requirement | Target |
+|-------------|--------|
+| Latency (tool response) | < 3s for reads, < 5s for writes |
+| Availability | 99.5% (dependent on upstream APIs) |
+| Rate limit | 60 req/min per user session |
+| Audit retention | 90 days minimum |
+| PKCE enforcement | Required for all OAuth flows |
+
+## Out of Scope (v1)
+
+- Odoo financial module writes (account.move, account.payment)
+- Odoo user/role management
+- Plane webhook inbound processing (handled by existing plane-webhook function)
+- File attachments / document uploads
+- Multi-workspace Plane support

--- a/spec/chatgpt-ops-assistant/tasks.md
+++ b/spec/chatgpt-ops-assistant/tasks.md
@@ -1,0 +1,112 @@
+# Tasks — ChatGPT Ops Assistant
+
+> Task breakdown for implementing the ops-assistant MCP server and ChatGPT App.
+> Each task maps to a phase in `plan.md`.
+
+## Phase 1: MCP Server Scaffold
+
+- [ ] Create `supabase/functions/ops-assistant/index.ts` with Deno SSE handler
+- [ ] Implement MCP protocol handlers: `initialize`, `tools/list`, `tools/call`
+- [ ] Add `GET /health` endpoint returning `{ status: "ok", version: "1.0.0" }`
+- [ ] Implement allowlist loader (parse YAML from bundled config or vault)
+- [ ] Add tool router with deny-by-default enforcement
+- [ ] Add audit logger (writes to `ops.run_events`)
+- [ ] Create Supabase migration: `ops.run_events` table
+- [ ] Create Supabase migration: `ops.idempotency_keys` table
+- [ ] Add idempotency key checker middleware
+- [ ] Deploy to Supabase Edge Functions (stage environment)
+- [ ] Validate: MCP inspector connects, health returns 200, empty tool list
+
+## Phase 2: Odoo Tools
+
+- [ ] Create `lib/odoo-rpc.ts` — XML-RPC client wrapper for Odoo
+- [ ] Implement service user auth (`authenticate` → cache uid)
+- [ ] Implement `odoo.search_read` tool (domain, fields, model, limit)
+- [ ] Implement `odoo.update_partner` tool with field allowlist enforcement
+- [ ] Implement `odoo.update_opportunity` tool with field allowlist enforcement
+- [ ] Implement `odoo.create_activity` tool with model allowlist enforcement
+- [ ] Add blocked-field rejection logic (reject entire request on blocked field)
+- [ ] Create Odoo service user `odoo_chatgpt_rpc` with restricted access group
+- [ ] Write unit tests for field allowlist enforcement
+- [ ] Validate: MCP inspector calls each Odoo tool successfully
+
+## Phase 3: Plane Tools
+
+- [ ] Create `lib/plane-api.ts` — Plane REST API client wrapper
+- [ ] Implement token-bucket rate limiter (60 req/min)
+- [ ] Implement `plane.list_work_items` tool
+- [ ] Implement `plane.create_work_item` tool
+- [ ] Implement `plane.update_work_item` tool
+- [ ] Implement `plane.create_page` tool
+- [ ] Implement `plane.add_comment` tool
+- [ ] Add request batching for list operations
+- [ ] Write unit tests for rate limiter
+- [ ] Validate: create work item via MCP, verify in Plane UI
+
+## Phase 4: Slack Tools
+
+- [ ] Create `lib/slack-api.ts` — Slack Web API client wrapper
+- [ ] Implement signing secret verification for inbound payloads
+- [ ] Implement `slack.post_message` tool with channel allowlist
+- [ ] Implement `slack.request_approval` tool with Block Kit interactive message
+- [ ] Create approval callback handler endpoint
+- [ ] Implement approval state machine (pending → approved | rejected | timeout)
+- [ ] Add 60-minute timeout with auto-cancellation
+- [ ] Write unit tests for signing verification
+- [ ] Validate: post message, then full approval flow end-to-end
+
+## Phase 5: Auth (OAuth 2.1)
+
+- [ ] Implement `/oauth/authorize` endpoint (authorization code + PKCE)
+- [ ] Implement `/oauth/token` endpoint (code exchange, PKCE verify)
+- [ ] Create Supabase migration: `ops.oauth_sessions` table
+- [ ] Implement refresh token rotation
+- [ ] Create Apps SDK app manifest (app.json)
+- [ ] Register app in OpenAI developer portal
+- [ ] Configure OAuth redirect URIs in OpenAI dashboard
+- [ ] Validate: ChatGPT connects, authenticates, sees tool list
+
+## Phase 6: Approval Workflow Integration
+
+- [ ] Add pre-execution hook in tool router for `requires_approval` check
+- [ ] Build approval request formatter (tool name, record, field changes)
+- [ ] Implement blocking wait (SSE keeps connection, polls for approval)
+- [ ] Handle approval callback → resume tool execution
+- [ ] Handle rejection callback → cancel and notify user
+- [ ] Handle timeout → cancel, log, notify user
+- [ ] Write integration test: approve flow, reject flow, timeout flow
+- [ ] Validate: end-to-end Odoo write with Slack approval in prod config
+
+## Phase 7: Cross-System Linking & Audit
+
+- [ ] Create Supabase migration: `ops.external_identities` table
+- [ ] Implement link writer in tool router (post-execution hook)
+- [ ] Handle partial links (one system succeeds, other fails)
+- [ ] Add Slack notification for partial link failures
+- [ ] Create Superset dashboard for `ops.run_events` audit data
+- [ ] Add error alerting: Slack notification on tool errors
+- [ ] Validate: cross-system operation creates identity link
+
+## Phase 8: Deploy & Register
+
+- [ ] Deploy MCP server to Supabase Edge Function (prod)
+- [ ] Configure production secrets in Supabase Vault
+- [ ] Register ChatGPT App in OpenAI marketplace (team-scoped)
+- [ ] Configure OAuth redirect URIs for prod
+- [ ] Set up uptime monitoring on `/health`
+- [ ] Create runbook: `docs/runbooks/OPS_ASSISTANT_RUNBOOK.md`
+- [ ] Validate: team member uses app in ChatGPT for real operation
+- [ ] Document: update `ssot/integrations/_index.yaml` with app entry
+
+## Acceptance Criteria
+
+- [ ] All 3 tool families functional (odoo.*, plane.*, slack.*)
+- [ ] Deny-by-default enforced (unknown tools rejected, logged)
+- [ ] Field-level access control on Odoo writes
+- [ ] Slack approval flow works end-to-end for prod Odoo writes
+- [ ] All tool calls audited to `ops.run_events`
+- [ ] Idempotency keys prevent duplicate writes
+- [ ] Cross-system links written to `ops.external_identities`
+- [ ] OAuth 2.1 + PKCE authentication working
+- [ ] Rate limiting enforced (60 req/min global, 60 req/min Plane)
+- [ ] Health endpoint returns 200 with version

--- a/ssot/apps/chatgpt_apps/odoo_plane_slack.yaml
+++ b/ssot/apps/chatgpt_apps/odoo_plane_slack.yaml
@@ -1,0 +1,99 @@
+# schema: ssot.chatgpt_app.v1
+# ChatGPT App: Odoo-Plane-Slack Ops Assistant
+# Platform: OpenAI Apps SDK (MCP-first)
+# Owner: ops
+# Created: 2026-03-05
+
+version: 1
+
+app:
+  slug: odoo-plane-slack-assistant
+  display_name: "Ops Assistant"
+  platform: openai_apps_sdk
+  description: >
+    ChatGPT App that updates Odoo records, coordinates Plane work items,
+    and uses Slack for approvals. Built on the OpenAI Apps SDK with an
+    MCP server as the execution backend.
+  references:
+    apps_sdk_root: "https://developers.openai.com/apps-sdk/"
+    apps_sdk_quickstart: "https://developers.openai.com/apps-sdk/quickstart/"
+    apps_sdk_auth: "https://developers.openai.com/apps-sdk/build/auth/"
+    apps_sdk_mcp: "https://developers.openai.com/apps-sdk/build/mcp/"
+  spec_bundle: spec/chatgpt-ops-assistant/
+
+  mcp_server:
+    name: ops-assistant
+    transport: sse
+    deploy_target: supabase_edge_function  # alternative: do_droplet
+    health_endpoint: /health
+    tool_discovery: /tools
+
+  auth:
+    method: oauth2.1
+    grant_type: authorization_code
+    pkce: required
+    scopes:
+      - "odoo:read"
+      - "odoo:write"
+      - "plane:read"
+      - "plane:write"
+      - "slack:notify"
+    token_endpoint: /oauth/token
+    authorize_endpoint: /oauth/authorize
+
+  execution_policy:
+    deny_by_default: true
+    allowlist_path: ssot/integrations/chatgpt_app_tool_allowlist.yaml
+    audit_sink: supabase.ops.run_events
+    idempotency_keys: required
+    rate_limits:
+      per_minute: 60
+      burst: 10
+      backoff: exponential
+
+  tool_families:
+    - prefix: "odoo.*"
+      system: system_of_record
+      backend: xml-rpc
+      host_ref: ssot/runtime/prod_settings.yaml#odoo.url
+      write_capable: true
+      approval_required: true
+      approval_channel: slack
+      service_user_ref: odoo_chatgpt_rpc_user
+
+    - prefix: "plane.*"
+      system: system_of_work
+      backend: rest_api
+      host_ref: ssot/integrations/plane.yaml#api_base_url
+      write_capable: true
+      approval_required: false
+      rate_limit: 60/min
+      auth: bot_token
+
+    - prefix: "slack.*"
+      system: notification
+      backend: web_api
+      write_capable: true
+      approval_required: false
+
+  cross_system_linking:
+    table: ops.external_identities
+    schema: supabase
+    columns:
+      - entity_type     # e.g. "crm.lead", "plane.work_item"
+      - source_system   # e.g. "odoo", "plane"
+      - source_id       # ID in source system
+      - target_system   # e.g. "plane", "odoo"
+      - target_id       # ID in target system
+      - created_by      # "chatgpt_ops_assistant"
+      - created_at      # timestamp
+
+  environments:
+    stage:
+      mcp_url: "https://spdtwktxdalcfigzeqrz.supabase.co/functions/v1/ops-assistant-stage"
+      odoo_db: odoo_dev
+      approval_required: false
+    prod:
+      mcp_url: "https://spdtwktxdalcfigzeqrz.supabase.co/functions/v1/ops-assistant"
+      odoo_db: odoo
+      approval_required: true

--- a/ssot/auth/oidc_clients.yaml
+++ b/ssot/auth/oidc_clients.yaml
@@ -1,0 +1,121 @@
+# schema: ssot.auth.oidc_clients.v1
+# Single source of truth for OIDC client registrations against Supabase Auth IdP.
+#
+# This file tracks:
+#   - Identity Provider (IdP) configuration
+#   - Registered OIDC/OAuth2 clients (relying parties)
+#   - Callback URLs, scopes, and activation status
+#
+# NEVER include client_secret values in this file.
+# Secret references point to ssot/secrets/registry.yaml entries.
+#
+# Related:
+#   - ssot/secrets/registry.yaml (secret name registry)
+#   - ssot/auth/github_auth_surface.yaml (GitHub OAuth surface)
+#   - addons/ipai/ipai_auth_oidc/ (Odoo OIDC module)
+
+version: "1.0.0"
+schema: ssot.auth.oidc_clients.v1
+last_reviewed: "2026-03-05"
+
+# ---------------------------------------------------------------------------
+# Identity Provider
+# ---------------------------------------------------------------------------
+idp:
+  name: "Supabase Auth"
+  type: oidc
+  project_ref: spdtwktxdalcfigzeqrz
+  issuer: "https://spdtwktxdalcfigzeqrz.supabase.co/auth/v1"
+  endpoints:
+    authorization: "https://spdtwktxdalcfigzeqrz.supabase.co/auth/v1/oauth/authorize"
+    token: "https://spdtwktxdalcfigzeqrz.supabase.co/auth/v1/oauth/token"
+    userinfo: "https://spdtwktxdalcfigzeqrz.supabase.co/auth/v1/oauth/userinfo"
+    jwks: "https://spdtwktxdalcfigzeqrz.supabase.co/auth/v1/.well-known/jwks.json"
+    discovery: "https://spdtwktxdalcfigzeqrz.supabase.co/auth/v1/.well-known/openid-configuration"
+  supported_scopes:
+    - openid
+    - email
+    - profile
+  notes: >
+    Supabase Auth acts as the central IdP for all InsightPulse AI services.
+    OIDC clients authenticate users via the Authorization Code flow.
+    Odoo is a relying party — never store primary passwords in Odoo
+    for users with a Supabase counterpart (per ssot-platform rule 9).
+
+# ---------------------------------------------------------------------------
+# Registered OIDC Clients (Relying Parties)
+# ---------------------------------------------------------------------------
+clients:
+
+  - id: odoo
+    name: "Odoo ERP"
+    description: "Primary ERP — SSO via Supabase OIDC"
+    base_url: "https://erp.insightpulseai.com"
+    callback_url: "https://erp.insightpulseai.com/auth_oauth/signin"
+    scopes:
+      - openid
+      - email
+      - profile
+    grant_type: authorization_code
+    status: planned
+    secret_ref:
+      client_id: SUPABASE_OIDC_CLIENT_ID_ODOO
+      client_secret: SUPABASE_OIDC_CLIENT_SECRET_ODOO
+    notes: >
+      Uses Odoo's built-in auth_oauth module.
+      Provider registered in auth.oauth.provider (disabled until client credentials provisioned).
+      Module: auth_oauth (core) + ipai_auth_oidc (custom mappings if needed).
+
+  - id: shelf
+    name: "Shelf Knowledge Base"
+    description: "Internal knowledge base — SSO via Supabase OIDC"
+    base_url: "https://shelf.insightpulseai.com"
+    callback_url: "https://shelf.insightpulseai.com/oauth/callback"
+    scopes:
+      - openid
+      - email
+      - profile
+    grant_type: authorization_code
+    status: planned
+    secret_ref:
+      client_id: SUPABASE_OIDC_CLIENT_ID_SHELF
+      client_secret: SUPABASE_OIDC_CLIENT_SECRET_SHELF
+    notes: >
+      Shelf uses standard OAuth2/OIDC callback.
+      Requires OIDC client registration in Supabase dashboard.
+
+  - id: n8n
+    name: "n8n Automation"
+    description: "Workflow automation — SSO via Supabase OIDC"
+    base_url: "https://n8n.insightpulseai.com"
+    callback_url: "https://n8n.insightpulseai.com/rest/oauth2-credential/callback"
+    scopes:
+      - openid
+      - email
+      - profile
+    grant_type: authorization_code
+    status: planned
+    secret_ref:
+      client_id: SUPABASE_OIDC_CLIENT_ID_N8N
+      client_secret: SUPABASE_OIDC_CLIENT_SECRET_N8N
+    notes: >
+      n8n supports generic OAuth2 credential type for SSO.
+      Callback path is n8n's standard OAuth2 credential callback.
+
+  - id: plane
+    name: "Plane Project Management"
+    description: "Project management — SSO via Supabase OIDC"
+    base_url: "https://plane.insightpulseai.com"
+    callback_url: "https://plane.insightpulseai.com/api/oauth/callback"
+    scopes:
+      - openid
+      - email
+      - profile
+    grant_type: authorization_code
+    status: planned
+    secret_ref:
+      client_id: SUPABASE_OIDC_CLIENT_ID_PLANE
+      client_secret: SUPABASE_OIDC_CLIENT_SECRET_PLANE
+    notes: >
+      Plane supports OIDC via its OAuth callback API endpoint.
+      Requires OIDC client registration in Supabase dashboard.

--- a/ssot/domains/insightpulseai.com.yaml
+++ b/ssot/domains/insightpulseai.com.yaml
@@ -80,6 +80,12 @@ canonical_subdomains:
     resolves_to: 178.128.112.214
     notes: "Self-hosted Shelf.nu fork — asset tracking"
 
+  - host: crm
+    service: Atomic CRM (marmelab/atomic-crm)
+    stack: self-hosted-docker
+    resolves_to: 178.128.112.214
+    notes: "React SPA CRM with Supabase backend — atomic-crm container on :3004"
+
   - host: superset
     service: Apache Superset BI
     stack: self-hosted-docker

--- a/ssot/edge/nginx_cloudflare_map.yaml
+++ b/ssot/edge/nginx_cloudflare_map.yaml
@@ -438,6 +438,50 @@ hostnames:
       expected_status: 200
 
   # ---------------------------------------------------------------------------
+  # crm.insightpulseai.com — Atomic CRM (marmelab/atomic-crm)
+  # ---------------------------------------------------------------------------
+  - hostname: crm.insightpulseai.com
+    service: atomic_crm
+    envs:
+      local:
+        compose_service: null
+        upstream: null
+        config_paths: []
+      prod:
+        edge_host: odoo-production
+        edge_ip: 178.128.112.214
+        upstream: 127.0.0.1:3004
+        upstream_name: atomic_crm
+        nginx_paths:
+          - /etc/nginx/sites-enabled/crm.insightpulseai.com.conf
+        repo_config: infra/deploy/nginx/crm.insightpulseai.com.conf
+        listen: "443 ssl http2"
+        server_name: crm.insightpulseai.com
+        tls: true
+        tls_provider: letsencrypt
+        cert_path: /etc/letsencrypt/live/insightpulseai.com/fullchain.pem
+        key_path: /etc/letsencrypt/live/insightpulseai.com/privkey.pem
+        log_access: /var/log/nginx/crm.insightpulseai.com.access.log
+        log_error: /var/log/nginx/crm.insightpulseai.com.error.log
+        note: "Atomic CRM SPA. Container atomic-crm :3004→80. Supabase backend."
+    cloudflare:
+      dns_type: A
+      proxied: true
+      ssl_mode: full_strict
+      origin_port: 443
+      http_redirect: true
+    proxy_headers:
+      - Host
+      - X-Real-IP
+      - X-Forwarded-For
+      - X-Forwarded-Proto
+    client_limits:
+      max_body_size: 50M
+    health_check:
+      path: /
+      expected_status: 200
+
+  # ---------------------------------------------------------------------------
   # auth.insightpulseai.com — Authentication service (Express)
   # ---------------------------------------------------------------------------
   - hostname: auth.insightpulseai.com

--- a/ssot/integrations/chatgpt_app_tool_allowlist.yaml
+++ b/ssot/integrations/chatgpt_app_tool_allowlist.yaml
@@ -1,0 +1,133 @@
+# schema: ssot.tool_allowlist.v1
+# ChatGPT App Tool Allowlist — deny-by-default
+# Owner: ops
+# Created: 2026-03-05
+# Referenced by: ssot/apps/chatgpt_apps/odoo_plane_slack.yaml
+
+version: 1
+
+policy:
+  default: deny
+  audit_all: true
+  audit_sink: supabase.ops.run_events
+  idempotency: required_for_writes
+
+  allow:
+    # -------------------------------------------------------------------------
+    # Odoo tools (approval-gated in prod via Slack)
+    # Backend: XML-RPC with dedicated service user (odoo_chatgpt_rpc_user)
+    # -------------------------------------------------------------------------
+    - tool: "odoo.update_partner"
+      description: "Update res.partner fields (name, contact info, categories)"
+      environments: ["prod"]
+      requires_approval: true
+      allowed_fields:
+        - name
+        - email
+        - phone
+        - street
+        - city
+        - country_id
+        - category_id
+      blocked_fields:
+        - vat
+        - bank_ids
+        - property_account_receivable_id
+        - property_account_payable_id
+
+    - tool: "odoo.update_opportunity"
+      description: "Update crm.lead fields (stage, revenue, probability, deadline)"
+      environments: ["prod"]
+      requires_approval: true
+      allowed_fields:
+        - stage_id
+        - expected_revenue
+        - probability
+        - date_deadline
+        - tag_ids
+        - description
+      blocked_fields:
+        - partner_id  # use odoo.update_partner instead
+        - user_id     # reassignment requires manager approval
+
+    - tool: "odoo.create_activity"
+      description: "Schedule activities on Odoo records"
+      environments: ["prod", "stage"]
+      requires_approval: false
+      allowed_models:
+        - crm.lead
+        - res.partner
+        - project.task
+        - sale.order
+      blocked_models:
+        - account.move
+        - account.payment
+
+    - tool: "odoo.search_read"
+      description: "Read-only search across allowed Odoo models"
+      environments: ["prod", "stage"]
+      requires_approval: false
+      allowed_models:
+        - res.partner
+        - crm.lead
+        - project.task
+        - sale.order
+        - product.product
+      max_limit: 100
+
+    # -------------------------------------------------------------------------
+    # Plane tools (no approval needed)
+    # Backend: REST API with Bot Token (X-API-Key)
+    # Rate limit: 60 req/min (Plane API constraint)
+    # -------------------------------------------------------------------------
+    - tool: "plane.create_work_item"
+      description: "Create a new work item (issue) in Plane"
+      environments: ["prod", "stage"]
+      requires_approval: false
+      required_fields:
+        - name
+        - project_id
+      optional_fields:
+        - description_html
+        - priority
+        - state_id
+        - assignee_ids
+        - label_ids
+
+    - tool: "plane.update_work_item"
+      description: "Update an existing Plane work item"
+      environments: ["prod", "stage"]
+      requires_approval: false
+
+    - tool: "plane.create_page"
+      description: "Create a Plane page (wiki/doc)"
+      environments: ["prod", "stage"]
+      requires_approval: false
+
+    - tool: "plane.add_comment"
+      description: "Add a comment to a Plane work item"
+      environments: ["prod", "stage"]
+      requires_approval: false
+
+    - tool: "plane.list_work_items"
+      description: "List/search work items in a Plane project"
+      environments: ["prod", "stage"]
+      requires_approval: false
+      max_limit: 100
+
+    # -------------------------------------------------------------------------
+    # Slack tools (no approval needed)
+    # Backend: Slack Web API (xoxb- bot token)
+    # -------------------------------------------------------------------------
+    - tool: "slack.post_message"
+      description: "Post a message to a Slack channel"
+      environments: ["prod", "stage"]
+      requires_approval: false
+      allowed_channels_ref: ssot/integrations/slack/allowed_channels.yaml
+
+    - tool: "slack.request_approval"
+      description: "Send an interactive approval request via Slack"
+      environments: ["prod"]
+      requires_approval: false
+      response_action: "block_until_approved"
+      timeout_minutes: 60


### PR DESCRIPTION
## Summary

- **Deploy Atomic CRM** at `crm.insightpulseai.com` (marmelab/atomic-crm)
  - Docker container on port 3004, nginx reverse proxy, Cloudflare DNS A record
  - React SPA + Supabase backend (CRM schema already in Supabase)
- **Create OIDC client registry** (`ssot/auth/oidc_clients.yaml`)
  - 4 OIDC clients: Odoo, Shelf, n8n, Plane → Supabase Auth as IdP
  - Provider registered in Odoo as id=8 (disabled, placeholder credentials)
- **Create ChatGPT Apps SDK SSOT + spec bundle**
  - App registry: `ssot/apps/chatgpt_apps/odoo_plane_slack.yaml`
  - Tool allowlist: 12 tools with deny-by-default policy
  - Spec: `spec/chatgpt-ops-assistant/` (constitution, PRD, plan, 60+ tasks)
- **Update DNS SSOT** with crm subdomain entry across all 3 SSOT files

## Manual required (follow-up)

- [ ] Provision actual OIDC clients in Supabase Auth dashboard
- [ ] Inject real OIDC client_id/secret into Odoo env vars
- [ ] Configure CRM Supabase connection for data persistence
- [ ] Fix Shelf auth redirect (currently redirects to erp.insightpulseai.com)

## Test plan

- [x] `curl -sI https://crm.insightpulseai.com/` returns HTTP/2 200
- [x] `atomic-crm` container running on droplet (port 3004)
- [x] Nginx vhost deployed and serving via Cloudflare proxy
- [ ] OIDC provider activation (blocked on Supabase client provisioning)
- [ ] CRM data CRUD (blocked on Supabase env config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)