### PR TITLE
fix(ci): corrective pass — DB naming + databricks env normalization

### DIFF
--- a/.github/workflows/databricks-dab-ci.yml
+++ b/.github/workflows/databricks-dab-ci.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate, lint-notebooks]
     if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
-    environment: development
+    environment: databricks-dev
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate, lint-notebooks]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    environment: staging
+    environment: databricks-staging
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deploy-staging]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    environment: production
+    environment: databricks-production
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,7 +293,7 @@ npm run dev:github-app                  # Run github-app
 | Problem | Old Setup | Canonical Setup |
 |---------|-----------|----------------|
 | AI Agent Commands | 36 possible combinations | 1 deterministic command |
-| Database Targets | 4 databases (odoo_core, odoo_dev, odoo_db, postgres) | 1 database (odoo) |
+| Database Targets | 4 databases (odoo_core, odoo_dev, odoo_db, postgres) | 1 database per env: `odoo_dev`, `odoo_staging`, `odoo_prod` (current prod runtime: `odoo`) |
 | Container Names | Custom (odoo-ce-core, odoo-dev) | Project-prefixed (odoo19-web-1, odoo19-db-1) |
 | Configuration | Docker volumes (not tracked) | Version-controlled (./config/odoo.conf) |
 | Database Selector | Enabled (UI confusion) | Disabled (list_db = False) |
@@ -310,7 +310,7 @@ docker compose exec -T web odoo -d odoo -i base   # Install module
 **Complete Documentation**: See `odoo19/CANONICAL_SETUP.md` and `odoo19/QUICK_REFERENCE.md`
 
 **Key Features**:
-- ✅ Single database target (`db_name = odoo`)
+- ✅ Single database target per environment (`db_name = odoo_dev` / `odoo_staging` / `odoo_prod`; current prod runtime: `odoo`)
 - ✅ No database selector (`list_db = False`)
 - ✅ File-based secrets (no hardcoded passwords)
 - ✅ Health checks (PostgreSQL guards web startup)


### PR DESCRIPTION
## Summary

Post-deploy audit corrective pass for the Claude Code GitHub Actions rollout.

- **CLAUDE.md**: Restore DB naming contract lost during rebase conflict (`odoo_dev`/`odoo_staging`/`odoo_prod` canonical targets with transitional note for current prod runtime `odoo`)
- **databricks-dab-ci.yml**: Normalize all 3 generic environment references to `databricks-*` pattern (`development` → `databricks-dev`, `staging` → `databricks-staging`, `production` → `databricks-production`)
- Created `databricks-staging` and `databricks-production` GitHub Environments

## Governance note

The prior rollout commit (`7e55e17d`) was pushed directly to `main`, bypassing the PR-only protection rule. This PR restores the correct delivery path. Future agent automation must use PR branches, not direct pushes to main.

## Non-ERP workflow boundary violations (tracked, not fixed here)

These workflows remain in `odoo` but belong in other repos:

| Workflow | Target repo |
|----------|------------|
| `databricks-*.yml` (5 files) | `lakehouse` |
| `deploy-odooops-console.yml`, `deploy-vercel-odooops.yml`, `odooops-sh-spec-gates.yml` | `web` or `ops-platform` |
| `docs-build-deploy.yml`, `docs-pages.yml` | `web` or dedicated docs repo |
| `e2e-playwright.yml` | with owning app |
| `control-room-ci.yml`, `lakehouse-smoke.yml` | `lakehouse` |

Tracked in task #8 for progressive decomposition.

## Test plan

- [x] `grep -r 'environment: production$' .github/workflows/` returns zero matches
- [x] `grep -r 'environment: staging$' .github/workflows/` returns zero matches
- [x] `CLAUDE.md` contains `odoo_dev`, `odoo_staging`, `odoo_prod` canonical naming
- [ ] Verify `databricks-staging` and `databricks-production` environments exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)