### PR TITLE
docs(contracts): codify mail architecture — Mailgun for Odoo, Zoho for business

### DIFF
--- a/.claude/rules/ssot-platform.md
+++ b/.claude/rules/ssot-platform.md
@@ -103,15 +103,18 @@ When generating or modifying n8n workflow JSON:
 
 ---
 
-## Rule 7: Odoo outbound email must route through the bridge when configured
+## Rule 7: Odoo outbound email uses Mailgun SMTP (not Zoho)
+
+Odoo outbound transactional mail routes through Mailgun on the `mg.insightpulseai.com` subdomain.
+Zoho handles root-domain human/business mailboxes only.
 
 When generating Odoo Python code that sends email:
 
-- Do not call `ir.mail_server` or `smtplib` directly
-- Use `mail.mail.create({...}).send()` — the `ipai_mail_bridge_zoho` override handles routing
-- If `ZOHO_MAIL_BRIDGE_URL` and `ZOHO_MAIL_BRIDGE_SECRET` are set, the bridge activates
-- If not set, standard SMTP is used (fallback)
-- Never suggest disabling the bridge override to "simplify" email sending
+- Use `mail.mail.create({...}).send()` — Odoo's standard `ir.mail_server` handles delivery via Mailgun SMTP
+- Sender addresses must use the `mg.insightpulseai.com` subdomain (e.g. `no-reply@mg.insightpulseai.com`)
+- Never configure Odoo to send from root-domain addresses (e.g. `business@insightpulseai.com`) — those are Zoho mailboxes
+- Never introduce a bridge module for mail routing — standard `ir.mail_server` with Mailgun SMTP credentials is the canonical path
+- See `docs/contracts/MAIL_ARCHITECTURE_CONTRACT.md` for the full provider split
 
 ---
 

--- a/docs/contracts/MAIL_ARCHITECTURE_CONTRACT.md
+++ b/docs/contracts/MAIL_ARCHITECTURE_CONTRACT.md
@@ -1,0 +1,141 @@
+# Mail Architecture Contract — insightpulseai.com
+
+> **Contract ID**: C-26
+> **Status**: Active
+> **Supersedes**: C-02 (Outbound Mail Bridge — deprecated)
+> **Owner**: Platform Engineering
+> **Last Updated**: 2026-03-08
+
+---
+
+## 1. Provider Split
+
+| Provider | Domain | Use Case | SMTP Host | Port |
+|----------|--------|----------|-----------|------|
+| **Mailgun** | `mg.insightpulseai.com` | Odoo outbound transactional mail | `smtp.mailgun.org` | 587 (prod), 2525 (dev/stage) |
+| **Zoho** | `insightpulseai.com` (root) | Human/business mailboxes | `smtppro.zoho.com` | 587 |
+
+---
+
+## 2. Sender Policy
+
+### Mailgun path (app/system mail)
+
+Allowed senders on `mg.insightpulseai.com`:
+
+| Sender | Use Case |
+|--------|----------|
+| `no-reply@mg.insightpulseai.com` | Default Odoo transactional mail |
+| `odoo@mg.insightpulseai.com` | Odoo system notifications |
+| `notifications@mg.insightpulseai.com` | Automated alerts |
+| `invoices@mg.insightpulseai.com` | Invoice/quotation delivery |
+| `auth@mg.insightpulseai.com` | Authentication/password reset |
+
+### Zoho path (human/business mail)
+
+Root-domain addresses handled by Zoho:
+
+| Sender | Use Case |
+|--------|----------|
+| `business@insightpulseai.com` | Primary business contact |
+| `info@insightpulseai.com` | General inquiries |
+| `billing@insightpulseai.com` | Billing correspondence |
+| `finance@insightpulseai.com` | Finance team |
+| `devops@insightpulseai.com` | DevOps/operations |
+
+### Forbidden
+
+- Odoo sending from root-domain addresses (e.g. `business@insightpulseai.com`) through Mailgun
+- Human/business correspondence routed through Mailgun transactional path
+- Any bridge module (`ipai_mail_bridge_zoho`) overriding standard `ir.mail_server`
+
+---
+
+## 3. DNS Authentication
+
+### Root domain (`insightpulseai.com`) — Zoho
+
+| Type | Name | Value | Purpose |
+|------|------|-------|---------|
+| MX | `@` | `mx.zoho.com` (10), `mx2.zoho.com` (20), `mx3.zoho.com` (50) | Mail routing |
+| TXT | `@` | `v=spf1 include:zoho.com ~all` | SPF |
+| TXT | `zoho._domainkey` | `<DKIM key>` | DKIM |
+| TXT | `_dmarc` | `v=DMARC1; p=quarantine; ...` | DMARC |
+
+### Subdomain (`mg.insightpulseai.com`) — Mailgun
+
+| Type | Name | Value | Purpose |
+|------|------|-------|---------|
+| CNAME | `email.mg` | Mailgun tracking CNAME | Tracking |
+| TXT | `mg` | `v=spf1 include:mailgun.org ~all` | SPF |
+| TXT | Mailgun DKIM selector under `mg` | `<DKIM key>` | DKIM |
+| TXT | `_dmarc.mg` | `v=DMARC1; p=quarantine; ...` | DMARC |
+
+---
+
+## 4. Odoo Configuration
+
+Odoo uses standard `ir.mail_server` pointed at Mailgun SMTP. No bridge module required.
+
+```
+Outgoing Mail Server:
+  Name: Mailgun (mg.insightpulseai.com)
+  SMTP Server: smtp.mailgun.org
+  SMTP Port: 587 (prod) / 2525 (dev/stage)
+  Connection Security: TLS (STARTTLS)
+  Username: <Mailgun SMTP credential>
+  Password: <Mailgun SMTP password>
+```
+
+Credentials are stored in env vars / secrets, never in source.
+
+---
+
+## 5. Environment Policy
+
+| Environment | SMTP Host | Port | Credentials | Mail Catcher |
+|-------------|-----------|------|-------------|--------------|
+| PROD | `smtp.mailgun.org` | 587 | Production Mailgun | No |
+| STAGE | `smtp.mailgun.org` | 2525 | Non-prod Mailgun | Required |
+| DEV | `smtp.mailgun.org` | 2525 | Non-prod Mailgun | Required |
+
+See `docs/contracts/C-MAIL-01-mail-catcher.md` for catcher requirements.
+
+---
+
+## 6. Why This Split
+
+- **Deliverability isolation**: Odoo transactional volume stays on `mg` subdomain, protecting root-domain business reputation
+- **Operational clarity**: App automation → Mailgun, people/business mail → Zoho
+- **DNS simplicity**: Each provider authenticates its own subdomain independently
+- **Bounce/complaint tracking**: Mailgun webhooks handle transactional delivery events without affecting business mail
+
+---
+
+## 7. Deprecated
+
+| Item | Status | Reason |
+|------|--------|--------|
+| `ipai_mail_bridge_zoho` module | Deprecated | Odoo uses `ir.mail_server` → Mailgun SMTP directly |
+| `zoho-mail-bridge` Edge Function | Deprecated | No bridge needed — standard SMTP |
+| C-02 (Outbound Mail Bridge Contract) | Superseded by C-26 | Bridge architecture replaced by direct SMTP |
+
+---
+
+## 8. SSOT References
+
+| Resource | Path |
+|----------|------|
+| DNS config (Zoho) | `infra/dns/zoho_mail_dns.yaml` |
+| DNS config (Mailgun) | `infra/dns/subdomain-registry.yaml` (mg subdomain) |
+| Mail catcher contract | `docs/contracts/C-MAIL-01-mail-catcher.md` |
+| Mailgun integration SSOT | `ssot/integrations/mailgun.yaml` |
+| Agent rule | `.claude/rules/ssot-platform.md` (Rule 7) |
+
+---
+
+## 9. Policy Statement
+
+> Root domain mailboxes on `insightpulseai.com` are handled by Zoho.
+> System-generated outbound mail from Odoo and other automated app flows uses Mailgun on the `mg.insightpulseai.com` subdomain.
+> Human/business correspondence must not be sent through the Mailgun transactional path unless explicitly approved.

--- a/docs/contracts/PLATFORM_CONTRACTS_INDEX.md
+++ b/docs/contracts/PLATFORM_CONTRACTS_INDEX.md
@@ -13,7 +13,7 @@
 | #    | Contract                                               | Source SSOT domain                          | Consumer domain                           | Status     | Validator                                  |
 | ---- | ------------------------------------------------------ | ------------------------------------------- | ----------------------------------------- | ---------- | ------------------------------------------ |
 | C-01 | [DNS & Email](DNS_EMAIL_CONTRACT.md)                   | Cloudflare DNS (`infra/dns/`)               | Zoho Mail, Vercel, Odoo                   | ✅ Active  | `dns-ssot-apply.yml`                       |
-| C-02 | [Outbound Mail Bridge](MAIL_BRIDGE_CONTRACT.md)        | Odoo `mail.mail`                            | Supabase Edge Function `zoho-mail-bridge` | ✅ Active  | `ipai-custom-modules-guard.yml`            |
+| C-02 | ~~[Outbound Mail Bridge](MAIL_BRIDGE_CONTRACT.md)~~    | Odoo `mail.mail`                            | ~~Supabase Edge Function `zoho-mail-bridge`~~ | ❌ Deprecated | Superseded by C-26 |
 | C-03 | [JWT Trust](JWT_TRUST_CONTRACT.md)                     | Supabase Auth                               | Odoo middleware, Vercel Edge              | 🔲 Pending | —                                          |
 | C-04 | [Task Queue](TASK_QUEUE_CONTRACT.md)                   | n8n workflows                               | `ops.task_queue` (Supabase)               | 🔲 Pending | —                                          |
 | C-05 | [Design Tokens](DESIGN_TOKENS_CONTRACT.md)             | Figma                                       | `packages/design-tokens/tokens.json`      | 🔲 Pending | —                                          |
@@ -37,6 +37,7 @@
 | C-23 | [Agent Workflows](C-AGENT-WORKFLOWS-01.md)                    | `ssot/agents/interface_schema.yaml`   | All IPAI agent skills, executor runtimes  | ✅ Active  | `scripts/ci/validate_skills_registry.py` |
 | C-24 | [Tool Permissions](C-TOOLS-PERMISSIONS-01.md)                 | `ssot/tools/registry.yaml`            | All IPAI agent skills (`ssot/agents/skills.yaml`) | ✅ Active | `scripts/ci/validate_skills_registry.py` |
 | C-25 | [Governed Tool Specs](../contracts/tools/)                    | `contracts/tools/*.md`                | `ipai_ai_copilot` tool dispatch                   | ✅ Active | `scripts/index_corpus_registry.py --check` |
+| C-26 | [Mail Architecture](MAIL_ARCHITECTURE_CONTRACT.md)            | Mailgun SMTP (`mg.insightpulseai.com`) + Zoho (root) | Odoo `ir.mail_server`, business mailboxes | ✅ Active | `C-MAIL-01` CI gate |
 
 ---
 
@@ -56,11 +57,16 @@
 
 ---
 
-## C-02 — Outbound Mail Bridge Contract
+## C-02 — Outbound Mail Bridge Contract (DEPRECATED)
 
-**File**: `docs/contracts/MAIL_BRIDGE_CONTRACT.md` _(this section is the canonical definition)_
-**SSOT**: `addons/ipai/ipai_mail_bridge_zoho/` (Odoo side) + `supabase/functions/zoho-mail-bridge/` (bridge side)
-**Consumer**: Any Odoo `mail.mail` record with `state=outgoing`
+> **DEPRECATED**: Superseded by C-26 (Mail Architecture Contract). Odoo outbound mail now uses
+> standard `ir.mail_server` → Mailgun SMTP directly. The `ipai_mail_bridge_zoho` module and
+> `zoho-mail-bridge` Edge Function are no longer the canonical path.
+> See `docs/contracts/MAIL_ARCHITECTURE_CONTRACT.md` for the current policy.
+
+**File**: `docs/contracts/MAIL_BRIDGE_CONTRACT.md` _(deprecated — kept for historical reference)_
+**SSOT**: ~~`addons/ipai/ipai_mail_bridge_zoho/`~~ + ~~`supabase/functions/zoho-mail-bridge/`~~
+**Consumer**: ~~Any Odoo `mail.mail` record with `state=outgoing`~~
 
 **Protocol**:
 


### PR DESCRIPTION
## Summary

- Adds **C-26 Mail Architecture Contract** establishing the canonical provider split:
  - Mailgun SMTP on `mg.insightpulseai.com` → Odoo outbound transactional mail
  - Zoho on root domain → human/business mailboxes
- **Deprecates C-02** (`ipai_mail_bridge_zoho` bridge architecture) — Odoo uses standard `ir.mail_server` → Mailgun SMTP directly
- Fixes `ssot-platform.md` Rule 7 to reflect direct Mailgun SMTP path (removes Zoho bridge references)

## Files changed

| File | Change |
|------|--------|
| `docs/contracts/MAIL_ARCHITECTURE_CONTRACT.md` | NEW — full provider split, sender policy, DNS auth, environment policy |
| `docs/contracts/PLATFORM_CONTRACTS_INDEX.md` | C-02 marked deprecated, C-26 added |
| `.claude/rules/ssot-platform.md` | Rule 7 rewritten: Mailgun SMTP, not Zoho bridge |

## Test plan

- [ ] Verify C-26 contract aligns with current DNS records (`dig MX insightpulseai.com`, `dig TXT mg.insightpulseai.com`)
- [ ] Verify Odoo `ir.mail_server` points at `smtp.mailgun.org:587` in prod
- [ ] Confirm no active code depends on `ipai_mail_bridge_zoho` or `zoho-mail-bridge` Edge Function

🤖 Generated with [Claude Code](https://claude.com/claude-code)