### PR TITLE
docs: add platform runtime state and Azure target-state positioning

### DIFF
--- a/docs/architecture/DEPLOY_TARGET_MATRIX.md
+++ b/docs/architecture/DEPLOY_TARGET_MATRIX.md
@@ -45,6 +45,15 @@ Is it Odoo (ERP runtime)?
 | **DO App Platform** | **Deprecated** | DO NOT use. See `ssot/infra/digitalocean/policy.yaml` |
 | **Azure Container Apps** | Planned | Future Odoo runtime target |
 
+### Marketplace and ecosystem classification
+
+Marketplace and ecosystem evidence indicate two different maturity patterns:
+
+- SAP has a first-class Azure ecosystem shape, including deeper Microsoft integration surfaces and a productized Databricks-aligned data/AI path.
+- Odoo appears primarily as a broad application platform with partner-packaged hosting and integration options, not as a first-class Azure workload category.
+
+Therefore, the canonical Odoo deployment baseline must remain first-party Azure primitives plus repository-owned IaC and CI/CD, not Marketplace listings.
+
 ## Why This Split
 
 - **Odoo** needs persistent filesystem (filestore), long-running processes, and direct PostgreSQL access. Droplet is the only fit.

--- a/docs/architecture/PLATFORM_RUNTIME_STATE.md
+++ b/docs/architecture/PLATFORM_RUNTIME_STATE.md
@@ -1,0 +1,70 @@
+# Platform Runtime State
+
+> Canonical snapshot of runtime infrastructure state across all deployment targets.
+
+---
+
+## Azure Subscription Runtime State
+
+### Current state
+
+Azure subscription 1 is already provisioned as an active AI/data platform substrate, not an empty or planning-only subscription. The current resource inventory includes Azure Databricks, Azure OpenAI, Azure AI Search, Document Intelligence, Computer Vision, Language, Key Vault, Application Insights, Log Analytics, managed identities, virtual networking, and a Databricks access connector.
+
+### Resource posture
+
+The current estate is development-weighted. Resource naming and grouping are centered on `*-dev`, including `rg-ipai-ai-dev`, `rg-ipai-shared-dev`, and `dbw-ipai-dev`. This indicates a real development landing zone rather than a promoted multi-environment runtime.
+
+### Present in inventory
+
+Core AI/data foundation presently visible in the subscription includes:
+
+- Azure Databricks (`dbw-ipai-dev`)
+- Azure OpenAI (`oai-ipai-dev`)
+- Azure AI Search (`srch-ipai-dev`)
+- Document Intelligence (`docai-ipai-dev`)
+- Computer Vision (`vision-ipai-dev`)
+- Language (`lang-ipai-dev`)
+- Key Vault (`kv-ipai-dev`)
+- Application Insights (`appi-ipai-dev`)
+- Log Analytics (`managed-appi-ipai-dev-ws`)
+- Virtual network (`vnet-ipai-databricks`)
+- Network security group (`nsg-dbw-ipai-dev`)
+- Databricks access connector (`unity-catalog-access-connector`)
+- Multiple managed identities for agents and Databricks execution paths
+
+### Not yet evidenced in current Azure inventory
+
+The current resource inventory does not yet evidence a complete Azure-native Odoo runtime layer. The following target-state components are not presently visible in the exported subscription inventory:
+
+- Azure-hosted Odoo application runtime
+- Azure Database for PostgreSQL for Odoo
+- Azure Container Registry
+- Azure Front Door / WAF ingress layer
+- explicit stage/prod Odoo runtime separation
+- ERP-specific deployment promotion path
+
+### Interpretation
+
+Azure capability is not the blocker. The subscription already contains the foundations for AI, analytics, identity, observability, and network governance. The remaining gap is to elevate Odoo into a first-class Azure workload shape on top of that substrate.
+
+### Positioning
+
+SAP remains the ecosystem maturity benchmark on Azure, especially across data, analytics, AI, and Microsoft integration surfaces. Odoo is a broad business platform across Community and Enterprise editions, but unlike SAP it does not arrive with SAP-grade Azure ecosystem depth. The target state is therefore to engineer that workload posture explicitly through repo-owned architecture, IaC, CI/CD, observability, security, and governed integration layers.
+
+---
+
+## DigitalOcean Runtime State
+
+See `DEPLOY_TARGET_MATRIX.md` and `PROD_RUNTIME_SNAPSHOT.md` for current DO droplet state.
+
+---
+
+## Supabase Runtime State
+
+See `SUPABASE_CONTROL_PLANE.md` for current Supabase project state.
+
+---
+
+## Vercel Runtime State
+
+See `VERCEL_CONTROL_PLANE_DEPLOYMENT.md` for current Vercel deployment state.

--- a/spec/azure-target-state/prd.md
+++ b/spec/azure-target-state/prd.md
@@ -10,6 +10,27 @@ Mixed platform usage creates:
 - Documentation fragmented across Azure Wiki, GitHub docs, Confluence
 - Confusion about which platform is authoritative
 
+## Current-State Evidence
+
+The current Azure subscription is already operating as an AI/data platform foundation. Existing resources cover Databricks, Azure OpenAI, AI Search, Document Intelligence, Vision, Language, Key Vault, observability, managed identities, and network controls. This means the Azure target state does not begin from zero infrastructure; it begins from a partially realized AI/data landing zone.
+
+However, the current resource inventory does not yet show a complete Azure-native ERP runtime for Odoo. The present gap is not subscription governance or AI capability. The gap is workload posture: Odoo has not yet been elevated into a first-class Azure runtime shape with standardized application hosting, database topology, ingress, deployment promotion, and ERP-specific operational controls.
+
+## Benchmark and target posture
+
+SAP is the benchmark for Azure ecosystem maturity, particularly across data and AI. SAP Databricks documents a productized SAP-integrated analytics and AI path, while Azure Databricks itself is presented by Microsoft as a unified analytics and governance platform.
+
+Odoo, by contrast, is a broad integrated business platform with explicit Community and Enterprise edition boundaries, but it does not currently present equivalent Azure ecosystem depth. Odoo should therefore be treated as an engineered workload rather than a workload with a native Azure operating model.
+
+## Design implication
+
+The Azure target state should not be framed as "move Odoo to Azure." It should be framed as:
+
+- extend an existing Azure AI/data substrate into an ERP-capable platform
+- define the missing Odoo workload shape using first-party Azure primitives
+- implement repo-controlled deployment, observability, security, and promotion discipline
+- make Odoo behave like a first-class Azure workload even though Azure does not provide that posture natively for Odoo today
+
 ## Target State
 
 ### GitHub (Primary — 95%+ of work)


### PR DESCRIPTION
## Summary

Added canonical documentation of runtime infrastructure state across all deployment targets and clarified Azure target-state positioning relative to current subscription inventory and ecosystem maturity benchmarks.

**Changes:**
- New `docs/architecture/PLATFORM_RUNTIME_STATE.md`: Snapshot of current runtime state across Azure, DigitalOcean, Supabase, and Vercel with cross-references to control plane docs
- Updated `spec/azure-target-state/prd.md`: Added current-state evidence section clarifying that Azure subscription already contains AI/data foundations but lacks first-class Odoo workload shape; added benchmark positioning (SAP vs. Odoo ecosystem maturity) and design implications
- Updated `docs/architecture/DEPLOY_TARGET_MATRIX.md`: Added marketplace/ecosystem classification section explaining why Odoo deployment baseline must remain first-party Azure primitives rather than Marketplace listings

## Policy Gates

All policy gates pass:
- **Gate 1** N/A — Documentation only, no code changes
- **Gate 2** ✅ No secrets or credentials in diff
- **Gate 3** N/A — No Odoo views modified
- **Gate 4** N/A — No database migrations
- **Gate 5** ✅ No deprecated references

## Spec Kit Compliance

- [x] N/A — Minor change (documentation and architecture positioning)

## Design Contract

- [x] N/A — No UI changes

## Odoo / Supabase / Ops Impact

- [x] N/A — No ops impact (documentation only)

## Validation Evidence

- [x] No CI gates apply to documentation-only changes
- [x] Documentation is internally consistent and cross-referenced

## Rollback

Revert this PR to remove the new documentation and restore prior prd.md state.

## Checklist

- [x] No secrets or credentials in code
- [x] Documentation follows existing architecture doc conventions

## Related Issues

Establishes canonical runtime state record for platform decision-making and target-state planning.

https://claude.ai/code/session_01LW6DB2n2T6RUJXb67peSp5