### PR TITLE
fix(finance-ppm): migrate create() to @api.model_create_multi

### DIFF
--- a/addons/ipai/ipai_finance_ppm/models/project_task_integration.py
+++ b/addons/ipai/ipai_finance_ppm/models/project_task_integration.py
@@ -15,16 +15,16 @@ _logger = logging.getLogger(__name__)
 class ProjectTaskIntegration(models.Model):
     _inherit = 'project.task'
 
-    @api.model
-    def create(self, vals):
+    @api.model_create_multi
+    def create(self, vals_list):
         """Override: Emit finance_task.created when BIR task is auto-created"""
-        task = super().create(vals)
+        tasks = super().create(vals_list)
 
         # Only emit for finance PPM tasks (linked to BIR schedule or logframe)
-        if task.bir_schedule_id or task.finance_logframe_id:
+        for task in tasks.filtered(lambda t: t.bir_schedule_id or t.finance_logframe_id):
             self._emit_finance_task_event(task, 'finance_task.created')
 
-        return task
+        return tasks
 
     def write(self, vals):
         """Override: Emit events when task state changes"""


### PR DESCRIPTION
## Summary
- Migrates the last remaining `def create(self, vals)` to `@api.model_create_multi` + `vals_list`
- File: `addons/ipai/ipai_finance_ppm/models/project_task_integration.py`
- All 9 ipai_* modules with create overrides now use the modern batch-compatible pattern

## Verification
```bash
# 0 matches = all migrated
grep -r "def create(self, vals)" addons/ipai/
# 9 files use modern pattern
grep -rl "@api.model_create_multi" addons/ipai/
```

## Test plan
- [ ] `python odoo-bin -d odoo_dev --test-tags ipai_finance_ppm --stop-after-init` passes
- [ ] BIR task creation still emits `finance_task.created` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)