### PR TITLE
feat(deploy): build-time enforcement for manifest-declared addon roots

### DIFF
--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -64,14 +64,41 @@ RUN pip3 install --no-cache-dir --break-system-packages \
     && rm /tmp/oca_rest_framework.txt
 
 # =============================================================================
+# Manifest-Driven Build Gate
+# =============================================================================
+# Validates that the build context only contains OCA repos declared in the
+# curated manifest. Prevents ad-hoc addon directories from entering the image.
+# Contract: docs/contracts/ADDONS_MANIFEST_CONTRACT.md (C-27)
+RUN pip3 install --no-cache-dir --break-system-packages pyyaml 2>/dev/null \
+    || python3 -c "import yaml" 2>/dev/null \
+    || { echo "ERROR: Cannot install PyYAML for manifest validation"; exit 1; }
+COPY config/addons.manifest.yaml /tmp/addons.manifest.yaml
+
+# =============================================================================
 # OCA Modules — Flatten from addons/oca into /opt/odoo/addons/oca
 # =============================================================================
-# Source: addons/oca/ (git submodules, each is an OCA repo with multiple modules)
+# Source: addons/oca/ (git-aggregator checkouts, each is an OCA repo)
 # Strategy: Flatten all modules with __manifest__.py into single directory
 # Benefit: Single addon path; collision detection prevents silent overwrites
+# Guard: Only repos listed in addons.manifest.yaml are allowed
 COPY ./addons/oca /tmp/oca-src
 
 RUN set -eux; \
+  # --- Build gate: extract allowed repos from manifest --- \
+  allowed_repos=$(python3 -c "\
+import yaml; \
+m = yaml.safe_load(open('/tmp/addons.manifest.yaml')); \
+print(' '.join(r['repo'] for r in m.get('oca_repositories', [])))"); \
+  # --- Validate: reject undeclared repos --- \
+  for repo in /tmp/oca-src/*; do \
+    [ -d "$repo" ] || continue; \
+    repo_name=$(basename "$repo"); \
+    case " $allowed_repos " in \
+      *" $repo_name "*) ;; \
+      *) echo "ERROR: OCA repo '$repo_name' not declared in addons.manifest.yaml"; exit 1 ;; \
+    esac; \
+  done; \
+  # --- Flatten declared repos --- \
   module_count=0; \
   for repo in /tmp/oca-src/*; do \
     [ -d "$repo" ] || continue; \
@@ -89,7 +116,7 @@ RUN set -eux; \
     done; \
   done; \
   echo "OCA modules flattened: $module_count"; \
-  rm -rf /tmp/oca-src
+  rm -rf /tmp/oca-src /tmp/addons.manifest.yaml
 
 # Install OCA module Python dependencies
 RUN find /opt/odoo/addons/oca -name "requirements.txt" \
@@ -103,6 +130,23 @@ COPY ./addons/ipai /opt/odoo/addons/ipai
 # Install IPAI module Python dependencies
 RUN find /opt/odoo/addons/ipai -name "requirements.txt" \
     -exec pip3 install --no-cache-dir --break-system-packages -r {} \; 2>/dev/null || true
+
+# =============================================================================
+# Final Addon Root Verification
+# =============================================================================
+# Ensure only the two declared addon roots exist under /opt/odoo/addons/
+# and no stray directories were introduced during the build.
+RUN set -eux; \
+  for dir in /opt/odoo/addons/*/; do \
+    dirname=$(basename "$dir"); \
+    case "$dirname" in \
+      oca|ipai) ;; \
+      *) echo "ERROR: Undeclared addon root: /opt/odoo/addons/$dirname"; exit 1 ;; \
+    esac; \
+  done; \
+  oca_count=$(find /opt/odoo/addons/oca -maxdepth 1 -mindepth 1 -type d | wc -l); \
+  ipai_count=$(find /opt/odoo/addons/ipai -maxdepth 1 -mindepth 1 -type d | wc -l); \
+  echo "Addon roots verified: oca=$oca_count modules, ipai=$ipai_count modules"
 
 # =============================================================================
 # Configuration


### PR DESCRIPTION
## Summary

Adds build-time gates to `docker/Dockerfile.unified` so only manifest-declared addon content enters the production image.

**Depends on PR #542** (manifest + validator + CI gate). Merge #542 first.

### Two enforcement layers

**1. OCA repo allowlist** (lines 83-97)
- Reads `config/addons.manifest.yaml` during `docker build`
- Extracts declared repo names via `python3 -c "import yaml; ..."`
- Iterates `addons/oca/*` directories in build context
- **Rejects** any repo directory not listed in the manifest
- Fails build with: `ERROR: OCA repo '<name>' not declared in addons.manifest.yaml`

**2. Final addon root verification** (lines 136-146)
- After all COPY steps complete, scans `/opt/odoo/addons/*/`
- **Rejects** any directory that isn't `oca` or `ipai`
- Fails build with: `ERROR: Undeclared addon root: /opt/odoo/addons/<name>`
- Prints module counts for both roots on success

### PyYAML handling

The `odoo:19` base image may not include PyYAML. The Dockerfile installs it if missing:
```dockerfile
RUN pip3 install --no-cache-dir --break-system-packages pyyaml 2>/dev/null \
    || python3 -c "import yaml" 2>/dev/null \
    || { echo "ERROR: Cannot install PyYAML for manifest validation"; exit 1; }
```

### Files changed (1)

| File | Lines | Change |
|------|-------|--------|
| `docker/Dockerfile.unified` | +46/-2 | Add manifest gate + addon root check |

### Post-merge followup

After PR #542 is merged, update `docs/contracts/ADDONS_MANIFEST_CONTRACT.md` invariants to reference the build-time enforcement.

## Test plan

- [ ] Merge PR #542 first
- [ ] `docker build -f docker/Dockerfile.unified -t ipai-odoo-runtime:19.0 .` succeeds with hydrated `addons/oca/`
- [ ] Add an undeclared dir `addons/oca/rogue-repo/` and verify build fails with explicit error
- [ ] Add a stray root `addons/other/` and verify final check catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)