### PR TITLE
docs(spec): ADLS ETL + Reverse ETL architecture

### DIFF
--- a/docs/architecture/ADLS_ETL_REVERSE_ETL_ARCHITECTURE.md
+++ b/docs/architecture/ADLS_ETL_REVERSE_ETL_ARCHITECTURE.md
@@ -1,0 +1,203 @@
+# ADLS ETL + Reverse ETL Architecture
+
+> Canonical architecture for data flows between Supabase (SSOT),
+> Odoo (SoR), and Azure Data Lake Storage (ADLS Gen2).
+>
+> Spec: `spec/adls-etl-reverse-etl/`
+> Contracts: `docs/contracts/DATA_AUTHORITY_CONTRACT.md`,
+>            `docs/contracts/REVERSE_ETL_GUARDRAILS.md`
+> SSOT: `ssot/integrations/adls-etl-reverse-etl.yaml`
+
+---
+
+## 1. System Authority Model
+
+```
+Supabase (SSOT)              Odoo (SoR)
+  Platform control-plane       ERP operations
+  App metadata                 Accounting / invoicing
+  Workflow state               Projects / tasks
+  Vector embeddings            BIR tax compliance
+  Agent memory                 Employees / vendors
+  Auth identity                Analytic accounts
+
+                    ↓ ETL ↓
+
+              ADLS Gen2 (Analytical Lake)
+              Authoritative for nothing operational
+              Bronze → Silver → Gold
+
+                    ↓ Reverse ETL ↓
+                    (bounded, typed, contract-governed)
+
+Supabase enrichment columns    Odoo enrichment fields
+Supabase materialized tables   Odoo draft documents
+Slack/n8n notifications
+```
+
+## 2. Target Enterprise Architecture
+
+```
+              AI Agents
+           Azure AI Foundry
+
+                 ↑ scoring / embeddings
+
+           Databricks / ML (optional)
+              ADLS Gen2
+
+                 ↑ ETL (Extract API / CDC / batch)
+
+            Odoo (SoR)          Supabase (SSOT)
+
+                 ↑ Reverse ETL (bounded)
+            JSON-2 API           Supabase client
+
+           ADLS curated/gold
+```
+
+## 3. Odoo Integration Surfaces
+
+The Odoo 19 developer reference defines 7 integration mechanisms:
+
+| Surface | ETL Role | Reverse ETL Role |
+|---------|----------|-----------------|
+| **Extract API** | Primary: bulk data extraction for bronze | — |
+| **JSON-2 API** | Secondary: targeted extractions | Primary: bounded writebacks |
+| **XML-RPC / JSON-RPC** | Legacy — avoid in new pipelines | — |
+| **ir.cron** | Trigger scheduled extractions | Trigger reverse ETL consumption |
+| **ORM API** | Internal module logic | Process writebacks inside Odoo |
+| **Data files (XML/CSV)** | Seed data for mapping tables | — |
+| **CLI (`odoo-bin`)** | CI/CD: module install, DB init | — |
+
+### Extract API (recommended for ETL)
+
+Purpose-built for large-scale data extraction:
+
+```
+Extract request → Parse → Dataset generation → Result retrieval
+```
+
+Use for: Odoo → ADLS bronze landing. Preferred over heavy RPC queries.
+
+### JSON-2 API (recommended for reverse ETL)
+
+Modern API with API key authentication:
+
+```
+POST /jsonrpc
+{
+  "model": "account.analytic.account",
+  "method": "write",
+  "args": [[record_id], {"x_forecast_amount": 150000}]
+}
+```
+
+Use for: ADLS → Odoo bounded writebacks (enrichment, draft creation).
+
+## 4. ADLS Zone Layout
+
+```
+adls-ipai-dev/
+├── raw/bronze/
+│   ├── supabase/{table}/dt={date}/     Append-only, schema-on-read
+│   └── odoo/{model}/dt={date}/         Append-only, schema-on-read
+│
+├── standardized/silver/
+│   ├── supabase/                       Normalized, typed, deduplicated
+│   └── odoo/                           Normalized, typed, deduplicated
+│
+├── curated/gold/
+│   ├── finance/                        Budget, actuals, variance
+│   ├── projects/                       Portfolio, resource, timeline
+│   ├── compliance/                     BIR filing status, deadlines
+│   ├── platform/                       User activity, events
+│   └── ml_features/                    Feature tables for Azure AI
+│
+├── reverse_etl_exports/
+│   ├── supabase/                       Staged writebacks
+│   └── odoo/                           Staged writebacks
+│
+├── rejected/quarantine/                Failed records + error metadata
+│
+└── audit/
+    ├── run_logs/                       Per-flow execution logs
+    ├── watermarks/                     High-water marks per entity
+    └── lineage/                        Data lineage metadata
+```
+
+## 5. Data Flow Catalog
+
+### ETL Flows (Inbound)
+
+| Flow | Source | Target | Method | Cadence | Key |
+|------|--------|--------|--------|---------|-----|
+| `supabase_users_to_adls` | Supabase `auth.users` | ADLS bronze | Incremental batch | Daily | `user_id` |
+| `supabase_events_to_adls` | Supabase `platform_events` | ADLS bronze | Incremental batch | Hourly | `event_id` |
+| `odoo_journal_entries_to_adls` | Odoo `account.move` | ADLS bronze | Extract API | Daily | `id` |
+| `odoo_projects_to_adls` | Odoo `project.project` | ADLS bronze | Extract API | Daily | `id` |
+| `odoo_employees_to_adls` | Odoo `hr.employee` | ADLS bronze | Extract API | Daily | `id` |
+| `odoo_bir_filings_to_adls` | Odoo `bir.tax.return` | ADLS bronze | Extract API | Weekly | `id` |
+
+### Reverse ETL Flows (Outbound)
+
+| Flow | Source | Target | Type | Cadence | Guard |
+|------|--------|--------|------|---------|-------|
+| `ml_scores_to_supabase` | ADLS gold | Supabase `_risk_score` | `scoring_writeback` | Daily | Enrichment column only |
+| `dashboard_refresh_supabase` | ADLS gold | Supabase mat tables | `read_model_refresh` | Daily | Full table replace |
+| `forecast_to_odoo_analytic` | ADLS gold | Odoo `x_forecast_*` | `enrichment_writeback` | Weekly | Enrichment fields only |
+
+## 6. Supabase Vector Database Positioning
+
+Supabase pgvector provides operational vector retrieval alongside relational data:
+
+| Use Case | Storage | Why |
+|----------|---------|-----|
+| Semantic search over app documents | Supabase pgvector | App-native, close to relational data, RLS-governed |
+| Agent memory / tool-routing context | Supabase pgvector | Low-latency operational retrieval |
+| Operational knowledge retrieval | Supabase pgvector | Tied to app workflows |
+| Historical ML feature embeddings | ADLS | Bulk analytical storage, not operational |
+| Training dataset embeddings | ADLS → Azure AI | Compute-bound, not operational |
+
+**Rule**: Supabase vector is for **operational RAG** close to app data.
+ADLS is for **analytical/historical** embeddings at scale.
+
+## 7. Security Model
+
+| Component | Mechanism |
+|-----------|-----------|
+| Supabase credentials | Azure Key Vault → managed identity |
+| Odoo API tokens | Azure Key Vault → managed identity |
+| ADLS access | Storage RBAC + managed identity |
+| ETL compute identity | Azure managed identity |
+| Reverse ETL compute identity | Azure managed identity |
+| Secrets in repo | **Prohibited** |
+
+### Storage RBAC Separation
+
+| Role | Access | Assigned To |
+|------|--------|-------------|
+| `Storage Blob Data Contributor` | Read/write bronze | ETL pipelines |
+| `Storage Blob Data Reader` | Read silver/gold | BI tools, Tableau |
+| `Storage Blob Data Reader` | Read reverse_etl_exports | Reverse ETL pipelines |
+
+## 8. Observability
+
+| Artifact | Location | Content |
+|----------|----------|---------|
+| Run logs | `audit/run_logs/{flow_id}/{dt}/` | Status, duration, row counts |
+| Watermarks | `audit/watermarks/{entity}.json` | High-water mark per entity |
+| Schema drift | `audit/evidence/{flow_id}/schema_changes.json` | Detected schema changes |
+| Quarantine | `rejected/quarantine/{source}/{entity}/{dt}/` | Failed records + errors |
+| Lineage | `audit/lineage/{flow_id}.json` | Source → bronze → silver → gold chain |
+
+## 9. Open Decisions
+
+| Decision | Recommendation | Status |
+|----------|----------------|--------|
+| Databricks required? | Optional — introduce for ML/complex transforms only | Open |
+| Delta Lake format? | Optional — Parquet baseline sufficient | Open |
+| Reverse ETL orchestrator | Azure Functions (simple) or Data Factory (complex) | Open |
+| Supabase CDC mechanism | Incremental batch first; Realtime later | Open |
+| Odoo extraction method | Extract API primary; DB replica for historical | Open |
+| ADLS region | `southeastasia` (co-locate with ACA) | Open |

--- a/docs/contracts/DATA_AUTHORITY_CONTRACT.md
+++ b/docs/contracts/DATA_AUTHORITY_CONTRACT.md
@@ -1,0 +1,55 @@
+# Contract — Data Authority
+
+> Defines which system owns which data domain. No system may claim
+> authority over another system's designated domain without an explicit
+> ownership transfer registered in this contract.
+
+---
+
+## Authority Matrix
+
+| System | Authority Level | Owns |
+|--------|----------------|------|
+| **Supabase** | SSOT | Platform/control-plane entities, app metadata, workflow state, vector embeddings, agent memory, Edge Function state, Auth identity |
+| **Odoo** | SoR | ERP-operational entities: accounting, invoicing, projects, tasks, BIR tax filings, employees, vendors, analytic accounts, expense documents |
+| **ADLS** | Analytical lake | Replicated bronze/silver/gold datasets, ML features, BI marts, reverse ETL staging. **Authoritative for nothing operational.** |
+| **Azure AI Foundry** | Compute only | Model training, scoring, embedding generation. No data ownership. |
+| **Tableau Cloud** | Presentation only | BI dashboards consuming ADLS gold. No data ownership. |
+
+## Entity-Level Authority
+
+| Entity | Authoritative System | Replication Target | Reverse ETL Allowed |
+|--------|---------------------|-------------------|---------------------|
+| `auth.users` | Supabase | ADLS bronze → silver → gold | Yes — `scoring_writeback` to `_segment`, `_risk_score` columns only |
+| `platform_events` | Supabase | ADLS bronze → silver | No |
+| `ops.task_queue` | Supabase | ADLS bronze → silver | No |
+| Workflow state | Supabase | ADLS bronze → silver | No |
+| Vector embeddings | Supabase | ADLS bronze | No |
+| `account.move` (journal entries) | Odoo | ADLS bronze → silver → gold | **Never** — posted entries are immutable |
+| `account.move` (invoices) | Odoo | ADLS bronze → silver → gold | No |
+| `project.project` | Odoo | ADLS bronze → silver → gold | Yes — `enrichment_writeback` to forecast fields |
+| `project.task` | Odoo | ADLS bronze → silver → gold | No |
+| `hr.employee` | Odoo | ADLS bronze → silver → gold | No |
+| `res.partner` | Odoo | ADLS bronze → silver → gold | No |
+| `account.analytic.account` | Odoo | ADLS bronze → silver → gold | Yes — `enrichment_writeback` to `x_forecast_*` fields |
+| `bir.tax.return` | Odoo | ADLS bronze → silver | No |
+| `hr.expense` | Odoo | ADLS bronze → silver → gold | Yes — `draft_record_creation` only |
+| ML feature tables | ADLS (computed) | — | Yes — `scoring_writeback` to Supabase/Odoo enrichment columns |
+| Dashboard summaries | ADLS (aggregated) | — | Yes — `read_model_refresh` to Supabase materialized tables |
+
+## Hard Rules
+
+1. ADLS is a **consumer**, not a source of truth. No operational system reads from ADLS as its primary data source.
+2. Supabase SSOT tables cannot be overwritten by ADLS reverse ETL. Only designated enrichment columns (`_enriched`, `_score`, `_segment`) are writable.
+3. Odoo posted accounting entries (`account.move` in `posted` state) are immutable from all external systems. No reverse ETL path may modify them.
+4. Odoo draft records created by reverse ETL require Odoo-side approval before posting.
+5. Every data flow between systems must have an entry in `ssot/integrations/adls-etl-reverse-etl.yaml`.
+
+## Ownership Transfer Protocol
+
+If a data domain needs to move between systems (e.g., a Supabase table becomes Odoo-owned), the following steps are required:
+
+1. Update this contract with the new authority assignment
+2. Update `ssot/integrations/adls-etl-reverse-etl.yaml`
+3. Update all downstream ETL/reverse ETL flows
+4. Commit all changes together with evidence of review

--- a/docs/contracts/REVERSE_ETL_GUARDRAILS.md
+++ b/docs/contracts/REVERSE_ETL_GUARDRAILS.md
@@ -1,0 +1,97 @@
+# Contract — Reverse ETL Guardrails
+
+> Defines what ADLS-derived data is allowed to write back into operational
+> systems, under what constraints, and what is prohibited.
+
+---
+
+## Reverse ETL Classification
+
+Every reverse ETL flow must be classified as exactly one type:
+
+| Type | Description | Mutates Authoritative Data? |
+|------|-------------|---------------------------|
+| `read_model_refresh` | Overwrite a pre-computed read model (materialized view/table) | No — read models are derived |
+| `enrichment_writeback` | Add derived fields to existing operational records | No — writes to designated enrichment columns only |
+| `scoring_writeback` | Write ML/AI scoring outputs to operational records | No — writes to designated score columns only |
+| `notification_trigger` | Fire an alert/notification based on analytical results | No — no data mutation |
+| `draft_record_creation` | Create draft (non-posted) records in operational systems | Partially — creates new records in draft state |
+
+Untyped, generic "sync" is **prohibited**.
+
+---
+
+## Approved Writeback Flows
+
+### To Supabase
+
+| Flow | Type | Target Table | Writable Columns | Guard |
+|------|------|-------------|-----------------|-------|
+| Customer segmentation | `scoring_writeback` | User profiles | `_segment` | Append/overwrite enrichment column only |
+| ML risk scores | `scoring_writeback` | Operational records | `_risk_score` | Append/overwrite enrichment column only |
+| Dashboard summaries | `read_model_refresh` | Materialized tables | All columns in designated mat tables | Full table replace on refresh |
+
+### To Odoo
+
+| Flow | Type | Target Model | Writable Fields | Guard |
+|------|------|-------------|----------------|-------|
+| Budget forecast | `enrichment_writeback` | `account.analytic.account` | `x_forecast_amount`, `x_forecast_date`, `x_forecast_confidence` | Write to `x_forecast_*` fields only |
+| Draft expense import | `draft_record_creation` | `account.move` | All fields (draft state) | Created in `draft` state only; posting requires Odoo approval |
+
+### To External Systems
+
+| Flow | Type | Target | Guard |
+|------|------|--------|-------|
+| Anomaly alerts | `notification_trigger` | Slack via n8n | Alert payload only; no data mutation |
+
+---
+
+## Prohibited Writebacks
+
+| Target | Prohibition | Reason |
+|--------|-------------|--------|
+| Odoo `account.move` (posted state) | No mutation of any field | Posted accounting entries are immutable — audit and regulatory requirement |
+| Odoo `account.move.line` (posted) | No mutation | Same as above |
+| Supabase `auth.users` (core fields) | No overwrite of `email`, `encrypted_password`, `role` | Identity authority belongs to Supabase Auth |
+| Supabase SSOT control tables | No overwrite of core operational columns | SSOT integrity |
+| Odoo `res.partner` (core fields) | No overwrite of `name`, `vat`, `company_type` | Master data authority belongs to Odoo |
+| Odoo `hr.employee` (core fields) | No overwrite of `name`, `job_id`, `department_id` | Master data authority belongs to Odoo |
+| Any system without a contract entry | All writes prohibited | Every writeback must be registered in this document |
+
+---
+
+## Idempotency Requirements
+
+Every reverse ETL flow must define an idempotency key:
+
+| Flow | Idempotency Key | Behavior |
+|------|----------------|----------|
+| Customer segmentation | `user_id` + `scoring_run_id` | Overwrite previous score for same user; skip if run_id already applied |
+| ML risk scores | `record_id` + `model_version` | Overwrite previous score; skip if model_version already applied |
+| Budget forecast | `analytic_account_id` + `forecast_period` | Overwrite forecast for same account+period |
+| Draft expense import | `source_document_id` | Skip if `account.move.ref` already exists with same source_document_id |
+| Dashboard summaries | `materialized_table_name` + `refresh_timestamp` | Full replace; skip if timestamp already processed |
+
+---
+
+## Failure Handling
+
+| Failure Mode | Response |
+|--------------|----------|
+| Target system unavailable | Queue to dead-letter; retry with exponential backoff (max 5 attempts) |
+| Idempotency key already exists (posted record) | Skip; log as "already processed" |
+| Field-level guard violation (attempt to write to prohibited field) | Reject entire record; log to quarantine with violation details |
+| Schema mismatch (target field does not exist) | Reject entire batch; alert; log to quarantine |
+| Partial batch failure | Commit successful records; quarantine failed records; log counts |
+
+---
+
+## Adding a New Writeback Flow
+
+To register a new reverse ETL flow:
+
+1. Add entry to the "Approved Writeback Flows" section above
+2. Add entry to `ssot/integrations/adls-etl-reverse-etl.yaml`
+3. Define idempotency key in the "Idempotency Requirements" section
+4. Commit all changes together
+5. Implement field-level guards in the writeback pipeline code

--- a/spec/adls-etl-reverse-etl/constitution.md
+++ b/spec/adls-etl-reverse-etl/constitution.md
@@ -1,0 +1,118 @@
+# Constitution — ADLS ETL + Reverse ETL
+
+> Immutable rules governing data flows between Supabase (SSOT),
+> Odoo (SoR), and Azure Data Lake Storage (ADLS Gen2).
+
+---
+
+## Rule 1: System Authority Is Non-Negotiable
+
+| System | Authority | Owns |
+|--------|-----------|------|
+| **Supabase** | SSOT | Platform/control-plane entities, metadata, workflow state, app-side control tables, operational vector retrieval, agent memory |
+| **Odoo** | SoR | ERP entities — accounting, invoicing, projects, tasks, master operational records, finance/operations workflows |
+| **ADLS** | Analytical/lake only | Replicated, curated, partitioned, historical, analytical, ML, and interoperability data products |
+
+ADLS is authoritative for **nothing operational**. It is a downstream
+consumption surface. No operational system may treat ADLS as source of truth.
+
+## Rule 2: Reverse ETL Is Bounded and Typed
+
+Every reverse ETL flow must be classified as exactly one of:
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `read_model_refresh` | Update a pre-computed read model in an operational system | Refresh materialized analytics summary in Supabase |
+| `enrichment_writeback` | Add derived fields to existing operational records | Append ML-computed risk score to Odoo partner record |
+| `scoring_writeback` | Write ML/AI scoring outputs to operational systems | Customer segmentation flag on Supabase user profile |
+| `notification_trigger` | Fire an alert or notification based on analytical results | Slack alert when anomaly detected in ADLS pipeline |
+| `draft_record_creation` | Create draft (non-posted) records in operational systems | Draft expense document in Odoo from curated ADLS output |
+
+Untyped, generic "sync" flows are prohibited.
+
+## Rule 3: No Overwrite of Authoritative Fields
+
+Reverse ETL must never overwrite authoritative fields in Supabase or Odoo
+without an explicit ownership transfer contract registered in
+`docs/contracts/REVERSE_ETL_GUARDRAILS.md`.
+
+- Supabase: reverse ETL may write to designated `_enriched` or `_score`
+  columns only. Core SSOT columns are read-only from ADLS perspective.
+- Odoo: reverse ETL may create draft records or write to designated
+  enrichment fields only. Posted accounting entries, approved workflows,
+  and master data fields are immutable from ADLS perspective.
+
+## Rule 4: Medallion Architecture Is Mandatory
+
+ADLS storage follows bronze → silver → gold:
+
+| Zone | Purpose | Format |
+|------|---------|--------|
+| `raw/bronze` | Append-only landing, schema-on-read | Parquet or JSON (source-native) |
+| `standardized/silver` | Normalized, deduplicated, typed | Parquet (Delta optional) |
+| `curated/gold` | Business-ready datasets, aggregated marts | Parquet (Delta optional) |
+| `reverse_etl_exports` | Staged outputs approved for writeback | Parquet or JSON |
+| `rejected/quarantine` | Failed records, schema violations | Source format + error metadata |
+| `audit/evidence` | Run logs, row counts, watermarks, lineage | JSON + Parquet |
+
+## Rule 5: Every Flow Has a Contract
+
+Every data flow must define:
+
+- Source system and target system
+- Authority model (who owns the data)
+- Data classification (PII, financial, operational, analytical)
+- Cadence (batch schedule or event trigger)
+- Idempotency key
+- Failure handling (retry, dead-letter, quarantine)
+- Replay behavior (safe to re-run?)
+- Evidence output (row counts, watermarks, checksums)
+
+Flows without contracts are prohibited.
+
+## Rule 6: No Secrets in Repo
+
+All credentials for Supabase, Odoo, ADLS, and orchestration runtimes
+are resolved via Azure Key Vault (`kv-ipai-dev`) + managed identity.
+No connection strings, API keys, or tokens in tracked files.
+
+## Rule 7: No Uncontrolled Bidirectional Sync
+
+There is no generic "sync" between Supabase and Odoo. Each direction
+has a different authority model:
+
+- Supabase → ADLS: ETL (Supabase is source)
+- Odoo → ADLS: ETL (Odoo is source)
+- ADLS → Supabase: Reverse ETL (bounded, typed, contract-required)
+- ADLS → Odoo: Reverse ETL (bounded, typed, contract-required)
+- Supabase → Odoo: Not via ADLS. Direct integration via existing contracts only.
+- Odoo → Supabase: Not via ADLS. Direct integration via existing contracts only.
+
+## Rule 8: Databricks Is Optional
+
+The architecture is ADLS-first and tool-agnostic. Databricks may be
+introduced for silver/gold transforms and ML workloads, but is not
+mandatory. If introduced, it owns the compute layer only — never the
+storage authority.
+
+## Rule 9: Odoo Extraction Uses Extract API or DB Replica
+
+Odoo data is extracted via:
+
+1. **Extract API** (preferred) — purpose-built for ETL, large-scale
+2. **JSON-2 API** — for smaller, targeted extractions
+3. **DB replica** (read-only PostgreSQL replica) — for bulk historical loads
+
+Never extract via XML-RPC in production ETL pipelines. Never write
+directly to Odoo's PostgreSQL database from external systems.
+
+## Rule 10: Supabase CDC Must Be Explicit
+
+If Supabase change data capture is used, it must be via:
+
+1. **Supabase Realtime** (postgres changes) — for event-driven CDC
+2. **Logical replication** — for bulk CDC
+3. **Periodic full/incremental export** — for batch ETL
+
+CDC mechanism must be documented per flow. Emulated CDC (timestamp-based
+incremental) must be explicitly labeled as such.

--- a/spec/adls-etl-reverse-etl/plan.md
+++ b/spec/adls-etl-reverse-etl/plan.md
@@ -1,0 +1,213 @@
+# Plan — ADLS ETL + Reverse ETL
+
+> Phased implementation plan for the canonical data flow architecture.
+
+---
+
+## System Authority Matrix
+
+| Entity | Authoritative System | ADLS Layer | Reverse ETL Eligible | Reverse ETL Mode |
+|--------|---------------------|------------|---------------------|-----------------|
+| Users / identities | Supabase (`auth.users`) | bronze → silver → gold | Yes | `scoring_writeback` to `_segment`, `_risk_score` columns |
+| App events | Supabase (`platform_events`) | bronze → silver | No | — |
+| Platform metadata | Supabase (config tables) | bronze | No | — |
+| Workflow state | Supabase (n8n records) | bronze → silver | No | — |
+| Vector embeddings | Supabase (pgvector) | bronze | No | — |
+| Projects | Odoo (`project.project`) | bronze → silver → gold | Yes | `enrichment_writeback` to forecast fields |
+| Tasks | Odoo (`project.task`) | bronze → silver → gold | No | — |
+| Journal entries | Odoo (`account.move`) | bronze → silver → gold | No | **Never** — posted entries are immutable |
+| Invoices | Odoo (`account.move`) | bronze → silver → gold | No | — |
+| BIR filings | Odoo (`bir.tax.return`) | bronze → silver | No | — |
+| Employees | Odoo (`hr.employee`) | bronze → silver → gold | No | — |
+| Vendors | Odoo (`res.partner`) | bronze → silver → gold | No | — |
+| Analytic accounts | Odoo (`account.analytic.account`) | bronze → silver → gold | Yes | `enrichment_writeback` to `x_forecast_*` fields |
+| Expense documents | Odoo (`hr.expense`) | bronze → silver → gold | Yes | `draft_record_creation` only |
+| ML feature tables | ADLS (computed) | gold | Yes | `scoring_writeback` to Supabase/Odoo enrichment columns |
+| AI scoring outputs | Azure AI Foundry | gold | Yes | `scoring_writeback` or `notification_trigger` |
+| Dashboard summaries | ADLS (aggregated) | gold | Yes | `read_model_refresh` to Supabase materialized tables |
+
+---
+
+## ADLS Zone Layout
+
+```
+adls-ipai-dev/
+├── raw/
+│   ├── supabase/
+│   │   ├── auth_users/          dt=2026-03-13/
+│   │   ├── platform_events/     dt=2026-03-13/
+│   │   ├── workflow_state/      dt=2026-03-13/
+│   │   └── pgvector/            dt=2026-03-13/
+│   └── odoo/
+│       ├── account_move/        dt=2026-03-13/
+│       ├── account_move_line/   dt=2026-03-13/
+│       ├── project_project/     dt=2026-03-13/
+│       ├── project_task/        dt=2026-03-13/
+│       ├── hr_employee/         dt=2026-03-13/
+│       ├── res_partner/         dt=2026-03-13/
+│       └── bir_tax_return/      dt=2026-03-13/
+│
+├── standardized/
+│   ├── supabase/                (normalized, typed, deduplicated)
+│   └── odoo/                    (normalized, typed, deduplicated)
+│
+├── curated/
+│   ├── finance/                 (gold marts: budget, actuals, variance)
+│   ├── projects/                (gold marts: portfolio, resource, timeline)
+│   ├── compliance/              (gold marts: BIR filings, deadlines)
+│   ├── platform/                (gold marts: user activity, events)
+│   └── ml_features/             (feature tables for Azure AI)
+│
+├── reverse_etl_exports/
+│   ├── supabase/                (staged writebacks)
+│   └── odoo/                    (staged writebacks)
+│
+├── rejected/
+│   └── quarantine/              (failed records + error metadata)
+│
+└── audit/
+    ├── run_logs/                (per-flow execution logs)
+    ├── watermarks/              (high-water marks per entity)
+    └── lineage/                 (data lineage metadata)
+```
+
+---
+
+## Odoo Integration Surfaces (from Odoo 19 Developer Reference)
+
+| Surface | Use in ETL | Use in Reverse ETL |
+|---------|-----------|-------------------|
+| **Extract API** | Primary: bulk data extraction for bronze landing | — |
+| **JSON-2 API** | Secondary: targeted small extractions | Primary: bounded writebacks (draft creation, field enrichment) |
+| **XML-RPC / JSON-RPC** | Legacy only — avoid in new pipelines | — |
+| **ir.cron** | Trigger scheduled extractions from Odoo side | Trigger scheduled reverse ETL consumption |
+| **ORM API** | Internal module logic for reverse ETL consumption | Internal module logic for processing writebacks |
+| **Data files (XML/CSV)** | Seed data for mapping tables | — |
+| **CLI (`odoo-bin`)** | CI/CD: module install, DB init | — |
+
+---
+
+## Phase 1 — Contract and Topology (Spec-Only)
+
+**Deliverables:**
+- `docs/contracts/DATA_AUTHORITY_CONTRACT.md` — system authority matrix
+- `docs/contracts/REVERSE_ETL_GUARDRAILS.md` — writeback rules and prohibited paths
+- `ssot/integrations/adls-etl-reverse-etl.yaml` — machine-readable flow catalog
+- Authority matrix reviewed and approved
+
+**Duration:** Spec pass (this PR)
+
+## Phase 2 — ADLS Infrastructure
+
+**Deliverables:**
+- ADLS Gen2 storage account provisioned (`adlsipaidev`)
+- Container/filesystem structure created per zone layout
+- Azure Key Vault secrets for Supabase and Odoo access
+- Managed identity bindings for ETL compute
+- Storage RBAC: separate roles for ETL-write, analytics-read, reverse-ETL-read
+
+**Open decisions:**
+- Storage account name and region (recommend `southeastasia` to match ACA)
+- Delta Lake format: optional for silver/gold, not mandatory
+- Databricks workspace: provision only if ML/transform workloads justify it
+
+## Phase 3 — Bronze Ingestion (Supabase)
+
+**Deliverables:**
+- Supabase → ADLS bronze pipeline for priority tables
+- CDC mechanism selected and documented (Realtime, logical replication, or batch)
+- Watermark tracking for incremental loads
+- Quarantine path for failed records
+- Evidence: row counts, run logs, watermarks per run
+
+**Priority tables:**
+1. `auth.users` (identity)
+2. `platform_events` (app events)
+3. `ops.task_queue` (workflow state)
+
+## Phase 4 — Bronze Ingestion (Odoo)
+
+**Deliverables:**
+- Odoo → ADLS bronze pipeline via Extract API
+- Mapping tables for Odoo model → ADLS path
+- Watermark tracking (using `write_date` or sequence IDs)
+- Quarantine path for failed records
+- Evidence: row counts, run logs, watermarks per run
+
+**Priority models:**
+1. `account.move` + `account.move.line` (finance)
+2. `project.project` + `project.task` (projects)
+3. `hr.employee` + `res.partner` (master data)
+
+## Phase 5 — Silver Normalization
+
+**Deliverables:**
+- Bronze → silver transforms (dedup, type casting, null handling)
+- Cross-source entity resolution (Supabase user ↔ Odoo employee/partner)
+- Schema validation (reject records that fail type/constraint checks)
+- Silver datasets partitioned by date and source
+
+**Compute options (decide in Phase 2):**
+- Azure Data Factory mapping data flows
+- Databricks notebooks/jobs
+- Azure Functions (for small-scale transforms)
+
+## Phase 6 — Gold Curation
+
+**Deliverables:**
+- Gold marts for each domain:
+  - `finance/` — budget vs. actual, variance, period close status
+  - `projects/` — portfolio health, resource utilization, timeline
+  - `compliance/` — BIR filing status, deadline adherence
+  - `platform/` — user activity, event aggregates, feature adoption
+  - `ml_features/` — feature tables for Azure AI scoring
+- Tableau Cloud connector pointed at gold layer
+- BI dashboard validation against gold marts
+
+## Phase 7 — Reverse ETL (Bounded)
+
+**Deliverables:**
+- Reverse ETL pipeline for each approved flow
+- Writeback validation (field-level guards per REVERSE_ETL_GUARDRAILS.md)
+- Idempotency enforcement (dedup key check before write)
+- Dead-letter queue for failed writebacks
+- Evidence: writeback counts, target field audit, error logs
+
+**Initial approved flows:**
+1. ML scoring → Supabase `_risk_score` column
+2. Budget forecast → Odoo `x_forecast_*` analytic fields
+3. Dashboard summaries → Supabase materialized tables
+
+## Phase 8 — Deprecate Legacy Export Paths
+
+**Deliverables:**
+- Inventory existing Supabase exports/jobs that duplicate ADLS pipelines
+- Inventory existing Odoo data extraction scripts
+- Redirect consumers to ADLS gold layer
+- Deprecate and remove legacy duplicate paths
+- Evidence: consumer migration checklist
+
+---
+
+## Observability and Evidence
+
+| Artifact | Location | Content |
+|----------|----------|---------|
+| Run logs | `audit/run_logs/{flow_id}/{dt}/` | Execution status, duration, row counts |
+| Watermarks | `audit/watermarks/{entity}.json` | High-water mark per entity per source |
+| Schema drift | `audit/evidence/{flow_id}/schema_changes.json` | Detected schema changes |
+| Quarantine | `rejected/quarantine/{source}/{entity}/{dt}/` | Failed records + error metadata |
+| Lineage | `audit/lineage/{flow_id}.json` | Source → bronze → silver → gold → reverse ETL chain |
+
+---
+
+## Open Decisions
+
+| Decision | Options | Recommendation | Status |
+|----------|---------|----------------|--------|
+| Databricks required? | Yes / No | Optional — introduce only for ML and complex transforms | Open |
+| Delta Lake format? | Mandatory / Optional | Optional for silver/gold — Parquet is sufficient baseline | Open |
+| Reverse ETL orchestrator | Azure Functions / Data Factory / Databricks jobs | Azure Functions for simplicity; Data Factory for complex flows | Open |
+| Supabase CDC mechanism | Realtime / logical replication / batch | Batch (incremental) for Phase 3; Realtime for Phase 8+ | Open |
+| Odoo extraction method | Extract API / JSON-2 API / DB replica | Extract API (primary); DB replica for initial historical load | Open |
+| ADLS region | `southeastasia` / other | `southeastasia` to co-locate with ACA | Open |

--- a/spec/adls-etl-reverse-etl/prd.md
+++ b/spec/adls-etl-reverse-etl/prd.md
@@ -1,0 +1,136 @@
+# PRD — ADLS ETL + Reverse ETL
+
+> Product requirements for the canonical data flow architecture between
+> Supabase (SSOT), Odoo (SoR), and Azure Data Lake Storage (ADLS Gen2).
+
+---
+
+## 1. Problem Statement
+
+The platform currently has:
+
+- **Supabase** as SSOT for control-plane data (208 tables, 59 functions,
+  pgvector, Auth, Realtime, Edge Functions)
+- **Odoo** as SoR for ERP operations (accounting, projects, BIR compliance,
+  HR, finance PPM)
+- No canonical analytical/lake storage layer
+- No structured ETL pipeline from either system to a shared analytical surface
+- No governed reverse ETL path for writing analytical outputs back to
+  operational systems
+
+This creates fragmented analytics, duplicate exports, and ungoverned
+data movement between systems.
+
+## 2. Objective
+
+Build a canonical ETL + reverse ETL architecture where:
+
+1. Supabase and Odoo data lands in ADLS (bronze → silver → gold)
+2. Analytical, ML, and BI workloads consume from ADLS gold layer
+3. Approved analytical outputs flow back to operational systems via
+   bounded, typed reverse ETL
+4. System authority boundaries are preserved at every stage
+
+## 3. Systems
+
+| System | Role | Key Data |
+|--------|------|----------|
+| Supabase (`spdtwktxdalcfigzeqrz`) | SSOT — control plane | Users, platform events, workflow state, app metadata, vector embeddings, Edge Function state |
+| Odoo CE 19 (`ipai-odoo-dev-web`) | SoR — ERP operations | Journal entries, invoices, projects, tasks, BIR tax filings, employees, vendors, analytic accounts |
+| ADLS Gen2 | Analytical lake | Replicated bronze/silver/gold datasets, ML features, BI marts, reverse ETL staging |
+| Azure AI Foundry | ML/AI compute | Model training, scoring, embedding generation |
+| Tableau Cloud | BI presentation | Dashboards consuming ADLS gold layer |
+
+## 4. Data Flow Topology
+
+```
+Supabase (SSOT)                    Odoo (SoR)
+    │                                  │
+    │ ETL (CDC or batch)               │ ETL (Extract API or DB replica)
+    ▼                                  ▼
+┌──────────────────────────────────────────────┐
+│              ADLS Gen2                        │
+│                                              │
+│  raw/bronze    ← append-only landing         │
+│  standardized/silver  ← normalized, typed    │
+│  curated/gold  ← business-ready marts        │
+│  reverse_etl_exports  ← approved writebacks  │
+│  rejected/quarantine  ← failed records       │
+│  audit/evidence  ← run logs, lineage         │
+│                                              │
+│         ┌──────────┐                         │
+│         │ Compute  │ (Databricks optional)   │
+│         │ Azure AI │ (scoring, embeddings)   │
+│         └──────────┘                         │
+└──────────────────────────────────────────────┘
+    │                    │                │
+    │ BI consumption     │ ML outputs     │ Reverse ETL
+    ▼                    ▼                ▼
+Tableau Cloud     Azure AI Foundry    Supabase / Odoo
+                                      (bounded writebacks)
+```
+
+## 5. ETL Flows (Inbound to ADLS)
+
+### 5.1 Supabase → ADLS Bronze
+
+| Object Category | Examples | Extraction Method | Cadence |
+|-----------------|----------|-------------------|---------|
+| App events | `platform_events`, `task_queue` | Realtime CDC or batch export | Hourly or event-driven |
+| User/identity | `auth.users`, profiles | Incremental batch | Daily |
+| Platform metadata | Edge Function state, config | Full snapshot | Daily |
+| Vector embeddings | pgvector tables | Incremental batch | Daily |
+| Workflow state | n8n job records, sync state | Incremental batch | Hourly |
+
+### 5.2 Odoo → ADLS Bronze
+
+| Object Category | Examples | Extraction Method | Cadence |
+|-----------------|----------|-------------------|---------|
+| Journal entries | `account.move`, `account.move.line` | Extract API | Daily |
+| Invoices | `account.move` (type=invoice) | Extract API | Daily |
+| Projects/tasks | `project.project`, `project.task` | Extract API | Daily |
+| BIR filings | `bir.tax.return`, schedules | Extract API | Weekly |
+| Employees | `hr.employee`, `res.partner` | Extract API | Daily |
+| Vendors | `res.partner` (supplier=True) | Extract API | Daily |
+| Analytic accounts | `account.analytic.account` | Extract API | Daily |
+| Expense documents | `hr.expense`, `hr.expense.sheet` | Extract API | Daily |
+
+## 6. Reverse ETL Flows (Outbound from ADLS)
+
+### 6.1 Approved Writeback Targets
+
+| Flow | Type | Target | Data | Guard |
+|------|------|--------|------|-------|
+| Customer segmentation | `scoring_writeback` | Supabase | Segment flags on user profiles | Write to `_segment` column only |
+| Anomaly alerts | `notification_trigger` | Slack / n8n | Alert payload | No data mutation |
+| Budget forecast | `enrichment_writeback` | Odoo | Forecast fields on analytic accounts | Write to `x_forecast_*` fields only |
+| ML risk scores | `scoring_writeback` | Supabase | Risk score on operational records | Write to `_risk_score` column only |
+| Draft expense import | `draft_record_creation` | Odoo | Expense documents from Concur/ADLS | Draft state only, requires approval |
+| Materialized summaries | `read_model_refresh` | Supabase | Pre-computed dashboard aggregates | Overwrite designated materialized tables |
+
+### 6.2 Prohibited Writebacks
+
+- Direct overwrite of Odoo posted journal entries
+- Direct overwrite of Supabase SSOT control tables
+- Mutation of Odoo `account.move` in posted state
+- Mutation of Supabase `auth.users` core fields
+- Any writeback without an entry in `REVERSE_ETL_GUARDRAILS.md`
+
+## 7. Non-Goals
+
+- Replacing Supabase as SSOT for platform data
+- Replacing Odoo as SoR for ERP data
+- Making ADLS an operational data store
+- Uncontrolled bidirectional sync between any systems
+- Mandating Databricks for all compute (ADLS-first, tool-agnostic)
+- Real-time streaming for analytical workloads (batch is sufficient)
+
+## 8. Success Criteria
+
+1. Supabase and Odoo data lands in ADLS bronze within defined SLAs
+2. Silver and gold layers produce clean, typed, deduplicated datasets
+3. Reverse ETL flows are bounded, typed, and contract-governed
+4. No authority boundary violations (Supabase=SSOT, Odoo=SoR, ADLS=lake)
+5. Every flow has idempotency, failure handling, and evidence output
+6. Machine-readable SSOT artifact tracks all flows
+7. Phased migration from legacy export paths to ADLS-native

--- a/spec/adls-etl-reverse-etl/tasks.md
+++ b/spec/adls-etl-reverse-etl/tasks.md
@@ -1,0 +1,102 @@
+# Tasks — ADLS ETL + Reverse ETL
+
+> Task breakdown for the canonical data flow architecture.
+
+---
+
+## T1 — Spec and Contract
+
+- [x] **T1.1** Create spec bundle `spec/adls-etl-reverse-etl/`
+- [x] **T1.2** Create `docs/contracts/DATA_AUTHORITY_CONTRACT.md`
+- [x] **T1.3** Create `docs/contracts/REVERSE_ETL_GUARDRAILS.md`
+- [x] **T1.4** Create `ssot/integrations/adls-etl-reverse-etl.yaml`
+- [x] **T1.5** Create `docs/architecture/ADLS_ETL_REVERSE_ETL_ARCHITECTURE.md`
+- [ ] **T1.6** Register contracts in `docs/contracts/PLATFORM_CONTRACTS_INDEX.md`
+
+## T2 — ADLS Infrastructure
+
+- [ ] **T2.1** Provision ADLS Gen2 storage account (`adlsipaidev`)
+- [ ] **T2.2** Create container/filesystem structure (6 zones)
+- [ ] **T2.3** Configure storage RBAC (ETL-write, analytics-read, reverse-ETL-read)
+- [ ] **T2.4** Add ADLS credentials to Key Vault (`kv-ipai-dev`)
+- [ ] **T2.5** Configure managed identity for ETL compute → ADLS
+- [ ] **T2.6** Decide: Databricks workspace — provision or defer?
+- [ ] **T2.7** Decide: Delta Lake format — mandatory or optional?
+
+## T3 — Supabase → ADLS Bronze
+
+- [ ] **T3.1** Inventory Supabase tables for ETL (priority: auth.users, platform_events, ops.task_queue)
+- [ ] **T3.2** Select CDC mechanism (Realtime, logical replication, or batch)
+- [ ] **T3.3** Build bronze landing pipeline (Supabase → ADLS raw/)
+- [ ] **T3.4** Implement watermark tracking
+- [ ] **T3.5** Implement quarantine path for failed records
+- [ ] **T3.6** Add run logging and evidence output
+
+## T4 — Odoo → ADLS Bronze
+
+- [ ] **T4.1** Inventory Odoo models for ETL (priority: account.move, project.project, hr.employee)
+- [ ] **T4.2** Build Extract API client for bulk extraction
+- [ ] **T4.3** Build bronze landing pipeline (Odoo → ADLS raw/)
+- [ ] **T4.4** Implement watermark tracking (using `write_date`)
+- [ ] **T4.5** Implement quarantine path for failed records
+- [ ] **T4.6** Add run logging and evidence output
+- [ ] **T4.7** Decide: DB replica for initial historical load?
+
+## T5 — Silver Normalization
+
+- [ ] **T5.1** Build bronze → silver transforms (dedup, type casting, null handling)
+- [ ] **T5.2** Implement cross-source entity resolution (Supabase user ↔ Odoo employee)
+- [ ] **T5.3** Add schema validation (reject → quarantine)
+- [ ] **T5.4** Partition silver by date and source
+- [ ] **T5.5** Decide: compute runtime (Data Factory, Databricks, or Azure Functions)
+
+## T6 — Gold Curation
+
+- [ ] **T6.1** Build finance gold mart (budget, actuals, variance)
+- [ ] **T6.2** Build projects gold mart (portfolio, resource, timeline)
+- [ ] **T6.3** Build compliance gold mart (BIR filing status, deadlines)
+- [ ] **T6.4** Build platform gold mart (user activity, events)
+- [ ] **T6.5** Build ML feature tables for Azure AI
+- [ ] **T6.6** Connect Tableau Cloud to gold layer
+- [ ] **T6.7** Validate BI dashboards against gold marts
+
+## T7 — Reverse ETL
+
+- [ ] **T7.1** Build scoring writeback pipeline (ML scores → Supabase)
+- [ ] **T7.2** Build enrichment writeback pipeline (forecasts → Odoo analytic fields)
+- [ ] **T7.3** Build materialized summary refresh (aggregates → Supabase)
+- [ ] **T7.4** Implement field-level write guards per REVERSE_ETL_GUARDRAILS.md
+- [ ] **T7.5** Implement idempotency enforcement (dedup key check)
+- [ ] **T7.6** Implement dead-letter queue for failed writebacks
+- [ ] **T7.7** Add writeback evidence (counts, field audit, errors)
+- [ ] **T7.8** Decide: reverse ETL orchestrator (Azure Functions, Data Factory, Databricks)
+
+## T8 — Deprecate Legacy Paths
+
+- [ ] **T8.1** Inventory existing Supabase export jobs
+- [ ] **T8.2** Inventory existing Odoo extraction scripts
+- [ ] **T8.3** Redirect consumers to ADLS gold layer
+- [ ] **T8.4** Deprecate and remove legacy duplicate paths
+- [ ] **T8.5** Evidence: consumer migration checklist
+
+## T9 — Observability
+
+- [ ] **T9.1** Implement schema drift detection
+- [ ] **T9.2** Implement per-flow evidence artifacts
+- [ ] **T9.3** Build production validation checklist
+- [ ] **T9.4** Add alerting for pipeline failures
+- [ ] **T9.5** Add lineage tracking per flow
+
+---
+
+## Dependency Map
+
+```
+T1 (spec/contract) ──► T2 (ADLS infra)
+T2 ──► T3 (Supabase bronze) + T4 (Odoo bronze)
+T3 + T4 ──► T5 (silver)
+T5 ──► T6 (gold)
+T6 ──► T7 (reverse ETL)
+T7 ──► T8 (deprecate legacy)
+T2–T8 ──► T9 (observability — runs in parallel from T3 onward)
+```

--- a/ssot/integrations/adls-etl-reverse-etl.yaml
+++ b/ssot/integrations/adls-etl-reverse-etl.yaml
@@ -1,0 +1,257 @@
+# ADLS ETL + Reverse ETL — Integration SSOT
+# Spec: spec/adls-etl-reverse-etl/
+# Contracts: docs/contracts/DATA_AUTHORITY_CONTRACT.md
+#            docs/contracts/REVERSE_ETL_GUARDRAILS.md
+
+version: "1.0"
+schema: ssot.integrations.v1
+updated_at: "2026-03-13"
+
+systems:
+  supabase:
+    role: ssot
+    instance: spdtwktxdalcfigzeqrz
+    owns: "Platform/control-plane entities, metadata, workflow state, vector embeddings, agent memory"
+
+  odoo:
+    role: system_of_record
+    instance: ipai-odoo-dev-web
+    runtime: azure_container_apps
+    owns: "ERP entities — accounting, invoicing, projects, tasks, BIR filings, employees, vendors"
+
+  adls:
+    role: analytical_lake
+    account: adlsipaidev  # pending provisioning
+    region: southeastasia
+    owns: "Nothing operational. Replicated bronze/silver/gold datasets, ML features, BI marts only."
+
+  azure_ai_foundry:
+    role: compute_only
+    instance: aifoundry-ipai-dev
+    owns: "No data ownership. Model training and scoring compute."
+
+authority_matrix:
+  - entity: auth.users
+    authoritative_system: supabase
+    adls_layers: [bronze, silver, gold]
+    reverse_etl_allowed: true
+    reverse_etl_mode: scoring_writeback
+    reverse_etl_columns: ["_segment", "_risk_score"]
+
+  - entity: platform_events
+    authoritative_system: supabase
+    adls_layers: [bronze, silver]
+    reverse_etl_allowed: false
+
+  - entity: ops.task_queue
+    authoritative_system: supabase
+    adls_layers: [bronze, silver]
+    reverse_etl_allowed: false
+
+  - entity: account.move
+    authoritative_system: odoo
+    adls_layers: [bronze, silver, gold]
+    reverse_etl_allowed: false
+    note: "Posted entries are immutable. Never writable from external systems."
+
+  - entity: project.project
+    authoritative_system: odoo
+    adls_layers: [bronze, silver, gold]
+    reverse_etl_allowed: true
+    reverse_etl_mode: enrichment_writeback
+    reverse_etl_columns: ["x_forecast_amount", "x_forecast_date"]
+
+  - entity: project.task
+    authoritative_system: odoo
+    adls_layers: [bronze, silver, gold]
+    reverse_etl_allowed: false
+
+  - entity: hr.employee
+    authoritative_system: odoo
+    adls_layers: [bronze, silver, gold]
+    reverse_etl_allowed: false
+
+  - entity: res.partner
+    authoritative_system: odoo
+    adls_layers: [bronze, silver, gold]
+    reverse_etl_allowed: false
+
+  - entity: account.analytic.account
+    authoritative_system: odoo
+    adls_layers: [bronze, silver, gold]
+    reverse_etl_allowed: true
+    reverse_etl_mode: enrichment_writeback
+    reverse_etl_columns: ["x_forecast_amount", "x_forecast_date", "x_forecast_confidence"]
+
+  - entity: bir.tax.return
+    authoritative_system: odoo
+    adls_layers: [bronze, silver]
+    reverse_etl_allowed: false
+
+  - entity: hr.expense
+    authoritative_system: odoo
+    adls_layers: [bronze, silver, gold]
+    reverse_etl_allowed: true
+    reverse_etl_mode: draft_record_creation
+
+flows:
+  # --- ETL: Supabase → ADLS ---
+  - id: supabase_users_to_adls
+    direction: etl
+    type: master_data_sync
+    source: supabase
+    target: adls
+    source_table: auth.users
+    target_path: raw/supabase/auth_users/
+    cadence: daily
+    extraction_method: incremental_batch
+    watermark_field: updated_at
+    idempotency_key: user_id
+    evidence_ref: audit/run_logs/supabase_users_to_adls/
+    status: planned
+
+  - id: supabase_events_to_adls
+    direction: etl
+    type: event_ingestion
+    source: supabase
+    target: adls
+    source_table: platform_events
+    target_path: raw/supabase/platform_events/
+    cadence: hourly
+    extraction_method: incremental_batch
+    watermark_field: created_at
+    idempotency_key: event_id
+    evidence_ref: audit/run_logs/supabase_events_to_adls/
+    status: planned
+
+  # --- ETL: Odoo → ADLS ---
+  - id: odoo_journal_entries_to_adls
+    direction: etl
+    type: document_exchange
+    source: odoo
+    target: adls
+    source_model: account.move
+    target_path: raw/odoo/account_move/
+    cadence: daily
+    extraction_method: extract_api
+    watermark_field: write_date
+    idempotency_key: id
+    evidence_ref: audit/run_logs/odoo_journal_entries_to_adls/
+    status: planned
+
+  - id: odoo_projects_to_adls
+    direction: etl
+    type: master_data_sync
+    source: odoo
+    target: adls
+    source_model: project.project
+    target_path: raw/odoo/project_project/
+    cadence: daily
+    extraction_method: extract_api
+    watermark_field: write_date
+    idempotency_key: id
+    evidence_ref: audit/run_logs/odoo_projects_to_adls/
+    status: planned
+
+  - id: odoo_employees_to_adls
+    direction: etl
+    type: master_data_sync
+    source: odoo
+    target: adls
+    source_model: hr.employee
+    target_path: raw/odoo/hr_employee/
+    cadence: daily
+    extraction_method: extract_api
+    watermark_field: write_date
+    idempotency_key: id
+    evidence_ref: audit/run_logs/odoo_employees_to_adls/
+    status: planned
+
+  - id: odoo_bir_filings_to_adls
+    direction: etl
+    type: document_exchange
+    source: odoo
+    target: adls
+    source_model: bir.tax.return
+    target_path: raw/odoo/bir_tax_return/
+    cadence: weekly
+    extraction_method: extract_api
+    watermark_field: write_date
+    idempotency_key: id
+    evidence_ref: audit/run_logs/odoo_bir_filings_to_adls/
+    status: planned
+
+  # --- Reverse ETL: ADLS → Supabase ---
+  - id: ml_scores_to_supabase
+    direction: reverse_etl
+    type: scoring_writeback
+    source: adls
+    target: supabase
+    source_path: curated/ml_features/risk_scores/
+    target_table: user_profiles
+    target_columns: ["_risk_score"]
+    cadence: daily
+    idempotency_key: "user_id + model_version"
+    guard: "Write to _risk_score column only"
+    evidence_ref: audit/run_logs/ml_scores_to_supabase/
+    status: planned
+
+  - id: dashboard_refresh_supabase
+    direction: reverse_etl
+    type: read_model_refresh
+    source: adls
+    target: supabase
+    source_path: curated/platform/dashboard_summaries/
+    target_table: materialized_dashboard
+    cadence: daily
+    idempotency_key: "table_name + refresh_timestamp"
+    guard: "Full table replace on designated materialized tables"
+    evidence_ref: audit/run_logs/dashboard_refresh_supabase/
+    status: planned
+
+  # --- Reverse ETL: ADLS → Odoo ---
+  - id: forecast_to_odoo_analytic
+    direction: reverse_etl
+    type: enrichment_writeback
+    source: adls
+    target: odoo
+    source_path: curated/finance/budget_forecasts/
+    target_model: account.analytic.account
+    target_fields: ["x_forecast_amount", "x_forecast_date", "x_forecast_confidence"]
+    cadence: weekly
+    idempotency_key: "analytic_account_id + forecast_period"
+    guard: "Write to x_forecast_* fields only. Core fields immutable."
+    api_method: json2_api
+    evidence_ref: audit/run_logs/forecast_to_odoo_analytic/
+    status: planned
+
+open_decisions:
+  - id: databricks_required
+    question: "Is Databricks required for silver/gold transforms and ML?"
+    options: ["Yes — provision workspace", "No — use Data Factory + Azure Functions"]
+    recommendation: "Optional. Introduce only for ML and complex transforms."
+    status: open
+
+  - id: delta_lake_format
+    question: "Is Delta Lake format mandatory for ADLS?"
+    options: ["Mandatory for silver/gold", "Optional — Parquet baseline"]
+    recommendation: "Optional. Parquet is sufficient baseline."
+    status: open
+
+  - id: reverse_etl_orchestrator
+    question: "Which orchestrator for reverse ETL?"
+    options: ["Azure Functions", "Data Factory", "Databricks jobs"]
+    recommendation: "Azure Functions for simplicity; Data Factory for complex flows."
+    status: open
+
+  - id: supabase_cdc_mechanism
+    question: "How to extract data from Supabase?"
+    options: ["Realtime CDC", "Logical replication", "Incremental batch export"]
+    recommendation: "Incremental batch for initial phases; Realtime for event-driven later."
+    status: open
+
+  - id: odoo_extraction_method
+    question: "How to extract data from Odoo?"
+    options: ["Extract API", "JSON-2 API", "DB replica"]
+    recommendation: "Extract API primary; DB replica for initial historical load."
+    status: open


### PR DESCRIPTION
## Summary
- Canonical data flow architecture: Supabase (SSOT) + Odoo (SoR) → ADLS Gen2 (analytical lake) → bounded reverse ETL
- Spec bundle (constitution, PRD, plan, tasks) with 10 immutable rules and 9 task groups (~45 tasks)
- Data authority contract defining entity-level ownership for 17 entities across 3 systems
- Reverse ETL guardrails: 5 classified writeback types, prohibited writebacks, idempotency requirements
- SSOT YAML with 9 flows (6 ETL inbound + 3 reverse ETL outbound) and 5 open decisions

## Files
- `spec/adls-etl-reverse-etl/` — constitution, PRD, plan, tasks
- `docs/contracts/DATA_AUTHORITY_CONTRACT.md` — entity-level authority matrix
- `docs/contracts/REVERSE_ETL_GUARDRAILS.md` — approved/prohibited writebacks
- `ssot/integrations/adls-etl-reverse-etl.yaml` — machine-readable integration SSOT
- `docs/architecture/ADLS_ETL_REVERSE_ETL_ARCHITECTURE.md` — full architecture reference

## Test plan
- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Review authority matrix against existing Supabase/Odoo schemas
- [ ] Validate reverse ETL guardrails cover all current integration surfaces
- [ ] Cross-reference with SAP Joule/Concur spec for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)