### PR TITLE
feat(ai): consolidate AI capabilities into Microsoft Foundry gateway

### DIFF
--- a/addons/ipai/ipai_ai_channel_actions/__manifest__.py
+++ b/addons/ipai/ipai_ai_channel_actions/__manifest__.py
@@ -1,0 +1,28 @@
+{
+    "name": "IPAI AI Channel Actions",
+    "version": "19.0.1.0.0",
+    "summary": "Expose Odoo business actions to external channels via Odoo Copilot",
+    "description": """
+Odoo Copilot — Channel Actions
+===============================
+
+Thin adapter module that exposes existing Odoo business actions to external
+channels (Slack, Teams) via copilot tools. Uses Odoo's existing mail.activity
+system — does not create new approval state machines.
+
+Part of the Odoo Copilot stack (spec/odoo-copilot/).
+    """,
+    "author": "InsightPulse AI",
+    "website": "https://insightpulseai.com",
+    "category": "Productivity/AI",
+    "license": "LGPL-3",
+    "depends": ["base", "mail", "ipai_ai_copilot"],
+    "data": [
+        "security/ir.model.access.csv",
+    ],
+    "installable": False,
+    "application": False,
+    "auto_install": False,
+    # DEPRECATED: Replaced by Foundry livechat mode via ipai_odoo_copilot (2026-03-15)
+    # See: ssot/governance/ai-consolidation-foundry.yaml
+}

--- a/addons/ipai/ipai_ai_copilot/__manifest__.py
+++ b/addons/ipai/ipai_ai_copilot/__manifest__.py
@@ -1,0 +1,41 @@
+{
+    "name": "IPAI AI Copilot",
+    "version": "19.0.1.0.0",
+    "summary": "DEPRECATED — Legacy Gemini/Supabase AI copilot bridge (superseded by ipai_odoo_copilot)",
+    "description": """
+        DEPRECATED as of 2026-03-13 (C-30).
+        Superseded by ipai_odoo_copilot (Azure AI Foundry).
+
+        Kept installable only because ipai_workspace_core depends on it.
+        No new features, tools, or integrations should target this module.
+        See docs/contracts/COPILOT_RUNTIME_CONTRACT.md for migration path.
+
+        Original scope: Gemini function calling, Supabase RAG, n8n bridge.
+    """,
+    "author": "InsightPulse AI",
+    "website": "https://insightpulseai.com",
+    "category": "Productivity",
+    "depends": ["mail", "web", "base", "ipai_ai_widget", "ipai_ai_core"],  # no enterprise deps
+    "data": [
+        "security/ir.model.access.csv",
+        "data/res_partner_bot.xml",
+        "data/mail_channel_ai.xml",
+        "data/copilot_tools.xml",
+        "data/copilot_cron.xml",
+        "views/res_config_settings_views.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "ipai_ai_copilot/static/src/js/copilot_service.js",
+            "ipai_ai_copilot/static/src/js/copilot_sidebar.js",
+            "ipai_ai_copilot/static/src/js/copilot_palette.js",
+            "ipai_ai_copilot/static/src/xml/copilot_sidebar.xml",
+            "ipai_ai_copilot/static/src/xml/copilot_palette.xml",
+            "ipai_ai_copilot/static/src/css/copilot.css",
+        ],
+    },
+    "external_dependencies": {"python": ["requests"]},
+    "installable": False,  # DEPRECATED: All dependents migrated to ipai_odoo_copilot (2026-03-15)
+    "application": False,
+    "license": "LGPL-3",
+}

--- a/addons/ipai/ipai_ai_platform/__manifest__.py
+++ b/addons/ipai/ipai_ai_platform/__manifest__.py
@@ -1,0 +1,40 @@
+{
+    "name": "IPAI AI Platform",
+    "version": "19.0.1.0.0",
+    "category": "Technical",
+    "summary": "AI Platform HTTP Client for Supabase Edge Functions",
+    "description": """
+        AI Platform Integration Module
+        ==============================
+
+        Provides HTTP client for calling Supabase Edge Functions from Odoo backend.
+
+        Features:
+        - OpenAI API integration (fallback when Edge Functions unavailable)
+        - Configurable via system parameters
+        - Audit trail logging to cms_artifacts (if exists)
+        - Usage tracking for billing limits
+        - Multi-org context support
+
+        Configuration:
+        - ipai.supabase.url: Supabase project URL
+        - ipai.supabase.service_role_key: Service role key for backend calls
+        - ipai.org.id: Default organization UUID
+        - ipai.openai.api_key: OpenAI API key (fallback)
+
+        Phase 5A: SaaS Platform Kit - AI × Odoo Integration
+    """,
+    "author": "InsightPulseAI",
+    "website": "https://insightpulseai.com",
+    "license": "LGPL-3",
+    "depends": ["base"],
+    "data": [
+        "security/ir.model.access.csv",
+        "data/config_parameters.xml",
+    ],
+    "installable": False,
+    "application": False,
+    "auto_install": False,
+    # DEPRECATED: Replaced by Foundry API via ipai_odoo_copilot (2026-03-15)
+    # See: ssot/governance/ai-consolidation-foundry.yaml
+}

--- a/addons/ipai/ipai_ai_widget/__manifest__.py
+++ b/addons/ipai/ipai_ai_widget/__manifest__.py
@@ -1,0 +1,36 @@
+# © 2026 InsightPulse AI
+# License LGPL-3.0-or-later
+{
+    "name": "IPAI AI Widget",
+    "summary": "Ask AI widget for Odoo 19 CE — calls IPAI provider bridge (no IAP dependency)",
+    "version": "19.0.2.0.0",
+    "category": "Technical",
+    "author": "InsightPulse AI",
+    "website": "https://insightpulseai.com",
+    "license": "LGPL-3",
+    "depends": ["mail", "web"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/res_config_settings_views.xml",
+        "data/presets.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "ipai_ai_widget/static/src/xml/ask_ai_widget.xml",
+            "ipai_ai_widget/static/src/xml/composer_ai_templates.xml",
+            "ipai_ai_widget/static/src/xml/composer_ai_patch.xml",
+            "ipai_ai_widget/static/src/js/ask_ai_widget.js",
+            "ipai_ai_widget/static/src/js/ai_inline_panel.js",
+            "ipai_ai_widget/static/src/js/preset_chips.js",
+            "ipai_ai_widget/static/src/js/composer_ai_action.js",
+            "ipai_ai_widget/static/src/js/composer_ai_patch.js",
+            "ipai_ai_widget/static/src/scss/ai_composer.scss",
+        ],
+    },
+    "installable": False,
+    "auto_install": False,
+    "application": False,
+    # DEPRECATED: Replaced by Foundry ask mode via ipai_odoo_copilot (2026-03-15)
+    # See: ssot/governance/ai-consolidation-foundry.yaml
+    "external_dependencies": {"python": ["requests"]},
+}

--- a/addons/ipai/ipai_ask_ai_azure/__manifest__.py
+++ b/addons/ipai/ipai_ask_ai_azure/__manifest__.py
@@ -1,0 +1,28 @@
+# (c) 2026 InsightPulse AI
+# License LGPL-3.0-or-later
+{
+    "name": "IPAI Ask AI (Azure OpenAI)",
+    "summary": "Systray Ask AI widget backed by Azure OpenAI — no IAP dependency",
+    "version": "19.0.1.0.0",
+    "category": "Technical",
+    "author": "InsightPulse AI",
+    "website": "https://insightpulseai.com",
+    "license": "LGPL-3",
+    "depends": ["web", "mail"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/res_config_settings_views.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "ipai_ask_ai_azure/static/src/scss/ask_ai_systray.scss",
+            "ipai_ask_ai_azure/static/src/xml/ask_ai_systray.xml",
+            "ipai_ask_ai_azure/static/src/js/ask_ai_systray.js",
+        ],
+    },
+    "installable": False,
+    "auto_install": False,
+    "application": False,
+    # DEPRECATED: Replaced by Foundry ask mode via ipai_odoo_copilot (2026-03-15)
+    # See: ssot/governance/ai-consolidation-foundry.yaml
+}

--- a/addons/ipai/ipai_llm_supabase_bridge/__manifest__.py
+++ b/addons/ipai/ipai_llm_supabase_bridge/__manifest__.py
@@ -1,0 +1,45 @@
+{
+    "name": "IPAI LLM Supabase Bridge",
+    "version": "19.0.1.0.0",
+    "category": "Technical",
+    "summary": "Bridge between Apexive odoo-llm and Supabase SSOT control plane",
+    "description": """
+Emits LLM tool calls, assistant threads, and generation events from Odoo (SOR)
+to Supabase (SSOT) via signed webhooks. Provides observability, audit trails,
+and governance integration for the InsightPulse AI platform.
+
+Key features:
+- Hook into llm_tool execution pipeline → emit events to Supabase ops.run_events
+- Log assistant thread lifecycle (create/message/complete) to ops.runs
+- Dead-letter queue for failed webhook deliveries with exponential backoff
+- Configurable webhook endpoint + HMAC signing
+- Cron-based retry for DLQ items
+- No write-back to Odoo-owned domains (respects SSOT/SOR doctrine)
+    """,
+    "author": "InsightPulse AI",
+    "website": "https://insightpulseai.com",
+    "license": "LGPL-3",
+    "depends": [
+        "base",
+        "mail",
+        "llm",            # Apexive core
+        "llm_tool",       # Apexive tool framework
+        "llm_assistant",  # Apexive assistants
+        "llm_thread",     # Apexive chat threads
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "security/ipai_llm_supabase_bridge_groups.xml",
+        "data/ipai_llm_supabase_bridge_data.xml",
+        "views/ipai_bridge_event_views.xml",
+        "views/ipai_bridge_config_views.xml",
+    ],
+    "external_dependencies": {
+        "python": ["requests"],
+    },
+    "installable": False,
+    "auto_install": False,
+    "application": False,
+    # DEPRECATED: Foundry is the single LLM gateway (2026-03-15)
+    # See: ssot/governance/ai-consolidation-foundry.yaml
+}

--- a/addons/ipai/ipai_workspace_core/__manifest__.py
+++ b/addons/ipai/ipai_workspace_core/__manifest__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) InsightPulse AI
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+{
+    "name": "IPAI Workspace Core",
+    "version": "19.0.2.0.0",
+    "category": "Productivity",
+    "summary": "Notion-like collaborative workspace with ERP data integration",
+    "author": "InsightPulse AI",
+    "website": "https://insightpulseai.com",
+    "license": "LGPL-3",
+    "depends": [
+        "base",
+        "mail",
+        "ipai_foundation",
+        "ipai_odoo_copilot",  # Foundry gateway (replaces ipai_ai_copilot)
+    ],
+    "data": [
+        "security/security.xml",
+        "security/ir.model.access.csv",
+        "views/workspace_views.xml",
+        "views/workspace_page_views.xml",
+        "views/workspace_saved_query_views.xml",
+        "views/workspace_evidence_pack_views.xml",
+        "views/workspace_menus.xml",
+        "data/copilot_tools.xml",
+    ],
+    "installable": True,
+    "application": True,
+    "auto_install": False,
+}

--- a/docs/architecture/AI_CONSOLIDATION_FOUNDRY.md
+++ b/docs/architecture/AI_CONSOLIDATION_FOUNDRY.md
@@ -1,0 +1,156 @@
+# AI Consolidation — Microsoft Foundry Gateway
+
+> One Foundry agent. One Odoo bridge module. Four capability modes.
+> SSOT: `ssot/governance/ai-consolidation-foundry.yaml`
+
+## Problem
+
+16 AI-related Odoo modules with overlapping capabilities, multiple inference backends (OpenAI direct, Azure OpenAI, Gemini, Supabase Edge Functions), and no unified gateway. This creates:
+
+- Inconsistent AI behavior across surfaces (Ask AI vs Copilot vs Channel Actions)
+- Multiple API key management paths
+- No centralized rate limiting, guardrails, or telemetry
+- Difficult to audit AI usage across the platform
+
+## Solution
+
+Consolidate all AI capabilities through **Microsoft Foundry** (`data-intel-ph` project) using the existing `ipai-odoo-copilot-azure` agent as the single entry point.
+
+## Architecture
+
+```
+                    ┌─────────────────────────────────┐
+                    │     Microsoft Foundry            │
+                    │     (data-intel-ph)              │
+                    │                                  │
+                    │  ipai-odoo-copilot-azure (v7)    │
+                    │  ┌─────────┬──────────────────┐  │
+                    │  │ Ask     │ search, read,    │  │
+                    │  │         │ knowledge        │  │
+                    │  ├─────────┼──────────────────┤  │
+                    │  │Author   │ draft creation   │  │
+                    │  ├─────────┼──────────────────┤  │
+                    │  │Livechat │ visitor Q&A      │  │
+                    │  ├─────────┼──────────────────┤  │
+                    │  │Transact │ bounded CRUD     │  │
+                    │  └─────────┴──────────────────┘  │
+                    │                                  │
+                    │  Model: gpt-4.1                  │
+                    │  Search: srch-ipai-dev            │
+                    │  Auth: Managed Identity           │
+                    └──────────────┬────────────────────┘
+                                  │
+                                  │ Azure AI Agent API
+                                  │
+                    ┌──────────────┴────────────────────┐
+                    │  Odoo CE 19                        │
+                    │                                    │
+                    │  ipai_odoo_copilot                 │
+                    │  (single bridge module)            │
+                    │  ├── FoundryService                │
+                    │  ├── ToolExecutor                  │
+                    │  ├── CopilotBot (mail.bot)         │
+                    │  └── App Insights telemetry        │
+                    │                                    │
+                    │  ipai_enterprise_bridge            │
+                    │  (Foundry provider config)         │
+                    └────────────────────────────────────┘
+```
+
+## Four Capability Modes
+
+| Mode | Purpose | Write Access | Replaces |
+|------|---------|-------------|----------|
+| **Ask** | Answer questions, search records, RAG retrieval | None (read-only) | `ipai_ai_widget`, `ipai_ask_ai_azure` |
+| **Authoring** | Draft documents, reports, emails | Draft only | `ipai_ai_copilot` (deprecated), `ipai_ai_prompts` |
+| **Livechat** | Website visitor Q&A via chat | None (read-only) | `ipai_ai_channel_actions`, `ipai_ai_livechat` |
+| **Transaction** | Bounded CRUD with approval gates | Whitelisted models | `ipai_ai_tools`, `ipai_ai_automations` |
+
+## Module Consolidation
+
+### Canonical (keep)
+
+| Module | Role |
+|--------|------|
+| `ipai_odoo_copilot` | Odoo-side bridge to Foundry (single entry point) |
+| `ipai_enterprise_bridge` | Foundry provider config + EE stubs |
+
+### Retained Infrastructure (keep, internal use)
+
+| Module | Role | Why Retained |
+|--------|------|-------------|
+| `ipai_ai_core` | Provider registry models | Internal model layer for bridge |
+| `ipai_ai_agent_builder` | Agent/topic/tool builder | Agent definitions sync to Foundry |
+| `ipai_ai_rag` | RAG pipeline | Feeds Foundry search index |
+| `ipai_agent_skills` | Skill registry | Skills consumed by Foundry instructions |
+
+### Deprecated by Foundry
+
+| Module | Replacement | Phase |
+|--------|-------------|-------|
+| `ipai_ai_widget` | Foundry ask mode | 2 |
+| `ipai_ask_ai_azure` | Foundry ask mode | 2 |
+| `ipai_ai_platform` | Foundry API | 2 |
+| `ipai_llm_supabase_bridge` | Foundry gateway | 2 |
+| `ipai_ai_oca_bridge` | Foundry gateway | 2 |
+| `ipai_ai_channel_actions` | Foundry livechat mode | 3 |
+| `ipai_ai_tools` | Foundry transaction mode | 3 |
+
+### Already Deprecated
+
+| Module | Status |
+|--------|--------|
+| `ipai_ai_copilot` | Superseded by `ipai_odoo_copilot` |
+| `ipai_copilot_ui` | Superseded by design system SDK |
+| `ipai_ai_livechat` | Migrated to enterprise bridge |
+| `ipai_ai_automations` | Migrated to enterprise bridge |
+| `ipai_ai_fields` | Retired |
+
+## Foundry Tools (Odoo-side)
+
+| Tool | Description | Write | Mode |
+|------|-------------|-------|------|
+| `search_records` | Search Odoo records by model + domain | No | All |
+| `read_record` | Read specific record by ID | No | All |
+| `search_knowledge` | Search RAG index | No | All |
+| `create_draft` | Create record in draft state | Yes (draft) | Authoring |
+| `create_record` | Create record | Yes (bounded) | Transaction |
+| `update_record` | Update record fields | Yes (bounded) | Transaction |
+| `execute_action` | Execute server action | Yes (approved) | Transaction |
+
+## Safety Controls
+
+- **Read-only by default**: write access requires explicit mode selection
+- **Audit all tool calls**: every Foundry tool invocation logged to App Insights
+- **Rate limiting**: 60 requests/minute per user
+- **PII redaction**: sensitive fields masked before sending to Foundry
+- **Model allowlist**: only `gpt-4.1` and `gpt-4.1-mini`
+- **No direct LLM calls**: all inference routes through Foundry — no OpenAI/Gemini/Supabase bypass
+
+## Migration Phases
+
+| Phase | Scope | Status |
+|-------|-------|--------|
+| 1 | Foundry ask + authoring modes active | **Active** |
+| 2 | Deprecate direct-call AI modules (5 modules) | Planned |
+| 3 | Livechat + transaction modes verified | Planned |
+| 4 | Set `installable=False` on all deprecated modules | Planned |
+
+## Foundry Coordinates
+
+| Setting | Value |
+|---------|-------|
+| Resource | `data-intel-ph-resource.services.ai.azure.com` |
+| Project | `data-intel-ph` |
+| Agent | `ipai-odoo-copilot-azure` |
+| Model | `gpt-4.1` |
+| API Version | `2024-12-01-preview` |
+| Search | `srch-ipai-dev` |
+| Auth | Managed Identity (primary), API Key (fallback) |
+| Secrets | Azure Key Vault (`kv-ipai-dev`) |
+
+---
+
+*SSOT: `ssot/governance/ai-consolidation-foundry.yaml`*
+*Agent policy: `infra/ssot/agents/prod_policy.yaml`*
+*Last updated: 2026-03-15*

--- a/infra/ssot/agents/prod_policy.yaml
+++ b/infra/ssot/agents/prod_policy.yaml
@@ -108,6 +108,26 @@ agents:
       - send_slack_notification
     forbidden_paths: []
 
+  foundry_copilot:
+    # Microsoft Foundry copilot agent (ipai-odoo-copilot-azure)
+    # Single AI gateway for all Odoo AI capabilities
+    # Modes: ask (read-only), authoring (draft), livechat (read-only), transaction (bounded)
+    default_mode: read_only
+    allowed_kinds:
+      - read_ops_tables
+      - read_odoo_records       # search_records, read_record tools
+      - read_knowledge_index    # search_knowledge tool (srch-ipai-dev)
+      - write_draft_records     # create_draft tool (authoring mode only)
+      - write_ops_runs          # audit trail for all AI interactions
+    forbidden_actions:
+      - direct_sql_ddl
+      - drop_database_table
+      - push_to_main_branch
+      - access_vault_secrets
+    rate_limit: "60/min per user"
+    telemetry: azure_app_insights
+    reference: ssot/governance/ai-consolidation-foundry.yaml
+
 # ── Evidence requirements ─────────────────────────────────────────────────────
 evidence:
   # Every agent run MUST write a row before starting any side effects

--- a/ssot/governance/ai-consolidation-foundry.yaml
+++ b/ssot/governance/ai-consolidation-foundry.yaml
@@ -1,0 +1,277 @@
+# AI Capability Consolidation — Microsoft Foundry Gateway
+# All AI capabilities route through a single Foundry agent.
+# Human doc: docs/architecture/AI_CONSOLIDATION_FOUNDRY.md
+
+version: "1.0"
+schema: ssot.governance.ai-consolidation-foundry.v1
+updated_at: "2026-03-15"
+
+# ---------------------------------------------------------------------------
+# Foundry Coordinates
+# ---------------------------------------------------------------------------
+foundry:
+  resource: data-intel-ph-resource.services.ai.azure.com
+  project: data-intel-ph
+  agent: ipai-odoo-copilot-azure
+  agent_versions: 7
+  agent_type: prompt
+  model_deployment: gpt-4.1
+  api_version: "2024-12-01-preview"
+  search_service: srch-ipai-dev
+  auth:
+    primary: managed_identity
+    fallback: api_key
+    source: azure_key_vault
+
+# ---------------------------------------------------------------------------
+# Consolidation Doctrine
+# ---------------------------------------------------------------------------
+doctrine: >
+  One Foundry agent. One Odoo bridge module. Four capability modes.
+  All AI surface area routes through Microsoft Foundry as the single
+  inference gateway. No direct OpenAI, Gemini, or Supabase LLM calls
+  from Odoo modules. The Foundry agent is the only AI endpoint.
+
+# ---------------------------------------------------------------------------
+# Capability Modes (single agent, multiple modes)
+# ---------------------------------------------------------------------------
+capability_modes:
+  ask:
+    description: "Answer questions using RAG retrieval, no side effects"
+    replaces:
+      - ipai_ai_widget
+      - ipai_ask_ai_azure
+      - ipai_ai_core (provider routing)
+    write_access: none
+    foundry_tools:
+      - search_records
+      - read_record
+      - search_knowledge
+    status: active
+
+  authoring:
+    description: "Draft documents, reports, emails — write to draft only"
+    replaces:
+      - ipai_ai_copilot (deprecated Gemini/Supabase)
+      - ipai_ai_prompts (prompt registry)
+    write_access: draft_only
+    foundry_tools:
+      - search_records
+      - read_record
+      - create_draft
+      - search_knowledge
+    status: active
+
+  livechat:
+    description: "Handle website visitor questions via chat"
+    replaces:
+      - ipai_ai_channel_actions
+      - ipai_ai_livechat (deprecated)
+    write_access: none
+    foundry_tools:
+      - search_records
+      - read_record
+      - search_knowledge
+    status: active
+
+  transaction:
+    description: "Assist with bounded CRUD operations (draft → approve)"
+    replaces:
+      - ipai_ai_tools (CRM/Calendar/Sale)
+      - ipai_ai_automations (deprecated)
+    write_access: bounded_crud
+    foundry_tools:
+      - search_records
+      - read_record
+      - create_record
+      - update_record
+      - execute_action
+    status: planned
+    gate: "Requires explicit approval per model/action"
+
+# ---------------------------------------------------------------------------
+# Module Consolidation Map
+# ---------------------------------------------------------------------------
+module_map:
+  canonical:
+    - module: ipai_odoo_copilot
+      role: "Odoo-side bridge to Foundry (single entry point)"
+      status: active
+      foundry_integrated: true
+
+    - module: ipai_enterprise_bridge
+      role: "Foundry provider config + EE stub redirections"
+      status: active
+      foundry_integrated: true
+
+  retained_infrastructure:
+    - module: ipai_ai_core
+      role: "Provider registry model (used by bridge, not directly by users)"
+      status: retained
+      note: "Kept as internal model layer; all user-facing AI routes through Foundry"
+
+    - module: ipai_ai_agent_builder
+      role: "Agent/topic/tool builder (Odoo 19 parity)"
+      status: retained
+      note: "Agent definitions sync to Foundry; builder UI stays in Odoo"
+
+    - module: ipai_ai_rag
+      role: "RAG pipeline for knowledge indexing"
+      status: retained
+      note: "Feeds Foundry search index (srch-ipai-dev)"
+
+    - module: ipai_agent_skills
+      role: "Skill registry for agent capabilities"
+      status: retained
+      note: "Skill definitions consumed by Foundry agent instructions"
+
+  deprecated_by_foundry:
+    - module: ipai_ai_widget
+      replacement: "Foundry ask mode via ipai_odoo_copilot"
+      status: deprecated
+      action: "Set installable=False, add deprecation notice"
+
+    - module: ipai_ask_ai_azure
+      replacement: "Foundry ask mode via ipai_odoo_copilot"
+      status: deprecated
+      action: "Set installable=False, add deprecation notice"
+
+    - module: ipai_ai_copilot
+      replacement: "Foundry authoring mode via ipai_odoo_copilot"
+      status: already_deprecated
+      note: "Already superseded; kept installable only for ipai_workspace_core dep"
+
+    - module: ipai_ai_channel_actions
+      replacement: "Foundry livechat mode via ipai_odoo_copilot"
+      status: deprecated
+      action: "Set installable=False after livechat mode verified"
+
+    - module: ipai_ai_tools
+      replacement: "Foundry transaction mode via ipai_odoo_copilot"
+      status: deprecated
+      action: "Set installable=False after transaction mode verified"
+
+    - module: ipai_ai_platform
+      replacement: "Foundry API replaces Supabase Edge Function calls"
+      status: deprecated
+      action: "Set installable=False"
+
+    - module: ipai_llm_supabase_bridge
+      replacement: "Foundry is the single LLM gateway"
+      status: deprecated
+      action: "Set installable=False"
+
+    - module: ipai_ai_oca_bridge
+      replacement: "Foundry replaces OCA AI provider routing"
+      status: deprecated
+      action: "Set installable=False"
+
+    - module: ipai_copilot_ui
+      replacement: "ipai_design_system_apps_sdk"
+      status: already_deprecated
+
+    - module: ipai_ai_livechat
+      replacement: "ipai_enterprise_bridge"
+      status: already_deprecated
+
+    - module: ipai_ai_automations
+      replacement: "ipai_enterprise_bridge"
+      status: already_deprecated
+
+    - module: ipai_ai_fields
+      replacement: "N/A"
+      status: already_deprecated
+
+# ---------------------------------------------------------------------------
+# Foundry Tools (Odoo-side executors)
+# ---------------------------------------------------------------------------
+foundry_tools:
+  read_only:
+    - id: search_records
+      description: "Search Odoo records by model + domain"
+      odoo_method: "env[model].search_read(domain, fields, limit)"
+      write: false
+
+    - id: read_record
+      description: "Read specific record by ID"
+      odoo_method: "env[model].browse(id).read(fields)"
+      write: false
+
+    - id: search_knowledge
+      description: "Search knowledge base / RAG index"
+      odoo_method: "Foundry search index (srch-ipai-dev)"
+      write: false
+
+  write_bounded:
+    - id: create_draft
+      description: "Create record in draft state only"
+      odoo_method: "env[model].create(vals)"
+      write: true
+      constraint: "state must be 'draft'"
+
+    - id: create_record
+      description: "Create record (transaction mode only)"
+      odoo_method: "env[model].create(vals)"
+      write: true
+      constraint: "allowed_models whitelist"
+
+    - id: update_record
+      description: "Update record fields (transaction mode only)"
+      odoo_method: "env[model].browse(id).write(vals)"
+      write: true
+      constraint: "allowed_models + allowed_fields whitelist"
+
+    - id: execute_action
+      description: "Execute server action (transaction mode only)"
+      odoo_method: "env[model].browse(id).action_*()"
+      write: true
+      constraint: "allowed_actions whitelist + approval gate"
+
+# ---------------------------------------------------------------------------
+# Safety Controls
+# ---------------------------------------------------------------------------
+safety:
+  read_only_default: true
+  write_requires_approval: true
+  audit_all_tool_calls: true
+  telemetry: azure_app_insights
+  rate_limit: "60 requests/minute per user"
+  max_tokens_per_request: 4096
+  pii_redaction: true
+  model_allowlist:
+    - gpt-4.1
+    - gpt-4.1-mini
+
+# ---------------------------------------------------------------------------
+# Migration Path
+# ---------------------------------------------------------------------------
+migration:
+  phase_1:
+    name: "Foundry ask + authoring modes"
+    status: active
+    modules_deprecated: []
+    note: "ipai_odoo_copilot already handles ask + authoring"
+
+  phase_2:
+    name: "Deprecate direct-call AI modules"
+    status: planned
+    modules_deprecated:
+      - ipai_ai_widget
+      - ipai_ask_ai_azure
+      - ipai_ai_platform
+      - ipai_llm_supabase_bridge
+      - ipai_ai_oca_bridge
+    prerequisite: "Verify all Ask AI use cases work through Foundry"
+
+  phase_3:
+    name: "Livechat + transaction modes"
+    status: planned
+    modules_deprecated:
+      - ipai_ai_channel_actions
+      - ipai_ai_tools
+    prerequisite: "Foundry livechat and transaction modes verified in staging"
+
+  phase_4:
+    name: "Cleanup deprecated modules"
+    status: planned
+    action: "Set installable=False on all deprecated modules, update dependency chain"


### PR DESCRIPTION
## Summary

- Consolidates 16 fragmented AI modules into single Microsoft Foundry gateway
- Single agent: `ipai-odoo-copilot-azure` (v7) on `data-intel-ph` project
- Single bridge module: `ipai_odoo_copilot` routes all AI requests through Foundry
- Four capability modes: Ask (read-only), Authoring (draft), Livechat (read-only), Transaction (planned)

## Module Changes

**Deprecated (installable=False):**
| Module | Replaced By |
|--------|-------------|
| `ipai_ai_widget` | Foundry ask mode |
| `ipai_ask_ai_azure` | Foundry ask mode |
| `ipai_ai_platform` | Foundry API |
| `ipai_llm_supabase_bridge` | Foundry gateway |
| `ipai_ai_channel_actions` | Foundry livechat mode |
| `ipai_ai_copilot` | `ipai_odoo_copilot` (already superseded) |

**Dependency migration:**
- `ipai_workspace_core`: `ipai_ai_copilot` → `ipai_odoo_copilot`

**Retained (infrastructure):**
- `ipai_ai_core`, `ipai_ai_agent_builder`, `ipai_ai_rag`, `ipai_agent_skills`

## New Files

- `ssot/governance/ai-consolidation-foundry.yaml` — machine-readable consolidation SSOT
- `docs/architecture/AI_CONSOLIDATION_FOUNDRY.md` — architecture doc
- `foundry_copilot` agent entry in `infra/ssot/agents/prod_policy.yaml`

## Test plan

- [ ] `ipai_odoo_copilot` remains installable
- [ ] `ipai_workspace_core` installs with new `ipai_odoo_copilot` dependency
- [ ] No circular dependency introduced
- [ ] Deprecated modules are `installable: False`
- [ ] Foundry agent coordinates match `data-intel-ph` project

🤖 Generated with [Claude Code](https://claude.com/claude-code)