### PR TITLE
feat(ai): align AI consolidation with Microsoft Foundry rebrand + v2 capabilities

### DIFF
--- a/docs/architecture/AI_CONSOLIDATION_FOUNDRY.md
+++ b/docs/architecture/AI_CONSOLIDATION_FOUNDRY.md
@@ -1,7 +1,11 @@
 # AI Consolidation — Microsoft Foundry Gateway
 
-> One Foundry agent. One Odoo bridge module. Four capability modes.
+> One Foundry agent. One Odoo bridge module. Five capability modes.
 > SSOT: `ssot/governance/ai-consolidation-foundry.yaml`
+>
+> **Rebrand**: Azure AI Studio → Azure AI Foundry → **Microsoft Foundry** (2025-11)
+> **API**: Assistants API → **Responses API (Agents v2)**
+> **SDK**: Multiple packages → **`azure-ai-projects` 2.x + `OpenAI()`**
 
 ## Problem
 
@@ -19,52 +23,100 @@ Consolidate all AI capabilities through **Microsoft Foundry** (`data-intel-ph` p
 ## Architecture
 
 ```
-                    ┌─────────────────────────────────┐
-                    │     Microsoft Foundry            │
-                    │     (data-intel-ph)              │
-                    │                                  │
-                    │  ipai-odoo-copilot-azure (v7)    │
-                    │  ┌─────────┬──────────────────┐  │
-                    │  │ Ask     │ search, read,    │  │
-                    │  │         │ knowledge        │  │
-                    │  ├─────────┼──────────────────┤  │
-                    │  │Author   │ draft creation   │  │
-                    │  ├─────────┼──────────────────┤  │
-                    │  │Livechat │ visitor Q&A      │  │
-                    │  ├─────────┼──────────────────┤  │
-                    │  │Transact │ bounded CRUD     │  │
-                    │  └─────────┴──────────────────┘  │
-                    │                                  │
-                    │  Model: gpt-4.1                  │
-                    │  Search: srch-ipai-dev            │
-                    │  Auth: Managed Identity           │
-                    └──────────────┬────────────────────┘
+                    ┌─────────────────────────────────────┐
+                    │     Microsoft Foundry                │
+                    │     (data-intel-ph)                  │
+                    │                                      │
+                    │  ipai-odoo-copilot-azure (v7)        │
+                    │  ┌──────────┬───────────────────┐    │
+                    │  │ Ask      │ search, read, RAG │    │
+                    │  ├──────────┼───────────────────┤    │
+                    │  │ Author   │ draft creation    │    │
+                    │  ├──────────┼───────────────────┤    │
+                    │  │ Livechat │ visitor Q&A       │    │
+                    │  ├──────────┼───────────────────┤    │
+                    │  │ Transact │ bounded CRUD      │    │
+                    │  ├──────────┼───────────────────┤    │
+                    │  │ Creative │ image gen, copy   │    │
+                    │  └──────────┴───────────────────┘    │
+                    │                                      │
+                    │  ┌── Platform ────────────────────┐  │
+                    │  │ Tool Catalog (1,400+ tools)    │  │
+                    │  │ Memory (user_profile + chat)   │  │
+                    │  │ Workflows (multi-agent)        │  │
+                    │  │ MCP / OpenAPI / A2A connectors │  │
+                    │  └───────────────────────────────┘  │
+                    │                                      │
+                    │  Model: gpt-4.1                      │
+                    │  API: Responses API (Agents v2)      │
+                    │  SDK: azure-ai-projects 2.x          │
+                    │  Search: srch-ipai-dev                │
+                    │  Auth: Managed Identity               │
+                    └──────────────┬────────────────────────┘
                                   │
-                                  │ Azure AI Agent API
+                                  │ Responses API (/openai/v1/)
                                   │
-                    ┌──────────────┴────────────────────┐
-                    │  Odoo CE 19                        │
-                    │                                    │
-                    │  ipai_odoo_copilot                 │
-                    │  (single bridge module)            │
-                    │  ├── FoundryService                │
-                    │  ├── ToolExecutor                  │
-                    │  ├── CopilotBot (mail.bot)         │
-                    │  └── App Insights telemetry        │
-                    │                                    │
-                    │  ipai_enterprise_bridge            │
-                    │  (Foundry provider config)         │
-                    └────────────────────────────────────┘
+                    ┌──────────────┴────────────────────────┐
+                    │  Odoo CE 19                            │
+                    │                                        │
+                    │  ipai_odoo_copilot                     │
+                    │  (single bridge module)                │
+                    │  ├── FoundryService                    │
+                    │  ├── ToolExecutor (MCP-registered)     │
+                    │  ├── CopilotBot (mail.bot)             │
+                    │  └── App Insights telemetry            │
+                    │                                        │
+                    │  ipai_enterprise_bridge                │
+                    │  (Foundry provider config)             │
+                    └────────────────────────────────────────┘
 ```
 
-## Four Capability Modes
+## Five Capability Modes
 
-| Mode | Purpose | Write Access | Replaces |
-|------|---------|-------------|----------|
-| **Ask** | Answer questions, search records, RAG retrieval | None (read-only) | `ipai_ai_widget`, `ipai_ask_ai_azure` |
-| **Authoring** | Draft documents, reports, emails | Draft only | `ipai_ai_copilot` (deprecated), `ipai_ai_prompts` |
-| **Livechat** | Website visitor Q&A via chat | None (read-only) | `ipai_ai_channel_actions`, `ipai_ai_livechat` |
-| **Transaction** | Bounded CRUD with approval gates | Whitelisted models | `ipai_ai_tools`, `ipai_ai_automations` |
+| Mode | Purpose | Write Access | Foundry Built-ins | Replaces |
+|------|---------|-------------|-------------------|----------|
+| **Ask** | Answer questions, search records, RAG | None (read-only) | Web Search, Memory (user_profile) | `ipai_ai_widget`, `ipai_ask_ai_azure` |
+| **Authoring** | Draft documents, reports, emails | Draft only | Code Interpreter, File Search, Memory (chat_summary) | `ipai_ai_copilot`, `ipai_ai_prompts` |
+| **Livechat** | Website visitor Q&A via chat | None (read-only) | Web Search, Memory (user_profile) | `ipai_ai_channel_actions`, `ipai_ai_livechat` |
+| **Transaction** | Bounded CRUD with approval gates | Whitelisted models | Memory (chat_summary) | `ipai_ai_tools`, `ipai_ai_automations` |
+| **Creative** | Image gen, campaign copy, email templates | Draft only | Image Generation, Code Interpreter, File Search | `ipai_marketing_agency_pack` |
+
+## Foundry Platform Capabilities
+
+### Tool Catalog (1,400+ tools)
+
+| Category | Tools | Status |
+|----------|-------|--------|
+| **Built-in** | Web Search, Code Interpreter, File Search, Function Calling, Azure AI Search | GA |
+| **Built-in (Preview)** | Image Generation, Browser Automation, Computer Use, Fabric, SharePoint | Preview |
+| **Custom** | MCP servers, OpenAPI specs, Agent-to-Agent (A2A) | GA (MCP/OpenAPI), Preview (A2A) |
+
+### Memory (Long-term, Cross-session)
+
+| Type | Description | Use Case |
+|------|-------------|----------|
+| **User Profile** | Static preferences (name, language, role) | Personalize Ask/Livechat responses |
+| **Chat Summary** | Distilled topic summaries per session | Continue Authoring/Transaction across sessions |
+
+### Workflow Orchestration
+
+| Pattern | Description | ERP Application |
+|---------|-------------|-----------------|
+| **Sequential** | Agent pipeline (A → B → C) | Multi-step approval workflows |
+| **Group Chat** | Dynamic agent handoff by context | Expert escalation (Sales → Finance) |
+| **Human-in-the-Loop** | Approval/clarification gates | PO approval, expense review |
+
+## Terminology Migration
+
+| Old (Assistants API) | New (Responses API) |
+|---------------------|---------------------|
+| Thread | Conversation |
+| Message | Item |
+| Run | Response |
+| Assistant | Agent Version |
+| `azure-ai-inference` SDK | `azure-ai-projects` 2.x |
+| Monthly `api-version` params | `v1` stable routes (`/openai/v1/`) |
+| Hub + Azure OpenAI resource | Single Foundry resource |
 
 ## Module Consolidation
 
@@ -108,15 +160,19 @@ Consolidate all AI capabilities through **Microsoft Foundry** (`data-intel-ph` p
 
 ## Foundry Tools (Odoo-side)
 
-| Tool | Description | Write | Mode |
-|------|-------------|-------|------|
-| `search_records` | Search Odoo records by model + domain | No | All |
-| `read_record` | Read specific record by ID | No | All |
-| `search_knowledge` | Search RAG index | No | All |
-| `create_draft` | Create record in draft state | Yes (draft) | Authoring |
-| `create_record` | Create record | Yes (bounded) | Transaction |
-| `update_record` | Update record fields | Yes (bounded) | Transaction |
-| `execute_action` | Execute server action | Yes (approved) | Transaction |
+| Tool | Description | Write | Mode | Connection |
+|------|-------------|-------|------|------------|
+| `search_records` | Search Odoo records by model + domain | No | All | MCP server |
+| `read_record` | Read specific record by ID | No | All | MCP server |
+| `search_knowledge` | Search RAG index | No | All | Foundry built-in |
+| `web_search` | Real-time web grounding | No | Ask, Livechat, Creative | Foundry built-in |
+| `code_interpreter` | Python sandbox (charts, analysis) | No | Authoring, Creative | Foundry built-in |
+| `file_search` | Vector search on uploaded docs | No | Authoring, Creative | Foundry built-in |
+| `image_generation` | DALL-E 3 image creation | Yes (draft) | Creative | Foundry built-in |
+| `create_draft` | Create record in draft state | Yes (draft) | Authoring | MCP server |
+| `create_record` | Create record | Yes (bounded) | Transaction | MCP server |
+| `update_record` | Update record fields | Yes (bounded) | Transaction | MCP server |
+| `execute_action` | Execute server action | Yes (approved) | Transaction | MCP server |
 
 ## Safety Controls
 
@@ -125,7 +181,9 @@ Consolidate all AI capabilities through **Microsoft Foundry** (`data-intel-ph` p
 - **Rate limiting**: 60 requests/minute per user
 - **PII redaction**: sensitive fields masked before sending to Foundry
 - **Model allowlist**: only `gpt-4.1` and `gpt-4.1-mini`
-- **No direct LLM calls**: all inference routes through Foundry — no OpenAI/Gemini/Supabase bypass
+- **No direct LLM calls**: all inference routes through Foundry
+- **MCP auth**: Managed Identity preferred (Entra token rotation), key-based and OAuth passthrough supported
+- **Content Safety**: Azure AI Content Safety with prompt injection detection
 
 ## Migration Phases
 
@@ -135,16 +193,20 @@ Consolidate all AI capabilities through **Microsoft Foundry** (`data-intel-ph` p
 | 2 | Deprecate direct-call AI modules (5 modules) | Planned |
 | 3 | Livechat + transaction modes verified | Planned |
 | 4 | Set `installable=False` on all deprecated modules | Planned |
+| 5 | Microsoft Foundry native (Responses API v2, Memory, MCP catalog, Workflows) | Planned |
 
 ## Foundry Coordinates
 
 | Setting | Value |
 |---------|-------|
+| Brand | **Microsoft Foundry** (formerly Azure AI Foundry) |
+| Portal | `https://ai.azure.com` |
 | Resource | `data-intel-ph-resource.services.ai.azure.com` |
 | Project | `data-intel-ph` |
 | Agent | `ipai-odoo-copilot-azure` |
 | Model | `gpt-4.1` |
-| API Version | `2024-12-01-preview` |
+| API | Responses API (Agents v2) — `/openai/v1/` |
+| SDK | `azure-ai-projects` 2.x |
 | Search | `srch-ipai-dev` |
 | Auth | Managed Identity (primary), API Key (fallback) |
 | Secrets | Azure Key Vault (`kv-ipai-dev`) |

--- a/ssot/governance/ai-consolidation-foundry.yaml
+++ b/ssot/governance/ai-consolidation-foundry.yaml
@@ -1,22 +1,38 @@
 # AI Capability Consolidation — Microsoft Foundry Gateway
 # All AI capabilities route through a single Foundry agent.
 # Human doc: docs/architecture/AI_CONSOLIDATION_FOUNDRY.md
+#
+# Rebrand: Azure AI Foundry → Microsoft Foundry (2025-11)
+# API: Assistants API → Responses API (Agents v2)
+# SDK: azure-ai-projects 2.x + OpenAI() against one project endpoint
+# Terminology: Threads→Conversations, Messages→Items, Runs→Responses
 
-version: "1.0"
-schema: ssot.governance.ai-consolidation-foundry.v1
+version: "2.0"
+schema: ssot.governance.ai-consolidation-foundry.v2
 updated_at: "2026-03-15"
 
 # ---------------------------------------------------------------------------
-# Foundry Coordinates
+# Foundry Coordinates (Microsoft Foundry — formerly Azure AI Foundry)
 # ---------------------------------------------------------------------------
 foundry:
+  brand: "Microsoft Foundry"
+  portal: "https://ai.azure.com"
   resource: data-intel-ph-resource.services.ai.azure.com
   project: data-intel-ph
   agent: ipai-odoo-copilot-azure
   agent_versions: 7
   agent_type: prompt
   model_deployment: gpt-4.1
-  api_version: "2024-12-01-preview"
+  api:
+    surface: "Responses API (Agents v2)"
+    version: "v1 stable routes (/openai/v1/)"
+    sdk: "azure-ai-projects 2.x"
+    client: "OpenAI()"
+  terminology:
+    session: conversation        # was: thread
+    message: item                # was: message
+    execution: response          # was: run
+    agent_def: agent_version     # was: assistant
   search_service: srch-ipai-dev
   auth:
     primary: managed_identity
@@ -27,13 +43,14 @@ foundry:
 # Consolidation Doctrine
 # ---------------------------------------------------------------------------
 doctrine: >
-  One Foundry agent. One Odoo bridge module. Four capability modes.
+  One Foundry agent. One Odoo bridge module. Five capability modes.
   All AI surface area routes through Microsoft Foundry as the single
   inference gateway. No direct OpenAI, Gemini, or Supabase LLM calls
   from Odoo modules. The Foundry agent is the only AI endpoint.
+  Agent tools connect via MCP, OpenAPI, or A2A protocols.
 
 # ---------------------------------------------------------------------------
-# Capability Modes (single agent, multiple modes)
+# Capability Modes (single agent, five modes)
 # ---------------------------------------------------------------------------
 capability_modes:
   ask:
@@ -47,6 +64,8 @@ capability_modes:
       - search_records
       - read_record
       - search_knowledge
+      - web_search                   # NEW: Foundry built-in web search
+    foundry_memory: user_profile     # NEW: recall user preferences
     status: active
 
   authoring:
@@ -60,6 +79,9 @@ capability_modes:
       - read_record
       - create_draft
       - search_knowledge
+      - code_interpreter             # NEW: data analysis, chart gen
+      - file_search                  # NEW: search uploaded docs
+    foundry_memory: chat_summary     # NEW: continue draft sessions
     status: active
 
   livechat:
@@ -72,6 +94,8 @@ capability_modes:
       - search_records
       - read_record
       - search_knowledge
+      - web_search
+    foundry_memory: user_profile
     status: active
 
   transaction:
@@ -86,8 +110,76 @@ capability_modes:
       - create_record
       - update_record
       - execute_action
+    foundry_memory: chat_summary
     status: planned
     gate: "Requires explicit approval per model/action"
+
+  creative:
+    description: "Generate images, campaign copy, email templates"
+    replaces:
+      - ipai_marketing_agency_pack (archive)
+    write_access: draft_only
+    foundry_tools:
+      - image_generation             # DALL-E 3 via Foundry built-in
+      - code_interpreter             # data viz, chart generation
+      - search_knowledge             # brand guidelines RAG
+      - file_search                  # uploaded brand assets
+      - web_search                   # trend/competitor research
+    foundry_memory: user_profile
+    status: planned
+    note: "Requires ipai_creative_studio module (port from 18.0 archive)"
+
+# ---------------------------------------------------------------------------
+# Foundry Platform Capabilities (new in Microsoft Foundry)
+# ---------------------------------------------------------------------------
+platform_capabilities:
+  tool_catalog:
+    total_tools: 1400+
+    tool_types:
+      built_in:
+        - web_search                 # GA — real-time web grounding
+        - code_interpreter           # GA — sandboxed Python
+        - file_search                # GA — vector search on uploads
+        - function_calling           # GA — custom function execution
+        - azure_ai_search            # GA — search index grounding
+        - image_generation           # Preview — DALL-E via Foundry
+        - browser_automation         # Preview — natural language browser tasks
+        - computer_use               # Preview — UI interaction
+        - fabric                     # Preview — Microsoft Fabric data agent
+        - sharepoint                 # Preview — chat with SharePoint docs
+      custom:
+        - mcp                        # GA — Model Context Protocol servers
+        - openapi                    # GA — any OpenAPI 3.0/3.1 spec
+        - agent_to_agent             # Preview — A2A cross-agent calls
+
+  memory:
+    types:
+      - user_profile: "Static user preferences (name, dietary, lang)"
+      - chat_summary: "Distilled topic summaries across sessions"
+    phases: [extraction, consolidation, retrieval]
+    quotas:
+      max_scopes_per_store: 100
+      max_memories_per_scope: 10000
+      search_rpm: 1000
+      update_rpm: 1000
+    status: preview
+
+  workflows:
+    patterns:
+      - sequential: "Agent-to-agent pipeline"
+      - group_chat: "Dynamic context-based handoff"
+      - human_in_the_loop: "Approval / clarification gates"
+    expression_engine: power_fx
+    versioning: immutable_per_save
+    status: ga
+
+  agent_publishing:
+    targets:
+      - microsoft_365
+      - teams
+      - bizchat
+      - containerized_deployment
+    status: ga
 
 # ---------------------------------------------------------------------------
 # Module Consolidation Map
@@ -241,6 +333,14 @@ safety:
   model_allowlist:
     - gpt-4.1
     - gpt-4.1-mini
+  mcp_auth:
+    preferred: managed_identity    # Entra token rotation, no secret mgmt
+    supported:
+      - key_based                  # API key via project connection
+      - entra_identity             # managed identity
+      - oauth_passthrough          # per-user consent
+  content_safety: azure_ai_content_safety
+  prompt_injection_detection: true
 
 # ---------------------------------------------------------------------------
 # Migration Path
@@ -275,3 +375,16 @@ migration:
     name: "Cleanup deprecated modules"
     status: planned
     action: "Set installable=False on all deprecated modules, update dependency chain"
+
+  phase_5:
+    name: "Microsoft Foundry native capabilities"
+    status: planned
+    capabilities:
+      - "Migrate to Responses API (Agents v2) — drop Assistants API calls"
+      - "Adopt azure-ai-projects 2.x SDK (replace multiple SDK packages)"
+      - "Enable Foundry Memory (user_profile + chat_summary)"
+      - "Register Odoo tools in Foundry Tool Catalog via MCP"
+      - "Add creative mode (image_generation + code_interpreter)"
+      - "Enable workflow orchestration for multi-step ERP tasks"
+      - "Publish copilot to Teams/BizChat via Foundry publishing"
+    prerequisite: "Phases 1-4 complete; Foundry resource upgraded from Azure OpenAI"


### PR DESCRIPTION
## Summary
- Updates AI consolidation SSOT and architecture doc to reflect the **Microsoft Foundry** rebrand (formerly Azure AI Foundry)
- Migrates from Assistants API to **Responses API (Agents v2)** with new terminology (Conversations/Items/Responses)
- Adds 5th capability mode: **Creative** (image generation, campaign copy, email templates)
- Documents Foundry platform capabilities: **1,400+ tool catalog**, MCP/OpenAPI/A2A connectors, **long-term memory** (user_profile + chat_summary), **workflow orchestration** (sequential, group chat, human-in-the-loop)
- Adds **Phase 5** migration path for adopting Foundry-native capabilities

## Test plan
- [ ] YAML validates (`python -c "import yaml; yaml.safe_load(open('ssot/governance/ai-consolidation-foundry.yaml'))"`)
- [ ] Verify terminology matches Microsoft Foundry docs (learn.microsoft.com/azure/foundry/)
- [ ] Confirm 5 capability modes documented consistently across YAML and MD

🤖 Generated with [Claude Code](https://claude.com/claude-code)