### PR TITLE
feat(ai): map Microsoft Agent Stack to consolidation strategy

### DIFF
--- a/docs/architecture/AI_CONSOLIDATION_FOUNDRY.md
+++ b/docs/architecture/AI_CONSOLIDATION_FOUNDRY.md
@@ -195,6 +195,59 @@ Consolidate all AI capabilities through **Microsoft Foundry** (`data-intel-ph` p
 | 4 | Set `installable=False` on all deprecated modules | Planned |
 | 5 | Microsoft Foundry native (Responses API v2, Memory, MCP catalog, Workflows) | Planned |
 
+## Microsoft Agent Stack (Upstream Repos)
+
+Three complementary layers power the Foundry agent ecosystem. We consume these as SDK dependencies — never fork.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                  Microsoft Agent Stack                   │
+├─────────────────────────────────────────────────────────┤
+│                                                          │
+│  ┌─────────────────────────────────────────────────┐    │
+│  │ CHANNEL LAYER (microsoft/Agents)                │    │
+│  │ M365 Agents SDK — deploy to Teams, BizChat, web │    │
+│  │ SDKs: C#, JavaScript, Python                    │    │
+│  └──────────────────────┬──────────────────────────┘    │
+│                         │                                │
+│  ┌──────────────────────┴──────────────────────────┐    │
+│  │ ORCHESTRATION LAYER (microsoft/agent-framework) │    │
+│  │ Multi-agent workflows, graph-based, OTel        │    │
+│  │ SDKs: Python, .NET                              │    │
+│  └──────────────────────┬──────────────────────────┘    │
+│                         │                                │
+│  ┌──────────────────────┴──────────────────────────┐    │
+│  │ FOUNDRY PLATFORM (Microsoft Foundry)            │    │
+│  │ Agent runtime, tools, memory, publishing        │    │
+│  │ SDK: azure-ai-projects 2.x + OpenAI()          │    │
+│  └─────────────────────────────────────────────────┘    │
+│                                                          │
+│  ┌─────────────────────────────────────────────────┐    │
+│  │ DEV TOOLING (github/copilot-sdk)                │    │
+│  │ Copilot CLI engine, JSON-RPC, auto-planning     │    │
+│  │ SDKs: Node, Python, Go, .NET (Preview)          │    │
+│  └─────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────┘
+```
+
+### How Each Layer Maps to Our Platform
+
+| Layer | Repo | Our Usage | Status |
+|-------|------|-----------|--------|
+| **Orchestration** | `microsoft/agent-framework` | Foundry workflow orchestration for multi-step ERP tasks (expense approval, month-end close, sequential GL/AP/AR) | Planned |
+| **Channel** | `microsoft/Agents` | Publish `ipai-odoo-copilot-azure` to Teams, surface ERP in BizChat, web channel for livechat | Planned |
+| **Dev Tooling** | `github/copilot-sdk` | Internal: module scaffolding, CI auto-fix, code review gates | Evaluate (Preview) |
+
+### Agent Framework Workflow Patterns for ERP
+
+| Pattern | Agent Framework Feature | ERP Application |
+|---------|------------------------|-----------------|
+| Sequential | Graph-based pipeline | Month-end close: GL → AP → AR → Tax → Consolidation |
+| Human-in-the-Loop | Checkpoint + approval | Expense: Agent draft → Manager approve → Finance review |
+| Group Chat | Dynamic handoff | Sales inquiry: CRM agent → Inventory agent → Pricing agent |
+| Streaming | Real-time progress | Live dashboard of close progress across all entities |
+| Time-travel Debug | Checkpoint replay | Audit trail: replay agent decisions for compliance |
+
 ## Foundry Coordinates
 
 | Setting | Value |
@@ -210,6 +263,14 @@ Consolidate all AI capabilities through **Microsoft Foundry** (`data-intel-ph` p
 | Search | `srch-ipai-dev` |
 | Auth | Managed Identity (primary), API Key (fallback) |
 | Secrets | Azure Key Vault (`kv-ipai-dev`) |
+
+## Upstream Repos
+
+| Repo | Install | Purpose |
+|------|---------|---------|
+| [`microsoft/agent-framework`](https://github.com/microsoft/agent-framework) | `pip install agent-framework --pre` | Multi-agent orchestration |
+| [`microsoft/Agents`](https://github.com/microsoft/Agents) | Language-specific (C#/JS/Python) | M365 channel deployment |
+| [`github/copilot-sdk`](https://github.com/github/copilot-sdk) | `pip install github-copilot-sdk` | Dev tooling (Preview) |
 
 ---
 

--- a/ssot/governance/ai-consolidation-foundry.yaml
+++ b/ssot/governance/ai-consolidation-foundry.yaml
@@ -385,6 +385,78 @@ migration:
       - "Enable Foundry Memory (user_profile + chat_summary)"
       - "Register Odoo tools in Foundry Tool Catalog via MCP"
       - "Add creative mode (image_generation + code_interpreter)"
-      - "Enable workflow orchestration for multi-step ERP tasks"
-      - "Publish copilot to Teams/BizChat via Foundry publishing"
+      - "Enable workflow orchestration via Microsoft Agent Framework"
+      - "Publish copilot to Teams/BizChat via M365 Agents SDK"
     prerequisite: "Phases 1-4 complete; Foundry resource upgraded from Azure OpenAI"
+
+# ---------------------------------------------------------------------------
+# Microsoft Agent Stack (upstream repos)
+# ---------------------------------------------------------------------------
+# Three complementary layers that power Foundry agent capabilities.
+# These are the canonical upstream repos — never fork, only consume as SDK.
+agent_stack:
+  orchestration:
+    repo: "github.com/microsoft/agent-framework"
+    purpose: "Multi-agent workflows, graph-based orchestration, OpenTelemetry"
+    sdks:
+      python: "pip install agent-framework --pre"
+      dotnet: "dotnet add package Microsoft.Agents.AI"
+    patterns:
+      - sequential: "Agent pipeline (A → B → C)"
+      - group_chat: "Dynamic context-based handoff"
+      - human_in_the_loop: "Approval / clarification gates"
+    features:
+      - graph_based_workflows
+      - streaming_and_checkpointing
+      - time_travel_debugging
+      - opentelemetry_distributed_tracing
+      - middleware_pipelines
+    our_usage:
+      - "Foundry workflow orchestration for multi-step ERP tasks"
+      - "Expense approval: Agent → Manager Approval → Finance Review"
+      - "Month-end close: Sequential agent pipeline across GL/AP/AR"
+    status: planned
+
+  channel:
+    repo: "github.com/microsoft/Agents"
+    purpose: "M365 Agents SDK — deploy agents to Teams, M365 Copilot, web"
+    sdks:
+      csharp: "github.com/microsoft/Agents-for-net"
+      javascript: "github.com/microsoft/Agents-for-js"
+      python: "github.com/microsoft/Agents-for-python"
+    targets:
+      - microsoft_365_copilot
+      - microsoft_teams
+      - web_applications
+      - custom_apps
+    features:
+      - state_and_storage_management
+      - activity_and_event_handling
+      - channel_customization
+      - ai_agnostic_architecture
+    our_usage:
+      - "Publish ipai-odoo-copilot-azure to Teams for internal chat"
+      - "Surface ERP data in M365 Copilot (BizChat) responses"
+      - "Web channel for customer-facing livechat mode"
+    note: "M365 Copilot subscription NOT required for Teams/web channels"
+    status: planned
+
+  developer_tooling:
+    repo: "github.com/github/copilot-sdk"
+    purpose: "Programmatic access to Copilot CLI engine (JSON-RPC)"
+    sdks:
+      node: "npm install @github/copilot-sdk"
+      python: "pip install github-copilot-sdk"
+      go: "go get github.com/github/copilot-sdk/go"
+      dotnet: "dotnet add package GitHub.Copilot.SDK"
+    features:
+      - planning_and_tool_invocation
+      - file_editing_automation
+      - custom_agents_skills_tools
+      - multiple_auth_methods
+    our_usage:
+      - "Internal dev tooling: automate Odoo module scaffolding"
+      - "CI agent: auto-fix lint/test failures via Copilot engine"
+      - "Code review agent: module quality gate automation"
+    note: "Technical Preview — not production-ready yet"
+    status: evaluate


### PR DESCRIPTION
## Summary
- Maps 3 upstream Microsoft agent repos to our AI consolidation:
  - **microsoft/agent-framework** → orchestration layer for multi-agent ERP workflows (month-end close, expense approval pipelines)
  - **microsoft/Agents** (M365 SDK) → channel layer to publish `ipai-odoo-copilot-azure` to Teams/BizChat/web
  - **github/copilot-sdk** → dev tooling for internal module scaffolding and CI automation (evaluate, preview only)
- Adds ERP-specific workflow pattern mapping (sequential, human-in-the-loop, group chat, streaming, time-travel debug)
- Includes install coordinates and SDK references

## Test plan
- [ ] YAML validates
- [ ] Architecture diagram renders correctly in markdown
- [ ] Upstream repo URLs verified accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)