### PR TITLE
feat(ai): add Foundry workflow authoring paths (pro-code + declarative)

### DIFF
--- a/docs/architecture/AI_CONSOLIDATION_FOUNDRY.md
+++ b/docs/architecture/AI_CONSOLIDATION_FOUNDRY.md
@@ -118,6 +118,83 @@ Consolidate all AI capabilities through **Microsoft Foundry** (`data-intel-ph` p
 | Monthly `api-version` params | `v1` stable routes (`/openai/v1/`) |
 | Hub + Azure OpenAI resource | Single Foundry resource |
 
+## Agent Workflows (Phase 5)
+
+Two authoring paths for multi-agent workflows:
+
+| Path | Tool | Best For |
+|------|------|----------|
+| **Declarative (low-code)** | YAML in Foundry portal or VS Code for Web | Simple sequential flows, non-developers |
+| **Pro-code (hosted)** | Python/C# with Agent Framework SDK | Complex orchestration, custom logic, OTel tracing |
+
+**Low-code → Pro-code bridge**: GitHub Copilot can convert YAML workflows to Agent Framework code (`Generate Code` button in VS Code). This lets you prototype in YAML, then customize in Python.
+
+## Pro-Code Hosted Workflows
+
+Multi-agent ERP workflows built with the Agent Framework SDK, deployed as hosted agents to Foundry.
+
+### Setup
+
+```bash
+# Python — hosted agent framework package
+pip install azure-ai-agentserver-agentframework
+
+# VS Code extension (required for visualization + deployment)
+# Install: TeamsDevApp.vscode-ai-foundry
+```
+
+### Project Structure
+
+```
+erp-workflow/
+├── .env                    # AZURE_AI_PROJECT_ENDPOINT + MODEL_DEPLOYMENT_NAME
+├── workflow.py             # Orchestration logic + agent definitions
+├── container.py            # Containerized deployment entry point
+├── main.py                 # Local dev entry point
+└── requirements.txt        # azure-ai-agentserver-agentframework
+```
+
+### Observability (OpenTelemetry)
+
+```python
+from agent_framework.observability import setup_observability
+setup_observability(vs_code_extension_port=4319)  # traces to VS Code visualizer
+```
+
+### Deployment Stages
+
+| Stage | Command | Purpose |
+|-------|---------|---------|
+| Local interactive | F5 in VS Code | Dev + debug with breakpoints |
+| Local container | `Microsoft Foundry: Open Container Agent Playground Locally` | Test containerized |
+| Cloud deploy | `Microsoft Foundry: Deploy Hosted Agent` | Production in Foundry workspace |
+
+### ERP Workflow Examples
+
+**Expense Approval (Human-in-the-Loop):**
+```
+[Expense Agent] → classify expense → [Manager Agent] → approve/reject → [Finance Agent] → post to GL
+         ↑                                    ↑
+    human input                          human approval
+```
+
+**Month-End Close (Sequential):**
+```
+[GL Agent] → reconcile → [AP Agent] → match invoices → [AR Agent] → age receivables → [Tax Agent] → compute
+```
+
+**Sales Inquiry (Group Chat):**
+```
+[CRM Agent] ←→ [Inventory Agent] ←→ [Pricing Agent]
+     dynamic handoff based on customer question
+```
+
+### Auth Requirements
+
+- `Azure AI User` role on Foundry project
+- `AcrPull` role for container deployment
+- `DefaultAzureCredential` (az login or managed identity)
+
 ## Module Consolidation
 
 ### Canonical (keep)

--- a/ssot/governance/ai-consolidation-foundry.yaml
+++ b/ssot/governance/ai-consolidation-foundry.yaml
@@ -418,7 +418,8 @@ agent_stack:
     repo: "github.com/microsoft/agent-framework"
     purpose: "Multi-agent workflows, graph-based orchestration, OpenTelemetry"
     sdks:
-      python: "pip install agent-framework --pre"
+      python_standalone: "pip install agent-framework --pre"
+      python_hosted: "pip install azure-ai-agentserver-agentframework"
       dotnet: "dotnet add package Microsoft.Agents.AI"
     patterns:
       - sequential: "Agent pipeline (A → B → C)"
@@ -430,10 +431,39 @@ agent_stack:
       - time_travel_debugging
       - opentelemetry_distributed_tracing
       - middleware_pipelines
+    declarative_workflow:
+      description: "Low-code YAML workflows — prototype in portal, edit in VS Code for Web"
+      authoring:
+        - "Foundry portal → Build → Workflows (visual builder)"
+        - "VS Code for Web → YAML editor + visual graph side-by-side"
+      conversion: "GitHub Copilot converts YAML → Agent Framework code (Python/C#)"
+      testing: "Remote Agent Playground in VS Code extension"
+      deployment: "Deploy from ellipsis menu → saves back to Foundry"
+      prerequisite: "GitHub Copilot subscription (for YAML → code conversion)"
+    hosted_workflow:
+      description: "Pro-code hosted agent workflows deployed to Foundry workspace"
+      vs_code_extension: "TeamsDevApp.vscode-ai-foundry"
+      project_structure:
+        - ".env (AZURE_AI_PROJECT_ENDPOINT, AZURE_AI_MODEL_DEPLOYMENT_NAME)"
+        - "workflow.py (orchestration logic + agent definitions)"
+        - "container.py (containerized deployment entry point)"
+        - "main.py (local dev entry point)"
+      observability: |
+        from agent_framework.observability import setup_observability
+        setup_observability(vs_code_extension_port=4319)
+      deployment:
+        local: "F5 in VS Code (Debug Local Workflow HTTP Server)"
+        container: "Microsoft Foundry: Open Container Agent Playground Locally"
+        cloud: "Microsoft Foundry: Deploy Hosted Agent"
+      auth: "DefaultAzureCredential (az login / managed identity)"
+      rbac_required:
+        - "Azure AI User"
+        - "AcrPull (for container deployment)"
     our_usage:
       - "Foundry workflow orchestration for multi-step ERP tasks"
       - "Expense approval: Agent → Manager Approval → Finance Review"
       - "Month-end close: Sequential agent pipeline across GL/AP/AR"
+      - "PO workflow: Draft → Review → Approve → Send (human-in-the-loop)"
     status: planned
 
   channel:


### PR DESCRIPTION
## Summary
- Documents both workflow authoring paths for multi-agent ERP orchestration:
  - **Pro-code**: `azure-ai-agentserver-agentframework` SDK with project structure, OpenTelemetry observability, 3-stage deployment (local → container → cloud)
  - **Declarative (low-code)**: YAML workflows in Foundry portal or VS Code for Web, with GitHub Copilot YAML-to-code conversion bridge
- Adds ERP-specific workflow examples: expense approval (human-in-the-loop), month-end close (sequential), sales inquiry (group chat)
- Documents RBAC requirements (Azure AI User + AcrPull)

## Test plan
- [ ] YAML validates
- [ ] Architecture doc renders workflow diagrams correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)