### PR TITLE
Apply full A2A interop doctrine

### DIFF
--- a/docs/architecture/A2A_INTEROP.md
+++ b/docs/architecture/A2A_INTEROP.md
@@ -1,83 +1,245 @@
-# A2A Interop and MCP Doctrine
+# A2A Interop Doctrine
 
-> When to use direct retrieval, MCP tools, and A2A delegation.
-> SSOT: `ssot/governance/agentops_policy.yaml`
-
----
-
-## Routing Doctrine
-
-| Mechanism | When to Use | Examples |
-|-----------|------------|---------|
-| **Direct retrieval / provider call** | Simple, single-step work within one assistant surface | KB lookup, single API call, record read |
-| **MCP (Model Context Protocol)** | Tool and resource access — structured input/output, reusable across surfaces | Odoo record CRUD, Azure resource queries, Databricks SQL, GitHub operations |
-| **A2A (Agent-to-Agent)** | Complex cross-assistant delegation or handoff — when the receiving agent has distinct context, permissions, or capabilities | Diva routes to Odoo Copilot for ERP execution; Studio hands off to Document Intelligence for extraction |
+> Use A2A for delegate / handoff / coordinate / aggregate. NOT for simple retrieval.
+> SSOT: `ssot/agents/assistant_surfaces.yaml` (a2a_interop block)
 
 ---
 
-## Decision Rules
+## 1. Purpose
 
-### Prefer Direct Calls When:
+Agent-to-Agent (A2A) interop enables one assistant surface to **delegate work**, **hand off context**, **coordinate multi-step workflows**, or **aggregate results** across distinct assistant surfaces. It is the mechanism for cross-surface collaboration when a single surface lacks the permissions, context, or capabilities to complete a task alone.
 
-- The task is a single retrieval or generation step
-- No cross-surface context assembly is needed
-- The calling surface has the necessary permissions
-- Response latency matters (direct is fastest)
+A2A is NOT a replacement for MCP tools or direct retrieval. It adds latency, complexity, and audit surface. Use it only when the benefits of cross-surface delegation outweigh those costs.
 
-### Use MCP When:
+### Canonical Rule
 
-- A tool provides structured, reusable access to a resource
-- Multiple surfaces need the same tool (e.g., Odoo record API)
-- The tool contract is stable and versioned
-- Auth is handled by managed identity or OAuth token
-
-### Use A2A When:
-
-- The task requires delegation to a surface with different permissions
-- The task requires context that only the receiving agent can assemble
-- The handoff is between distinct product surfaces (not modes within one surface)
-- The interaction model is request-response or streaming with completion signals
+> **Use A2A when one surface must delegate to another surface that has distinct permissions, context, or capabilities. Use MCP for tool access. Use direct retrieval for single-step lookups. Never route through A2A what a single tool call can resolve.**
 
 ---
 
-## A2A Interaction Model
+## 2. Surface Roles
+
+Every assistant surface has exactly one A2A role:
+
+| Surface | A2A Role | Rationale |
+|---------|----------|-----------|
+| **Diva Copilot** | **Hub** | Classifies intent, routes to specialists, aggregates results |
+| **Odoo Copilot** | Participant | ERP execution — receives delegated tasks, escalates when out of scope |
+| **Studio Copilot** | Participant | Creative finishing — receives asset/workflow handoffs |
+| **Genie** | Participant | Analytics context — returns query results and provenance |
+| **Document Intelligence Assistant** | Participant | Extraction/review — returns structured document data |
+| **Landing Public Assistant** | **None** | Public surface, no A2A capability, no tenant context |
+
+**Hub** means: can initiate delegation to any participant, aggregates cross-surface results, owns the conversation lifecycle.
+
+**Participant** means: can receive delegated tasks from the hub, can escalate back to the hub, can hand off to other participants only via explicit allowed-target list.
+
+**None** means: no A2A messages sent or received. The surface operates independently.
+
+---
+
+## 3. Allowed Patterns
+
+### Pattern A: Hub delegates to participant
+
+Diva classifies user intent, determines that a specialist surface is required, and sends a `delegate_task` message.
 
 ```
-Diva Copilot (orchestrator)
-  |
-  |-- classifies intent
-  |-- picks target surface
-  |-- assembles handoff context
-  |
-  +---> [A2A] Odoo Copilot (ERP execution)
-  +---> [A2A] Studio Copilot (creative finishing)
-  +---> [A2A] Genie (analytics Q&A)
-  +---> [A2A] Document Intelligence (extraction)
+User -> Diva (hub)
+         |
+         +-- delegate_task --> Odoo Copilot
+         |                        |
+         +<-- return_result ------+
+         |
+User <-- aggregated response
 ```
 
-### Handoff Contract
+### Pattern B: Participant escalates to hub
 
-Each A2A handoff includes:
+A participant determines the task is outside its scope and escalates back to Diva for rerouting.
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `source_surface` | Yes | Originating assistant surface ID |
-| `target_surface` | Yes | Receiving assistant surface ID |
-| `customer_tenant_id` | Yes | Tenant context |
-| `intent_class` | Yes | Classified user intent |
-| `context_payload` | Yes | Assembled context for the target surface |
-| `correlation_id` | Yes | Trace ID for observability |
-| `timeout_ms` | Yes | Maximum wait before fallback |
+```
+User -> Odoo Copilot (participant)
+         |
+         +-- request_context --> Diva (hub)
+         |                         |
+         +<-- delegate_task -------+  (Diva may reroute to another participant)
+```
 
-### What A2A Is Not
+### Pattern C: Participant-to-participant (explicit handoff)
 
-- A2A is not a message bus for fire-and-forget events (use n8n workflows)
-- A2A is not a replacement for MCP tools (tools are simpler)
-- A2A does not mean every surface talks to every other surface (hub-spoke via Diva)
+A participant hands off to another participant that is in its `a2a_allowed_targets` list. The hub is notified for audit purposes.
+
+```
+Studio Copilot -- delegate_task --> Document Intelligence
+                                       |
+Studio Copilot <-- return_result ------+
+Diva (hub)     <-- audit_notify -------+
+```
+
+### Pattern D: Result return
+
+Any participant returns structured results to the caller (hub or another participant).
+
+```
+Genie -- return_result --> Diva (hub)
+  {query_provenance, result_set, confidence}
+```
 
 ---
 
-## MCP Tool Governance
+## 4. Prohibited Patterns
+
+These patterns are **banned**. Violations must be caught in code review and CI.
+
+| Prohibited Pattern | Why |
+|-------------------|-----|
+| **A2A for every tool call** | Use MCP tools directly. A2A adds unnecessary latency and complexity for single-step operations. |
+| **A2A for simple retrieval** | KB lookups, record reads, and single API calls do not need cross-surface delegation. Use direct retrieval or MCP. |
+| **Recursive delegation loops** | Surface A delegates to B, B delegates back to A. Detect and reject in the message handler. Max delegation depth = 2. |
+| **Silent delegation** | User must be informed (inline or via UI indicator) when their request is being handled by a different surface. No invisible handoffs. |
+| **Public surface initiating A2A** | The landing public assistant has no tenant context and cannot initiate or receive A2A messages. |
+| **Bypassing the hub for cross-domain aggregation** | Only Diva (hub) may aggregate results from multiple participants. Participants do not aggregate across surfaces. |
+
+---
+
+## 5. Message Types
+
+All A2A communication uses exactly three message types:
+
+### 5.1 delegate_task
+
+Sent by hub or participant to request work from another surface.
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `message_type` | Yes | string | `"delegate_task"` |
+| `source_surface` | Yes | string | Originating surface ID |
+| `target_surface` | Yes | string | Receiving surface ID |
+| `customer_tenant_id` | Yes | string | Tenant context (UUID) |
+| `workspace_id` | When applicable | string | Workspace/company scope |
+| `intent_class` | Yes | string | Classified user intent |
+| `context_payload` | Yes | object | Assembled context for the target |
+| `correlation_id` | Yes | string | Trace ID for observability |
+| `timeout_ms` | Yes | integer | Max wait before fallback (default: 30000) |
+| `max_depth` | Yes | integer | Remaining delegation depth (starts at 2, decrements) |
+
+### 5.2 request_context
+
+Sent by a participant to request additional context from the hub or another allowed target.
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `message_type` | Yes | string | `"request_context"` |
+| `source_surface` | Yes | string | Requesting surface ID |
+| `target_surface` | Yes | string | Surface being queried |
+| `customer_tenant_id` | Yes | string | Tenant context (UUID) |
+| `context_keys` | Yes | list[string] | Specific context items requested |
+| `correlation_id` | Yes | string | Same trace ID as the parent delegation |
+
+### 5.3 return_result
+
+Sent by any surface to return structured results to the caller.
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `message_type` | Yes | string | `"return_result"` |
+| `source_surface` | Yes | string | Surface returning results |
+| `target_surface` | Yes | string | Surface receiving results |
+| `customer_tenant_id` | Yes | string | Tenant context (UUID) |
+| `correlation_id` | Yes | string | Same trace ID as the parent delegation |
+| `status` | Yes | string | `"success"`, `"partial"`, `"error"`, `"timeout"` |
+| `result_payload` | Yes | object | Structured result data |
+| `confidence` | No | float | 0.0-1.0, surface-specific confidence score |
+
+---
+
+## 6. Tenancy Rules
+
+A2A messages are tenant-scoped. These rules are non-negotiable:
+
+1. **`customer_tenant_id` is required** on every A2A message. Messages without a tenant ID are rejected.
+2. **`workspace_id` is required** when the target surface is workspace-scoped (e.g., Odoo Copilot operates within a specific Odoo company).
+3. **Public surfaces cannot initiate A2A.** The landing public assistant has no tenant context and is excluded from all A2A flows.
+4. **Cross-tenant delegation is forbidden.** A message's `customer_tenant_id` must match the receiving surface's active tenant context.
+5. **Tenant context propagates.** When Diva delegates to Odoo Copilot, the tenant ID from the original request propagates unchanged. No re-authentication mid-chain.
+
+---
+
+## 7. Retrieval Rules
+
+A2A does not replace retrieval. The routing decision is:
+
+| Need | Mechanism | Example |
+|------|-----------|---------|
+| Read a record | MCP tool | `odoo.record.read(model='account.move', id=42)` |
+| Search a KB | Direct retrieval | Azure AI Search query against `odoo-docs-kb` index |
+| Execute a multi-step ERP workflow | A2A delegation | Diva delegates "close the month" to Odoo Copilot |
+| Get analytics context for a decision | A2A delegation | Diva delegates "revenue trend Q1" to Genie |
+| Extract fields from a document | A2A delegation | Studio delegates invoice PDF to Document Intelligence |
+
+**Rule:** If the task can be completed with a single MCP tool call or a single retrieval query, do NOT use A2A.
+
+---
+
+## 8. Action Rules
+
+When a delegated task involves a **write operation** (record create/update, workflow transition, approval), additional rules apply:
+
+1. **Fail-closed by default.** If the receiving surface cannot verify permissions, it rejects the action and returns an error.
+2. **Confirmation required for destructive actions.** Delete, cancel, and reversal actions require explicit user confirmation before execution. The participant returns a `"confirmation_required"` status.
+3. **Audit trail is mandatory.** Every write action triggered via A2A must be logged in `ipai.copilot.audit` with the full delegation chain (source, hub, target, correlation_id).
+4. **No escalation of privilege.** A delegated task runs with the permissions of the user who initiated the original request, not the hub's service identity.
+
+---
+
+## 9. Audit and Observability
+
+Every A2A interaction must produce audit records:
+
+| Event | Logged By | Required Fields |
+|-------|-----------|----------------|
+| Delegation sent | Source surface | correlation_id, source, target, intent_class, tenant_id, timestamp |
+| Delegation received | Target surface | correlation_id, source, target, tenant_id, timestamp |
+| Result returned | Target surface | correlation_id, status, latency_ms, tenant_id |
+| Result received | Source surface | correlation_id, status, latency_ms |
+| Timeout | Source surface | correlation_id, target, timeout_ms |
+| Rejection | Target surface | correlation_id, reason, tenant_id |
+
+**Trace propagation:** The `correlation_id` propagates through the entire delegation chain. All surfaces emit OpenTelemetry spans tagged with the correlation ID.
+
+**Dashboard:** A2A metrics (delegation count, latency p50/p95, error rate, timeout rate) must be visible in the platform operations dashboard.
+
+---
+
+## 10. Rollout Phases
+
+### Phase 1: Hub-to-participant only (target: Q2 2026)
+
+- Diva (hub) delegates to Odoo Copilot and Genie only
+- No participant-to-participant handoffs
+- All delegations are read-only (no write actions via A2A)
+- Audit logging active, dashboard passive
+
+### Phase 2: Full participant mesh (target: Q3 2026)
+
+- Enable participant-to-participant handoffs (Pattern C)
+- Add Studio Copilot and Document Intelligence as A2A participants
+- Enable write actions with confirmation flow
+- Dashboard active with alerting
+
+### Phase 3: Multi-tenant production (target: Q4 2026)
+
+- Enable cross-workspace delegation (same tenant, different workspace)
+- Performance optimization (connection pooling, message batching)
+- SLA enforcement (timeout budgets, circuit breakers)
+- External A2A surface onboarding (partner integrations)
+
+---
+
+## 11. MCP Tool Governance (Unchanged)
+
+A2A does not change MCP tool governance. Tools remain the primary mechanism for structured resource access.
 
 ### First-Wave Tool Envelope
 
@@ -99,23 +261,13 @@ Tools are registered in Azure AI Foundry Agent Service. Each tool has:
 
 ---
 
-## Current State
-
-| Capability | Status |
-|-----------|--------|
-| Direct retrieval | Active — Odoo Copilot uses KB + runtime context |
-| MCP tools | Active — Azure DevOps, GitHub, Foundry MCP servers connected |
-| A2A delegation | Not implemented — Diva modes are internal routing, not true A2A |
-
-A2A is a target-state capability. Current architecture uses Diva's internal mode routing. True cross-surface A2A handoff will be implemented when multi-surface deployments are live.
-
----
-
 ## SSOT References
 
+- Machine-readable surfaces: `ssot/agents/assistant_surfaces.yaml`
 - AgentOps policy: `ssot/governance/agentops_policy.yaml`
-- Assistant surfaces: `ssot/agents/assistant_surfaces.yaml`
 - Tool profiles: `ssot/agents/diva_copilot.yaml#tool_profiles`
+- Assistant surfaces doc: `docs/architecture/ASSISTANT_SURFACES.md`
+- Tenancy model: `ssot/architecture/tenancy_model.yaml`
 
 ---
 

--- a/docs/architecture/ASSISTANT_SURFACES.md
+++ b/docs/architecture/ASSISTANT_SURFACES.md
@@ -145,6 +145,27 @@ See `docs/architecture/DOMAIN_INTELLIGENCE_SHELLS.md` for the full doctrine.
 
 ---
 
+## 7. A2A Role by Surface
+
+Agent-to-Agent (A2A) interop enables cross-surface delegation and handoff. Each surface has exactly one A2A role. Full doctrine: `docs/architecture/A2A_INTEROP.md`.
+
+| Surface | A2A Role | Mode | Description |
+|---------|----------|------|-------------|
+| **Diva Copilot** | Hub | route_and_aggregate | Classifies intent, delegates to specialists, aggregates cross-surface results |
+| **Odoo Copilot** | Participant | bounded_escalation | Receives ERP tasks from hub, escalates out-of-scope requests back to Diva |
+| **Studio Copilot** | Participant | workflow_handoff | Receives creative/asset handoffs, can delegate extraction to Document Intelligence |
+| **Genie** | Participant | return_analytics_context | Returns analytics query results and provenance to requesting surface |
+| **Document Intelligence Assistant** | Participant | return_document_context | Returns structured extraction/review results to requesting surface |
+| **Landing Public Assistant** | None | n/a | Public surface with no tenant context -- excluded from all A2A flows |
+
+**Key rules:**
+- Only the hub (Diva) may aggregate results from multiple participants
+- `customer_tenant_id` is required on every A2A message
+- Public surfaces cannot initiate or receive A2A messages
+- A2A is for delegation and handoff, not for simple retrieval or single tool calls
+
+---
+
 ## SSOT References
 
 - Machine-readable: `ssot/agents/assistant_surfaces.yaml`

--- a/ssot/agents/assistant_surfaces.yaml
+++ b/ssot/agents/assistant_surfaces.yaml
@@ -16,6 +16,14 @@ assistant_surfaces:
     action_mode: read_only_first
     launch_posture: internal_beta
     ssot_ref: ssot/agents/diva_copilot.yaml#modes.odoo
+    a2a_role: participant
+    a2a_enabled: true
+    a2a_allowed_targets:
+      - diva_copilot
+      - genie
+      - document_intelligence
+      - studio_copilot
+    a2a_default_mode: bounded_escalation
 
   diva_copilot:
     role: orchestration_and_schema_assistant
@@ -28,6 +36,17 @@ assistant_surfaces:
       - governance
     action_mode: route_and_assemble
     ssot_ref: ssot/agents/diva_copilot.yaml
+    a2a_role: hub
+    a2a_enabled: true
+    a2a_allowed_targets:
+      - odoo_copilot
+      - studio_copilot
+      - genie
+      - document_intelligence
+      - tax_guru
+      - capability_assistant
+      - governance_assistant
+    a2a_default_mode: route_and_aggregate
 
   studio_copilot:
     role: creative_finishing_and_mediaops_assistant
@@ -45,18 +64,47 @@ assistant_surfaces:
       mixed_media: fal
       multimodal_review: openai
     product_name: W9 Studio
+    a2a_role: participant
+    a2a_enabled: true
+    a2a_allowed_targets:
+      - diva_copilot
+      - genie
+      - document_intelligence
+      - odoo_copilot
+    a2a_default_mode: workflow_handoff
 
   genie:
     role: conversational_analytics
     scope: authenticated
     citation_model: query_provenance
     is_copilot: false
+    a2a_role: participant
+    a2a_enabled: true
+    a2a_allowed_targets:
+      - diva_copilot
+      - odoo_copilot
+      - studio_copilot
+    a2a_default_mode: return_analytics_context
 
   document_intelligence:
     role: document_review_and_extraction
     scope: authenticated
     citation_model: page_field_anchor
     is_copilot: false
+    a2a_role: participant
+    a2a_enabled: true
+    a2a_allowed_targets:
+      - diva_copilot
+      - odoo_copilot
+      - studio_copilot
+    a2a_default_mode: return_document_context
+
+  landing_public_assistant:
+    role: public_marketing_and_onboarding
+    scope: public
+    is_copilot: false
+    a2a_role: none
+    a2a_enabled: false
 
 shared_runtime:
   identity: entra_id
@@ -103,6 +151,44 @@ naming_rules:
     - calling public landing assistant Odoo Copilot
     - making Studio Copilot sound like generic social-media chatbot
     - using Foundry as user-facing brand
+
+a2a_interop:
+  status: planned
+  doctrine_ref: docs/architecture/A2A_INTEROP.md
+  doctrine_summary: >
+    Use A2A for delegate/handoff/coordinate/aggregate across distinct assistant
+    surfaces. NOT for simple retrieval or single-step tool calls.
+  hub_assistant: diva_copilot
+  initial_message_types:
+    - delegate_task
+    - request_context
+    - return_result
+  tenancy_rules:
+    customer_tenant_id_required: true
+    workspace_id_required_when: workspace_scoped_surface
+    public_surfaces_excluded: true
+    cross_tenant_delegation: forbidden
+  prohibited_patterns:
+    - a2a_for_every_tool_call
+    - a2a_for_simple_retrieval
+    - recursive_delegation_loops
+    - silent_delegation
+    - public_surface_initiating_a2a
+    - bypassing_hub_for_cross_domain_aggregation
+  max_delegation_depth: 2
+  rollout:
+    phase_1:
+      target: "Q2 2026"
+      scope: hub_to_participant_read_only
+      participants: [odoo_copilot, genie]
+    phase_2:
+      target: "Q3 2026"
+      scope: full_participant_mesh_with_writes
+      participants: [odoo_copilot, genie, studio_copilot, document_intelligence]
+    phase_3:
+      target: "Q4 2026"
+      scope: multi_tenant_production
+      features: [cross_workspace, sla_enforcement, external_onboarding]
 
 cross_references:
   tenancy_model: ssot/architecture/tenancy_model.yaml


### PR DESCRIPTION
## Summary

- **docs/architecture/A2A_INTEROP.md**: Replaced short routing doc with full 11-section A2A interop doctrine covering purpose, surface roles (hub/participant/none), four allowed patterns (A-D), six prohibited patterns, three message types with field schemas, tenancy rules, retrieval/action rules, audit/observability requirements, and three rollout phases (Q2-Q4 2026).
- **ssot/agents/assistant_surfaces.yaml**: Added `a2a_role`, `a2a_enabled`, `a2a_allowed_targets`, `a2a_default_mode` to each surface. Added `landing_public_assistant` surface (a2a_role=none). Added top-level `a2a_interop` block with doctrine summary, message types, tenancy rules, prohibited patterns, max delegation depth, and rollout phases.
- **docs/architecture/ASSISTANT_SURFACES.md**: Added section 7 "A2A Role by Surface" summarizing each surface's A2A role and key rules.

## Test plan

- [ ] Verify YAML parses cleanly: `python -c "import yaml; yaml.safe_load(open('ssot/agents/assistant_surfaces.yaml'))"`
- [ ] Confirm no existing content was removed from ASSISTANT_SURFACES.md
- [ ] Review A2A_INTEROP.md sections 1-11 for completeness against the doctrine spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)