### PR TITLE
feat(agents): consolidate Pulser skill + KB registries

### DIFF
--- a/agents/foundry/agents/agents__runtime__odoo_copilot__v1.manifest.yaml
+++ b/agents/foundry/agents/agents__runtime__odoo_copilot__v1.manifest.yaml
@@ -108,11 +108,20 @@ tools:
 knowledge:
   primary_kb: ipai-knowledge-index
   search_service: srch-ipai-dev
+  registry: agents/knowledge/pulser/KB_REGISTRY.yaml
   sources:
     - odoo_19_official_docs
     - oca_module_documentation
     - bir_compliance_rules
     - ipai_internal_procedures
+
+skills:
+  registry: agents/skills/pulser/SKILL_REGISTRY.yaml
+  active_packs:
+    - pulser_erp_core
+    - pulser_taxpulse_ph
+    - pulser_finance_ops
+    - pulser_knowledge_search
 
 consumption:
   odoo_discuss: true     # Via ipai_odoo_copilot Discuss bot

--- a/agents/foundry/odoo-copilot/agent_config.yaml
+++ b/agents/foundry/odoo-copilot/agent_config.yaml
@@ -1,5 +1,5 @@
 # =============================================================================
-# Odoo Copilot — Foundry Agent Configuration
+# Pulser — Foundry Agent Configuration
 # =============================================================================
 # Defines the hosted agent for Azure AI Foundry deployment.
 # Uses Responses API (Agents v2) with function calling.
@@ -7,6 +7,9 @@
 # Foundry project: data-intel-ph
 # Foundry resource: data-intel-ph-resource
 # Model: gpt-4.1
+#
+# Skill registry: agents/skills/pulser/SKILL_REGISTRY.yaml
+# KB registry: agents/knowledge/pulser/KB_REGISTRY.yaml
 # =============================================================================
 
 agent:
@@ -146,6 +149,11 @@ search:
   index: odoo-knowledge
   semantic_config: default
   top_k: 5
+
+# Consolidated registries (canonical skill + KB definitions)
+registries:
+  skills: agents/skills/pulser/SKILL_REGISTRY.yaml
+  knowledge: agents/knowledge/pulser/KB_REGISTRY.yaml
 
 auth:
   mode: entra_id

--- a/agents/knowledge/pulser/KB_REGISTRY.yaml
+++ b/agents/knowledge/pulser/KB_REGISTRY.yaml
@@ -1,0 +1,180 @@
+# =============================================================================
+# Pulser Knowledge Base Registry — Canonical Index
+# =============================================================================
+# Master registry of all knowledge base segments available to the Pulser
+# assistant family. All segments are indexed in Azure AI Search.
+#
+# Naming doctrine: docs/brand/PULSER_NAMING_DOCTRINE.md
+# Skill registry: agents/skills/pulser/SKILL_REGISTRY.yaml
+# Supersedes: agents/knowledge/diva-copilot-sources.yaml
+# =============================================================================
+
+version: 1.0.0
+created: 2026-04-04
+domain: pulser
+owner: "@Insightpulseai/platform"
+
+index:
+  service: srch-ipai-copilot
+  primary_index: odoo-knowledge
+  semantic_config: default
+
+# =============================================================================
+# Knowledge Segments
+# =============================================================================
+
+segments:
+
+  # ---------------------------------------------------------------------------
+  # ERP Domain — Odoo 19 CE documentation and runtime
+  # ---------------------------------------------------------------------------
+  - id: kb_odoo_docs
+    name: "Odoo 19 Official Documentation"
+    domain: erp
+    description: "Odoo 19 CE official docs — modules, ORM, controllers, views, JS framework"
+    sources:
+      - type: documentation
+        origin: "Odoo 19 official docs (crawled)"
+        chunk_count: 7224
+        status: active
+    update_frequency: on_release
+    grounding_required: true
+    used_by: [pulser_erp_core, pulser_knowledge_search]
+
+  - id: kb_oca_docs
+    name: "OCA Module Documentation"
+    domain: erp
+    description: "OCA community module documentation — accounting, HR, sale, purchase, project"
+    sources:
+      - type: documentation
+        origin: "OCA repos README + technical docs"
+        status: scaffold
+    update_frequency: quarterly
+    grounding_required: true
+    used_by: [pulser_erp_core, pulser_knowledge_search]
+
+  - id: kb_ipai_procedures
+    name: "IPAI Internal Procedures"
+    domain: erp
+    description: "InsightPulseAI internal workflows, policies, and module documentation"
+    sources:
+      - type: documentation
+        path: docs/
+        description: "Runbooks, architecture docs, brand guidelines"
+      - type: module_docs
+        path: addons/ipai/
+        description: "IPAI module READMEs and inline documentation"
+    update_frequency: on_change
+    grounding_required: true
+    used_by: [pulser_erp_core, pulser_knowledge_search]
+
+  # ---------------------------------------------------------------------------
+  # Tax Domain — Philippine BIR compliance
+  # ---------------------------------------------------------------------------
+  - id: kb_tax_policy_ph
+    name: "Philippine Tax Policy"
+    domain: tax
+    description: "BIR regulations, TRAIN law provisions, Revenue Memorandum Circulars, ATC codes"
+    sources:
+      - type: regulations
+        description: "BIR Revenue Regulations and Revenue Memorandum Circulars"
+      - type: rates
+        path: addons/ipai/ipai_bir_tax_compliance/data/
+        description: "TRAIN law brackets, EWT/FWT ATC codes, tax rate tables"
+      - type: reference
+        path: agents/skills/odoo/taxpulse-ph-pack/SKILL.md
+        description: "TaxPulse capability pack documentation"
+    update_frequency: on_regulation_change
+    grounding_required: true
+    used_by: [pulser_taxpulse_ph]
+
+  - id: kb_odoo_tax_runtime
+    name: "Odoo Tax Runtime"
+    domain: tax
+    description: "Odoo tax module configuration, filing workflows, form templates, computation engine"
+    sources:
+      - type: module_docs
+        path: addons/ipai/ipai_bir_tax_compliance/
+        description: "BIR tax compliance module — models, views, data"
+      - type: workflows
+        description: "BIR filing workflow definitions and stage sequences"
+      - type: configuration
+        description: "Tax computation engine configuration and entity setup"
+    update_frequency: on_config_change
+    grounding_required: true
+    used_by: [pulser_taxpulse_ph]
+
+  - id: kb_tax_evidence
+    name: "Tax Evidence & Audit"
+    domain: tax
+    description: "Tax computation audit trails, filing artifacts, evidence pack templates"
+    sources:
+      - type: audit_trails
+        description: "Computation logs and decision records"
+      - type: artifacts
+        description: "Filed BIR forms, eFPS submissions, payment confirmations"
+      - type: templates
+        description: "Evidence pack structure for tax audits"
+    update_frequency: per_filing_period
+    grounding_required: true
+    used_by: [pulser_taxpulse_ph]
+
+  # ---------------------------------------------------------------------------
+  # Finance Domain — expense, budget, close
+  # ---------------------------------------------------------------------------
+  - id: kb_expense_policy
+    name: "Expense & Reimbursement Policy"
+    domain: finance
+    description: "Transportation reimbursement, liquidation rules, approval thresholds"
+    sources:
+      - type: policy
+        path: docs/policies/transportation-reimbursement-policy.md
+        description: "Canonical expense and reimbursement policies"
+      - type: module_docs
+        path: addons/ipai/ipai_hr_expense_liquidation/
+        description: "Expense liquidation module documentation"
+    update_frequency: on_policy_change
+    grounding_required: true
+    used_by: [pulser_finance_ops]
+
+  # ---------------------------------------------------------------------------
+  # Agent Domain — capability inventory and governance
+  # ---------------------------------------------------------------------------
+  - id: kb_agent_capability
+    name: "Agent Capability Inventory"
+    domain: agent
+    description: "Agent skill inventories, readiness criteria, promotion gate definitions"
+    sources:
+      - type: ssot
+        path: ssot/agents/
+        description: "Agent SSOT definitions and capability inventories"
+      - type: evals
+        description: "Agent evaluation results and benchmark scores"
+      - type: criteria
+        description: "Promotion criteria per environment (dev/staging/prod)"
+    update_frequency: per_eval_cycle
+    grounding_required: true
+    used_by: [pulser_erp_core]
+
+  - id: kb_governance
+    name: "Governance & Compliance Policy"
+    domain: governance
+    description: "Policy templates, compliance rules, drift thresholds, orphan detection"
+    sources:
+      - type: policies
+        description: "Governance policy template library"
+      - type: rules
+        description: "Drift detection thresholds and orphan detection rules"
+      - type: compliance
+        description: "Compliance gate definitions and enforcement rules"
+    update_frequency: on_policy_change
+    grounding_required: true
+    used_by: [pulser_erp_core]
+
+# =============================================================================
+# Supersedes
+# =============================================================================
+
+supersedes:
+  - path: agents/knowledge/diva-copilot-sources.yaml
+    reason: "Diva naming retired per PULSER_NAMING_DOCTRINE. All segments migrated to this registry."

--- a/agents/skills/bir_workflow_diva.skill.json
+++ b/agents/skills/bir_workflow_diva.skill.json
@@ -1,7 +1,9 @@
 {
   "name": "bir_workflow_diva",
   "version": "1.0.0",
-  "description": "Coordinate BIR filing workflows within the Diva Goals context. Tracks filing deadlines, preparation status, and submission progress.",
+  "deprecated": true,
+  "superseded_by": "agents/skills/pulser/SKILL_REGISTRY.yaml#packs.taxpulse_ph.skills[bir_workflow]",
+  "description": "DEPRECATED — migrated to Pulser skill registry. Coordinate BIR filing workflows within the Pulser context. Tracks filing deadlines, preparation status, and submission progress.",
   "intent": "Manage BIR filing workflow coordination and status tracking",
   "inputs": [
     {"name": "workflow_type", "type": "string", "description": "filing_status | deadline_check | preparation_guide", "required": true},

--- a/agents/skills/pulser/SKILL_REGISTRY.yaml
+++ b/agents/skills/pulser/SKILL_REGISTRY.yaml
@@ -1,0 +1,205 @@
+# =============================================================================
+# Pulser Skill Registry — Canonical Index
+# =============================================================================
+# Master registry of all skills available to the Pulser assistant family.
+# Naming doctrine: docs/brand/PULSER_NAMING_DOCTRINE.md
+# Foundry manifest: agents/foundry/agents/agents__runtime__odoo_copilot__v1.manifest.yaml
+# =============================================================================
+
+version: 1.0.0
+created: 2026-04-04
+domain: pulser
+owner: "@Insightpulseai/platform"
+
+naming:
+  brand: Pulser
+  doctrine: docs/brand/PULSER_NAMING_DOCTRINE.md
+  rule: >
+    All skills use "pulser_" prefix internally. Customer-facing labels use
+    "Pulser" or "Pulser [Edition]". Never "Copilot" as proper noun.
+    Never "Diva" standalone — use "Pulser Diva" if referencing orchestration.
+
+# =============================================================================
+# Skill Packs
+# =============================================================================
+
+packs:
+
+  # ---------------------------------------------------------------------------
+  # ERP Core — base Odoo operations
+  # ---------------------------------------------------------------------------
+  erp_core:
+    id: pulser_erp_core
+    display_name: "Pulser ERP Core"
+    description: "Core ERP read/write skills for Odoo 19 CE"
+    module: ipai_odoo_copilot
+    foundry_tools:
+      - odoo_search_partners
+      - odoo_list_opportunities
+      - odoo_search_sale_orders
+      - odoo_list_overdue_invoices
+      - odoo_list_project_tasks
+      - odoo_get_product_availability
+      - odoo_create_activity
+      - odoo_health_check
+    capabilities:
+      - navigational
+      - informational
+      - transactional
+    write_policy: read_only  # Default; escalates per action_mode
+    kb_segments:
+      - kb_odoo_docs
+      - kb_oca_docs
+
+  # ---------------------------------------------------------------------------
+  # TaxPulse PH — Philippine BIR tax compliance
+  # ---------------------------------------------------------------------------
+  taxpulse_ph:
+    id: pulser_taxpulse_ph
+    display_name: "TaxPulse PH"
+    description: "Philippine BIR tax compliance — form generation, filing workflows, AI review"
+    module: ipai_bir_tax_compliance
+    upstream: agents/skills/odoo/taxpulse-ph-pack/SKILL.md
+    skills:
+      - id: tax_advisory
+        description: "Answer tax queries with BIR regulation grounding"
+        intent: "Provide Philippine tax guidance within Pulser context"
+        inputs:
+          - {name: query, type: string, required: true}
+          - {name: tax_period, type: string, required: false}
+        outputs:
+          - {name: response, type: string}
+          - {name: citations, type: array}
+          - {name: delegated_to_taxpulse, type: boolean}
+          - {name: confidence_score, type: float}
+        kb_segments: [kb_tax_policy_ph, kb_odoo_tax_runtime]
+        instructions: >
+          Answer from KB segments when possible. For computation, filing,
+          or form generation, delegate to TaxPulse engine. Always cite
+          BIR regulations. Never provide ungrounded tax advice.
+
+      - id: bir_workflow
+        description: "Coordinate BIR filing workflows — deadlines, preparation, submission"
+        intent: "Manage BIR filing workflow coordination and status tracking"
+        inputs:
+          - {name: workflow_type, type: string, required: true, enum: [filing_status, deadline_check, preparation_guide]}
+          - {name: bir_form_type, type: string, required: false}
+          - {name: tax_period, type: string, required: false}
+        outputs:
+          - {name: workflow_status, type: object}
+          - {name: deadlines, type: array}
+          - {name: preparation_checklist, type: array}
+          - {name: blockers, type: array}
+        kb_segments: [kb_tax_policy_ph, kb_odoo_tax_runtime, kb_tax_evidence]
+        instructions: >
+          Read filing status from Odoo records. For deadline checks,
+          reference BIR calendar from KB. For preparation guides,
+          provide step-by-step checklist from KB. Delegate actual
+          filing execution to TaxPulse engine.
+
+      - id: tax_computation
+        description: "Compute tax from Odoo account.move records"
+        intent: "Run BIR tax computation engine against journal entries"
+        inputs:
+          - {name: entity_id, type: string, required: true}
+          - {name: form_type, type: string, required: true, enum: ["1601-C", "2550Q", "1702-RT"]}
+          - {name: date_from, type: string, required: true}
+          - {name: date_to, type: string, required: true}
+        outputs:
+          - {name: computed_values, type: object}
+          - {name: form_data, type: object}
+          - {name: audit_trail, type: object}
+        kb_segments: [kb_tax_policy_ph]
+        instructions: >
+          Execute via TaxPulse engine. Source data from account.move
+          records. Return computed values with full audit trail.
+          Never modify tax data without explicit user confirmation.
+
+    supported_forms:
+      - {form: "1601-C", type: Monthly, description: "Withholding tax on compensation + final payments"}
+      - {form: "2550Q", type: Quarterly, description: "VAT return"}
+      - {form: "1702-RT", type: Annual, description: "Income tax return"}
+    entities: [RIM, CKVC, BOM, JPAL, JLI, JAP, LAS, RMQB]
+    capabilities:
+      - informational
+      - compliance_intel
+      - transactional
+    write_policy: approval_required
+
+  # ---------------------------------------------------------------------------
+  # Finance Ops — expense, budget, close
+  # ---------------------------------------------------------------------------
+  finance_ops:
+    id: pulser_finance_ops
+    display_name: "Pulser Finance Ops"
+    description: "Finance operations — expense intelligence, budget tracking, period close"
+    modules:
+      - ipai_finance_ppm
+      - ipai_hr_expense_liquidation
+      - ipai_copilot_actions
+    skills:
+      - id: expense_draft
+        description: "Draft expense reports from natural language"
+        intent: "Create expense report drafts with policy validation"
+        proposal_schema: agents/schemas/pulser_proposals.py#PulserFinanceActionProposal
+        kb_segments: [kb_expense_policy]
+        write_policy: draft_only
+
+      - id: budget_query
+        description: "Query budget utilization and variance"
+        intent: "Report on budget status across cost centers"
+        kb_segments: [kb_odoo_docs]
+        write_policy: read_only
+
+    capabilities:
+      - informational
+      - transactional
+    write_policy: draft_only
+
+  # ---------------------------------------------------------------------------
+  # Knowledge Search — documentation grounding
+  # ---------------------------------------------------------------------------
+  knowledge_search:
+    id: pulser_knowledge_search
+    display_name: "Pulser Knowledge"
+    description: "Documentation and knowledge base search via Azure AI Search"
+    foundry_tools:
+      - search_odoo_knowledge
+    search:
+      service: srch-ipai-copilot
+      index: odoo-knowledge
+      semantic_config: default
+      top_k: 5
+    kb_segments:
+      - kb_odoo_docs
+      - kb_oca_docs
+      - kb_ipai_procedures
+    capabilities:
+      - informational
+
+# =============================================================================
+# Proposal Schema
+# =============================================================================
+
+proposal_schema:
+  base: agents/schemas/pulser_proposals.py#PulserActionProposal
+  extensions:
+    tax: agents/schemas/pulser_proposals.py#PulserTaxActionProposal
+    finance: agents/schemas/pulser_proposals.py#PulserFinanceActionProposal
+  action_modes:
+    - suggest_only     # Default — show proposal, no execution
+    - approval_required  # Require explicit user confirmation
+    - direct           # Execute immediately (admin only)
+
+# =============================================================================
+# Supersedes (deprecated — do not reference)
+# =============================================================================
+
+supersedes:
+  - path: agents/skills/tax_advisory_diva.skill.json
+    replaced_by: packs.taxpulse_ph.skills[tax_advisory]
+    reason: "Diva naming retired per PULSER_NAMING_DOCTRINE"
+
+  - path: agents/skills/bir_workflow_diva.skill.json
+    replaced_by: packs.taxpulse_ph.skills[bir_workflow]
+    reason: "Diva naming retired per PULSER_NAMING_DOCTRINE"

--- a/agents/skills/tax_advisory_diva.skill.json
+++ b/agents/skills/tax_advisory_diva.skill.json
@@ -1,7 +1,9 @@
 {
   "name": "tax_advisory_diva",
   "version": "1.0.0",
-  "description": "Provide Philippine tax guidance within the Diva Goals context. Wraps TaxPulse sub-agent for deep compliance; handles surface-level tax queries from KB segments.",
+  "deprecated": true,
+  "superseded_by": "agents/skills/pulser/SKILL_REGISTRY.yaml#packs.taxpulse_ph.skills[tax_advisory]",
+  "description": "DEPRECATED — migrated to Pulser skill registry. Provide Philippine tax guidance within the Pulser context. Wraps TaxPulse sub-agent for deep compliance; handles surface-level tax queries from KB segments.",
   "intent": "Answer tax-related queries with BIR regulation grounding",
   "inputs": [
     {"name": "query", "type": "string", "description": "Tax-related question from user", "required": true},


### PR DESCRIPTION
## Summary

- Create canonical **Pulser Skill Registry** (`agents/skills/pulser/SKILL_REGISTRY.yaml`) with 4 skill packs: ERP Core, TaxPulse PH, Finance Ops, Knowledge Search
- Create canonical **Pulser KB Registry** (`agents/knowledge/pulser/KB_REGISTRY.yaml`) with 9 knowledge segments across ERP, tax, finance, agent, and governance domains
- Deprecate Diva-branded skill files (`tax_advisory_diva.skill.json`, `bir_workflow_diva.skill.json`) with `superseded_by` pointers
- Update Foundry agent config and manifest to reference consolidated registries

## Why

12+ scattered skill/KB definitions across `agents/skills/`, `agents/knowledge/`, and `agents/foundry/` used inconsistent naming ("Diva", "Copilot", legacy paths). This consolidates under the canonical **Pulser** brand per `docs/brand/PULSER_NAMING_DOCTRINE.md`.

## What changed

| File | Change |
|------|--------|
| `agents/skills/pulser/SKILL_REGISTRY.yaml` | **New** — master skill index |
| `agents/knowledge/pulser/KB_REGISTRY.yaml` | **New** — master KB index |
| `agents/skills/tax_advisory_diva.skill.json` | Marked `deprecated: true` |
| `agents/skills/bir_workflow_diva.skill.json` | Marked `deprecated: true` |
| `agents/foundry/odoo-copilot/agent_config.yaml` | Added `registries` block |
| `agents/foundry/agents/...manifest.yaml` | Added `skills.registry` + `active_packs` |

## Test plan

- [ ] Verify YAML is valid: `python -c "import yaml; yaml.safe_load(open('agents/skills/pulser/SKILL_REGISTRY.yaml'))"`
- [ ] Verify KB registry: `python -c "import yaml; yaml.safe_load(open('agents/knowledge/pulser/KB_REGISTRY.yaml'))"`
- [ ] Verify deprecated files still parse: `python -c "import json; json.load(open('agents/skills/tax_advisory_diva.skill.json'))"`
- [ ] No module code changes — skill/KB registries are declarative only

🤖 Generated with [Claude Code](https://claude.com/claude-code)