### PR TITLE
feat(go-live): accounting go-live sections + PayMongo payment config

### DIFF
--- a/agents/knowledge/pulser/KB_REGISTRY.yaml
+++ b/agents/knowledge/pulser/KB_REGISTRY.yaml
@@ -120,6 +120,26 @@ segments:
     used_by: [pulser_taxpulse_ph]
 
   # ---------------------------------------------------------------------------
+  # Go-Live Domain — accounting setup, payment, opening entries
+  # ---------------------------------------------------------------------------
+  - id: kb_go_live_accounting
+    name: "Odoo Go-Live Accounting Checklist"
+    domain: go_live
+    description: "Opening entries (AR/AP), inventory valuation, trial balance import, payment journal config, PayMongo setup"
+    sources:
+      - type: runbook
+        path: docs/runbooks/ODOO19_GO_LIVE_CHECKLIST.md
+        description: "Master go-live checklist with accounting sections A-E"
+      - type: ssot
+        path: ssot/go_live/odoo19_checklist.manifest.yaml
+        description: "CI-enforced checklist manifest"
+      - type: reference
+        description: "Odoo 18 SF-Experts go-live checklist (Pei Hua Tsai, accrual basis, USA localization adapted to PH)"
+    update_frequency: on_change
+    grounding_required: true
+    used_by: [pulser_erp_core, pulser_finance_ops]
+
+  # ---------------------------------------------------------------------------
   # Finance Domain — expense, budget, close
   # ---------------------------------------------------------------------------
   - id: kb_expense_policy

--- a/docs/runbooks/ODOO19_GO_LIVE_CHECKLIST.md
+++ b/docs/runbooks/ODOO19_GO_LIVE_CHECKLIST.md
@@ -83,6 +83,108 @@
 
 ---
 
+## A) Opening Entries — Accounts Receivable (AR)
+
+> Adapted from Odoo 18 SF-Experts go-live checklist (accrual basis).
+> All journal entries execute via CLI against `pg-ipai-odoo` (Azure PG Flexible Server).
+
+- [ ] Create account: **AR Clearing** (ARC), type: Current Assets, allow reconciliation
+- [ ] Create account: **AP Clearing** (APC), type: Current Liabilities, allow reconciliation
+- [ ] Verify open invoice + credit note sums match open AR balance (client accountant sign-off)
+- [ ] Check multi-currency open invoices — update exchange rates before import
+- [ ] Import open invoices and credit notes
+- [ ] Adjust open customer payments to AR credit on initial balance (per line item, partner set)
+- [ ] Verify AR Clearing balance = 0 after reconciliation
+
+---
+
+## B) Opening Entries — Accounts Payable (AP)
+
+- [ ] Verify open bill + refund sums match open AP balance (client accountant sign-off)
+- [ ] Check multi-currency open bills — update exchange rates before import
+- [ ] Import open bills and refunds
+- [ ] Adjust open vendor payments to AP debit on initial balance (per line item, partner set)
+- [ ] Verify AP Clearing balance = 0 after reconciliation
+
+---
+
+## C) Inventory Opening
+
+> Choose automated or manual valuation per product category.
+
+### Automated Valuation
+
+- [ ] Accounting settings: enable Automatic Accounting
+- [ ] Product categories configured with costing method and valuation
+- [ ] Products imported with correct category, cost, type=Goods, track=Quantity
+- [ ] Create **Inventory Clearing** account (type: Current Asset, allow reconciliation)
+- [ ] Set Inventory Clearing on virtual inventory adjustment location
+- [ ] Collect inventory import file (product, location, quantity, lot/SN optional)
+- [ ] Verify: sum(cost * qty) = initial balance inventory value
+- [ ] Physical inventory imported and validated via Inventory app
+- [ ] Change normal loss account on virtual adjustment location post-import
+
+### Manual Valuation
+
+- [ ] Products set up with cost
+- [ ] Inventory file collected and imported
+- [ ] Verify: sum(cost * qty) = initial balance inventory value
+- [ ] Confirm: Balance Sheet shows no stock valuation line (manual mode)
+
+---
+
+## D) Trial Balance Import
+
+### Payment Journal Configuration
+
+> Choose A (payment entries needed) or B (no payment entries after go-live).
+
+**Option A — Bank journal with payment entry:**
+
+- [ ] Create **Outstanding Receipt** and **Outstanding Payment** accounts (Current Asset, allow reconciliation)
+- [ ] Add Outstanding Receipt/Payment to bank journal incoming/outgoing sections
+- [ ] Map bank account to Outstanding Receipt account
+
+**Option B — Bank journal without payment entry:**
+
+- [ ] Create **Bank Clearing** account (Current Asset, allow reconciliation)
+- [ ] Map bank account to Bank Clearing account
+
+### Trial Balance Steps (both options)
+
+- [ ] Prepare client original trial balance (Excel)
+- [ ] Modify TB AR account → AR Clearing (exclude open customer payments)
+- [ ] Modify TB AP account → AP Clearing (exclude open vendor payments)
+- [ ] Modify TB Inventory account → Inventory Clearing (if automated valuation)
+- [ ] Import journal entry for trial balance and post
+- [ ] Verify: General Ledger → AR Clearing = 0
+- [ ] Verify: General Ledger → AP Clearing = 0
+- [ ] Verify: General Ledger → Inventory Clearing = 0
+- [ ] **Balance Sheet ties to signed-off Trial Balance**
+
+---
+
+## E) Payment Provider Configuration (Azure + PH Market)
+
+> Module: `ipai_payment_paymongo` (v18.0.1.0.0)
+> Secrets: Azure Key Vault (`kv-ipai-dev`)
+
+- [ ] PayMongo API keys vaulted in `kv-ipai-dev` (`paymongo-secret-key`, `paymongo-public-key`)
+- [ ] Payment provider activated in Odoo (Accounting → Configuration → Payment Providers)
+- [ ] Supported methods enabled: Credit/Debit, GCash, Maya, GrabPay, BPI/UnionBank
+- [ ] Webhook endpoint registered with PayMongo (`https://erp.insightpulseai.com/payment/paymongo/webhook`)
+- [ ] Test transaction completed in sandbox mode
+- [ ] Production mode activated after sandbox verification
+
+### Bank Account Configuration
+
+- [ ] Company bank accounts created in Odoo (matching BIR-registered accounts)
+- [ ] Bank journals created per account with correct outstanding receipt/payment accounts
+- [ ] Bank statement import method configured (manual CSV or OCA bank-statement-import)
+- [ ] Reconciliation model configured for common payment patterns
+
+---
+
 ## 6. Integration Readiness
 
 - [x] **Foundry endpoint** tested (gpt-4.1 live, ~3s latency) -- 2026-03-18

--- a/ssot/go_live/odoo19_checklist.manifest.yaml
+++ b/ssot/go_live/odoo19_checklist.manifest.yaml
@@ -1,0 +1,65 @@
+# =============================================================================
+# Go-Live Runbook Manifest — Odoo 19 CE
+# =============================================================================
+# Machine-verifiable contract that prevents the go-live checklist from being
+# accidentally truncated, renamed, or stripped of required sections.
+#
+# Enforced by: .github/workflows/go-live-runbook-gate.yml
+# Runbook:     docs/runbooks/ODOO19_GO_LIVE_CHECKLIST.md
+# =============================================================================
+
+schema: "ssot.go_live.manifest.v1"
+version: "1.1"
+last_updated: "2026-04-04"
+owner: "DevOps / Finance"
+
+runbook_path: docs/runbooks/ODOO19_GO_LIVE_CHECKLIST.md
+
+# Required section headings (must appear verbatim in the runbook file).
+# CI fails if any heading is renamed, removed, or mangled.
+required_sections:
+  # Accounting go-live (adapted from Odoo 18 SF-Experts checklist)
+  - "## A) Opening Entries — Accounts Receivable (AR)"
+  - "## B) Opening Entries — Accounts Payable (AP)"
+  - "## C) Inventory Opening"
+  - "## D) Trial Balance Import"
+  - "## E) Payment Provider Configuration (Azure + PH Market)"
+  # Infrastructure + operations
+  - "## 6. Integration Readiness"
+  - "## 7. Security Readiness"
+  - "## 8. Smoke Test Execution"
+  - "## 9. Go/No-Go Decision"
+
+# Representative checklist items that must be present verbatim.
+# These pin critical controls — accidental removal fails CI.
+required_items:
+  - "AR Clearing balance = 0 after reconciliation"
+  - "AP Clearing balance = 0 after reconciliation"
+  - "Balance Sheet ties to signed-off Trial Balance"
+  - "PayMongo API keys vaulted"
+  - "Test transaction completed in sandbox mode"
+  - "General Ledger → Inventory Clearing = 0"
+
+# CI workflows that must be green before declaring go-live complete.
+# Informational only — cutover managers must verify these manually.
+required_ci_gates:
+  - odoo-ci-gate
+  - repo-structure-gate
+  - odoo-env-neutralization-gate
+  - go-live-runbook-gate
+  - secrets-scan-gate
+
+# Minimum number of checklist items (- [ ] markers) to catch accidental truncation.
+minimum_checklist_items: 60
+
+# Self-hosted specifics that must be covered (verified by substring match in runbook).
+required_content_markers:
+  - "ipai_zoho_mail_api"          # Zoho email transport referenced
+  - "odoo-core"                   # Container name documented
+  - "erp.insightpulseai.com"      # Production domain documented
+  - "web/docs/evidence"           # Evidence path convention present
+  - "STATUS=COMPLETE"             # Completion semantics present
+
+# Runbook size sanity bounds (lines).
+min_lines: 200
+max_lines: 1000


### PR DESCRIPTION
## Summary

- Add **accounting go-live sections A-E** to the Odoo go-live runbook covering full cutover workflow
- Add **PayMongo payment provider configuration** section with Azure Key Vault integration
- Update **SSOT manifest** to enforce new required sections via CI
- Add **go-live accounting KB segment** to Pulser knowledge base registry

## What changed

### Go-Live Runbook — 5 new sections

| Section | What it covers |
|---------|---------------|
| **A) AR Opening Entries** | AR/AP clearing accounts, open invoice import, reconciliation verification |
| **B) AP Opening Entries** | Vendor payment adjustments, AP clearing verification |
| **C) Inventory Opening** | Automated vs manual valuation, inventory clearing account, physical import |
| **D) Trial Balance Import** | Payment journal config (2 options), TB Excel preparation, clearing verification |
| **E) Payment Provider Config** | PayMongo (PH market: GCash, Maya, cards), KV-backed secrets, webhook endpoint |

### Azure Integration Points

- PayMongo API keys → `kv-ipai-dev` (`paymongo-secret-key`, `paymongo-public-key`)
- Webhook endpoint → `erp.insightpulseai.com/payment/paymongo/webhook` (via AFD)
- Bank statements → OCA `bank-statement-import` module (already in OCA baseline)
- All journal entries execute against `pg-ipai-odoo` (Azure PG Flexible Server)

### Source

Adapted from Odoo 18 SF-Experts go-live checklist by Pei Hua Tsai (USA localization, adapted to PH market).

## Test plan

- [ ] Verify SSOT manifest sections match runbook headings
- [ ] Verify KB registry YAML is valid
- [ ] Checklist item count >= 60 (manifest minimum)

🤖 Generated with [Claude Code](https://claude.com/claude-code)