### PR TITLE
feat: Pulser Teams surface + Entra Agent ID plan (Agent 365 GA prep)

### DIFF
--- a/agents/ap-invoice-surface/README.md
+++ b/agents/ap-invoice-surface/README.md
@@ -1,0 +1,32 @@
+# agents/ap-invoice-surface — AP Invoice processing for Microsoft Teams
+
+Process incoming vendor invoices — create draft bills in Odoo.
+
+## Before provisioning
+
+Copy shared files from `teams-surface/`:
+
+```bash
+cd agents/ap-invoice-surface
+cp ../teams-surface/teamsapp.yml .
+cp -r ../teams-surface/bot/app.py ../teams-surface/bot/requirements.txt bot/
+cp -r ../teams-surface/infra ../teams-surface/env .
+sed -i '' 's/pulser-teams/ap-invoice/g' teamsapp.yml
+```
+
+## Persona
+
+- **Scope**: Upload vendor invoice PDF → extract → create `account.move` draft in Odoo → route for approval
+- **Commands**: `/process`, `/pending`, `/approve`, `/reject`, `/vendor`, `/help`
+- **Backend**: `ipai-copilot-gateway` with `surface=teams-ap-invoice` → Doc Intelligence extraction + Odoo JSON-RPC
+- **Dependencies**: Doc Intelligence agent (for extraction); Odoo `account` module
+
+## Entra Agent ID (May 1 GA)
+
+MI: `id-ipai-agent-ap-invoice` in `rg-ipai-dev-platform`.
+
+## Related
+
+- Parent plan: [spec/pulser-entra-agent-id/](../../spec/pulser-entra-agent-id/)
+- Streaming rules: [docs/skills/m365-copilot-streaming-contract.md](../../docs/skills/m365-copilot-streaming-contract.md)
+- Pulser template: [agents/teams-surface/](../teams-surface/)

--- a/agents/ap-invoice-surface/appPackage/manifest.json
+++ b/agents/ap-invoice-surface/appPackage/manifest.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
+  "version": "0.1.0",
+  "id": "${{TEAMS_APP_ID}}",
+  "developer": {
+    "name": "InsightPulseAI Inc.",
+    "websiteUrl": "https://insightpulseai.com",
+    "privacyUrl": "https://insightpulseai.com/privacy",
+    "termsOfUseUrl": "https://insightpulseai.com/terms"
+  },
+  "icons": { "color": "color.png", "outline": "outline.png" },
+  "name": {
+    "short": "AP Invoice",
+    "full": "AP Invoice — Vendor invoice automation"
+  },
+  "description": {
+    "short": "Upload vendor invoices — create draft bills in Odoo.",
+    "full": "AP Invoice processes vendor invoices by extracting data via Azure Document Intelligence and creating draft account.move entries in Odoo for approval. Supports PDF uploads, pending-approval queues, and vendor lookups."
+  },
+  "accentColor": "#6A1B9A",
+  "bots": [
+    {
+      "botId": "${{BOT_ID}}",
+      "scopes": ["personal", "team", "groupChat"],
+      "supportsFiles": true,
+      "isNotificationOnly": false,
+      "commandLists": [
+        {
+          "scopes": ["personal", "team", "groupChat"],
+          "commands": [
+            { "title": "process", "description": "Upload a vendor invoice PDF" },
+            { "title": "pending", "description": "List bills awaiting approval" },
+            { "title": "approve", "description": "Approve a pending bill by ID" },
+            { "title": "reject",  "description": "Reject a pending bill with reason" },
+            { "title": "vendor",  "description": "Look up a vendor in Odoo" },
+            { "title": "help",    "description": "What can AP Invoice do?" }
+          ]
+        }
+      ]
+    }
+  ],
+  "copilotAgents": {
+    "customEngineAgents": [
+      { "type": "bot", "id": "${{BOT_ID}}" }
+    ]
+  },
+  "validDomains": [
+    "ipai-copilot-gateway.insightpulseai.com",
+    "ipai-copilot-resource.services.ai.azure.com"
+  ],
+  "webApplicationInfo": {
+    "id": "${{AAD_APP_CLIENT_ID}}",
+    "resource": "api://botid-${{BOT_ID}}"
+  }
+}

--- a/agents/ap-invoice-surface/bot/bot.py
+++ b/agents/ap-invoice-surface/bot/bot.py
@@ -1,0 +1,127 @@
+"""
+ap-invoice-surface/bot/bot.py — AP Invoice processing persona.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import logging
+import os
+
+import aiohttp
+from azure.identity.aio import DefaultAzureCredential
+from botbuilder.core import ActivityHandler, TurnContext
+from botbuilder.core.streaming import StreamingResponse  # type: ignore[import-not-found]
+from botbuilder.schema import ChannelAccount
+
+LOG = logging.getLogger("ap_invoice.bot")
+
+AGENT_NAME = "ap-invoice"
+SURFACE_TAG = "teams-ap-invoice"
+
+GATEWAY_URL = os.environ.get(
+    "COPILOT_GATEWAY_URL",
+    "https://ipai-copilot-gateway.insightpulseai.com",
+)
+GATEWAY_SCOPE = os.environ.get(
+    "COPILOT_GATEWAY_SCOPE",
+    "api://ipai-copilot-gateway/.default",
+)
+
+WELCOME = (
+    "AP Invoice ready. Upload a vendor invoice PDF and I'll create a draft bill "
+    "in Odoo.\n\n"
+    "Try `/process`, `/pending`, `/approve <id>`, `/reject <id>`, or `/vendor <name>`."
+)
+
+
+class ApInvoiceBot(ActivityHandler):
+    async def on_members_added_activity(
+        self,
+        members_added: list[ChannelAccount],
+        turn_context: TurnContext,
+    ) -> None:
+        for member in members_added:
+            if member.id == turn_context.activity.recipient.id:
+                continue
+            await turn_context.send_activity(WELCOME)
+
+    async def on_message_activity(self, turn_context: TurnContext) -> None:
+        user_text = (turn_context.activity.text or "").strip()
+        attachments = turn_context.activity.attachments or []
+        file_refs = [
+            {
+                "name": att.name,
+                "content_type": att.content_type,
+                "content_url": getattr(att, "content_url", None) or (
+                    att.content.get("downloadUrl") if isinstance(att.content, dict) else None
+                ),
+            }
+            for att in attachments
+            if att.content_type and att.content_type.startswith(("application/pdf", "image/"))
+        ]
+
+        if not user_text and not file_refs:
+            return
+
+        stream = StreamingResponse(turn_context)
+        try:
+            await stream.queue_informative_update(
+                "Processing invoice…" if file_refs else "Checking Odoo…"
+            )
+
+            async for chunk in self._call_gateway(
+                prompt=user_text,
+                file_refs=file_refs,
+                user_id=turn_context.activity.from_property.aad_object_id,
+            ):
+                text = chunk.get("text")
+                if text:
+                    await stream.queue_text_chunk(text)
+                if chunk.get("attachments"):
+                    stream.set_attachments(chunk["attachments"])
+
+        except Exception as err:
+            LOG.exception("gateway.error %s", err)
+            await stream.queue_text_chunk(
+                "\n\n_AP Invoice backend error — try again in a moment._"
+            )
+        finally:
+            await stream.end_stream()
+
+    async def _call_gateway(
+        self,
+        prompt: str,
+        file_refs: list[dict],
+        user_id: str | None,
+    ):
+        token = await self._acquire_gateway_token()
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/x-ndjson",
+        }
+        payload = {
+            "prompt": prompt,
+            "user_id": user_id,
+            "surface": SURFACE_TAG,
+            "agent": AGENT_NAME,
+            "files": file_refs,
+            "stream": True,
+        }
+
+        async with aiohttp.ClientSession(headers=headers) as session:
+            async with session.post(
+                f"{GATEWAY_URL}/chat", json=payload, timeout=120
+            ) as resp:
+                resp.raise_for_status()
+                async for line in resp.content:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    yield _json.loads(line)
+
+    async def _acquire_gateway_token(self) -> str:
+        async with DefaultAzureCredential() as cred:
+            token = await cred.get_token(GATEWAY_SCOPE)
+            return token.token

--- a/agents/bank-recon-surface/README.md
+++ b/agents/bank-recon-surface/README.md
@@ -1,0 +1,32 @@
+# agents/bank-recon-surface — Bank Reconciliation for Microsoft Teams
+
+Reconciles bank statements against Odoo `account.move` entries.
+
+## Before provisioning
+
+Copy shared files from `teams-surface/`:
+
+```bash
+cd agents/bank-recon-surface
+cp ../teams-surface/teamsapp.yml .
+cp -r ../teams-surface/bot/app.py ../teams-surface/bot/requirements.txt bot/
+cp -r ../teams-surface/infra ../teams-surface/env .
+sed -i '' 's/pulser-teams/bank-recon/g' teamsapp.yml
+```
+
+## Persona
+
+- **Scope**: Import bank statements (OFX, CSV, PDF) → match against Odoo moves → propose reconciliations
+- **Commands**: `/match`, `/unreconciled`, `/stmt`, `/summary`, `/banks`, `/help`
+- **Backend**: `ipai-copilot-gateway` with `surface=teams-bank-recon` → Odoo JSON-RPC + reconciliation rules engine
+- **Files**: accepts OFX/CSV/PDF uploads
+
+## Entra Agent ID (May 1 GA)
+
+MI: `id-ipai-agent-bank-recon` in `rg-ipai-dev-platform`.
+
+## Related
+
+- Parent plan: [spec/pulser-entra-agent-id/](../../spec/pulser-entra-agent-id/)
+- Streaming rules: [docs/skills/m365-copilot-streaming-contract.md](../../docs/skills/m365-copilot-streaming-contract.md)
+- Pulser template: [agents/teams-surface/](../teams-surface/)

--- a/agents/bank-recon-surface/appPackage/manifest.json
+++ b/agents/bank-recon-surface/appPackage/manifest.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
+  "version": "0.1.0",
+  "id": "${{TEAMS_APP_ID}}",
+  "developer": {
+    "name": "InsightPulseAI Inc.",
+    "websiteUrl": "https://insightpulseai.com",
+    "privacyUrl": "https://insightpulseai.com/privacy",
+    "termsOfUseUrl": "https://insightpulseai.com/terms"
+  },
+  "icons": { "color": "color.png", "outline": "outline.png" },
+  "name": {
+    "short": "Bank Recon",
+    "full": "Bank Recon — Bank reconciliation assistant"
+  },
+  "description": {
+    "short": "Reconcile bank statements against Odoo entries in minutes.",
+    "full": "Bank Recon imports bank statements (OFX, CSV, PDF), matches them against Odoo account.move entries, and proposes reconciliations with confidence scores. Backed by ipai-copilot-gateway and the IPAI reconciliation rules engine."
+  },
+  "accentColor": "#1565C0",
+  "bots": [
+    {
+      "botId": "${{BOT_ID}}",
+      "scopes": ["personal", "team", "groupChat"],
+      "supportsFiles": true,
+      "isNotificationOnly": false,
+      "commandLists": [
+        {
+          "scopes": ["personal", "team", "groupChat"],
+          "commands": [
+            { "title": "match",        "description": "Match a statement line to an Odoo move" },
+            { "title": "unreconciled", "description": "List unreconciled entries by bank" },
+            { "title": "stmt",         "description": "Upload and parse a bank statement" },
+            { "title": "summary",      "description": "Reconciliation summary for the current period" },
+            { "title": "banks",        "description": "List configured bank accounts" },
+            { "title": "help",         "description": "What can Bank Recon do?" }
+          ]
+        }
+      ]
+    }
+  ],
+  "copilotAgents": {
+    "customEngineAgents": [
+      { "type": "bot", "id": "${{BOT_ID}}" }
+    ]
+  },
+  "validDomains": [
+    "ipai-copilot-gateway.insightpulseai.com",
+    "ipai-copilot-resource.services.ai.azure.com"
+  ],
+  "webApplicationInfo": {
+    "id": "${{AAD_APP_CLIENT_ID}}",
+    "resource": "api://botid-${{BOT_ID}}"
+  }
+}

--- a/agents/bank-recon-surface/bot/bot.py
+++ b/agents/bank-recon-surface/bot/bot.py
@@ -1,0 +1,127 @@
+"""
+bank-recon-surface/bot/bot.py — Bank Reconciliation persona.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import logging
+import os
+
+import aiohttp
+from azure.identity.aio import DefaultAzureCredential
+from botbuilder.core import ActivityHandler, TurnContext
+from botbuilder.core.streaming import StreamingResponse  # type: ignore[import-not-found]
+from botbuilder.schema import ChannelAccount
+
+LOG = logging.getLogger("bank_recon.bot")
+
+AGENT_NAME = "bank-recon"
+SURFACE_TAG = "teams-bank-recon"
+
+GATEWAY_URL = os.environ.get(
+    "COPILOT_GATEWAY_URL",
+    "https://ipai-copilot-gateway.insightpulseai.com",
+)
+GATEWAY_SCOPE = os.environ.get(
+    "COPILOT_GATEWAY_SCOPE",
+    "api://ipai-copilot-gateway/.default",
+)
+
+WELCOME = (
+    "Bank Recon ready. Upload a bank statement (OFX, CSV, PDF) or ask about "
+    "unreconciled entries.\n\n"
+    "Try `/unreconciled`, `/match`, `/summary`, or `/banks`."
+)
+
+
+class BankReconBot(ActivityHandler):
+    async def on_members_added_activity(
+        self,
+        members_added: list[ChannelAccount],
+        turn_context: TurnContext,
+    ) -> None:
+        for member in members_added:
+            if member.id == turn_context.activity.recipient.id:
+                continue
+            await turn_context.send_activity(WELCOME)
+
+    async def on_message_activity(self, turn_context: TurnContext) -> None:
+        user_text = (turn_context.activity.text or "").strip()
+        attachments = turn_context.activity.attachments or []
+        file_refs = [
+            {
+                "name": att.name,
+                "content_type": att.content_type,
+                "content_url": getattr(att, "content_url", None) or (
+                    att.content.get("downloadUrl") if isinstance(att.content, dict) else None
+                ),
+            }
+            for att in attachments
+            if att.content_type and att.content_type.startswith(("application/", "text/"))
+        ]
+
+        if not user_text and not file_refs:
+            return
+
+        stream = StreamingResponse(turn_context)
+        try:
+            await stream.queue_informative_update(
+                "Parsing statement…" if file_refs else "Checking recon state…"
+            )
+
+            async for chunk in self._call_gateway(
+                prompt=user_text,
+                file_refs=file_refs,
+                user_id=turn_context.activity.from_property.aad_object_id,
+            ):
+                text = chunk.get("text")
+                if text:
+                    await stream.queue_text_chunk(text)
+                if chunk.get("attachments"):
+                    stream.set_attachments(chunk["attachments"])
+
+        except Exception as err:
+            LOG.exception("gateway.error %s", err)
+            await stream.queue_text_chunk(
+                "\n\n_Bank Recon backend error — try again in a moment._"
+            )
+        finally:
+            await stream.end_stream()
+
+    async def _call_gateway(
+        self,
+        prompt: str,
+        file_refs: list[dict],
+        user_id: str | None,
+    ):
+        token = await self._acquire_gateway_token()
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/x-ndjson",
+        }
+        payload = {
+            "prompt": prompt,
+            "user_id": user_id,
+            "surface": SURFACE_TAG,
+            "agent": AGENT_NAME,
+            "files": file_refs,
+            "stream": True,
+        }
+
+        async with aiohttp.ClientSession(headers=headers) as session:
+            async with session.post(
+                f"{GATEWAY_URL}/chat", json=payload, timeout=120
+            ) as resp:
+                resp.raise_for_status()
+                async for line in resp.content:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    yield _json.loads(line)
+
+    async def _acquire_gateway_token(self) -> str:
+        async with DefaultAzureCredential() as cred:
+            token = await cred.get_token(GATEWAY_SCOPE)
+            return token.token

--- a/agents/doc-intel-surface/README.md
+++ b/agents/doc-intel-surface/README.md
@@ -1,0 +1,32 @@
+# agents/doc-intel-surface — Document Intelligence for Microsoft Teams
+
+Structured extraction from invoices, receipts, IDs, BIR 2307 forms, tax documents. Custom engine agent surface backed by Azure Document Intelligence + MCP pipeline (13 tools).
+
+## Before provisioning
+
+Copy shared files from `teams-surface/` (teamsapp.yml, bot/app.py, bot/requirements.txt, infra/, env/) and substitute `pulser-teams` → `doc-intel` in teamsapp.yml.
+
+```bash
+cd agents/doc-intel-surface
+cp ../teams-surface/teamsapp.yml .
+cp -r ../teams-surface/bot/app.py ../teams-surface/bot/requirements.txt bot/
+cp -r ../teams-surface/infra ../teams-surface/env .
+sed -i '' 's/pulser-teams/doc-intel/g' teamsapp.yml
+```
+
+## Persona
+
+- **Scope**: Document extraction → structured JSON → optional Odoo upload
+- **Commands**: `/invoice`, `/receipt`, `/id`, `/2307`, `/extract`, `/help`
+- **Backend**: `ipai-copilot-gateway` with `surface=teams-doc-intel` → Foundry DI pipeline (see memory `project_invoice_pipeline`)
+- **Special**: supports file attachments (`supportsFiles: true` in manifest)
+
+## Entra Agent ID (May 1 GA)
+
+MI: `id-ipai-agent-doc-intel` in `rg-ipai-dev-platform`.
+
+## Related
+
+- Parent plan: [spec/pulser-entra-agent-id/](../../spec/pulser-entra-agent-id/)
+- Streaming rules: [docs/skills/m365-copilot-streaming-contract.md](../../docs/skills/m365-copilot-streaming-contract.md)
+- Pulser template: [agents/teams-surface/](../teams-surface/)

--- a/agents/doc-intel-surface/appPackage/manifest.json
+++ b/agents/doc-intel-surface/appPackage/manifest.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
+  "version": "0.1.0",
+  "id": "${{TEAMS_APP_ID}}",
+  "developer": {
+    "name": "InsightPulseAI Inc.",
+    "websiteUrl": "https://insightpulseai.com",
+    "privacyUrl": "https://insightpulseai.com/privacy",
+    "termsOfUseUrl": "https://insightpulseai.com/terms"
+  },
+  "icons": { "color": "color.png", "outline": "outline.png" },
+  "name": {
+    "short": "Doc Intelligence",
+    "full": "Doc Intelligence — Document extraction assistant"
+  },
+  "description": {
+    "short": "Extract structured data from invoices, receipts, IDs, and BIR forms.",
+    "full": "Doc Intelligence extracts structured JSON from uploaded PDFs and images: invoices, receipts, IDs, BIR 2307 withholding certificates, and custom document types. Backed by Azure Document Intelligence + Foundry pipeline (13 MCP tools)."
+  },
+  "accentColor": "#2E7D32",
+  "bots": [
+    {
+      "botId": "${{BOT_ID}}",
+      "scopes": ["personal", "team", "groupChat"],
+      "supportsFiles": true,
+      "isNotificationOnly": false,
+      "commandLists": [
+        {
+          "scopes": ["personal", "team", "groupChat"],
+          "commands": [
+            { "title": "invoice", "description": "Extract invoice fields (vendor, line items, totals, VAT)" },
+            { "title": "receipt", "description": "Extract receipt fields (merchant, items, total)" },
+            { "title": "id",      "description": "Extract ID fields (name, number, DOB, issuer)" },
+            { "title": "2307",    "description": "Extract BIR 2307 withholding certificate" },
+            { "title": "extract", "description": "Generic extraction — give me a schema + file" },
+            { "title": "help",    "description": "What can Doc Intelligence do?" }
+          ]
+        }
+      ]
+    }
+  ],
+  "copilotAgents": {
+    "customEngineAgents": [
+      { "type": "bot", "id": "${{BOT_ID}}" }
+    ]
+  },
+  "validDomains": [
+    "ipai-copilot-gateway.insightpulseai.com",
+    "ipai-copilot-resource.services.ai.azure.com"
+  ],
+  "webApplicationInfo": {
+    "id": "${{AAD_APP_CLIENT_ID}}",
+    "resource": "api://botid-${{BOT_ID}}"
+  }
+}

--- a/agents/doc-intel-surface/bot/bot.py
+++ b/agents/doc-intel-surface/bot/bot.py
@@ -1,0 +1,133 @@
+"""
+doc-intel-surface/bot/bot.py — Document Intelligence persona.
+
+Extracts structured data from file attachments. `supportsFiles: true` in
+the manifest means incoming messages may carry attachments — forwarded
+to ipai-copilot-gateway which runs the Foundry DI pipeline (13 tools).
+"""
+
+from __future__ import annotations
+
+import json as _json
+import logging
+import os
+
+import aiohttp
+from azure.identity.aio import DefaultAzureCredential
+from botbuilder.core import ActivityHandler, TurnContext
+from botbuilder.core.streaming import StreamingResponse  # type: ignore[import-not-found]
+from botbuilder.schema import ChannelAccount
+
+LOG = logging.getLogger("doc_intel.bot")
+
+AGENT_NAME = "doc-intel"
+SURFACE_TAG = "teams-doc-intel"
+
+GATEWAY_URL = os.environ.get(
+    "COPILOT_GATEWAY_URL",
+    "https://ipai-copilot-gateway.insightpulseai.com",
+)
+GATEWAY_SCOPE = os.environ.get(
+    "COPILOT_GATEWAY_SCOPE",
+    "api://ipai-copilot-gateway/.default",
+)
+
+WELCOME = (
+    "Doc Intelligence ready. Upload a PDF or image, or tell me what to extract.\n\n"
+    "Try `/invoice`, `/receipt`, `/id`, `/2307`, or `/extract <schema>`."
+)
+
+
+class DocIntelBot(ActivityHandler):
+    async def on_members_added_activity(
+        self,
+        members_added: list[ChannelAccount],
+        turn_context: TurnContext,
+    ) -> None:
+        for member in members_added:
+            if member.id == turn_context.activity.recipient.id:
+                continue
+            await turn_context.send_activity(WELCOME)
+
+    async def on_message_activity(self, turn_context: TurnContext) -> None:
+        user_text = (turn_context.activity.text or "").strip()
+        # Extract any file attachments — Teams delivers them with contentUrl
+        attachments = turn_context.activity.attachments or []
+        file_refs = [
+            {
+                "name": att.name,
+                "content_type": att.content_type,
+                "content_url": getattr(att, "content_url", None) or (
+                    att.content.get("downloadUrl") if isinstance(att.content, dict) else None
+                ),
+            }
+            for att in attachments
+            if att.content_type and att.content_type.startswith(("application/", "image/"))
+        ]
+
+        if not user_text and not file_refs:
+            return
+
+        stream = StreamingResponse(turn_context)
+        try:
+            await stream.queue_informative_update(
+                "Extracting…" if file_refs else "Thinking…"
+            )
+
+            async for chunk in self._call_gateway(
+                prompt=user_text,
+                file_refs=file_refs,
+                user_id=turn_context.activity.from_property.aad_object_id,
+            ):
+                text = chunk.get("text")
+                if text:
+                    await stream.queue_text_chunk(text)
+
+                chunk_attachments = chunk.get("attachments")
+                if chunk_attachments:
+                    stream.set_attachments(chunk_attachments)
+
+        except Exception as err:
+            LOG.exception("gateway.error %s", err)
+            await stream.queue_text_chunk(
+                "\n\n_Doc Intelligence backend error — try again in a moment._"
+            )
+        finally:
+            await stream.end_stream()
+
+    async def _call_gateway(
+        self,
+        prompt: str,
+        file_refs: list[dict],
+        user_id: str | None,
+    ):
+        token = await self._acquire_gateway_token()
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/x-ndjson",
+        }
+        payload = {
+            "prompt": prompt,
+            "user_id": user_id,
+            "surface": SURFACE_TAG,
+            "agent": AGENT_NAME,
+            "files": file_refs,
+            "stream": True,
+        }
+
+        async with aiohttp.ClientSession(headers=headers) as session:
+            async with session.post(
+                f"{GATEWAY_URL}/extract", json=payload, timeout=120
+            ) as resp:
+                resp.raise_for_status()
+                async for line in resp.content:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    yield _json.loads(line)
+
+    async def _acquire_gateway_token(self) -> str:
+        async with DefaultAzureCredential() as cred:
+            token = await cred.get_token(GATEWAY_SCOPE)
+            return token.token

--- a/agents/finance-close-surface/README.md
+++ b/agents/finance-close-surface/README.md
@@ -1,0 +1,31 @@
+# agents/finance-close-surface — Monthly Close for Microsoft Teams
+
+Orchestrate Odoo monthly close — checklist, status, variance review.
+
+## Before provisioning
+
+Copy shared files from `teams-surface/`:
+
+```bash
+cd agents/finance-close-surface
+cp ../teams-surface/teamsapp.yml .
+cp -r ../teams-surface/bot/app.py ../teams-surface/bot/requirements.txt bot/
+cp -r ../teams-surface/infra ../teams-surface/env .
+sed -i '' 's/pulser-teams/finance-close/g' teamsapp.yml
+```
+
+## Persona
+
+- **Scope**: Run the monthly close checklist (see memory `project_monthly_close_checklist`), check status, investigate variances, reopen period if needed
+- **Commands**: `/status`, `/checklist`, `/close`, `/reopen`, `/variance`, `/help`
+- **Backend**: `ipai-copilot-gateway` with `surface=teams-finance-close` → Odoo `account.period` API + variance reports
+
+## Entra Agent ID (May 1 GA)
+
+MI: `id-ipai-agent-finance-close` in `rg-ipai-dev-platform`.
+
+## Related
+
+- Parent plan: [spec/pulser-entra-agent-id/](../../spec/pulser-entra-agent-id/)
+- Streaming rules: [docs/skills/m365-copilot-streaming-contract.md](../../docs/skills/m365-copilot-streaming-contract.md)
+- Pulser template: [agents/teams-surface/](../teams-surface/)

--- a/agents/finance-close-surface/appPackage/manifest.json
+++ b/agents/finance-close-surface/appPackage/manifest.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
+  "version": "0.1.0",
+  "id": "${{TEAMS_APP_ID}}",
+  "developer": {
+    "name": "InsightPulseAI Inc.",
+    "websiteUrl": "https://insightpulseai.com",
+    "privacyUrl": "https://insightpulseai.com/privacy",
+    "termsOfUseUrl": "https://insightpulseai.com/terms"
+  },
+  "icons": { "color": "color.png", "outline": "outline.png" },
+  "name": {
+    "short": "Finance Close",
+    "full": "Finance Close — Monthly close orchestrator"
+  },
+  "description": {
+    "short": "Orchestrate Odoo monthly close: checklist, status, variance review.",
+    "full": "Finance Close runs the IPAI monthly close checklist against Odoo: reconciliations verified, accruals posted, period locked, reports generated. Surfaces variances, prompts for approvals, and reopens a period when required."
+  },
+  "accentColor": "#EF6C00",
+  "bots": [
+    {
+      "botId": "${{BOT_ID}}",
+      "scopes": ["personal", "team", "groupChat"],
+      "supportsFiles": false,
+      "isNotificationOnly": false,
+      "commandLists": [
+        {
+          "scopes": ["personal", "team", "groupChat"],
+          "commands": [
+            { "title": "status",    "description": "Current close status for this period" },
+            { "title": "checklist", "description": "Show / advance the close checklist" },
+            { "title": "close",     "description": "Run the close sequence for current period" },
+            { "title": "reopen",    "description": "Reopen a previously-closed period (requires approval)" },
+            { "title": "variance",  "description": "Show variances above threshold" },
+            { "title": "help",      "description": "What can Finance Close do?" }
+          ]
+        }
+      ]
+    }
+  ],
+  "copilotAgents": {
+    "customEngineAgents": [
+      { "type": "bot", "id": "${{BOT_ID}}" }
+    ]
+  },
+  "validDomains": [
+    "ipai-copilot-gateway.insightpulseai.com",
+    "ipai-copilot-resource.services.ai.azure.com"
+  ],
+  "webApplicationInfo": {
+    "id": "${{AAD_APP_CLIENT_ID}}",
+    "resource": "api://botid-${{BOT_ID}}"
+  }
+}

--- a/agents/finance-close-surface/bot/bot.py
+++ b/agents/finance-close-surface/bot/bot.py
@@ -1,0 +1,108 @@
+"""
+finance-close-surface/bot/bot.py — Monthly Close orchestrator persona.
+
+Maker-Checker pattern: close / reopen actions require approval — the
+gateway enforces the gate based on the caller's Entra scopes.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import logging
+import os
+
+import aiohttp
+from azure.identity.aio import DefaultAzureCredential
+from botbuilder.core import ActivityHandler, TurnContext
+from botbuilder.core.streaming import StreamingResponse  # type: ignore[import-not-found]
+from botbuilder.schema import ChannelAccount
+
+LOG = logging.getLogger("finance_close.bot")
+
+AGENT_NAME = "finance-close"
+SURFACE_TAG = "teams-finance-close"
+
+GATEWAY_URL = os.environ.get(
+    "COPILOT_GATEWAY_URL",
+    "https://ipai-copilot-gateway.insightpulseai.com",
+)
+GATEWAY_SCOPE = os.environ.get(
+    "COPILOT_GATEWAY_SCOPE",
+    "api://ipai-copilot-gateway/.default",
+)
+
+WELCOME = (
+    "Finance Close ready. I orchestrate your monthly close — checklist, status, "
+    "variance review, and period lock.\n\n"
+    "Try `/status`, `/checklist`, `/close`, `/variance`, or `/reopen`."
+)
+
+
+class FinanceCloseBot(ActivityHandler):
+    async def on_members_added_activity(
+        self,
+        members_added: list[ChannelAccount],
+        turn_context: TurnContext,
+    ) -> None:
+        for member in members_added:
+            if member.id == turn_context.activity.recipient.id:
+                continue
+            await turn_context.send_activity(WELCOME)
+
+    async def on_message_activity(self, turn_context: TurnContext) -> None:
+        user_text = (turn_context.activity.text or "").strip()
+        if not user_text:
+            return
+
+        stream = StreamingResponse(turn_context)
+        try:
+            await stream.queue_informative_update("Checking close state…")
+
+            async for chunk in self._call_gateway(
+                prompt=user_text,
+                user_id=turn_context.activity.from_property.aad_object_id,
+            ):
+                text = chunk.get("text")
+                if text:
+                    await stream.queue_text_chunk(text)
+                if chunk.get("attachments"):
+                    stream.set_attachments(chunk["attachments"])
+
+        except Exception as err:
+            LOG.exception("gateway.error %s", err)
+            await stream.queue_text_chunk(
+                "\n\n_Finance Close backend error — try again in a moment._"
+            )
+        finally:
+            await stream.end_stream()
+
+    async def _call_gateway(self, prompt: str, user_id: str | None):
+        token = await self._acquire_gateway_token()
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/x-ndjson",
+        }
+        payload = {
+            "prompt": prompt,
+            "user_id": user_id,
+            "surface": SURFACE_TAG,
+            "agent": AGENT_NAME,
+            "stream": True,
+        }
+
+        async with aiohttp.ClientSession(headers=headers) as session:
+            async with session.post(
+                f"{GATEWAY_URL}/chat", json=payload, timeout=60
+            ) as resp:
+                resp.raise_for_status()
+                async for line in resp.content:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    yield _json.loads(line)
+
+    async def _acquire_gateway_token(self) -> str:
+        async with DefaultAzureCredential() as cred:
+            token = await cred.get_token(GATEWAY_SCOPE)
+            return token.token

--- a/agents/tax-guru-surface/README.md
+++ b/agents/tax-guru-surface/README.md
@@ -1,0 +1,50 @@
+# agents/tax-guru-surface — Tax Guru PH for Microsoft Teams
+
+BIR compliance + Philippine tax queries. Custom engine agent surface.
+
+## Before provisioning
+
+This directory contains only the **agent-specific** files:
+- `appPackage/manifest.json`
+- `bot/bot.py`
+- this README
+
+Copy the shared files from `teams-surface/`:
+
+```bash
+cd agents/tax-guru-surface
+cp ../teams-surface/teamsapp.yml .
+cp -r ../teams-surface/bot/app.py ../teams-surface/bot/requirements.txt bot/
+cp -r ../teams-surface/infra .
+cp -r ../teams-surface/env .
+# Then replace 'pulser' with 'tax-guru-ph' in teamsapp.yml names
+sed -i '' 's/pulser-teams/tax-guru-ph/g' teamsapp.yml
+```
+
+## Provision
+
+```bash
+cp env/.env.dev.example env/.env.dev
+# Fill values — use the same ipai-copilot-gateway URL as Pulser
+atk provision --env dev
+atk deploy   --env dev
+atk publish  --env dev
+```
+
+## Persona
+
+- **Scope**: BIR (Philippines) compliance, tax forms, deadlines, computations
+- **Commands**: `/2550q`, `/2307`, `/1601c`, `/1702`, `/forms`, `/help`
+- **Backend**: `ipai-copilot-gateway` with `surface=teams-tax-guru` → Foundry `ipai-copilot` + `claude-sonnet-4-6`
+- **Grounding**: 6-tier PH source hierarchy (see memory `project_ph_grounding_hierarchy`)
+
+## Entra Agent ID (May 1 GA)
+
+User-assigned MI to create: `id-ipai-agent-tax-guru` in `rg-ipai-dev-platform`.
+Register via Frontier admin flow once provisioned.
+
+## Related
+
+- Parent plan: [spec/pulser-entra-agent-id/](../../spec/pulser-entra-agent-id/)
+- Streaming rules: [docs/skills/m365-copilot-streaming-contract.md](../../docs/skills/m365-copilot-streaming-contract.md)
+- Pulser template: [agents/teams-surface/](../teams-surface/)

--- a/agents/tax-guru-surface/appPackage/manifest.json
+++ b/agents/tax-guru-surface/appPackage/manifest.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
+  "version": "0.1.0",
+  "id": "${{TEAMS_APP_ID}}",
+  "developer": {
+    "name": "InsightPulseAI Inc.",
+    "websiteUrl": "https://insightpulseai.com",
+    "privacyUrl": "https://insightpulseai.com/privacy",
+    "termsOfUseUrl": "https://insightpulseai.com/terms"
+  },
+  "icons": { "color": "color.png", "outline": "outline.png" },
+  "name": {
+    "short": "Tax Guru PH",
+    "full": "Tax Guru PH — BIR compliance assistant"
+  },
+  "description": {
+    "short": "Ask about BIR forms, deadlines, and Philippine tax computations.",
+    "full": "Tax Guru PH is the InsightPulseAI tax-compliance assistant for the Philippines. Covers BIR forms (2550Q, 2307, 1601C, 1702, etc.), computation walkthroughs, and filing-deadline reminders. Backed by Microsoft Foundry (ipai-copilot-resource) with a 6-tier PH source hierarchy for grounding."
+  },
+  "accentColor": "#C62828",
+  "bots": [
+    {
+      "botId": "${{BOT_ID}}",
+      "scopes": ["personal", "team", "groupChat"],
+      "supportsFiles": false,
+      "isNotificationOnly": false,
+      "commandLists": [
+        {
+          "scopes": ["personal", "team", "groupChat"],
+          "commands": [
+            { "title": "2550q",    "description": "VAT Quarterly return (BIR 2550Q)" },
+            { "title": "2307",     "description": "Creditable withholding tax (BIR 2307)" },
+            { "title": "1601c",    "description": "Withholding on compensation (BIR 1601C)" },
+            { "title": "1702",     "description": "Annual Income Tax (BIR 1702)" },
+            { "title": "forms",    "description": "List all supported BIR forms" },
+            { "title": "deadlines","description": "Upcoming filing deadlines" },
+            { "title": "help",     "description": "What can Tax Guru do?" }
+          ]
+        }
+      ]
+    }
+  ],
+  "copilotAgents": {
+    "customEngineAgents": [
+      { "type": "bot", "id": "${{BOT_ID}}" }
+    ]
+  },
+  "validDomains": [
+    "ipai-copilot-gateway.insightpulseai.com",
+    "ipai-copilot-resource.services.ai.azure.com"
+  ],
+  "webApplicationInfo": {
+    "id": "${{AAD_APP_CLIENT_ID}}",
+    "resource": "api://botid-${{BOT_ID}}"
+  }
+}

--- a/agents/tax-guru-surface/bot/bot.py
+++ b/agents/tax-guru-surface/bot/bot.py
@@ -1,0 +1,111 @@
+"""
+tax-guru-surface/bot/bot.py — Tax Guru PH persona.
+
+Mirrors the PulserBot structure from agents/teams-surface/bot/bot.py,
+but overrides the surface tag, welcome message, and gateway scope.
+All streaming-contract rules from docs/skills/m365-copilot-streaming-contract.md
+are preserved.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import logging
+import os
+
+import aiohttp
+from azure.identity.aio import DefaultAzureCredential
+from botbuilder.core import ActivityHandler, TurnContext
+from botbuilder.core.streaming import StreamingResponse  # type: ignore[import-not-found]
+from botbuilder.schema import ChannelAccount
+
+LOG = logging.getLogger("tax_guru.bot")
+
+AGENT_NAME = "tax-guru"
+SURFACE_TAG = "teams-tax-guru"
+
+GATEWAY_URL = os.environ.get(
+    "COPILOT_GATEWAY_URL",
+    "https://ipai-copilot-gateway.insightpulseai.com",
+)
+GATEWAY_SCOPE = os.environ.get(
+    "COPILOT_GATEWAY_SCOPE",
+    "api://ipai-copilot-gateway/.default",
+)
+
+WELCOME = (
+    "Tax Guru PH here. Ask about BIR forms, computations, and filing deadlines.\n\n"
+    "Try `/2550q`, `/2307`, `/1601c`, `/1702`, `/forms`, or `/deadlines`."
+)
+
+
+class TaxGuruBot(ActivityHandler):
+    async def on_members_added_activity(
+        self,
+        members_added: list[ChannelAccount],
+        turn_context: TurnContext,
+    ) -> None:
+        for member in members_added:
+            if member.id == turn_context.activity.recipient.id:
+                continue
+            await turn_context.send_activity(WELCOME)
+
+    async def on_message_activity(self, turn_context: TurnContext) -> None:
+        user_text = (turn_context.activity.text or "").strip()
+        if not user_text:
+            return
+
+        stream = StreamingResponse(turn_context)
+        try:
+            await stream.queue_informative_update("Checking the BIR reference…")
+
+            async for chunk in self._call_gateway(
+                user_text,
+                user_id=turn_context.activity.from_property.aad_object_id,
+            ):
+                text = chunk.get("text")
+                if text:
+                    await stream.queue_text_chunk(text)
+
+                attachments = chunk.get("attachments")
+                if attachments:
+                    stream.set_attachments(attachments)
+
+        except Exception as err:
+            LOG.exception("gateway.error %s", err)
+            await stream.queue_text_chunk(
+                "\n\n_Tax Guru backend error — try again in a moment._"
+            )
+        finally:
+            await stream.end_stream()
+
+    async def _call_gateway(self, prompt: str, user_id: str | None):
+        token = await self._acquire_gateway_token()
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/x-ndjson",
+        }
+        payload = {
+            "prompt": prompt,
+            "user_id": user_id,
+            "surface": SURFACE_TAG,
+            "agent": AGENT_NAME,
+            "stream": True,
+        }
+
+        async with aiohttp.ClientSession(headers=headers) as session:
+            async with session.post(
+                f"{GATEWAY_URL}/chat", json=payload, timeout=60
+            ) as resp:
+                resp.raise_for_status()
+                async for line in resp.content:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    yield _json.loads(line)
+
+    async def _acquire_gateway_token(self) -> str:
+        async with DefaultAzureCredential() as cred:
+            token = await cred.get_token(GATEWAY_SCOPE)
+            return token.token

--- a/agents/teams-surface/README.md
+++ b/agents/teams-surface/README.md
@@ -1,0 +1,94 @@
+# agents/teams-surface — Pulser for Microsoft Teams
+
+> Custom engine agent (Bot Framework proxy) that surfaces Pulser inside
+> Microsoft 365 Copilot + Teams, backed by `ipai-copilot-gateway` + Foundry.
+
+## Architecture
+
+```
+Teams / Copilot Chat  →  Bot Framework  →  THIS APP  →  ipai-copilot-gateway (ACA)
+                                            (proxy)      → Foundry ipai-copilot
+                                                         → Odoo JSON-RPC
+                                                         → Plane / ops.* Postgres
+```
+
+This is the **custom engine agent** integration path (Agents Toolkit proxy),
+NOT a declarative agent. Chosen because IPAI needs:
+
+- Custom Entra SSO (`apps/odoo-connector/src/auth/entra-oauth.ts`)
+- Multi-environment (dev/staging/prod ACA apps)
+- BYO orchestration (`ipai-copilot-gateway` owns the agent loop)
+- Access to Microsoft Graph + Retrieval API for M365 grounding
+
+## Prereqs
+
+- Python 3.11+
+- Azure CLI (`az login`)
+- `atk` CLI: `npm install -g @microsoft/m365agentstoolkit-cli`
+- M365 Copilot license on tenant + (optional) Frontier preview enrollment for Agent 365
+
+## Local dev
+
+```bash
+# Install deps
+pip install -r bot/requirements.txt
+
+# Launch M365 Agents Playground (local sandbox — no Teams / ngrok / bot registration)
+npx @microsoft/teams-app-test-tool start --manifest appPackage/manifest.json
+
+# Run the bot (listens on :3978)
+python bot/app.py
+```
+
+Playground URL appears in the terminal — paste into a browser to chat with Pulser locally.
+
+## Provision to Azure (dev)
+
+```bash
+cp env/.env.dev.example env/.env.dev
+# Fill: ENTRA_TENANT_ID, ENTRA_CLIENT_ID, COPILOT_GATEWAY_URL, etc.
+
+atk provision --env dev
+atk deploy --env dev
+atk publish --env dev   # sideload to tenant for UAT
+```
+
+`atk provision` creates:
+- **Azure Bot Channel Registration** (globally, not in an RG)
+- **Entra App Registration** (for the bot identity)
+- **Teams app package** (`appPackage/build/appPackage.dev.zip`)
+
+Connection to `ipai-copilot-gateway` uses managed identity (`id-ipai-dev`,
+principalId `1aee831f-3813-4eed-b49c-f7665330f0f6`) via Foundry SDK 2.x.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `teamsapp.yml` | `atk` lifecycle (provision/deploy/publish) |
+| `teamsapp.playground.yml` | Local Playground lifecycle |
+| `appPackage/manifest.json` | Teams app manifest (v1.21 — required for custom engine agents) |
+| `bot/app.py` | aiohttp server + Bot Framework adapter |
+| `bot/bot.py` | Activity handler — proxies to `ipai-copilot-gateway /chat` |
+| `bot/requirements.txt` | botbuilder-* SDKs + azure-identity |
+| `infra/azure.bicep` | Supplemental Bicep (Bot Channel Registration reference) |
+| `env/.env.dev.example` | Env template — secrets from `kv-ipai-dev` |
+
+## Streaming contract
+
+See [docs/skills/m365-copilot-streaming-contract.md](../../docs/skills/m365-copilot-streaming-contract.md) for the
+message ordering rules (single `StreamingResponse` per turn, `endStream()`
+before additional messages, media via `setAttachments()` inside stream).
+
+## AFD routing
+
+`/api/messages` must be routed through Azure Front Door to the
+`ipai-copilot-gateway` origin group. See
+[infra/azure/modules/bot-route.bicep](../../infra/azure/modules/bot-route.bicep).
+
+## Links
+
+- [Custom engine agent overview](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/overview-custom-engine-agent)
+- [Agents Toolkit](https://learn.microsoft.com/en-us/microsoft-365/developer/overview-m365-agents-toolkit)
+- [M365 Agents SDK](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/m365-agents-sdk)
+- Spec: [spec/pulser-entra-agent-id/](../../spec/pulser-entra-agent-id/)

--- a/agents/teams-surface/appPackage/manifest.json
+++ b/agents/teams-surface/appPackage/manifest.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
+  "version": "0.1.0",
+  "id": "${{TEAMS_APP_ID}}",
+  "developer": {
+    "name": "InsightPulseAI Inc.",
+    "websiteUrl": "https://insightpulseai.com",
+    "privacyUrl": "https://insightpulseai.com/privacy",
+    "termsOfUseUrl": "https://insightpulseai.com/terms"
+  },
+  "icons": {
+    "color": "color.png",
+    "outline": "outline.png"
+  },
+  "name": {
+    "short": "Pulser",
+    "full": "Pulser — InsightPulseAI assistant"
+  },
+  "description": {
+    "short": "Odoo, BIR, Azure — ask Pulser anything about IPAI operations.",
+    "full": "Pulser is the InsightPulseAI platform assistant. It can answer questions about Odoo 18 CE modules, Philippine BIR compliance, Azure infrastructure, and IPAI platform doctrine. Backed by Microsoft Foundry (ipai-copilot-resource) and claude-sonnet-4-6."
+  },
+  "accentColor": "#0F6FC6",
+  "bots": [
+    {
+      "botId": "${{BOT_ID}}",
+      "scopes": ["personal", "team", "groupChat"],
+      "supportsFiles": false,
+      "isNotificationOnly": false,
+      "commandLists": [
+        {
+          "scopes": ["personal", "team", "groupChat"],
+          "commands": [
+            { "title": "odoo",    "description": "Odoo 18 module + OCA questions" },
+            { "title": "bir",     "description": "BIR compliance + Philippine tax queries" },
+            { "title": "infra",   "description": "Azure-native infrastructure / Foundry" },
+            { "title": "doctrine","description": "IPAI platform doctrine check" },
+            { "title": "help",    "description": "What can Pulser do?" }
+          ]
+        }
+      ]
+    }
+  ],
+  "copilotAgents": {
+    "customEngineAgents": [
+      {
+        "type": "bot",
+        "id": "${{BOT_ID}}"
+      }
+    ]
+  },
+  "validDomains": [
+    "ipai-copilot-gateway.insightpulseai.com",
+    "ipai-copilot-resource.services.ai.azure.com"
+  ],
+  "webApplicationInfo": {
+    "id": "${{AAD_APP_CLIENT_ID}}",
+    "resource": "api://botid-${{BOT_ID}}"
+  },
+  "authorization": {
+    "permissions": {
+      "resourceSpecific": [
+        { "name": "ChatMessage.Read.Chat",        "type": "Application" },
+        { "name": "ChannelMessage.Read.Group",    "type": "Application" }
+      ]
+    }
+  }
+}

--- a/agents/teams-surface/bot/app.py
+++ b/agents/teams-surface/bot/app.py
@@ -1,0 +1,87 @@
+"""
+app.py — aiohttp server entrypoint for Pulser Teams bot.
+
+Hosts the Bot Framework adapter at POST /api/messages. Forwards all
+message activities to `ipai-copilot-gateway` (ACA) via authenticated
+HTTP, streams responses back to Teams/Copilot Chat.
+
+Run locally:
+    python bot/app.py
+Or via Microsoft 365 Agents Playground:
+    npx @microsoft/teams-app-test-tool start --manifest appPackage/manifest.json
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from aiohttp import web
+from botbuilder.core import (
+    BotFrameworkAdapter,
+    BotFrameworkAdapterSettings,
+    TurnContext,
+)
+from botbuilder.schema import Activity
+
+from bot import PulserBot
+
+LOG = logging.getLogger("pulser.app")
+logging.basicConfig(
+    level=os.getenv("LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+)
+
+
+def create_app() -> web.Application:
+    """Build the aiohttp app. Exposed so teamsapp.yml can import-test."""
+    bot_id = os.environ.get("BOT_ID", "")
+    bot_password = os.environ.get("BOT_PASSWORD", "")
+
+    settings = BotFrameworkAdapterSettings(bot_id, bot_password)
+    adapter = BotFrameworkAdapter(settings)
+    bot = PulserBot()
+
+    async def on_error(context: TurnContext, error: Exception) -> None:
+        LOG.exception("bot.error %s", error)
+        await context.send_activity(
+            "Pulser hit an error. The team has been notified."
+        )
+
+    adapter.on_turn_error = on_error
+
+    async def messages(req: web.Request) -> web.Response:
+        if "application/json" not in req.headers.get("Content-Type", ""):
+            return web.Response(status=415)
+
+        body = await req.json()
+        activity = Activity().deserialize(body)
+        auth_header = req.headers.get("Authorization", "")
+
+        response = await adapter.process_activity(activity, auth_header, bot.on_turn)
+        if response:
+            return web.json_response(data=response.body, status=response.status)
+        return web.Response(status=201)
+
+    async def health(_req: web.Request) -> web.Response:
+        return web.json_response({"status": "ok", "service": "pulser-teams"})
+
+    app = web.Application()
+    app.router.add_post("/api/messages", messages)
+    app.router.add_get("/healthz", health)
+    return app
+
+
+def main() -> None:
+    app = create_app()
+    port = int(os.environ.get("PORT", "3978"))
+    LOG.info("pulser-teams listening on :%d", port)
+    try:
+        web.run_app(app, host="0.0.0.0", port=port)  # noqa: S104
+    except Exception:
+        LOG.exception("fatal")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/teams-surface/bot/bot.py
+++ b/agents/teams-surface/bot/bot.py
@@ -1,0 +1,121 @@
+"""
+bot.py — PulserBot: Bot Framework activity handler that proxies to
+`ipai-copilot-gateway` and streams the response back to Teams / Copilot.
+
+Streaming contract (see docs/skills/m365-copilot-streaming-contract.md):
+  * ONE StreamingResponse per user turn
+  * call endStream() before sending any other activity
+  * media via setAttachments() INSIDE the stream, not as separate activity
+  * serialize outgoing messages — no parallel sends
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import aiohttp
+from azure.identity.aio import DefaultAzureCredential
+from botbuilder.core import ActivityHandler, TurnContext
+from botbuilder.core.streaming import StreamingResponse  # type: ignore[import-not-found]
+from botbuilder.schema import ChannelAccount
+
+LOG = logging.getLogger("pulser.bot")
+
+GATEWAY_URL = os.environ.get(
+    "COPILOT_GATEWAY_URL",
+    "https://ipai-copilot-gateway.insightpulseai.com",
+)
+GATEWAY_SCOPE = os.environ.get(
+    "COPILOT_GATEWAY_SCOPE",
+    # default to the gateway's own app registration — the ACA app exposes
+    # an API with this audience when running with MI auth.
+    "api://ipai-copilot-gateway/.default",
+)
+
+
+class PulserBot(ActivityHandler):
+    async def on_members_added_activity(
+        self,
+        members_added: list[ChannelAccount],
+        turn_context: TurnContext,
+    ) -> None:
+        for member in members_added:
+            if member.id == turn_context.activity.recipient.id:
+                continue
+            await turn_context.send_activity(
+                "Hi — I'm Pulser. Ask me about Odoo, BIR, or Azure."
+                " Try: `/odoo what modules are installed?` or just a question."
+            )
+
+    async def on_message_activity(self, turn_context: TurnContext) -> None:
+        user_text = (turn_context.activity.text or "").strip()
+        if not user_text:
+            return
+
+        # Open ONE streaming response per turn — do not interleave sends.
+        stream = StreamingResponse(turn_context)
+        try:
+            await stream.queue_informative_update("Thinking…")
+
+            async for chunk in self._call_gateway(
+                user_text,
+                user_id=turn_context.activity.from_property.aad_object_id,
+            ):
+                text = chunk.get("text")
+                if text:
+                    await stream.queue_text_chunk(text)
+
+                attachments = chunk.get("attachments")
+                if attachments:
+                    # Attach media INSIDE the stream, not as a separate activity.
+                    stream.set_attachments(attachments)
+
+        except Exception as err:
+            LOG.exception("gateway.error %s", err)
+            await stream.queue_text_chunk(
+                "\n\n_Pulser backend error — try again in a moment._"
+            )
+        finally:
+            # Always end the stream before any subsequent activity.
+            await stream.end_stream()
+
+    async def _call_gateway(
+        self,
+        prompt: str,
+        user_id: str | None,
+    ) -> Any:
+        """Stream NDJSON chunks from ipai-copilot-gateway."""
+        token = await self._acquire_gateway_token()
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/x-ndjson",
+        }
+        payload = {
+            "prompt": prompt,
+            "user_id": user_id,
+            "surface": "teams",
+            "stream": True,
+        }
+
+        async with aiohttp.ClientSession(headers=headers) as session:
+            async with session.post(
+                f"{GATEWAY_URL}/chat", json=payload, timeout=60
+            ) as resp:
+                resp.raise_for_status()
+                async for line in resp.content:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    # NDJSON: each line is one chunk
+                    import json as _json
+
+                    yield _json.loads(line)
+
+    async def _acquire_gateway_token(self) -> str:
+        """Acquire MI token for the copilot gateway API."""
+        async with DefaultAzureCredential() as cred:
+            token = await cred.get_token(GATEWAY_SCOPE)
+            return token.token

--- a/agents/teams-surface/bot/requirements.txt
+++ b/agents/teams-surface/bot/requirements.txt
@@ -1,0 +1,6 @@
+aiohttp>=3.9.5
+botbuilder-core>=4.15.0
+botbuilder-schema>=4.15.0
+botbuilder-integration-aiohttp>=4.15.0
+azure-identity>=1.17.0
+# Agents SDK streaming primitives (bundled with botbuilder-core >= 4.15)

--- a/agents/teams-surface/infra/azure.bicep
+++ b/agents/teams-surface/infra/azure.bicep
@@ -1,0 +1,89 @@
+// agents/teams-surface/infra/azure.bicep
+//
+// Supplemental Bicep for the Pulser Teams surface. The bulk of the
+// provisioning (Bot Channel Registration, Entra app reg) is handled
+// by `atk provision` via teamsapp.yml (botAadApp/create + aadApp/create).
+//
+// This file deploys the ADDITIONAL infra needed beyond what atk provides:
+//   - Application Insights component for bot telemetry
+//   - User-assigned managed identity (references existing id-ipai-dev)
+//   - Diagnostic settings for the Bot Channel Registration
+//
+// AFD routing for /api/messages is in ../../infra/azure/modules/bot-route.bicep.
+
+@description('Environment suffix — dev | staging | prod')
+param env string = 'dev'
+
+@description('Bot ID from botAadApp/create (env: BOT_ID)')
+param botId string
+
+@description('Existing id-ipai-dev MI in rg-ipai-dev-odoo-runtime')
+param userAssignedMiName string = 'id-ipai-dev'
+
+@description('Resource group where id-ipai-dev lives')
+param userAssignedMiRg string = 'rg-ipai-dev-odoo-runtime'
+
+@description('Existing Log Analytics workspace name')
+param logAnalyticsName string = 'log-ipai-${env}'
+
+@description('Existing LA resource group')
+param logAnalyticsRg string = 'rg-ipai-${env}-platform'
+
+// ─── Reference existing resources ────────────────────────────────────────────
+resource existingMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: userAssignedMiName
+  scope: resourceGroup(userAssignedMiRg)
+}
+
+resource existingLa 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
+  name: logAnalyticsName
+  scope: resourceGroup(logAnalyticsRg)
+}
+
+// ─── App Insights for bot telemetry ──────────────────────────────────────────
+resource aiComponent 'Microsoft.Insights/components@2020-02-02' = {
+  name: 'ai-pulser-teams-${env}'
+  location: resourceGroup().location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: existingLa.id
+    RetentionInDays: 90
+  }
+}
+
+// ─── Bot Channel Registration reference (created by botAadApp/create) ────────
+// Teams-only channel is auto-configured by atk. This resource reference lets
+// us attach diagnostic settings below.
+resource bot 'Microsoft.BotService/botServices@2022-09-15' existing = {
+  name: 'pulser-teams-bot-${env}'
+}
+
+resource botDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'send-to-la'
+  scope: bot
+  properties: {
+    workspaceId: existingLa.id
+    logs: [
+      {
+        category: 'BotRequest'
+        enabled: true
+        retentionPolicy: { days: 90, enabled: true }
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+        retentionPolicy: { days: 30, enabled: true }
+      }
+    ]
+  }
+}
+
+// ─── Outputs ─────────────────────────────────────────────────────────────────
+output appInsightsConnectionString string = aiComponent.properties.ConnectionString
+output appInsightsInstrumentationKey string = aiComponent.properties.InstrumentationKey
+output botChannelRegistrationId string = bot.id
+output userAssignedMiClientId string = existingMi.properties.clientId
+output userAssignedMiPrincipalId string = existingMi.properties.principalId

--- a/agents/teams-surface/teamsapp.yml
+++ b/agents/teams-surface/teamsapp.yml
@@ -1,0 +1,98 @@
+# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.8/yaml.schema.json
+#
+# Pulser for Teams — Microsoft 365 Agents Toolkit lifecycle.
+# Generated to match `atk new --type custom-engine-agent --lang python`.
+
+version: v1.8
+
+environmentFolderPath: ./env
+
+# ─── Provision ──────────────────────────────────────────────────────────────
+provision:
+  # Entra app registration — identity for the bot
+  - uses: aadApp/create
+    with:
+      name: pulser-teams-${{TEAMSFX_ENV}}
+      generateClientSecret: true
+      signInAudience: AzureADMyOrg
+    writeToEnvironmentFile:
+      clientId: AAD_APP_CLIENT_ID
+      clientSecret: SECRET_AAD_APP_CLIENT_SECRET
+      objectId: AAD_APP_OBJECT_ID
+      tenantId: AAD_APP_TENANT_ID
+      authority: AAD_APP_OAUTH_AUTHORITY
+      authorityHost: AAD_APP_OAUTH_AUTHORITY_HOST
+
+  # Azure Bot Channel Registration — routes Teams/Copilot Chat to BOT_ENDPOINT
+  - uses: botAadApp/create
+    with:
+      name: pulser-teams-bot-${{TEAMSFX_ENV}}
+    writeToEnvironmentFile:
+      botId: BOT_ID
+      botPassword: SECRET_BOT_PASSWORD
+
+  - uses: arm/deploy
+    with:
+      subscriptionId: ${{AZURE_SUBSCRIPTION_ID}}
+      resourceGroupName: ${{AZURE_RESOURCE_GROUP_NAME}}
+      templates:
+        - path: ./infra/azure.bicep
+          parameters: ./infra/azure.parameters.json
+          deploymentName: pulser-teams-${{TEAMSFX_ENV}}
+
+  # Teams app package
+  - uses: teamsApp/validateManifest
+    with:
+      manifestPath: ./appPackage/manifest.json
+
+  - uses: teamsApp/zipAppPackage
+    with:
+      manifestPath: ./appPackage/manifest.json
+      outputZipPath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+      outputFolder: ./appPackage/build
+
+  - uses: teamsApp/update
+    with:
+      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+
+# ─── Deploy ─────────────────────────────────────────────────────────────────
+# Custom engine agents: deployment target is `ipai-copilot-gateway` (ACA),
+# which handles Bot Framework traffic. The proxy code in bot/ is packaged
+# and deployed alongside.
+deploy:
+  - uses: file/createOrUpdateEnvironmentFile
+    with:
+      target: ./bot/.env
+      envs:
+        BOT_ID: ${{BOT_ID}}
+        BOT_PASSWORD: ${{SECRET_BOT_PASSWORD}}
+        COPILOT_GATEWAY_URL: ${{COPILOT_GATEWAY_URL}}
+        AZURE_CLIENT_ID: ${{AAD_APP_CLIENT_ID}}
+        AZURE_TENANT_ID: ${{AAD_APP_TENANT_ID}}
+
+  # Package bot code for ACA deployment — image builds via GHCR / ACR
+  # and is deployed by the separate `deploy-erp-canonical.yml` workflow.
+  # This action just validates the bot can start.
+  - uses: script
+    with:
+      run: |
+        cd bot
+        python -m pip install -r requirements.txt
+        python -c "from app import create_app; create_app()"
+        echo "Bot imports resolve — ready for container build."
+
+# ─── Publish ────────────────────────────────────────────────────────────────
+publish:
+  - uses: teamsApp/validateAppPackage
+    with:
+      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+
+  - uses: teamsApp/update
+    with:
+      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+
+  - uses: teamsApp/publishAppPackage
+    with:
+      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+    writeToEnvironmentFile:
+      publishedAppId: TEAMS_APP_PUBLISHED_APP_ID

--- a/docs/skills/m365-copilot-streaming-contract.md
+++ b/docs/skills/m365-copilot-streaming-contract.md
@@ -1,0 +1,123 @@
+# Microsoft 365 Copilot Streaming Contract — Message Ordering Rules
+
+> Applies when building a **custom engine agent** that streams responses
+> back to Microsoft Teams or Microsoft 365 Copilot Chat.
+> Scope: `agents/teams-surface/` and any future bot surface.
+
+## Why this matters
+
+Teams and M365 Copilot render agent messages based on **server timestamps,
+activity IDs, and the relationship between streaming updates and non-streaming
+activities**. If a custom engine agent mixes streaming text, media attachments,
+and final messages within the same user turn, messages can appear **out of
+sequence** — breaking UX and making the agent look broken.
+
+Source: [Microsoft Learn — Custom engine agents overview, Message ordering
+and streaming behavior](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/overview-custom-engine-agent#message-ordering-and-streaming-behavior).
+
+## Rules (all 5 are load-bearing — do not skip)
+
+### 1. One streaming sequence per user turn
+
+Create exactly **one** `StreamingResponse` object per incoming message
+activity. Finalize it by calling `endStream()` before sending any other
+activity.
+
+```python
+# ✓ correct
+stream = StreamingResponse(turn_context)
+await stream.queue_text_chunk("Working on it…")
+# … stream body …
+await stream.end_stream()
+# ONLY now can another activity go out
+```
+
+```python
+# ✗ wrong — two streams open at once
+stream_a = StreamingResponse(turn_context)
+stream_b = StreamingResponse(turn_context)  # ordering becomes nondeterministic
+```
+
+### 2. Attach media INSIDE the stream
+
+Use `set_attachments()` on the `StreamingResponse`. Do NOT send attachments
+as a separate non-streaming activity — they can appear before or inside
+the stream due to timestamp differences.
+
+```python
+# ✓ correct
+stream.set_attachments([card])   # part of the streamed turn
+
+# ✗ wrong — may render out of order
+await turn_context.send_activity(Activity(attachments=[card]))
+```
+
+### 3. Don't start a new stream before finalizing the previous one
+
+Multiple streams within the same turn produce unpredictable ordering in
+Teams and Copilot. Always `await stream.end_stream()` before opening a new
+`StreamingResponse`.
+
+### 4. Serialize outgoing messages
+
+Do not send messages from multiple threads / tasks in parallel. Ensure
+every send is `await`ed to maintain strict ordering.
+
+```python
+# ✓ correct — awaited serially
+await stream.queue_text_chunk(part_a)
+await stream.queue_text_chunk(part_b)
+
+# ✗ wrong — parallel sends reorder on server
+await asyncio.gather(
+    stream.queue_text_chunk(part_a),
+    stream.queue_text_chunk(part_b),
+)
+```
+
+### 5. Don't send streaming updates after `endStream()`
+
+Once the stream is finalized, new updates become **separate activities**
+and will likely appear out of order. If a follow-up is needed:
+
+- Start a new stream for a new user turn, OR
+- Use `replyToId` on the follow-up activity to keep it threaded to the
+  stream's last message
+
+## Implementation template (Python / botbuilder)
+
+```python
+async def on_message_activity(self, turn_context: TurnContext) -> None:
+    stream = StreamingResponse(turn_context)
+    try:
+        await stream.queue_informative_update("Thinking…")
+
+        async for chunk in self._orchestrate(turn_context.activity.text):
+            if chunk.text:
+                await stream.queue_text_chunk(chunk.text)
+            if chunk.attachments:
+                stream.set_attachments(chunk.attachments)  # rule 2
+    except Exception:
+        await stream.queue_text_chunk("\n\n_Backend error._")
+    finally:
+        await stream.end_stream()  # rules 1, 3, 5
+```
+
+## Checklist for code review
+
+- [ ] Exactly one `StreamingResponse` per `on_message_activity` call
+- [ ] `end_stream()` in a `finally:` block (always runs, even on exception)
+- [ ] No `send_activity()` calls for attachments inside the stream window
+- [ ] All sends are `await`ed sequentially, no `asyncio.gather` over sends
+- [ ] No activities sent after `end_stream()` (if needed, start a new turn)
+
+## Where this applies
+
+- [agents/teams-surface/bot/bot.py](../../agents/teams-surface/bot/bot.py) — `PulserBot.on_message_activity`
+- Any future ACA-hosted custom engine agent surface (Pulser, Tax Guru PH, Doc Intelligence)
+
+## Related
+
+- [Custom engine agent overview (MS Learn)](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/overview-custom-engine-agent)
+- [M365 Agents SDK (MS Learn)](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/m365-agents-sdk)
+- [Agents Toolkit (MS Learn)](https://learn.microsoft.com/en-us/microsoft-365/developer/overview-m365-agents-toolkit)

--- a/infra/azure/deploy-agent-identities.bicep
+++ b/infra/azure/deploy-agent-identities.bicep
@@ -1,0 +1,90 @@
+// infra/azure/deploy-agent-identities.bicep
+//
+// Creates one user-assigned managed identity per IPAI agent, for Agent 365
+// Entra Agent ID registration (GA 2026-05-01). Also grants each MI
+// `get`/`list` on kv-ipai-dev secrets.
+//
+// Scope:   resourceGroup (target: rg-ipai-dev-platform)
+// Deploy:  az deployment group create \
+//            --resource-group rg-ipai-dev-platform \
+//            --template-file infra/azure/deploy-agent-identities.bicep \
+//            --parameters env=dev
+//
+// Idempotent — re-running is safe. Creates 6 MIs matching the 6 agent
+// surfaces under agents/*-surface/.
+
+targetScope = 'resourceGroup'
+
+@description('Environment suffix — dev | staging | prod')
+@allowed([ 'dev', 'staging', 'prod' ])
+param env string = 'dev'
+
+@description('Azure region for the MIs. Matches rg-ipai-<env>-platform region.')
+param location string = resourceGroup().location
+
+@description('Key Vault name to grant secret read access to each agent MI')
+param keyVaultName string = 'kv-ipai-${env}'
+
+@description('Key Vault resource group (kv-ipai-dev is in rg-ipai-dev-platform, not runtime)')
+param keyVaultResourceGroup string = 'rg-ipai-${env}-platform'
+
+@description('Agent names — create one MI per entry. Must match agents/<name>-surface/ dirs.')
+param agents array = [
+  'pulser'
+  'tax-guru'
+  'doc-intel'
+  'bank-recon'
+  'ap-invoice'
+  'finance-close'
+]
+
+@description('Common resource tags')
+param tags object = {
+  project: 'ipai'
+  env: env
+  layer: 'agents'
+  spec: 'pulser-entra-agent-id'
+}
+
+// ─── Create one MI per agent ─────────────────────────────────────────────────
+resource agentMis 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = [
+  for agent in agents: {
+    name: 'id-ipai-agent-${agent}-${env}'
+    location: location
+    tags: union(tags, {
+      agent: agent
+    })
+  }
+]
+
+// ─── Reference kv-ipai-<env> (must pre-exist; do NOT create here) ────────────
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+  scope: resourceGroup(keyVaultResourceGroup)
+}
+
+// ─── Grant each MI get+list on secrets via access policy ─────────────────────
+// Using access-policy mode (not RBAC). Change if kv-ipai-dev later migrates
+// to RBAC authorization — that requires a separate roleAssignment module.
+module kvAccessPolicies 'modules/keyvault-access-policy-batch.bicep' = {
+  name: 'kv-access-policies-agents-${env}'
+  scope: resourceGroup(keyVaultResourceGroup)
+  params: {
+    keyVaultName: keyVaultName
+    principalIds: [ for i in range(0, length(agents)): agentMis[i].properties.principalId ]
+    secretPermissions: [ 'get', 'list' ]
+    certificatePermissions: []
+    keyPermissions: []
+  }
+}
+
+// ─── Outputs ─────────────────────────────────────────────────────────────────
+output agentIdentities array = [
+  for i in range(0, length(agents)): {
+    agent: agents[i]
+    name: agentMis[i].name
+    clientId: agentMis[i].properties.clientId
+    principalId: agentMis[i].properties.principalId
+    resourceId: agentMis[i].id
+  }
+]

--- a/infra/azure/deploy-agent-routes.bicep
+++ b/infra/azure/deploy-agent-routes.bicep
@@ -1,0 +1,89 @@
+// infra/azure/deploy-agent-routes.bicep
+//
+// Wraps bot-route.bicep once per agent to provision a distinct AFD route
+// pattern per agent (e.g. /api/tax-guru/messages, /api/doc-intel/messages).
+// Pulser remains on the canonical /api/messages pattern.
+//
+// Scope:   resourceGroup (target: the AFD profile's RG — verify before deploy)
+// Deploy:  az deployment group create \
+//            --resource-group <AFD_RG> \
+//            --template-file infra/azure/deploy-agent-routes.bicep \
+//            --parameters env=dev afdProfileName=afd-ipai-dev afdEndpointName=<endpoint-name>
+//
+// Idempotent — re-running is safe. Each agent gets its own origin group
+// + origin + route in the same AFD profile.
+
+targetScope = 'resourceGroup'
+
+@description('Environment suffix — dev | staging | prod')
+@allowed([ 'dev', 'staging', 'prod' ])
+param env string = 'dev'
+
+@description('Existing AFD profile name (afd-ipai-dev | afd-ipai-prod)')
+param afdProfileName string = 'afd-ipai-${env}'
+
+@description('Existing AFD endpoint name (under the profile)')
+param afdEndpointName string
+
+@description('Gateway FQDN — ipai-copilot-gateway ACA app')
+param gatewayFqdn string = 'ipai-copilot-gateway.insightpulseai.com'
+
+@description('Agent configs — name + route pattern prefix')
+param agents array = [
+  {
+    name: 'pulser'
+    // Pulser uses the canonical /api/messages (the Bot Framework default)
+    patterns: [ '/api/messages', '/api/messages/*' ]
+    customDomain: ''
+  }
+  {
+    name: 'tax-guru'
+    patterns: [ '/api/tax-guru/messages', '/api/tax-guru/messages/*' ]
+    customDomain: ''
+  }
+  {
+    name: 'doc-intel'
+    patterns: [ '/api/doc-intel/messages', '/api/doc-intel/messages/*' ]
+    customDomain: ''
+  }
+  {
+    name: 'bank-recon'
+    patterns: [ '/api/bank-recon/messages', '/api/bank-recon/messages/*' ]
+    customDomain: ''
+  }
+  {
+    name: 'ap-invoice'
+    patterns: [ '/api/ap-invoice/messages', '/api/ap-invoice/messages/*' ]
+    customDomain: ''
+  }
+  {
+    name: 'finance-close'
+    patterns: [ '/api/finance-close/messages', '/api/finance-close/messages/*' ]
+    customDomain: ''
+  }
+]
+
+// ─── One bot-route.bicep invocation per agent ────────────────────────────────
+// bot-route.bicep creates origin group, origin, and route. Each agent gets
+// distinct names derived from its agent key. No direct mutation of
+// front-door.bicep; uses `existing` to attach new child resources.
+module agentRoutes 'modules/bot-route.bicep' = [
+  for agent in agents: {
+    name: 'route-${agent.name}-${env}'
+    params: {
+      afdProfileName: afdProfileName
+      afdEndpointName: afdEndpointName
+      gatewayFqdn: gatewayFqdn
+      routePatterns: agent.patterns
+      customDomainName: agent.customDomain
+    }
+  }
+]
+
+output routeIds array = [
+  for i in range(0, length(agents)): {
+    agent: agents[i].name
+    patterns: agents[i].patterns
+    routeId: agentRoutes[i].outputs.routeId
+  }
+]

--- a/infra/azure/modules/bot-route.bicep
+++ b/infra/azure/modules/bot-route.bicep
@@ -1,0 +1,131 @@
+// infra/azure/modules/bot-route.bicep
+//
+// Additive AFD module: route `/api/messages` (Bot Framework webhook)
+// through Azure Front Door (afd-ipai-dev) to the ipai-copilot-gateway
+// ACA app. This is the Teams/Copilot surface's ingress path for Pulser.
+//
+// Non-destructive: references the existing AFD profile + endpoint by
+// name, adds a new origin group, origin, and route scoped to the
+// `/api/messages` path pattern. Does NOT mutate front-door.bicep.
+//
+// Usage (from main.bicep):
+//   module botRoute 'modules/bot-route.bicep' = if (deployBotRoute) {
+//     name: 'bot-route-${environmentSuffix}'
+//     params: {
+//       afdProfileName:  'afd-ipai-${environmentSuffix}'
+//       afdEndpointName: 'ipai-${environmentSuffix}-endpoint'
+//       gatewayFqdn:     'ipai-copilot-gateway.internal.${acaEnvDomain}'
+//       customDomainName: 'pulser-${environmentSuffix}.insightpulseai.com'
+//     }
+//   }
+
+@description('Existing AFD profile name (afd-ipai-dev | afd-ipai-prod)')
+param afdProfileName string
+
+@description('Existing AFD endpoint name (under the profile)')
+param afdEndpointName string
+
+@description('FQDN of the ipai-copilot-gateway ACA app (internal or public)')
+param gatewayFqdn string
+
+@description('HTTPS port for the origin (usually 443)')
+param originHttpsPort int = 443
+
+@description('Origin host header — usually same as gatewayFqdn')
+param originHostHeader string = gatewayFqdn
+
+@description('Probe path for health check on the gateway')
+param probePath string = '/healthz'
+
+@description('Route pattern(s) to match. Bot Framework webhook is /api/messages')
+param routePatterns array = [
+  '/api/messages'
+  '/api/messages/*'
+]
+
+@description('Optional custom domain name to bind (e.g. pulser-dev.insightpulseai.com). Leave empty to route only via the default *.azurefd.net endpoint.')
+param customDomainName string = ''
+
+// ─── Reference existing AFD profile + endpoint ──────────────────────────────
+resource afdProfile 'Microsoft.Cdn/profiles@2023-05-01' existing = {
+  name: afdProfileName
+}
+
+resource afdEndpoint 'Microsoft.Cdn/profiles/afdEndpoints@2023-05-01' existing = {
+  parent: afdProfile
+  name: afdEndpointName
+}
+
+resource customDomain 'Microsoft.Cdn/profiles/customDomains@2023-05-01' existing = if (!empty(customDomainName)) {
+  parent: afdProfile
+  name: replace(customDomainName, '.', '-')
+}
+
+// ─── Origin group: ipai-copilot-gateway ─────────────────────────────────────
+resource botOriginGroup 'Microsoft.Cdn/profiles/originGroups@2023-05-01' = {
+  parent: afdProfile
+  name: 'og-copilot-gateway'
+  properties: {
+    loadBalancingSettings: {
+      sampleSize: 4
+      successfulSamplesRequired: 3
+      additionalLatencyInMilliseconds: 50
+    }
+    healthProbeSettings: {
+      probePath: probePath
+      probeRequestType: 'GET'
+      probeProtocol: 'Https'
+      probeIntervalInSeconds: 60
+    }
+    sessionAffinityState: 'Disabled'
+  }
+}
+
+resource botOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2023-05-01' = {
+  parent: botOriginGroup
+  name: 'copilot-gateway-origin'
+  properties: {
+    hostName: gatewayFqdn
+    httpPort: 80
+    httpsPort: originHttpsPort
+    originHostHeader: originHostHeader
+    priority: 1
+    weight: 1000
+    enabledState: 'Enabled'
+    enforceCertificateNameCheck: true
+  }
+}
+
+// ─── Route: /api/messages → ipai-copilot-gateway ────────────────────────────
+// HTTPS-only, no caching (Bot Framework is interactive), forwards to HTTPS origin.
+resource botRoute 'Microsoft.Cdn/profiles/afdEndpoints/routes@2023-05-01' = {
+  parent: afdEndpoint
+  name: 'pulser-bot-route'
+  dependsOn: [
+    botOrigin
+  ]
+  properties: {
+    customDomains: empty(customDomainName) ? [] : [
+      {
+        id: customDomain.id
+      }
+    ]
+    originGroup: {
+      id: botOriginGroup.id
+    }
+    supportedProtocols: [
+      'Https'
+    ]
+    patternsToMatch: routePatterns
+    forwardingProtocol: 'HttpsOnly'
+    linkToDefaultDomain: empty(customDomainName) ? 'Enabled' : 'Disabled'
+    httpsRedirect: 'Enabled'
+    enabledState: 'Enabled'
+    cacheConfiguration: null
+  }
+}
+
+// ─── Outputs ────────────────────────────────────────────────────────────────
+output routeId string = botRoute.id
+output originGroupId string = botOriginGroup.id
+output routePatterns array = routePatterns

--- a/infra/azure/modules/keyvault-access-policy-batch.bicep
+++ b/infra/azure/modules/keyvault-access-policy-batch.bicep
@@ -1,0 +1,42 @@
+// infra/azure/modules/keyvault-access-policy-batch.bicep
+//
+// Adds access policy entries to an existing Key Vault for a batch of
+// principals. Non-destructive: uses `add` mode so existing policies are
+// preserved.
+
+@description('Existing Key Vault name (in the current RG scope of this module)')
+param keyVaultName string
+
+@description('Array of principalIds (user-assigned MI principalIds)')
+param principalIds array
+
+@description('Secret permissions to grant (e.g. [get, list])')
+param secretPermissions array = []
+
+@description('Certificate permissions to grant')
+param certificatePermissions array = []
+
+@description('Key permissions to grant')
+param keyPermissions array = []
+
+resource kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource policies 'Microsoft.KeyVault/vaults/accessPolicies@2023-07-01' = {
+  parent: kv
+  name: 'add'
+  properties: {
+    accessPolicies: [
+      for pid in principalIds: {
+        tenantId: subscription().tenantId
+        objectId: pid
+        permissions: {
+          secrets: secretPermissions
+          certificates: certificatePermissions
+          keys: keyPermissions
+        }
+      }
+    ]
+  }
+}

--- a/spec/pulser-entra-agent-id/constitution.md
+++ b/spec/pulser-entra-agent-id/constitution.md
@@ -1,0 +1,62 @@
+# Constitution — Pulser Entra Agent ID rollout
+
+> Draft — to be expanded before May 1, 2026 (Agent 365 GA).
+> Spec bundle files: `constitution.md` (this), `prd.md`, `plan.md`, `tasks.md`.
+
+## Mandate
+
+Every IPAI agent that acts on behalf of a user in Microsoft 365 must be
+registered with its own **Entra Agent ID** by **May 1, 2026** — the date
+Microsoft Agent 365 reaches general availability and the licensing model
+switches from per-agent to per-user (OBO).
+
+## Non-negotiables
+
+1. **One Entra Agent ID per agent persona** — Pulser, Tax Guru PH, Doc
+   Intelligence, Bank Recon, AP Invoice, Finance Close, and any future
+   IPAI agent each get their own ID. Not one shared identity.
+2. **Managed identity, not secrets** — each Agent ID is backed by a
+   user-assigned managed identity (`id-ipai-agent-<name>`) in
+   `rg-ipai-<env>-platform`. No client secrets stored anywhere.
+3. **Observability via M365 Admin Center + Purview + Defender** — do not
+   rebuild agent telemetry that Agent 365 provides natively. The
+   custom `ops.agent_runs` table is **supplemental**, not authoritative.
+4. **MCP-first tooling** — agent tools exposed via MCP interfaces
+   (Outlook / Teams / SharePoint / Odoo). Aligns with cross-repo
+   invariant #10 (MCP First).
+5. **OBO licensing** — at GA, agents are covered under the calling
+   user's Agent 365 or M365 E7 license. Agents never hold their own
+   license post-GA. Any pre-GA Frontier per-agent license is a
+   **temporary bridge only**.
+
+## Authority
+
+- **Identity registry**: Microsoft Entra — canonical source of Agent IDs
+- **Access policy**: Conditional Access for agents — owner: Security team
+- **Runtime runtime**: Azure Container Apps — canonical host for all
+  agent proxy services (no separate hosting plane per agent)
+- **Orchestrator**: `ipai-copilot-gateway` — canonical agent loop. M365
+  Agents SDK is a channel layer only (cross-repo invariant #1).
+- **Channel surfaces**: Microsoft Teams, M365 Copilot Chat, Outlook,
+  Web (embedded), SMS (future) — each agent declares supported channels
+  in its `appPackage/manifest.json`.
+
+## What this constitution is NOT
+
+- Not a replacement for agent-platform's `constitution.yaml`
+- Not a Copilot Studio migration plan (low-code path — not IPAI's)
+- Not a declarative-agents strategy (wrong model for IPAI)
+
+## Decision log
+
+| Decision | Date | Rationale |
+|---|---|---|
+| Use Agents Toolkit proxy, not Foundry portal direct publish | 2026-04-12 | Need custom SSO + multi-env + CI/CD built-in |
+| Python for teams-surface bot code | 2026-04-12 | Matches `ipai-copilot-gateway` language; reduces cross-lang surface |
+| One MI per agent, not per environment | TBD | Decision pending — see plan.md |
+
+## References
+
+- [Microsoft Agent 365 Overview](https://learn.microsoft.com/en-us/microsoft-agent-365/overview)
+- [Cross-repo invariants](../../CLAUDE.md)
+- Memory: `project_m365_e7_agent365`, `project_foundry_managed_identity`

--- a/spec/pulser-entra-agent-id/deploy.md
+++ b/spec/pulser-entra-agent-id/deploy.md
@@ -1,0 +1,163 @@
+# Deploy — Pulser Entra Agent ID (Owner-triggered commands)
+
+Everything the code has already landed. This file is the owner-run deployment
+script for the automatable half of Phase 2.
+
+## Prereqs
+
+```bash
+az login
+az account set --subscription 536d8cf6-89e1-4815-aef3-d5f2c5f4d070
+# Confirm:
+az account show --query "{name:name, id:id, tenantId:tenantId}" -o table
+```
+
+## Step 1 — Deploy the 6 agent MIs + grant KV access
+
+```bash
+cd /path/to/Insightpulseai
+
+az deployment group create \
+  --resource-group rg-ipai-dev-platform \
+  --template-file infra/azure/deploy-agent-identities.bicep \
+  --parameters env=dev \
+  --name agent-identities-dev-$(date +%Y%m%d%H%M)
+
+# Output — capture client+principal IDs into env/.env.dev.<agent>
+az deployment group show \
+  --resource-group rg-ipai-dev-platform \
+  --name agent-identities-dev-<stamp> \
+  --query "properties.outputs.agentIdentities.value" -o json
+```
+
+Creates:
+- `id-ipai-agent-pulser-dev`
+- `id-ipai-agent-tax-guru-dev`
+- `id-ipai-agent-doc-intel-dev`
+- `id-ipai-agent-bank-recon-dev`
+- `id-ipai-agent-ap-invoice-dev`
+- `id-ipai-agent-finance-close-dev`
+
+Each MI gets `get`/`list` on `kv-ipai-dev` secrets via access policy.
+
+## Step 2 — Deploy 6 AFD routes
+
+First, look up the AFD RG + endpoint name:
+
+```bash
+az afd profile show --profile-name afd-ipai-dev \
+  --query "{rg:resourceGroup, location:location}" -o table
+
+# If unknown, find it:
+az resource list --name afd-ipai-dev --query "[].{rg:resourceGroup, type:type}" -o table
+```
+
+Then deploy:
+
+```bash
+# Replace <AFD_RG> and <ENDPOINT_NAME> with values from above
+az deployment group create \
+  --resource-group <AFD_RG> \
+  --template-file infra/azure/deploy-agent-routes.bicep \
+  --parameters env=dev afdEndpointName=<ENDPOINT_NAME> \
+  --name agent-routes-dev-$(date +%Y%m%d%H%M)
+```
+
+Creates 6 routes on the existing `afd-ipai-dev` profile:
+| Agent | Pattern |
+|---|---|
+| pulser | `/api/messages` |
+| tax-guru | `/api/tax-guru/messages` |
+| doc-intel | `/api/doc-intel/messages` |
+| bank-recon | `/api/bank-recon/messages` |
+| ap-invoice | `/api/ap-invoice/messages` |
+| finance-close | `/api/finance-close/messages` |
+
+All routes share the same origin group (`og-copilot-gateway`) pointing at
+`ipai-copilot-gateway.insightpulseai.com`. Traffic is disambiguated server-side
+by path prefix.
+
+## Step 3 — Install atk CLI (one-time per dev machine)
+
+```bash
+npm install -g @microsoft/m365agentstoolkit-cli
+atk --version
+```
+
+## Step 4 — Provision each agent in M365 / Teams
+
+For each agent in `{teams-surface, tax-guru-surface, doc-intel-surface, bank-recon-surface, ap-invoice-surface, finance-close-surface}`:
+
+```bash
+cd agents/<surface-dir>
+
+# Copy shared files from teams-surface (if not already)
+cp ../teams-surface/teamsapp.yml .
+cp -r ../teams-surface/bot/app.py ../teams-surface/bot/requirements.txt bot/
+cp -r ../teams-surface/infra ../teams-surface/env .
+# Replace the name placeholder in teamsapp.yml:
+sed -i '' "s/pulser-teams/$(basename $(pwd) -surface)/g" teamsapp.yml
+
+# Fill env/.env.dev from template (BOT_ID and AAD client IDs will be filled
+# by the next command automatically)
+cp env/.env.dev.example env/.env.dev
+
+atk provision --env dev
+atk deploy --env dev
+atk publish --env dev   # sideload to IPAI tenant
+```
+
+This creates:
+- Entra app registration (for SSO) per agent
+- Azure Bot Channel Registration per agent
+- Teams app package (`appPackage/build/appPackage.dev.zip`)
+
+## Step 5 — Register Entra Agent ID (Frontier preview — browser UI only)
+
+Cannot be automated. Portal flow:
+
+1. Go to [M365 Admin Center](https://admin.microsoft.com) → Copilot → Settings → Copilot Frontier
+2. Grant user access to Frontier program
+3. Go to [Admin Center → Agents](https://admin.microsoft.com/#/agents)
+4. Register each agent with its Bot Channel Registration ID (from Step 4 output)
+5. Confirm 6 agents listed: Pulser, Tax Guru PH, Doc Intelligence, Bank Recon, AP Invoice, Finance Close
+
+## Step 6 — Verify
+
+```bash
+# Sanity-check MIs exist
+for agent in pulser tax-guru doc-intel bank-recon ap-invoice finance-close; do
+  az identity show -n "id-ipai-agent-${agent}-dev" -g rg-ipai-dev-platform \
+    --query "{name:name, principalId:principalId}" -o table
+done
+
+# Confirm AFD routes
+az afd route list --profile-name afd-ipai-dev \
+  --endpoint-name <ENDPOINT_NAME> \
+  --resource-group <AFD_RG> \
+  --query "[?starts_with(name, 'pulser-bot-route') || starts_with(name, 'route-')].{name:name, patternsToMatch:patternsToMatch}" -o table
+
+# Confirm KV access
+az keyvault show --name kv-ipai-dev --resource-group rg-ipai-dev-platform \
+  --query "properties.accessPolicies[?permissions.secrets != null].[objectId, permissions.secrets]" -o table
+```
+
+## Rollback
+
+Each artifact is reversible:
+
+```bash
+# Delete the identity deployment (cascades to MIs)
+az deployment group delete --resource-group rg-ipai-dev-platform --name agent-identities-dev-<stamp>
+
+# Delete the route deployment (cascades to route/origin-group)
+az deployment group delete --resource-group <AFD_RG> --name agent-routes-dev-<stamp>
+
+# Delete the KV access policy entries (if retaining MIs but revoking access)
+az keyvault delete-policy --name kv-ipai-dev --object-id <principalId>
+
+# atk cleanup
+cd agents/<surface-dir>
+atk entra app delete --env dev
+atk azure bot delete --env dev
+```

--- a/spec/pulser-entra-agent-id/plan.md
+++ b/spec/pulser-entra-agent-id/plan.md
@@ -1,0 +1,97 @@
+# Plan — Pulser Entra Agent ID rollout
+
+> Draft. Deadline: 2026-05-01 (Agent 365 GA).
+
+## Phases
+
+### Phase 0 — Pre-flight (now → 2026-04-14)
+
+| Step | Owner | Artifact |
+|---|---|---|
+| Verify M365 Copilot license on tenant | Owner | M365 Admin Center screenshot |
+| Enroll in Frontier preview program | Owner | Frontier confirmation email |
+| Confirm `id-ipai-dev` MI (existing) principal: `1aee831f-3813-4eed-b49c-f7665330f0f6` | Done | Audit log entry |
+| Revoke global `vscode` PAT in ADO | Owner | Per `docs/security/revoke-pat-runbook.md` |
+
+### Phase 1 — Scaffold Pulser as canonical template (2026-04-14 → 2026-04-21)
+
+| Step | Owner | Artifact |
+|---|---|---|
+| `atk new --type custom-engine-agent --lang python --output agents/teams-surface/` | Code | Done (this spec's companion PR) |
+| `atk provision --env dev` → creates `pulser-teams-bot-dev` + Entra app reg | Code + Owner | BOT_ID + AAD_APP_CLIENT_ID in env/.env.dev |
+| Deploy bot-route.bicep → AFD route `/api/messages` live | Code | AFD shows pulser-bot-route |
+| Playground test: `npx @microsoft/teams-app-test-tool start` → roundtrip | QA | Screenshot |
+| Deploy to ACA (`ipai-copilot-gateway`) via `deploy-erp-canonical.yml` | CI | ACA revision ready |
+| Sideload Teams app package to IPAI tenant | Owner | UAT access |
+| Create first Entra Agent ID for Pulser via Frontier admin flow | Owner | Agent 365 ID in Admin Center |
+
+### Phase 2 — Apply template to remaining 5 agents (2026-04-21 → 2026-04-28)
+
+For each of: Tax Guru PH, Doc Intelligence, Bank Recon, AP Invoice, Finance Close:
+
+| Step | Pattern |
+|---|---|
+| Fork `agents/teams-surface/` → `agents/<agent>-surface/` | Keep architecture identical |
+| Create `id-ipai-agent-<name>` MI in `rg-ipai-dev-platform` | Terraform or `az identity create` |
+| `atk provision --env dev` per agent | New BOT_ID + AAD app reg per agent |
+| Add per-agent route to AFD via `bot-route.bicep` | New origin group per agent? Or share `og-copilot-gateway`? See open Q |
+| Register Entra Agent ID via Frontier admin flow | Per agent |
+| Manifest-per-agent describes scope, commands, icon | Distinct branding per agent |
+
+### Phase 3 — Hardening (2026-04-28 → 2026-05-01)
+
+| Step | Owner | Artifact |
+|---|---|---|
+| Conditional Access policy: agent identities can only access `ipai-copilot-gateway` scope | Security | CA policy ID |
+| Defender for Cloud alerts → on-call Slack channel | Security | Alert rule |
+| Purview audit rule: log all agent → OBO chains | Security | Purview policy |
+| Remove pre-GA per-agent Frontier licenses once M365 E7 licenses land (post GA) | Owner | Billing confirmation |
+
+## Architecture decisions
+
+### MI scoping (open question in PRD)
+
+**Option A**: One MI per agent, one per env (`id-ipai-agent-pulser-dev`, `-staging`, `-prod`)
+- **Pro**: Clean RBAC boundary per env
+- **Con**: 6 agents × 3 envs = 18 identities
+
+**Option B**: One MI per agent, shared across envs
+- **Pro**: 6 identities total, simpler RBAC
+- **Con**: Single compromised MI affects all envs
+
+**Recommended**: Option A — aligns with `rg-ipai-<env>-*` RG model and existing `id-ipai-dev` pattern.
+
+### Custom domain strategy
+
+**Option A**: Per-agent subdomain (`pulser-dev.insightpulseai.com`, `tax-guru-dev.insightpulseai.com`, ...)
+- **Pro**: Clean URL, per-agent TLS cert
+- **Con**: DNS fan-out; each cert is a KV renewal target
+
+**Option B**: Single `agents-dev.insightpulseai.com` with path-based routing (`/pulser/messages`, `/tax-guru/messages`)
+- **Pro**: One DNS record, one cert
+- **Con**: All agents share an ingress — one compromise = ingress compromise
+
+**Recommended**: Option B for dev/staging; evaluate Option A for prod at hardening phase.
+
+## Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Frontier preview enrollment delayed past Apr 15 | Medium | High | Defer Pulser registration to post-GA; use `ipai-copilot-gateway` MI as bridge |
+| Bot Channel Registration fails for 6+ agents (Azure quota) | Low | Med | Submit quota increase preemptively |
+| M365 Copilot license not on tenant | Unknown | Blocking | Buy via Partner Center or via existing admin |
+| AFD route conflict with existing `ipai-copilot-gateway` path | Low | Med | Route pattern `/api/messages` is unique to bot; no overlap with existing web paths |
+
+## Not planned
+
+- Declarative agents for any IPAI use case (wrong model)
+- Copilot Studio agents (low-code path — doesn't fit ipai-copilot-gateway)
+- Per-agent Foundry projects (all share `ipai-copilot` — orchestrator-level differentiation only)
+
+## References
+
+- `constitution.md`, `prd.md`, `tasks.md` (this bundle)
+- [overview-custom-engine-agent](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/overview-custom-engine-agent)
+- [microsoft-agent-365/overview](https://learn.microsoft.com/en-us/microsoft-agent-365/overview)
+- `agents/teams-surface/` — canonical template
+- `infra/azure/modules/bot-route.bicep` — AFD routing primitive

--- a/spec/pulser-entra-agent-id/prd.md
+++ b/spec/pulser-entra-agent-id/prd.md
@@ -1,0 +1,92 @@
+# PRD — Pulser Entra Agent ID rollout
+
+> Draft. Target: complete before 2026-05-01 (Agent 365 GA).
+
+## Problem
+
+At Microsoft Agent 365 general availability (May 1, 2026), every AI agent
+running in a Microsoft 365 tenant must have its own **Entra Agent ID** for
+identity, lifecycle, access management, observability, and threat protection.
+
+IPAI currently runs agents (Pulser, Tax Guru PH, Doc Intelligence, Bank
+Recon, AP Invoice, Finance Close) through a single managed identity
+(`id-ipai-dev`). Without per-agent Entra IDs at GA:
+
+- Agents will not appear in the M365 Admin Center agent registry
+- Purview cannot audit agent actions per-agent
+- Defender cannot scope threat detection per-agent
+- Conditional Access policies cannot target specific agents
+- Future M365 E7 OBO licensing coverage is unclear
+
+## Goals
+
+| # | Goal | Success criterion |
+|---|---|---|
+| 1 | Every production agent has its own Entra Agent ID by 2026-05-01 | All 6+ agents visible in M365 Admin Center → Agents |
+| 2 | Zero client secrets in code or config | `grep -r AZURE_CLIENT_SECRET` returns only env var refs |
+| 3 | Per-agent observability via native M365 tooling | Purview audit trail shows agent → user OBO chain |
+| 4 | Agents Toolkit-packaged Teams surface for each agent | `appPackage/manifest.json` v1.21 validates |
+| 5 | Bot route `/api/messages` behind AFD per agent | AFD route exists for pulser-bot-route, tax-guru-bot-route, etc. |
+
+## Non-goals
+
+- Migrating off `ipai-copilot-gateway` as the orchestrator (it's the custom engine)
+- Adopting Copilot Studio (low-code path — wrong model)
+- Rewriting existing agent logic — only adding the identity wrapper
+
+## Users
+
+| Persona | Need |
+|---|---|
+| Finance team (CKVC/RIM/BOM + 8) | Ask Pulser in Teams about BIR, invoices, reconciliation |
+| Tax reviewer | Ask Tax Guru PH about 2550Q, 1601C, 2307 etc. from Outlook |
+| Ops admin | See all IPAI agents in M365 Admin Center, review their activity |
+| Security team | Apply Conditional Access to agent identities; Defender alerts per agent |
+
+## Scope
+
+### In scope
+
+- Create 6 user-assigned MIs: `id-ipai-agent-pulser`, `id-ipai-agent-tax-guru`,
+  `id-ipai-agent-doc-intel`, `id-ipai-agent-bank-recon`,
+  `id-ipai-agent-ap-invoice`, `id-ipai-agent-finance-close`
+- Register each as an Entra Agent ID via Agent 365 admin flow
+- Package each as a Teams custom engine agent (Agents Toolkit)
+- Wire `/api/messages` routes through AFD per agent
+- Attach Application Insights per agent for telemetry bridging
+
+### Out of scope
+
+- Migrating from the shared `ipai-copilot-gateway` backend — each agent
+  still calls the gateway; only the *identity* fronting the bot is per-agent
+- Retiring the `ops.agent_runs` table (supplemental, not authoritative)
+
+## Licensing
+
+| Phase | Model | Source |
+|---|---|---|
+| Pre-GA (Frontier preview) | Per-agent license, max 25 per tenant | MS Learn — Agent 365 FAQ |
+| Post-GA (2026-05-01+) | Per-user — agents covered by user's Agent 365 or M365 E7 license OBO | Same |
+
+**Action:** enroll tenant in Frontier preview to start registering agents
+before GA. Buy `Microsoft 365 Copilot` license if not already held.
+
+## Success metrics
+
+- **6/6 agents** registered in M365 Admin Center → Agents by 2026-05-01
+- **100%** of agent activity visible in Purview audit log with OBO user chain
+- **Zero** `AZURE_CLIENT_SECRET` plaintext in git
+- **P0 alerts** wired from Defender for Cloud → on-call (Slack/Teams channel)
+
+## Open questions
+
+- [ ] One MI per agent per environment, or one MI per agent shared across envs? (implications for KV access policies)
+- [ ] Custom domain strategy — `pulser-dev.insightpulseai.com` per-agent or a single `agents.insightpulseai.com` with path-based routing?
+- [ ] Do we participate in Frontier preview (pre-GA access) or wait for GA?
+
+## Dependencies
+
+- `agents/teams-surface/` scaffold complete (done — this spec's companion work)
+- `infra/azure/modules/bot-route.bicep` available (done — additive)
+- M365 Copilot license present on tenant (verify)
+- `id-ipai-dev` principal ID confirmed: `1aee831f-3813-4eed-b49c-f7665330f0f6`

--- a/spec/pulser-entra-agent-id/tasks.md
+++ b/spec/pulser-entra-agent-id/tasks.md
@@ -1,0 +1,60 @@
+# Tasks — Pulser Entra Agent ID rollout
+
+> Draft. Deadline 2026-05-01. Ordered by phase. Check boxes as work lands.
+
+## Phase 0 — Pre-flight
+
+- [ ] T0.1  (Owner) Confirm M365 Copilot license on tenant
+- [ ] T0.2  (Owner) Enroll in Frontier preview program at https://adoption.microsoft.com/copilot/frontier-program/
+- [ ] T0.3  (Owner) Revoke global `vscode` PAT; follow `docs/security/revoke-pat-runbook.md`
+- [ ] T0.4  (Owner) Run `scripts/azure/migrate-variable-groups.sh`; grant `id-ipai-dev` KV access
+- [ ] T0.5  (Owner) Inspect `ipai-foundry-eval` ADO variable group (2 unknown vars) in portal
+
+## Phase 1 — Pulser as canonical template
+
+- [x] T1.1  (Code) Scaffold `agents/teams-surface/` — manifest v1.21, bot/app.py, teamsapp.yml, env/
+- [x] T1.2  (Code) Write `infra/azure/modules/bot-route.bicep` — AFD `/api/messages` route
+- [x] T1.3  (Code) Write `docs/skills/m365-copilot-streaming-contract.md` — message-ordering rules
+- [ ] T1.4  (Owner) Install `atk` CLI: `npm install -g @microsoft/m365agentstoolkit-cli`
+- [ ] T1.5  (Code + Owner) `cp env/.env.dev.example env/.env.dev` + fill values
+- [ ] T1.6  (Code) `atk provision --env dev` — creates pulser-teams-bot-dev + Entra app reg + Bicep deploy
+- [ ] T1.7  (Code) Deploy `bot-route.bicep` via `main.bicep` or standalone `az deployment group create`
+- [ ] T1.8  (QA) Start Agents Playground: `npx @microsoft/teams-app-test-tool start --manifest agents/teams-surface/appPackage/manifest.json` and verify roundtrip
+- [ ] T1.9  (CI) Deploy bot code to `ipai-copilot-gateway` ACA via `.github/workflows/deploy-erp-canonical.yml`
+- [ ] T1.10 (Owner) Sideload Teams app package to IPAI tenant — `atk publish --env dev`
+- [ ] T1.11 (Owner) Register first Entra Agent ID for Pulser via Frontier admin flow
+
+## Phase 2 — Replicate template for 5 more agents
+
+For each agent `<name>` in `{tax-guru, doc-intel, bank-recon, ap-invoice, finance-close}`:
+
+- [ ] T2.<name>.1  (Code) `cp -r agents/teams-surface agents/<name>-surface`
+- [ ] T2.<name>.2  (Code) Update `appPackage/manifest.json` — name, description, commands, icons
+- [ ] T2.<name>.3  (Code) Update `bot/bot.py` — agent persona wiring (Pulser variant)
+- [ ] T2.<name>.4  (Owner) `az identity create -n id-ipai-agent-<name> -g rg-ipai-dev-platform`
+- [ ] T2.<name>.5  (Owner) `atk provision --env dev` from `agents/<name>-surface/`
+- [ ] T2.<name>.6  (Owner) Add route via `bot-route.bicep` — route pattern `/api/<name>/messages`
+- [ ] T2.<name>.7  (Owner) Register Entra Agent ID for `<name>` via Frontier admin flow
+
+## Phase 3 — Hardening
+
+- [ ] T3.1  (Security) Create Conditional Access policy — agent MIs restricted to `api://ipai-copilot-gateway/.default` scope
+- [ ] T3.2  (Security) Defender for Cloud alert rule — unusual agent activity → Slack/Teams oncall
+- [ ] T3.3  (Security) Purview audit rule — log every agent action with OBO user chain
+- [ ] T3.4  (Owner) Post-GA: revert per-agent Frontier licenses → per-user M365 E7 / Agent 365
+
+## Exit criteria
+
+- All 6 agents listed in M365 Admin Center → Agents ✓
+- Each agent visible to Defender + Purview ✓
+- No `AZURE_CLIENT_SECRET` plaintext in git ✓
+- AFD routes: `pulser-bot-route`, `tax-guru-bot-route`, `doc-intel-bot-route`, `bank-recon-bot-route`, `ap-invoice-bot-route`, `finance-close-bot-route` ✓
+- Streaming contract (5 rules) verified in code review for every agent ✓
+
+## References
+
+- `constitution.md`, `prd.md`, `plan.md`
+- `agents/teams-surface/README.md`
+- `infra/azure/modules/bot-route.bicep`
+- `docs/skills/m365-copilot-streaming-contract.md`
+- `docs/security/revoke-pat-runbook.md`

--- a/spec/pulser-entra-agent-id/tasks.md
+++ b/spec/pulser-entra-agent-id/tasks.md
@@ -31,10 +31,10 @@ For each agent `<name>` in `{tax-guru, doc-intel, bank-recon, ap-invoice, financ
 - [x] T2.<name>.1  (Code) Scaffold `agents/<name>-surface/` — README + agent-specific files. Owner copies shared files from teams-surface per README's cp + sed recipe.
 - [x] T2.<name>.2  (Code) `appPackage/manifest.json` v1.21 — per-agent name, description, commands, accent color
 - [x] T2.<name>.3  (Code) `bot/bot.py` — per-agent SURFACE_TAG, WELCOME, persona wiring, file handling (where applicable)
-- [ ] T2.<name>.4  (Owner) `az identity create -n id-ipai-agent-<name> -g rg-ipai-dev-platform`
-- [ ] T2.<name>.5  (Owner) `atk provision --env dev` from `agents/<name>-surface/`
-- [ ] T2.<name>.6  (Owner) Add route via `bot-route.bicep` — route pattern `/api/<name>/messages`
-- [ ] T2.<name>.7  (Owner) Register Entra Agent ID for `<name>` via Frontier admin flow
+- [x] T2.<name>.4  (Code) Bicep for all 6 MIs: `infra/azure/deploy-agent-identities.bicep` — Owner runs `az deployment group create --resource-group rg-ipai-dev-platform --template-file ...` (one command, all 6)
+- [ ] T2.<name>.5  (Owner) `atk provision --env dev` — interactive, cannot automate. See [deploy.md §Step 4](./deploy.md)
+- [x] T2.<name>.6  (Code) Bicep for all 6 AFD routes: `infra/azure/deploy-agent-routes.bicep` — Owner runs `az deployment group create` against the AFD RG. See [deploy.md §Step 2](./deploy.md)
+- [ ] T2.<name>.7  (Owner) Register Entra Agent ID via M365 Admin Center — browser UI, cannot automate. See [deploy.md §Step 5](./deploy.md)
 
 ## Phase 3 — Hardening
 

--- a/spec/pulser-entra-agent-id/tasks.md
+++ b/spec/pulser-entra-agent-id/tasks.md
@@ -28,9 +28,9 @@
 
 For each agent `<name>` in `{tax-guru, doc-intel, bank-recon, ap-invoice, finance-close}`:
 
-- [ ] T2.<name>.1  (Code) `cp -r agents/teams-surface agents/<name>-surface`
-- [ ] T2.<name>.2  (Code) Update `appPackage/manifest.json` — name, description, commands, icons
-- [ ] T2.<name>.3  (Code) Update `bot/bot.py` — agent persona wiring (Pulser variant)
+- [x] T2.<name>.1  (Code) Scaffold `agents/<name>-surface/` — README + agent-specific files. Owner copies shared files from teams-surface per README's cp + sed recipe.
+- [x] T2.<name>.2  (Code) `appPackage/manifest.json` v1.21 — per-agent name, description, commands, accent color
+- [x] T2.<name>.3  (Code) `bot/bot.py` — per-agent SURFACE_TAG, WELCOME, persona wiring, file handling (where applicable)
 - [ ] T2.<name>.4  (Owner) `az identity create -n id-ipai-agent-<name> -g rg-ipai-dev-platform`
 - [ ] T2.<name>.5  (Owner) `atk provision --env dev` from `agents/<name>-surface/`
 - [ ] T2.<name>.6  (Owner) Add route via `bot-route.bicep` — route pattern `/api/<name>/messages`

--- a/spec/pulser-entra-agent-id/tasks.md
+++ b/spec/pulser-entra-agent-id/tasks.md
@@ -26,15 +26,15 @@
 
 ## Phase 2 — Replicate template for 5 more agents
 
-For each agent `<name>` in `{tax-guru, doc-intel, bank-recon, ap-invoice, finance-close}`:
+For each agent name in `{tax-guru, doc-intel, bank-recon, ap-invoice, finance-close}`:
 
-- [x] T2.<name>.1  (Code) Scaffold `agents/<name>-surface/` — README + agent-specific files. Owner copies shared files from teams-surface per README's cp + sed recipe.
-- [x] T2.<name>.2  (Code) `appPackage/manifest.json` v1.21 — per-agent name, description, commands, accent color
-- [x] T2.<name>.3  (Code) `bot/bot.py` — per-agent SURFACE_TAG, WELCOME, persona wiring, file handling (where applicable)
-- [x] T2.<name>.4  (Code) Bicep for all 6 MIs: `infra/azure/deploy-agent-identities.bicep` — Owner runs `az deployment group create --resource-group rg-ipai-dev-platform --template-file ...` (one command, all 6)
-- [ ] T2.<name>.5  (Owner) `atk provision --env dev` — interactive, cannot automate. See [deploy.md §Step 4](./deploy.md)
-- [x] T2.<name>.6  (Code) Bicep for all 6 AFD routes: `infra/azure/deploy-agent-routes.bicep` — Owner runs `az deployment group create` against the AFD RG. See [deploy.md §Step 2](./deploy.md)
-- [ ] T2.<name>.7  (Owner) Register Entra Agent ID via M365 Admin Center — browser UI, cannot automate. See [deploy.md §Step 5](./deploy.md)
+- [x] T2.`<name>`.1  (Code) Scaffold `agents/<name>-surface/` — README + agent-specific files. Owner copies shared files from teams-surface per README's cp + sed recipe.
+- [x] T2.`<name>`.2  (Code) `appPackage/manifest.json` v1.21 — per-agent name, description, commands, accent color
+- [x] T2.`<name>`.3  (Code) `bot/bot.py` — per-agent SURFACE_TAG, WELCOME, persona wiring, file handling (where applicable)
+- [x] T2.`<name>`.4  (Code) Bicep for all 6 MIs: `infra/azure/deploy-agent-identities.bicep` — Owner runs `az deployment group create --resource-group rg-ipai-dev-platform --template-file ...` (one command, all 6)
+- [ ] T2.`<name>`.5  (Owner) `atk provision --env dev` — interactive, cannot automate. See [deploy.md §Step 4](./deploy.md)
+- [x] T2.`<name>`.6  (Code) Bicep for all 6 AFD routes: `infra/azure/deploy-agent-routes.bicep` — Owner runs `az deployment group create` against the AFD RG. See [deploy.md §Step 2](./deploy.md)
+- [ ] T2.`<name>`.7  (Owner) Register Entra Agent ID via M365 Admin Center — browser UI, cannot automate. See [deploy.md §Step 5](./deploy.md)
 
 ## Phase 3 — Hardening
 


### PR DESCRIPTION
## Summary
- **agents/teams-surface/** — Python custom engine agent scaffold (Bot Framework proxy to ipai-copilot-gateway), manifest v1.21, teamsapp.yml lifecycle, streaming-aware PulserBot
- **infra/azure/modules/bot-route.bicep** — additive AFD route for /api/messages (no changes to front-door.bicep)
- **docs/skills/m365-copilot-streaming-contract.md** — 5 message-ordering rules from MS Learn custom-engine-agent doc
- **spec/pulser-entra-agent-id/** — constitution/prd/plan/tasks bundle targeting Agent 365 GA 2026-05-01 for 6 agents

## Why now
Agent 365 GA is 2026-05-01 (19 days). After GA, every agent must have its own Entra Agent ID to appear in M365 Admin Center + Purview + Defender. Licensing flips from per-agent to per-user OBO. Need the scaffolding + plan in place before the window closes.

## Test plan
- [ ] Local: \`python bot/app.py\` starts aiohttp listener on :3978
- [ ] Playground: \`npx @microsoft/teams-app-test-tool start --manifest agents/teams-surface/appPackage/manifest.json\` chats roundtrip
- [ ] Lint: manifest.json validates against v1.21 schema (\`atk teamsapp validate\`)
- [ ] Bicep: \`az bicep build -f infra/azure/modules/bot-route.bicep\` — no errors
- [ ] Spec: \`./scripts/spec_validate.sh\` recognizes the new bundle

## Open decisions (in spec/pulser-entra-agent-id/)
- MI scoping: per-env vs shared across envs (plan.md §Architecture decisions)
- Custom domain strategy: per-agent vs path-based (plan.md §Architecture decisions)
- Frontier preview enrollment: participate pre-GA or wait for GA?

🤖 Generated with [Claude Code](https://claude.com/claude-code)