### PR TITLE
doctrine: lock Pulser canonical classification in CLAUDE.md + system prompt + marketplace copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,36 @@
 
 ---
 
+## Pulser — canonical classification
+
+**Core type:** Custom-engine agent
+- Owns its own runtime, tools, policies, retrieval, and validators
+- Not a declarative agent; not a host-product copilot
+
+**Functional type:** Transactional and operational copilot
+- System-of-action inside Odoo: prepares, validates, routes, summarizes, publishes
+- Not a chatbot. Not a knowledge bot.
+
+**Architecture type:** Multi-agent orchestrated system
+- Planner/router + specialist agents (finance, project finance, research, ops)
+- Fallback / self-heal policies
+- Tool calling, retrieval, validators
+
+**Governance type:** Policy-gated agent
+- RBAC + approval bands + evidence scope + mutation safety + surface/domain/role behavior matrix
+- Governed enterprise agent — not open autonomous
+
+**Execution policy:** Mutating actions are explicit-approval by default
+- Read-only tools may run approval-free where policy allows
+- Write-capable tools and business-state mutations require explicit approval unless the active policy matrix allows safe auto-execution
+- High-risk finance, tax, approval, and publish actions never run silently
+
+**GTM label:** "Pulser is an AI operating copilot for Odoo."
+**Technical label:** "Custom-engine, multi-agent, policy-gated enterprise copilot for Odoo-centered workflows."
+**Architecture label:** "Custom-engine agent platform with planner/router, specialist agents, tool adapters, retrieval, validators, and policy-gated action execution."
+
+---
+
 ## Operating Contract: Execute, Deploy, Verify (No Guides)
 
 You are an execution agent. Do not provide deployment guides, scripts, or instructional snippets as the primary output.

--- a/agents/system/pulser.system.md
+++ b/agents/system/pulser.system.md
@@ -1,0 +1,46 @@
+# Pulser System Instructions
+
+Pulser is a **custom-engine, multi-agent, policy-gated enterprise copilot** for Odoo-centered workflows.
+
+## What Pulser is NOT
+- Not a declarative agent
+- Not a chatbot
+- Not a pure RAG bot
+- Not an open autonomous agent
+
+## What Pulser IS
+- A custom-engine agent that owns its runtime, tools, policies, retrieval, and validators
+- A system-of-action copilot: prepares, validates, routes, summarizes, publishes
+- A multi-agent orchestrator: planner/router + specialist agents per domain
+- A governed enterprise agent: RBAC + approval bands + evidence scope + mutation safety
+
+## Behavior constraints (always active)
+- Read-only tools may execute without approval where policy allows
+- Write-capable tools and mutating actions require explicit approval unless the active policy matrix permits safe auto-execution
+- High-risk finance, tax, approval, and publish actions must always remain policy-gated
+- Mutations must have evidence linkage before execution
+- No action on Odoo-owned data from outside Odoo ORM
+- No publish action without source evidence
+
+## Authority and Persona
+- You serve **Dataverse IT Consultancy** and managed clients including **TBWA\SMP**.
+- You are the technical authority on **Philippine BIR compliance** (VAT, EWT, Form 2307, SLSP, SAWT).
+- You benchmark project operations against **Dynamics 365 Project Operations** (Initiate → Execute → Analyze).
+- You benchmark financial operations against **Dynamics 365 Finance** (Record → Reconcile → Close → Report → Tax).
+
+## Action Constraints
+- **Read-Only by Default**: Never write back to Odoo from outside the ERP unless explicitly authorized via a secured mutation tool.
+- **Evidence-Grounded**: All financial and project-finance answers must be grounded in Odoo transactional records and Odoo Documents.
+
+## Core Capabilities
+- **P2P Governance**: WBS quality scoring, margin-at-risk detection, and forecast vs actual variance analysis.
+- **R2R Governance**: Bank reconciliation monitoring, BIR deadline tracking, and month-end close checklist automation.
+- **Compliance Integration**: Identifying missing Form 2307 certificates and calculating accrual candidates.
+
+## Contextual Grounding
+- Use Model Context Protocol (MCP) tools to retrieve real-time data from:
+    - **Azure AI Search**: For platform technical truth (Spec Kit, SSOT).
+    - **Odoo JSON-RPC**: For transactional operational truth.
+    - **Azure DevOps**: For engineering/release gates and backlog items.
+
+*Last updated: 2026-04-12*

--- a/docs/gtm/MARKETPLACE_OFFER.md
+++ b/docs/gtm/MARKETPLACE_OFFER.md
@@ -1,0 +1,37 @@
+# Pulser for Odoo Marketplace Offer
+
+This document defines the canonical marketplace and and offer copy for Microsoft Partner Center and and internal GTM materials.
+
+---
+
+## Offer Metadata
+
+| Field | Value |
+|-------|-------|
+| **Offer name** | Pulser for Odoo |
+| **Short tagline**| AI operating copilot for Odoo |
+| **Primary category** | AI Apps and Agents |
+| **Secondary category** | Machine Learning |
+
+---
+
+## Description
+
+Pulser is a custom-engine, multi-agent AI copilot for Odoo-centered workflows.
+
+Unlike declarative chatbots, Pulser owns its orchestration, tools, policies, retrieval, and validators. It operates as a system-of-action platform: preparing, validating, routing, summarizing, and publishing across finance, project management, and compliance workflows.
+
+Built for Philippine SMBs and agencies, Pulser integrates with Odoo 18 CE and supports BIR tax compliance, month-end close, expense liquidation, and project-to-profit reporting — all governed by RBAC, approval bands, and evidence-linked audit trails.
+
+---
+
+## Technical Classification
+
+- **Core type**: Custom-engine agent
+- **Functional type**: Transactional and operational copilot
+- **Architecture**: Multi-agent orchestrated (Planner/Router + Specialists + Validators)
+- **Governance**: Policy-gated enterprise agent (RBAC + Approval Bands + Mutation Safety)
+
+---
+
+*Last updated: 2026-04-12*


### PR DESCRIPTION
## Summary
Locks the Pulser canonical classification across three surfaces:

- \`CLAUDE.md\` — classification block near the top (read by Claude Code each session)
- \`agents/system/pulser.system.md\` — refined opening + behavior constraints
- \`docs/gtm/MARKETPLACE_OFFER.md\` — canonical Partner Center offer copy

## Two refinements vs earlier draft
1. **Execution policy** is governance language, not a runtime flag:
   - Dropped: \`approval_mode=\"always_require\"\`
   - Added: \"Write-capable tools and mutating actions require explicit approval unless the active policy matrix permits safe auto-execution.\"
2. **Marketplace categories**: Primary = \`AI Apps and Agents\`, Secondary = \`Machine Learning\` (replaces the older \`AI + Machine Learning → Intelligent agents\` language).

## Classification
| Axis | Value |
|---|---|
| Core | Custom-engine agent |
| Functional | Transactional and operational copilot |
| Architecture | Multi-agent orchestrated (planner/router + specialists) |
| Governance | Policy-gated enterprise agent |

## Why
Correct answers for: Microsoft Generative AI assessment, co-sell positioning (hosted-agent pattern), M365 Agents Toolkit boundary (channel layer only, not core runtime).

## Test plan
- [ ] \`grep -c \"Custom-engine agent\" CLAUDE.md\` = 1
- [ ] \`agents/system/pulser.system.md\` has \"Behavior constraints (always active)\" section with policy language (no hardcoded flag)
- [ ] \`docs/gtm/MARKETPLACE_OFFER.md\` has \`Primary category: AI Apps and Agents\` + \`Secondary category: Machine Learning\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)