### PR TITLE
feat(governance): Azure tagging pack + Databricks local-dev guide

### DIFF
--- a/docs/ai/AZURE_TAGGING.md
+++ b/docs/ai/AZURE_TAGGING.md
@@ -1,0 +1,161 @@
+# Azure Tagging Doctrine — IPAI
+
+**Canonical schema:** [ssot/azure/tagging-standard.yaml](../../ssot/azure/tagging-standard.yaml)
+**Policy-as-code:** [infra/azure/policy/tagging-baseline.bicep](../../infra/azure/policy/tagging-baseline.bicep)
+**Drift audit:** [scripts/azure/audit-tags.sh](../../scripts/azure/audit-tags.sh)
+
+---
+
+## Executive summary
+
+Azure tags are the load-bearing metadata layer for **cost allocation, governance, automation, and compliance** across IPAI's footprint. This doctrine consolidates:
+
+- Microsoft Cloud Adoption Framework (CAF) Ready tagging guidance (June 2025 refresh)
+- FinOps Foundation Framework 2026 — Allocation + Invoicing/Chargeback capabilities
+- Azure Policy built-in definitions for tag compliance
+- Cost Management tag inheritance mechanics
+
+into a single enforceable schema ready for IPAI's subscription `536d8cf6-89e1-4815-aef3-d5f2c5f4d070`.
+
+## Current state (audit 2026-04-13)
+
+Subscription has **17 unique tag keys** with significant drift:
+
+| Drift class | Example | Impact |
+|---|---|---|
+| Case collisions | `Environment` (59×), `env` (1), `environment` (4), `ENV` | Cost reports show duplicate rows |
+| Semantic collisions | `Owner:ipai`, `owner:jake`, `Owner:platform` | Ownership ambiguous |
+| Key synonyms | `Service`, `Stack`, `workload`, `product`, `app` | Same concept, 5 keys |
+| Non-canonical values | `CostCenter: platform` (not a GL code) | Can't roll up to finance |
+| Managed-by casing | `managedBy`, `ManagedBy`, `managed_by`, `managed-by` | 4 variants |
+
+Two resources also carry operational signals missed by anyone not looking at tags:
+- `ipai-copilot-gateway` is marked `quarantine: true` / `retain-until: 2026-05-05` — **schedule for deprecation before May 5**
+- `acripaiodoo` has `Environment: Development` (value case drift — should be `env=dev`)
+
+## Three findings that drive the schema
+
+### 1. Azure does not inherit tags by default
+
+Resources do NOT inherit from resource group; resource groups do NOT inherit from subscription. This is the single most-cited source of tag drift. Two remediation paths:
+
+- **Azure Policy `modify` effect** — writes tags onto the actual resource (visible in Resource Graph, Policy compliance, and Cost Management)
+- **Cost Management tag inheritance** — writes tags onto usage records only (visible in Cost Analysis / budgets / exports, but NOT on the resource)
+
+**IPAI enables both.** Policy-based inheritance closes the governance gap; Cost Management inheritance closes the cost-reporting gap for resources whose tags don't flow into usage (SQL child types, BotService channels, some network types).
+
+### 2. Not every resource can carry tags
+
+Classic resources, IP Groups, Firewall Policies (no PATCH), Entra app registrations (Graph-only, string-list-not-map), Bot Service channels, SQL child types — all either refuse tags or carry them without propagation.
+
+**Workaround** for untaggable resources: carry metadata in naming convention (`ipai-<app>-<env>-<region>`), place in a dedicated RG, rely on Cost Management inheritance from RG/subscription. Entra apps get a parallel SSOT mirror at `ssot/entra/app-registrations.yaml`.
+
+### 3. CAF Ready and FinOps F2 converge on five tag categories
+
+- **Functional** → `env`, `app`, `region`, `managed-by`, `repo`, `created-date`
+- **Classification** → `data-classification`, `criticality`
+- **Accounting** → `costcenter`, `project`, `businessunit`
+- **Purpose** (optional) → `businessprocess`, `revenueimpact`
+- **Ownership** → `owner`, `businessunit`
+
+IPAI's required set matches 1:1 with the CAF required set. See `ssot/azure/tagging-standard.yaml` for the full schema.
+
+## Enforcement plan (3-phase)
+
+### Phase 1 — Stage the policy (no enforcement yet)
+
+```bash
+az deployment sub create \
+  --location southeastasia \
+  --template-file infra/azure/policy/tagging-baseline.bicep \
+  --subscription 536d8cf6-89e1-4815-aef3-d5f2c5f4d070 \
+  --parameters requiredTagKeys='["env","costcenter","owner"]'
+```
+
+Deploys 5 policy assignments at subscription scope:
+1. `ipai-require-env` — deny resources missing `env`
+2. `ipai-require-costcenter` — deny resources missing `costcenter`
+3. `ipai-require-owner` — deny resources missing `owner`
+4. `ipai-rg-require-owner` — deny resource groups missing `owner`
+5. `ipai-inherit-rg-{env|costcenter|owner|businessunit|project|data-classification}` — modify (inherit-if-missing) from RG
+
+### Phase 2 — Remediate existing non-compliant resources
+
+After deploy, the policy MIs are granted Contributor to run remediation tasks:
+
+```bash
+for tag in env costcenter owner businessunit project data-classification; do
+  az policy remediation create \
+    --name "remediate-inherit-rg-${tag}-$(date +%Y%m%d)" \
+    --policy-assignment "ipai-inherit-rg-${tag}" \
+    --resource-discovery-mode ReEvaluateCompliance
+done
+```
+
+This sweeps existing resources and writes the missing tags from the RG. Does NOT overwrite existing values.
+
+### Phase 3 — Drift detection in CI
+
+Wire `scripts/azure/audit-tags.sh` into:
+
+- GitHub Actions **scheduled run** (twice weekly) — alerts on drift
+- GitHub Actions **pre-deploy gate** on `infra/azure/**` changes — blocks deploys that introduce drift
+- Evidence bundle writes to `docs/evidence/<stamp>/azure-tags/` for audit trail
+
+Exit code 0 on zero drift, 1 otherwise. Per IPAI operating contract.
+
+## Case-drift cleanup (one-time, manual)
+
+The policy baseline does NOT automatically remove forbidden case-variant keys (`Environment`, `managedBy`, etc.). Remediate manually or via targeted scripts:
+
+```bash
+# Find all resources with forbidden keys
+bash scripts/azure/audit-tags.sh
+# Inspect docs/evidence/<stamp>/azure-tags/drift-forbidden-keys.json
+# Then for each affected resource, either:
+#  - use az resource tag --operation merge to add the canonical key
+#  - use az resource update --remove tags.<ForbiddenKey> to drop the drift
+```
+
+## Cost Management companion step (portal, owner-only)
+
+Cost Management tag inheritance is **not available via CLI**. One-time owner step:
+
+1. Portal → Cost Management → Settings → Manage subscription
+2. Tag inheritance → Edit → **Enable** "Automatically apply subscription and resource group tags to new usage data"
+3. Save — propagation takes 8–24 hours
+
+After enable, `env`, `costcenter`, `owner`, `businessunit` will appear in Cost Analysis `Group by` even for resource types that don't emit tags in their usage records.
+
+## Integration with existing IPAI standards
+
+- **Naming convention** (`ipai-<app>-<env>-<region>`) still applies — tags complement names, don't replace them
+- **Secrets policy** — `data-classification: restricted` triggers stricter KV access review in CI
+- **SSOT rule #10** (no console-only infra changes) — policy assignments deploy via Bicep; drift audit is scripted
+- **Operating contract** — audit output lands in `docs/evidence/<stamp>/azure-tags/`
+
+## Related
+
+- [ssot/azure/tagging-standard.yaml](../../ssot/azure/tagging-standard.yaml) — the canonical schema
+- [infra/azure/policy/tagging-baseline.bicep](../../infra/azure/policy/tagging-baseline.bicep) — policy-as-code
+- [scripts/azure/audit-tags.sh](../../scripts/azure/audit-tags.sh) — drift detector
+- [docs/security/revoke-pat-runbook.md](../security/revoke-pat-runbook.md) — PAT cleanup (prerequisite — tags reference `owner`/`managed-by` which require Entra auth)
+
+## Sources
+
+Microsoft Learn (primary):
+- [Define your tagging strategy (CAF Ready, June 2025)](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-tagging)
+- [Use tags to organize Azure resources](https://learn.microsoft.com/azure/azure-resource-manager/management/tag-resources)
+- [Tag support for Azure resources](https://learn.microsoft.com/azure/azure-resource-manager/management/tag-support)
+- [Assign policy definitions for tag compliance](https://learn.microsoft.com/azure/azure-resource-manager/management/tag-policies)
+- [Group and allocate costs using tag inheritance](https://learn.microsoft.com/azure/cost-management-billing/costs/enable-tag-inheritance)
+- [Group related resources (cm-resource-parent)](https://learn.microsoft.com/azure/cost-management-billing/costs/group-filter#group-related-resources-in-the-resources-view)
+
+FinOps Foundation:
+- [Allocation capability](https://www.finops.org/framework/capabilities/allocation/)
+- [Invoicing & Chargeback capability](https://www.finops.org/framework/capabilities/invoicing-chargeback/)
+- [FinOps Framework 2026](https://www.finops.org/insights/2026-finops-framework/)
+
+---
+
+*Last updated: 2026-04-13*

--- a/docs/databricks/LOCAL_DEV.md
+++ b/docs/databricks/LOCAL_DEV.md
@@ -1,0 +1,215 @@
+# Databricks Local Development — IPAI
+
+Three viable patterns for local Databricks development against IPAI's data platform,
+ordered from most to least capable. Pick based on whether a live workspace exists.
+
+---
+
+## Environment reality check (2026-04-13)
+
+Run these **first** to confirm which levels apply to your current state:
+
+```bash
+# Expected Databricks workspace
+az databricks workspace list --query "[?name=='dbw-ipai-dev']" -o json
+
+# Expected lakehouse storage
+az storage account list --query "[?starts_with(name, 'st') && contains(name, 'ipai')].{name:name, rg:resourceGroup}" -o table
+```
+
+**Current state (verified 2026-04-13):**
+- `dbw-ipai-dev` Databricks workspace: **NOT PROVISIONED** in the active subscription
+- Lakehouse storage: `stipaidev` in `rg-ipai-dev-odoo-runtime` (memory referenced `stipaidevlake` — stale)
+
+Until `dbw-ipai-dev` is provisioned, only **Level 3** (fully local Spark) works without an Azure-side dependency. Levels 1 and 2 remain the target architecture.
+
+If you need to provision the workspace now, the Bicep spine lives in
+[../../infra/azure/modules/](../../infra/azure/modules/) — add a `databricks.bicep`
+module binding to `rg-ipai-dev-odoo-runtime` (Premium SKU for Unity Catalog).
+
+---
+
+## Level 1 — Databricks Connect *(recommended once workspace exists)*
+
+Runs Python **locally** but Spark executes on the remote cluster. Best developer
+experience: local IDE + debugger + hot reload + real cluster.
+
+```bash
+# Install — version MUST match the workspace's DBR version
+pip install databricks-connect==15.4.0
+
+# Preferred auth: DefaultAzureCredential (no PATs, no tokens)
+databricks configure --host https://adb-<workspace-id>.azuredatabricks.net
+
+# Or — explicit Entra token (rotated per hour via az CLI)
+export DATABRICKS_HOST=https://adb-<workspace-id>.azuredatabricks.net
+export DATABRICKS_TOKEN=$(az account get-access-token \
+  --resource 2ff814a6-3304-4ab8-85cb-cd0e6f879c1d \
+  --query accessToken -o tsv)
+```
+
+Once configured, write code that runs as if it were on the cluster:
+
+```python
+# local_dev.py — Python runs locally, Spark runs on dbw-ipai-dev
+from databricks.connect import DatabricksSession
+
+spark = DatabricksSession.builder.getOrCreate()
+
+# Read bronze layer from stipaidev (ADLS Gen2)
+df = spark.read.format("delta").load(
+    "abfss://bronze@stipaidev.dfs.core.windows.net/odoo/account_move/"
+)
+df.show(5)
+```
+
+**Costs / constraints:**
+- Requires a running cluster. Use **job clusters** for batch work or **auto-terminating
+  interactive clusters** (10-minute timeout) for dev.
+- Min cluster cost: ~$0.40/hr for a 1-worker DS3_v2 dev cluster.
+- Unity Catalog metadata is resolved remotely — you see `stipaidev` volumes from VS Code.
+
+---
+
+## Level 2 — VS Code Databricks extension
+
+Same cluster execution as Level 1, but notebook-style workflow in the IDE. File
+sync + notebook runs + inline output.
+
+```bash
+# Install the extension
+code --install-extension databricks.databricks
+```
+
+Then: `Cmd+Shift+P` → **Databricks: Configure Workspace** → enter the workspace URL →
+authenticate with Entra (DefaultAzureCredential flow — no PAT).
+
+Capabilities:
+- Sync local `.py` / `.ipynb` to DBFS automatically on save
+- Run notebooks on the remote cluster, see output inline in VS Code
+- Unity Catalog browser (schemas, tables, volumes) in the sidebar
+- Job run logs stream to the VS Code output panel
+
+This is effectively the Databricks web UI surfaced in your editor — no browser tab
+needed for most dev loops. Pairs naturally with Level 1 for interactive Spark.
+
+---
+
+## Level 3 — Fully local Spark *(works TODAY, no Azure dependency)*
+
+For unit-testing DLT pipeline transformation logic without provisioning a workspace.
+The only option currently viable given the workspace gap above.
+
+```bash
+pip install pyspark==3.5.0 delta-spark
+```
+
+```python
+# tests/test_dlt_logic.py — pure local, no cluster, no cost
+from pyspark.sql import SparkSession
+from delta import configure_spark_with_delta_pip
+
+builder = (
+    SparkSession.builder
+        .appName("ipai-local-test")
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+)
+spark = configure_spark_with_delta_pip(builder).getOrCreate()
+
+# Test transformation logic with synthetic data
+test_df = spark.createDataFrame(
+    [
+        {"account_id": 1, "amount": 1000.0, "company_id": 1},
+        {"account_id": 2, "amount": 2500.0, "company_id": 1},
+    ],
+    schema="account_id INT, amount DOUBLE, company_id INT",
+)
+
+# Same transformation you'd write in a DLT pipeline
+result = test_df.filter("amount > 1500").groupBy("company_id").sum("amount")
+result.show()
+```
+
+**What this CAN'T test:**
+- DLT decorators (`@dlt.table`, `@dlt.expect_or_fail`) — the `dlt` module only runs
+  on Databricks Runtime.
+- Unity Catalog permissions / table ACLs.
+- Photon / Delta Live Tables autoscaling behavior.
+- Streaming checkpoints against real cloud storage.
+
+**What it IS good for:**
+- Business-logic correctness of filters, joins, window functions, aggregates
+- Schema validation (StructType match)
+- Pure-function transformations from Bronze → Silver rules
+- CI integration (runs in GitHub Actions / Azure DevOps without any cloud creds)
+
+---
+
+## Recommended IPAI workflow
+
+```
+  ┌────────────────────────┐
+  │  Level 3 (now)         │   ← write + unit-test transformation
+  │  PySpark + delta-spark │     logic on synthetic data, CI-friendly
+  └──────────┬─────────────┘
+             │  (when dbw-ipai-dev is provisioned)
+             ▼
+  ┌────────────────────────┐
+  │  Level 1               │   ← validate against real bronze data
+  │  Databricks Connect    │     from stipaidev; debug locally, Spark remote
+  └──────────┬─────────────┘
+             │  (when pipeline is stable)
+             ▼
+  ┌────────────────────────┐
+  │  Level 2 + Asset Bundle│   ← deploy DLT pipeline definitions via CI
+  │  databricks CLI deploy │     (data-intelligence/databricks/databricks.yml)
+  └────────────────────────┘
+```
+
+### Why this order
+
+`dbw-ipai-dev` is **read-only analytics** — it consumes from Odoo mirrored data into
+`stipaidev` bronze, never writes back to Odoo. That makes Level 3 unusually safe:
+there is no transactional side-effect to guard against when testing locally.
+
+The existing bundle config at [data-intelligence/databricks/databricks.yml](../../data-intelligence/databricks/databricks.yml)
+targets the workspace via `databricks bundle deploy`. Wire it to CI once the
+workspace exists.
+
+---
+
+## Auth posture (when workspace lands)
+
+Preferred order:
+1. **Managed identity** — `id-ipai-dev` (or a new `id-ipai-dbw-dev`) with `Contributor` or `Databricks SQL Administrator` on the workspace
+2. **Entra token via `az account get-access-token`** — rotates hourly, no stored credential
+3. **Databricks PAT** — last resort, 30-day lifespan, stored in `kv-ipai-dev` as `databricks-workspace-pat`
+
+NEVER:
+- Commit PATs or workspace tokens to git
+- Use workspace admin PATs for user workflows
+- Bind cluster creation authority to end-user MIs (use service principals scoped
+  narrowly)
+
+Related: [docs/security/revoke-pat-runbook.md](../security/revoke-pat-runbook.md) for
+the broader IPAI PAT policy (all global PATs revoked 2026-04-12).
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `databricks.connect.ClusterUnavailableException` | Cluster not running | Start via UI, or let Level 2 auto-start |
+| `ProtocolException: version mismatch` | `databricks-connect` version ≠ DBR | Pin matching: `pip install databricks-connect==<DBR.version>` |
+| `abfss://...` 404 on `stipaidev` | Wrong container or no RBAC | Verify container name + grant `Storage Blob Data Reader` to your MI |
+| Local Spark OOM on laptop | `spark.driver.memory` default too low | Set `.config("spark.driver.memory", "4g")` in builder |
+| `dlt` module not found locally | By design — DLT is Databricks-only | Stay in Level 3 for pure unit tests; run DLT in Level 1 |
+
+---
+
+*Last updated: 2026-04-13*

--- a/infra/azure/policy/tagging-baseline.bicep
+++ b/infra/azure/policy/tagging-baseline.bicep
@@ -1,0 +1,150 @@
+// infra/azure/policy/tagging-baseline.bicep
+//
+// IPAI canonical tagging baseline — 5 built-in Azure Policy definitions
+// assigned at subscription scope. Matches ssot/azure/tagging-standard.yaml.
+//
+// Assigns:
+//   1. Deny resources missing `env`, `costcenter`, `owner`
+//   2. Deny resource groups missing `owner`
+//   3. Modify (inherit-if-missing) from RG for 6 tags
+//   4. Modify (inherit-if-missing) from subscription for `businessunit`
+// + role assignments for each `modify` policy's MI to run remediation tasks.
+//
+// Deploy:
+//   az deployment sub create \
+//     --location southeastasia \
+//     --template-file infra/azure/policy/tagging-baseline.bicep \
+//     --subscription 536d8cf6-89e1-4815-aef3-d5f2c5f4d070
+//
+// After deploy — trigger remediation on existing non-compliant resources:
+//   for tag in env costcenter owner businessunit project data-classification; do
+//     az policy remediation create \
+//       --name "remediate-inherit-rg-${tag}-$(date +%Y%m%d)" \
+//       --policy-assignment "ipai-inherit-rg-${tag}" \
+//       --resource-discovery-mode ReEvaluateCompliance
+//   done
+
+targetScope = 'subscription'
+
+@description('Required tag keys — deny if missing on resources')
+param requiredTagKeys array = [ 'env', 'costcenter', 'owner' ]
+
+@description('Tag keys to inherit from resource group if missing')
+param inheritedFromRgKeys array = [
+  'env'
+  'costcenter'
+  'owner'
+  'businessunit'
+  'project'
+  'data-classification'
+]
+
+@description('Tag keys to inherit from subscription if missing')
+param inheritedFromSubKeys array = [ 'businessunit' ]
+
+@description('Location for policy MI (where remediation tasks run)')
+param location string = 'southeastasia'
+
+// ─── Built-in policy definition IDs ──────────────────────────────────────────
+var policyRequireOnResources    = tenantResourceId('Microsoft.Authorization/policyDefinitions', '871b6d14-10aa-478d-b590-94f262ecfa99')
+var policyRequireOnResourceGroups = tenantResourceId('Microsoft.Authorization/policyDefinitions', '96670d01-0a4d-4649-9c89-2d3abc0a5025')
+var policyInheritFromRgIfMissing  = tenantResourceId('Microsoft.Authorization/policyDefinitions', 'ea3f2387-9b95-492a-a190-fcdc54f7b070')
+var policyInheritFromSubIfMissing = tenantResourceId('Microsoft.Authorization/policyDefinitions', '40df99da-1232-49b1-a39a-6da8d878f469')
+
+// Contributor role (built-in) — required for policy MIs to run remediation
+var contributorRoleId = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
+
+// ─── 1. Deny: resources missing each required tag ───────────────────────────
+resource denyRequired 'Microsoft.Authorization/policyAssignments@2023-04-01' = [
+  for tagKey in requiredTagKeys: {
+    name: 'ipai-require-${tagKey}'
+    properties: {
+      displayName: 'IPAI: Require ${tagKey} on resources'
+      description: 'Denies creation of resources missing the ${tagKey} tag. Part of ipai canonical tagging baseline.'
+      policyDefinitionId: policyRequireOnResources
+      parameters: {
+        tagName: { value: tagKey }
+      }
+      enforcementMode: 'Default'
+    }
+  }
+]
+
+// ─── 2. Deny: resource groups missing owner ─────────────────────────────────
+resource denyRgOwner 'Microsoft.Authorization/policyAssignments@2023-04-01' = {
+  name: 'ipai-rg-require-owner'
+  properties: {
+    displayName: 'IPAI: Require owner on resource groups'
+    description: 'Denies RG creation without an owner tag.'
+    policyDefinitionId: policyRequireOnResourceGroups
+    parameters: {
+      tagName: { value: 'owner' }
+    }
+  }
+}
+
+// ─── 3. Modify: inherit each key from RG if missing ─────────────────────────
+resource inheritFromRg 'Microsoft.Authorization/policyAssignments@2023-04-01' = [
+  for tagKey in inheritedFromRgKeys: {
+    name: 'ipai-inherit-rg-${tagKey}'
+    location: location
+    identity: {
+      type: 'SystemAssigned'
+    }
+    properties: {
+      displayName: 'IPAI: Inherit ${tagKey} from RG if missing'
+      description: 'Adds ${tagKey} from resource group tags when resource is missing it. Never overwrites.'
+      policyDefinitionId: policyInheritFromRgIfMissing
+      parameters: {
+        tagName: { value: tagKey }
+      }
+    }
+  }
+]
+
+// ─── 4. Modify: inherit businessunit from subscription if missing ───────────
+resource inheritFromSub 'Microsoft.Authorization/policyAssignments@2023-04-01' = [
+  for tagKey in inheritedFromSubKeys: {
+    name: 'ipai-inherit-sub-${tagKey}'
+    location: location
+    identity: {
+      type: 'SystemAssigned'
+    }
+    properties: {
+      displayName: 'IPAI: Inherit ${tagKey} from subscription if missing'
+      description: 'Adds ${tagKey} from subscription tags when resource is missing it.'
+      policyDefinitionId: policyInheritFromSubIfMissing
+      parameters: {
+        tagName: { value: tagKey }
+      }
+    }
+  }
+]
+
+// ─── 5. Grant Contributor to each modify-policy MI (for remediation) ───────
+resource grantRg 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for (tagKey, i) in inheritedFromRgKeys: {
+    name: guid(subscription().id, 'ipai-inherit-rg', tagKey)
+    properties: {
+      roleDefinitionId: tenantResourceId('Microsoft.Authorization/roleDefinitions', contributorRoleId)
+      principalId: inheritFromRg[i].identity.principalId
+      principalType: 'ServicePrincipal'
+    }
+  }
+]
+
+resource grantSub 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for (tagKey, i) in inheritedFromSubKeys: {
+    name: guid(subscription().id, 'ipai-inherit-sub', tagKey)
+    properties: {
+      roleDefinitionId: tenantResourceId('Microsoft.Authorization/roleDefinitions', contributorRoleId)
+      principalId: inheritFromSub[i].identity.principalId
+      principalType: 'ServicePrincipal'
+    }
+  }
+]
+
+// ─── Outputs ────────────────────────────────────────────────────────────────
+output requireAssignmentIds array = [ for i in range(0, length(requiredTagKeys)): denyRequired[i].id ]
+output inheritRgAssignmentIds array = [ for i in range(0, length(inheritedFromRgKeys)): inheritFromRg[i].id ]
+output rgOwnerAssignmentId string = denyRgOwner.id

--- a/scripts/azure/audit-tags.sh
+++ b/scripts/azure/audit-tags.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# scripts/azure/audit-tags.sh
+#
+# Detects tag drift across the IPAI Azure subscription against
+# ssot/azure/tagging-standard.yaml. Writes an evidence bundle to
+# docs/evidence/<YYYYMMDD-HHMM>/azure-tags/ per IPAI operating contract.
+#
+# Run:
+#   bash scripts/azure/audit-tags.sh
+#
+# Exits 0 on PASS (zero drift), 1 on FAIL (any drift found).
+# Suitable for CI (GitHub Actions scheduled run twice weekly) and
+# pre-deploy gate on infra/azure/** changes.
+
+set -euo pipefail
+
+SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID:-536d8cf6-89e1-4815-aef3-d5f2c5f4d070}"
+REQUIRED_TAGS=(env app costcenter owner data-classification)
+FORBIDDEN_KEYS=(Environment environment ENV Owner OWNER CostCenter Cost-Center Project Service Stack workload managedBy ManagedBy managed_by Managed-By)
+
+STAMP="$(date -u +%Y%m%d-%H%M)"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+OUT_DIR="${REPO_ROOT}/docs/evidence/${STAMP}/azure-tags"
+mkdir -p "${OUT_DIR}/logs"
+
+echo "[CONTEXT]"
+echo "  repo:         ${REPO_ROOT}"
+echo "  subscription: ${SUBSCRIPTION_ID}"
+echo "  stamp:        ${STAMP}"
+echo "  out:          ${OUT_DIR}"
+echo ""
+
+# ─── 1. Enumerate all resources with missing required tags ──────────────────
+echo "=== Drift query (resources missing required tags) ==="
+az graph query -q "
+  resources
+  | where subscriptionId == '${SUBSCRIPTION_ID}'
+  | project id, type, name, resourceGroup, location, tags
+  | extend missing_env = iif(isnull(tags['env']),1,0),
+           missing_app = iif(isnull(tags['app']),1,0),
+           missing_costcenter = iif(isnull(tags['costcenter']),1,0),
+           missing_owner = iif(isnull(tags['owner']),1,0),
+           missing_classification = iif(isnull(tags['data-classification']),1,0)
+  | extend drift_score = missing_env + missing_app + missing_costcenter + missing_owner + missing_classification
+  | where drift_score > 0
+  | order by drift_score desc, type asc
+" --first 1000 -o json > "${OUT_DIR}/drift-missing.json"
+
+MISSING_COUNT=$(jq 'length' "${OUT_DIR}/drift-missing.json")
+echo "  resources missing >=1 required tag: ${MISSING_COUNT}"
+
+# ─── 2. Enumerate resources with forbidden (case-drift) keys ────────────────
+echo ""
+echo "=== Forbidden-key query (case-drift of canonical keys) ==="
+FORBIDDEN_EXPR=$(printf '"%s",' "${FORBIDDEN_KEYS[@]}" | sed 's/,$//')
+az graph query -q "
+  resources
+  | where subscriptionId == '${SUBSCRIPTION_ID}'
+  | project id, type, name, resourceGroup, tags
+  | mv-expand tagKV = tags
+  | extend tagKey = tostring(tagKV)
+  | where tagKey in (${FORBIDDEN_EXPR})
+  | summarize resource_count = count() by tagKey
+  | order by resource_count desc
+" -o json > "${OUT_DIR}/drift-forbidden-keys.json"
+
+FORBIDDEN_COUNT=$(jq '[.[].resource_count] | add // 0' "${OUT_DIR}/drift-forbidden-keys.json")
+echo "  uses of forbidden case-variant keys: ${FORBIDDEN_COUNT}"
+
+# ─── 3. Policy compliance state ─────────────────────────────────────────────
+echo ""
+echo "=== Policy assignment compliance ==="
+az policy state summarize --subscription "${SUBSCRIPTION_ID}" \
+  --filter "startswith(PolicyAssignmentName, 'ipai-')" \
+  -o json > "${OUT_DIR}/policy-compliance.json" 2>/dev/null || {
+    echo "  (policy assignments not yet deployed — see infra/azure/policy/tagging-baseline.bicep)"
+}
+
+# ─── 4. Unique key inventory (surfaces drift over time) ─────────────────────
+echo ""
+echo "=== Unique tag keys observed ==="
+az resource list --subscription "${SUBSCRIPTION_ID}" --query "[].tags" -o json 2>/dev/null | \
+  python3 -c "
+import json, sys
+from collections import Counter
+data = json.load(sys.stdin)
+keys = Counter()
+for r in data or []:
+    if r:
+        for k in r.keys():
+            keys[k] += 1
+print(json.dumps({'total_unique_keys': len(keys), 'by_usage': dict(keys.most_common(50))}, indent=2))
+" > "${OUT_DIR}/unique-keys.json"
+UNIQUE=$(jq -r '.total_unique_keys' "${OUT_DIR}/unique-keys.json")
+echo "  total unique keys across subscription: ${UNIQUE}"
+
+# ─── 5. Summary + exit code ─────────────────────────────────────────────────
+echo ""
+{
+  echo "=== audit-tags summary — ${STAMP} ==="
+  echo "subscription:        ${SUBSCRIPTION_ID}"
+  echo "unique keys:         ${UNIQUE}"
+  echo "missing required:    ${MISSING_COUNT} resources"
+  echo "forbidden case-drift: ${FORBIDDEN_COUNT} uses"
+  echo ""
+  if [ "${MISSING_COUNT}" -eq 0 ] && [ "${FORBIDDEN_COUNT}" -eq 0 ]; then
+    echo "result: PASS"
+  else
+    echo "result: FAIL"
+    echo ""
+    echo "=== Top 10 missing-required resources ==="
+    jq -r '.[] | "  - [\(.drift_score)] \(.type) \(.name) (\(.resourceGroup))"' "${OUT_DIR}/drift-missing.json" | head -10
+    echo ""
+    echo "=== Forbidden keys in use ==="
+    jq -r '.[] | "  - \(.tagKey): \(.resource_count) uses"' "${OUT_DIR}/drift-forbidden-keys.json"
+  fi
+} | tee "${OUT_DIR}/logs/summary.txt"
+
+if [ "${MISSING_COUNT}" -eq 0 ] && [ "${FORBIDDEN_COUNT}" -eq 0 ]; then
+  exit 0
+else
+  exit 1
+fi

--- a/ssot/azure/tagging-standard.yaml
+++ b/ssot/azure/tagging-standard.yaml
@@ -1,0 +1,230 @@
+# ssot/azure/tagging-standard.yaml
+#
+# Canonical Azure tagging standard for IPAI.
+# Authority:  Microsoft CAF Ready (June 2025 refresh) + FinOps F2 Allocation capability
+# Enforcement: scripts/azure/audit-tags.sh + infra/azure/policy/tagging-baseline.bicep
+# Related:    docs/ai/AZURE_TAGGING.md (doctrine + rationale)
+
+version: 1.0.0
+subscription_id: 536d8cf6-89e1-4815-aef3-d5f2c5f4d070
+updated: 2026-04-13
+
+# ─── Required tags — enforced by Azure Policy `deny` at subscription scope ──
+required:
+  env:
+    description: Environment separation
+    category: functional
+    allowed_values: [prod, staging, dev, sandbox, test]
+    inherit_from: resource_group
+  app:
+    description: Workload or application identifier
+    category: functional
+    allowed_values:
+      - odoo-erp
+      - bot-proxy
+      - copilot-gateway
+      - agents-platform
+      - sora
+      - prismalab
+      - platform-shared
+    inherit_from: resource_group
+  costcenter:
+    description: Finance cost center code (maps to GL)
+    category: accounting
+    pattern: "^[0-9]{5}$"
+    inherit_from: subscription
+  owner:
+    description: Operational accountability (email or team alias)
+    category: ownership
+    pattern: "^[a-z0-9._-]+@insightpulseai\\.com$|^[a-z-]+$"
+    inherit_from: resource_group
+  data-classification:
+    description: Security and compliance posture
+    category: classification
+    allowed_values: [public, internal, confidential, restricted]
+    inherit_from: resource_group
+
+# ─── Recommended tags — enforced via `modify` (inherit-if-missing) + `audit` ─
+recommended:
+  businessunit:
+    description: Org unit or P&L owner
+    category: ownership
+    allowed_values: [ipai, tbwa-finance, shared, w9studio, prismalab]
+    inherit_from: subscription
+  project:
+    description: Spec bundle or initiative
+    category: accounting
+    examples: [odoo-erp, agent-factory, tax-guru, w9studio, sora-phase3]
+  criticality:
+    description: Business impact tier
+    category: classification
+    allowed_values: [mission-critical, high, medium, low]
+  region:
+    description: Azure region (matches resource location)
+    category: functional
+    examples: [southeastasia, eastus2, global]
+  managed-by:
+    description: IaC tool or pipeline that owns the resource
+    category: functional
+    allowed_values: [bicep, terraform, manual, arm, azd]
+  repo:
+    description: Git repo path for drift detection
+    category: functional
+    examples: [Insightpulseai/odoo, Insightpulseai/agents]
+  created-date:
+    description: Provisioning date ISO-8601
+    category: functional
+    pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+
+# ─── Optional tags — discoverable, no enforcement ──────────────────────────
+optional:
+  sla:
+    allowed_values: [24hours, 8hours, best-effort]
+  backup-policy:
+    allowed_values: [daily, weekly, none]
+  expiration-date:
+    pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+  compliance-framework:
+    allowed_values: [bir-ph, soc2, iso27001, none]
+  cm-resource-parent:
+    description: Cost Management parent grouping — value is parent Resource ID
+    reserved: true
+
+# ─── Forbidden tag keys — deny via policy (case-variants of required keys) ──
+forbidden_keys:
+  - Environment       # use env
+  - environment       # use env (case collapse)
+  - ENV               # use env
+  - Owner             # use owner
+  - OWNER             # use owner
+  - CostCenter        # use costcenter
+  - Cost-Center       # use costcenter
+  - Project           # use project
+  - Service           # use app
+  - Stack             # use app
+  - workload          # use app
+  - managedBy         # use managed-by
+  - ManagedBy         # use managed-by
+  - managed_by        # use managed-by
+  - Managed-By        # use managed-by
+
+# ─── Resources with known tagging limitations ───────────────────────────────
+exceptions:
+  - type: classic_resources
+    action: migrate_to_arm_or_subscription_split
+  - type: Microsoft.Network/ipGroups
+    action: update_via_cli_only  # az network ip-group update
+  - type: Microsoft.Network/firewallPolicies
+    action: update_via_cli_only
+  - type: Microsoft.Graph/applications
+    description: Entra app registrations — not ARM-scoped, tags are a string list via Graph
+    action: encode_as_string_list
+    convention: "key:value strings (e.g. 'env:prod', 'app:bot-proxy')"
+    ssot_mirror: ssot/entra/app-registrations.yaml
+  - type: Microsoft.BotService/botServices/channels
+    action: inherit_from_parent_bot_service
+  - type: Microsoft.Sql/servers/*  # child types
+    action: tag_parent_server_only
+  - type: storage_account
+    constraint: tag_key_max_128_chars  # vs 512 elsewhere
+
+# ─── Applied examples per IPAI resource type ────────────────────────────────
+examples:
+  container_app:
+    resource_id: /subscriptions/.../Microsoft.App/containerApps/ipai-bot-proxy-dev
+    tags:
+      env: dev
+      app: bot-proxy
+      costcenter: "55332"
+      owner: platform@insightpulseai.com
+      data-classification: internal
+      businessunit: ipai
+      project: agent-factory
+      criticality: medium
+      region: southeastasia
+      managed-by: bicep
+      repo: Insightpulseai/odoo
+      cm-resource-parent: /subscriptions/.../managedEnvironments/ipai-odoo-dev-env-v2
+
+  front_door:
+    resource_id: /subscriptions/.../Microsoft.Cdn/profiles/afd-ipai-dev
+    tags:
+      env: dev
+      app: platform-shared
+      costcenter: "55332"
+      owner: platform@insightpulseai.com
+      data-classification: public
+      businessunit: ipai
+      project: odoo-erp
+      criticality: mission-critical
+      region: global
+      managed-by: bicep
+
+  key_vault:
+    resource_id: /subscriptions/.../Microsoft.KeyVault/vaults/kv-ipai-dev
+    tags:
+      env: dev
+      app: platform-shared
+      costcenter: "55332"
+      owner: platform@insightpulseai.com
+      data-classification: restricted
+      businessunit: ipai
+      criticality: mission-critical
+      managed-by: bicep
+
+  user_assigned_mi:
+    resource_id: /subscriptions/.../userAssignedIdentities/id-ipai-agent-pulser-dev
+    tags:
+      env: dev
+      app: bot-proxy
+      costcenter: "55332"
+      owner: platform@insightpulseai.com
+      data-classification: internal
+      businessunit: ipai
+      cm-resource-parent: /subscriptions/.../containerApps/ipai-bot-proxy-dev
+
+  entra_app_registration:
+    description: Not an ARM resource — tags are a string list via Microsoft Graph
+    tags: ["env:dev", "app:bot-proxy", "costcenter:55332", "owner:platform"]
+    ssot_source: ssot/entra/app-registrations.yaml
+
+# ─── Policy mapping — which built-in definitions enforce each key ───────────
+policy_mapping:
+  require_on_resources: 871b6d14-10aa-478d-b590-94f262ecfa99
+  require_on_resource_groups: 96670d01-0a4d-4649-9c89-2d3abc0a5025
+  inherit_from_rg_if_missing: ea3f2387-9b95-492a-a190-fcdc54f7b070
+  inherit_from_rg_add_or_replace: cd3aa116-8754-49c9-a813-ad46512ece54
+  inherit_from_subscription_if_missing: 40df99da-1232-49b1-a39a-6da8d878f469
+  inherit_from_subscription_add_or_replace: b27a0cbd-a167-4dfa-ae64-4337be671140
+  append_tag_from_rg: 9ea02ca2-71db-412d-8b00-7c7ca9fcd32d
+
+# ─── Cost Management tag inheritance ────────────────────────────────────────
+cost_management:
+  tag_inheritance_enabled: false  # owner action — enable via portal
+  note: |
+    Enable via Cost Management → Settings → Manage subscription → Tag inheritance.
+    Closes the gap for resource types whose tags are not emitted in cost usage
+    records (Classic services, SQL child types, BotService children, etc.).
+    8-24 hour propagation after enable.
+
+# ─── Audit drift baseline (from 2026-04-13 scan) ────────────────────────────
+drift_baseline:
+  total_unique_keys_observed: 17
+  casing_collisions:
+    - [Environment, environment, env, ENV]
+    - [Owner, owner, OWNER]
+    - [CostCenter, costcenter]
+    - [Project, project]
+    - [managedBy, ManagedBy, managed_by, managed-by]
+  semantic_collisions:
+    - keys: [Service, Stack, workload, product, app]
+      canonical: app
+    - keys: [layer, component]
+      canonical: null  # drop — covered by app + project
+  concerning_values:
+    - resource: acripaiodoo
+      issue: "Environment: Development (value case drift; should be env=dev)"
+    - resource: ipai-copilot-gateway
+      issue: "quarantine=true retain-until=2026-05-05 — marked for deprecation"
+    - resource: multiple
+      issue: "costcenter value is 'platform' (not a 5-digit GL code)"


### PR DESCRIPTION
## Summary
Two governance artifacts on one branch — both grounded in **live Azure state audits** done as part of this session.

### 1. Azure tagging governance pack
Canonical tagging doctrine + policy-as-code + drift audit. Grounded in Microsoft CAF Ready (June 2025 refresh) + FinOps Framework 2026.

- [ssot/azure/tagging-standard.yaml](ssot/azure/tagging-standard.yaml) — canonical schema (required/recommended/optional/forbidden keys, exceptions, examples)
- [infra/azure/policy/tagging-baseline.bicep](infra/azure/policy/tagging-baseline.bicep) — 5 subscription-scope policy assignments (deny + modify with MI + Contributor role)
- [scripts/azure/audit-tags.sh](scripts/azure/audit-tags.sh) — Resource Graph drift detector, writes evidence bundle to \`docs/evidence/<stamp>/azure-tags/\`
- [docs/ai/AZURE_TAGGING.md](docs/ai/AZURE_TAGGING.md) — doctrine + 3-phase enforcement plan + current-state findings

### 2. Databricks local-dev guide
- [docs/databricks/LOCAL_DEV.md](docs/databricks/LOCAL_DEV.md) — 3 levels (Databricks Connect, VS Code extension, fully local PySpark), with two corrections vs stale memory

## Current-state findings (verified via \`az\`)

### Tagging drift — 17 unique keys across the subscription
| Drift class | Example | Count |
|---|---|---|
| Case collisions | \`Environment\` (59×), \`env\` (1), \`environment\` (4) | 63 usage rows for one concept |
| Semantic synonyms | \`Service\`, \`Stack\`, \`workload\`, \`product\`, \`app\` | 5 keys, 1 concept |
| Managed-by casing | \`managedBy\`, \`ManagedBy\`, \`managed_by\`, \`managed-by\` | 4 variants |
| Non-canonical values | \`CostCenter: platform\` (not a GL code) | Can't roll to finance |

### Operational signals hidden in tags
- \`ipai-copilot-gateway\` is marked \`quarantine=true retain-until=2026-05-05\` — **deprecate before May 5**
- \`acripaiodoo\` has \`Environment: Development\` — value case drift (should be \`env=dev\`)

### Databricks workspace not provisioned
- Memory + CLAUDE.md reference \`dbw-ipai-dev\`, but \`az databricks workspace list\` returns \`[]\` in active subscription
- Lakehouse storage is **\`stipaidev\`** (not \`stipaidevlake\` as memory claimed)

## Three-phase enforcement plan (in doctrine doc)
1. **Stage** — \`az deployment sub create\` for the Bicep (no resources changed yet)
2. **Remediate** — \`az policy remediation create\` for the 6 modify assignments (sweeps existing resources, inherit from RG)
3. **CI gate** — wire \`audit-tags.sh\` into GitHub Actions (twice weekly + pre-deploy)

## Test plan
- [ ] \`az deployment sub validate --template-file infra/azure/policy/tagging-baseline.bicep\` → OK
- [ ] \`bash scripts/azure/audit-tags.sh\` → writes evidence bundle + exits 1 (drift exists pre-remediation)
- [ ] YAML schema parses clean
- [ ] Markdown renders on GitHub

## Not in scope
- **Actual policy deploy** — owner triggers with one \`az deployment sub create\`
- **Cost Management tag inheritance** — portal-only toggle, owner action
- **Case-drift cleanup on existing resources** — non-destructive by design; handled per-resource or via a targeted follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)