### PR TITLE
deploy(staging): sponsored staging substrate + Microsoft partner brand attribution

### DIFF
--- a/docs/brand/microsoft-partner-copy.md
+++ b/docs/brand/microsoft-partner-copy.md
@@ -1,0 +1,132 @@
+# Microsoft Solutions Partner — Canonical Copy
+
+> Source of truth for all Microsoft partnership language across the website,
+> sales collateral, email signatures, and badge usage. Microsoft's Partner
+> Brand Guide requires qualifying the designation by **solution area** —
+> never shorten to "Microsoft Solutions Partner" alone.
+
+**Designation:** Microsoft Solutions Partner for Business Applications
+
+---
+
+## The one-line compliance rule
+
+```text
+Always use "Microsoft Solutions Partner for Business Applications," never just "Microsoft Solutions Partner."
+```
+
+## ✅ Use
+
+```text
+InsightPulseAI is a Microsoft Solutions Partner for Business Applications.
+```
+
+## ❌ Do not use
+
+```text
+InsightPulseAI is a Microsoft Solutions Partner.
+InsightPulseAI is a Microsoft MSP.
+InsightPulseAI is an MSP for Microsoft.
+```
+
+---
+
+## Paste-ready blocks
+
+### Homepage trust block (minimal)
+
+```html
+<section aria-labelledby="microsoft-partner-heading">
+  <h3 id="microsoft-partner-heading">Microsoft partnership</h3>
+  <p>InsightPulseAI is a Microsoft Solutions Partner for Business Applications.</p>
+</section>
+```
+
+### Homepage trust block (richer — used on `/`)
+
+```html
+<section aria-labelledby="microsoft-partner-heading">
+  <h3 id="microsoft-partner-heading">Microsoft partnership</h3>
+  <p>
+    InsightPulseAI is a Microsoft Solutions Partner for Business Applications.
+    We help organizations modernize business applications, operations, and ERP workflows using Microsoft technologies.
+  </p>
+</section>
+```
+
+### Footer copy
+
+```html
+<p>InsightPulseAI is a Microsoft Solutions Partner for Business Applications.</p>
+```
+
+### About / credibility section
+
+```html
+<p>
+  InsightPulseAI is a Microsoft Solutions Partner for Business Applications.
+  Our work focuses on business-application modernization, AI-enabled operations, and connected enterprise workflows.
+</p>
+```
+
+### Contact / CTA support line
+
+```html
+<p>
+  Work with a Microsoft Solutions Partner for Business Applications on ERP, AI, and business-process transformation.
+</p>
+```
+
+### Email signature line
+
+```text
+InsightPulseAI is a Microsoft Solutions Partner for Business Applications.
+```
+
+### Badge alt text
+
+```text
+Microsoft Solutions Partner for Business Applications badge
+```
+
+### Caption under the official badge
+
+```html
+<p>InsightPulseAI is a Microsoft Solutions Partner for Business Applications.</p>
+```
+
+---
+
+## Badge usage rules
+
+1. **Generate only from Logo Builder** in Partner Center. Do not manufacture or copy from third parties.
+2. **Full-color by default.** Use the monochrome variant only where contrast requires it.
+3. **Never stretch, recolor, crop, or rebuild** the badge.
+4. **Clean background** — no photos, busy patterns, gradients conflicting with the badge.
+5. **Preserve clear space** around the badge per the Logo Builder output.
+6. **Small-logo lockup** only if the full badge doesn't fit.
+7. **Preferred digital placement:** lower left of the page, top-right, or bottom-right.
+
+## Current placements on insightpulseai.com
+
+| Location | Variant | Status |
+|---|---|---|
+| Homepage Trust & Governance section | Homepage trust block (richer) | ✓ landed [web/ipai-landing/src/App.tsx](../../web/ipai-landing/src/App.tsx) |
+| Footer (bottom-left, under company address) | Footer copy | ✓ landed |
+| `/features` placeholder page | — | **Blocked** — page shows template text "This is the space to describe the product" on the live site (not served from this repo). Unpublish, redirect, or rewrite before leaning harder into Microsoft-partner branding. |
+| About / credibility | About section | Pending — apply when About page is added |
+| Contact / CTA | CTA support line | Pending |
+
+## Known blockers
+
+1. **Live `/features` page shows placeholder copy** — source is not in this repo (likely a stale Wix or other off-repo host). Owner action: unpublish, redirect to `/products`, or rewrite the page. Weakens trust if reachable from navigation or search alongside Microsoft-partner branding.
+2. **Official badge asset not yet downloaded** — Owner must visit Partner Center → Logo Builder, generate the badge, save to `web/ipai-landing/public/microsoft-partner-badge.png`, then embed via the caption block above.
+
+---
+
+## References
+
+- Microsoft Partner Brand Guide — https://partner.microsoft.com/en-us/marketing/partnerbrandguide (must be logged in)
+- Partner Center Logo Builder — https://partner.microsoft.com/en-us/dashboard/ → Benefits → Logos
+
+*Last updated: 2026-04-13*

--- a/docs/evidence/20260413-sponsored-staging/DEPLOYMENT_REPORT.md
+++ b/docs/evidence/20260413-sponsored-staging/DEPLOYMENT_REPORT.md
@@ -1,0 +1,149 @@
+# Sponsored Staging Deployment — 2026-04-13
+
+**Subscription:** `Microsoft Azure Sponsorship` (`eba824fb-332d-4623-9dfb-2c9f7ee83f4e`)
+**Tenant:** `402de71a-87ec-4302-a609-fb76098d1da7`
+**Region:** `southeastasia`
+**Executor:** `admin@insightpulseai.com` via az CLI
+
+---
+
+## 1. What merged
+
+**Nothing.** No mergeable PRs exist that are blocked only by systemic CI noise.
+
+| PR | State | Reason not merged |
+|---|---|---|
+| [#703](https://github.com/Insightpulseai/odoo/pull/703) `fix(copilot): wire Document Intelligence + enforce cross-repo PPM sourcing` | `CONFLICTING / DIRTY` | 61 commits behind `main`, diff >300 files — genuine semantic conflict. Per mission rule "Do not merge conflicted or semantically broken work." Left blocked. |
+
+Cross-org search returned no additional open PRs in reachable repos. Session's prior 7 PRs (#714–#732) already merged on `main`.
+
+## 2. What deployed
+
+Four resources created in `eba824fb-332d-4623-9dfb-2c9f7ee83f4e` / `southeastasia`:
+
+| Type | Name | Resource group | Purpose |
+|---|---|---|---|
+| Resource group | `rg-ipai-stg-odoo-runtime` | — | Staging runtime RG |
+| Resource group | `rg-ipai-stg-odoo-data` | — | Staging data RG |
+| `Microsoft.OperationalInsights/workspaces` | `log-ipai-stg` | `rg-ipai-stg-odoo-runtime` | ACA env log sink (required dependency) |
+| `Microsoft.App/managedEnvironments` | `ipai-stg-env` | `rg-ipai-stg-odoo-runtime` | ACA managed environment — minimum runtime substrate |
+
+### ACA environment
+- **Name:** `ipai-stg-env`
+- **Default domain:** `happycoast-577e3b67.southeastasia.azurecontainerapps.io`
+- **Provisioning state:** `Succeeded`
+- **Region:** `Southeast Asia`
+- **Log Analytics:** `log-ipai-stg` (customerId `213d8af6-a91d-4548-8498-d13c8d4c7133`)
+
+### Tagging (canonical baseline from `ssot/azure/tagging-standard.yaml`)
+
+All 4 resources carry the same required+recommended tag set:
+
+```
+env                 = staging
+app                 = platform-shared
+costcenter          = 55332
+owner               = platform@insightpulseai.com
+data-classification = internal
+businessunit        = ipai
+managed-by          = azcli
+created-date        = 2026-04-13
+repo                = Insightpulseai/odoo
+```
+
+Note: Azure CLI additionally writes `managedBy: cli` on RGs (system metadata, harmless).
+
+## 3. What validated
+
+| Check | Result |
+|---|---|
+| Subscription accessible | ✓ `Microsoft Azure Sponsorship` visible from `admin@insightpulseai.com` |
+| Target RGs created | ✓ Both RGs reach `Succeeded` state |
+| Log Analytics workspace | ✓ Provisioned, customerId captured |
+| ACA env reaches Succeeded | ✓ Confirmed via `az containerapp env show` |
+| Tags applied per canonical schema | ✓ 9 required+recommended tags on every resource |
+| `id-ipai-dev` Contributor on sponsored sub | ✓ `az role assignment list` confirms |
+| `id-ipai-dev` AcrPull on `acripaiodoo` | ✓ Role assignment present on prod-sub registry |
+| Default branch protection on main | — **Disabled** (confirmed via `gh api /branches/main/protection` → 404) |
+
+## 4. What remains blocked
+
+### Blocker 1 — Vercel deprecated status check pollution
+- **Symptom:** Every PR to `main` receives a red `Vercel / failure` status check from `vercel.com/tbwa/insightpulseai-web` (deprecated TBWA project).
+- **Impact:** Cosmetic — branch protection is disabled so Vercel doesn't *block* merges, but `UNSTABLE` status clutters every PR and trains reviewers to ignore check failures.
+- **Source:** External Vercel GitHub integration/app on the repo. No `vercel.json`, no `.vercel/`, no workflow file references it.
+- **One concrete next action:** Owner visits https://vercel.com/tbwa/insightpulseai-web/settings/git and clicks **Disconnect Git Repository** (or alternatively, GitHub repo → Settings → Integrations → Vercel → Configure → remove `Insightpulseai/odoo` from the project's repo list). Zero CLI path for this — requires Vercel dashboard access by the project owner.
+
+### Blocker 2 — PR #703 genuinely conflicted
+- **Symptom:** 61 commits behind main, `MergeStateStatus: DIRTY`, `>300 files` in diff.
+- **Impact:** Cannot be merged without a manual rebase/recreate.
+- **One concrete next action:** Author closes #703, re-opens a focused PR containing only the Document Intelligence wiring (small change), against current main. The cross-repo PPM sourcing work belongs in a separate PR.
+
+### Blocker 3 — Staging DB + ACR pull path end-to-end validation
+- **Symptom:** No app deployed yet — the ACA env is empty. Cannot confirm end-to-end `acripaiodoo → staging ACA` image pull until a real container app is deployed.
+- **Impact:** The "prove staged rollout capability" objective from the mission is partially satisfied (env ready) but not fully closed (no app deployed yet to prove a full pull+start cycle).
+- **One concrete next action:** Deploy a single ACA app (e.g., a smoke-test image or a clone of `ipai-bot-proxy-dev`) into `ipai-stg-env` referencing `acripaiodoo.azurecr.io/ipai-bot-proxy:latest` with `id-ipai-dev` as the pull identity. First Deploy is a revision-create; ~2 min. If image pulls and starts, the staged rollout substrate is fully validated.
+
+### Blocker 4 — PostgreSQL Flexible Server for staging (out of scope for this slice)
+- **Symptom:** `rg-ipai-stg-odoo-data` is empty.
+- **Impact:** Odoo staging app cannot be deployed until a staging PG exists.
+- **Deliberate deferral:** Per mission rule "only if required by the chosen deployment slice" — this slice validates the ACA+logging substrate, not a full Odoo staging instance. PG should land in a separate focused PR (`infra/azure/deploy-stg-postgres.bicep`).
+- **One concrete next action:** When Odoo-staging clone work begins, deploy via `az postgres flexible-server create -n pg-ipai-stg -g rg-ipai-stg-odoo-data -l southeastasia --sku-name Standard_D2ds_v5 --tier GeneralPurpose --storage-size 32 --version 16 --administrator-login odooadmin --administrator-login-password <from kv-ipai-dev/stg-pg-admin-password>` + canonical tags + Fabric mirroring config to match prod `pg-ipai-odoo` architecture.
+
+## 5. Recommended immediate next 3 actions
+
+1. **Owner disconnects Vercel GitHub integration** from https://vercel.com/tbwa/insightpulseai-web/settings/git — removes the cosmetic failure status from all future PRs and closes the CI-hygiene mission item cleanly.
+2. **Deploy a single test container app** into `ipai-stg-env` pulling `acripaiodoo.azurecr.io/ipai-bot-proxy:latest` via `id-ipai-dev`. Validates the cross-subscription ACR pull path end-to-end. Single `az containerapp create` call; reversible.
+3. **Author re-scopes PR #703** into two focused PRs — one for the Document Intelligence wiring (small, reviewable), one for the cross-repo PPM sourcing rules (spec bundle update). Close #703 as-is; both replacement PRs will merge clean against current main.
+
+---
+
+## Execution evidence
+
+### Commands executed (in order)
+
+```bash
+az account set --subscription eba824fb-332d-4623-9dfb-2c9f7ee83f4e
+
+az group create -n rg-ipai-stg-odoo-runtime -l southeastasia --tags ...
+az group create -n rg-ipai-stg-odoo-data    -l southeastasia --tags ...
+
+az monitor log-analytics workspace create -n log-ipai-stg \
+  -g rg-ipai-stg-odoo-runtime -l southeastasia --tags ...
+
+az containerapp env create -n ipai-stg-env \
+  -g rg-ipai-stg-odoo-runtime -l southeastasia \
+  --logs-workspace-id <id> --logs-workspace-key <key> --tags ...
+
+# tag reconciliation (original `--tags "$STR"` collapsed 9 pairs into 1):
+az group update         -n <rg>  --set tags.env=staging tags.app=platform-shared ...
+az resource tag  --ids <ws-id>   --tags env=staging app=platform-shared ...
+az containerapp env update -n ipai-stg-env -g rg-ipai-stg-odoo-runtime --tags env=staging ...
+
+az account set --subscription 536d8cf6-89e1-4815-aef3-d5f2c5f4d070  # return to prod context
+```
+
+### Validation snapshots
+
+```
+$ az containerapp env show -n ipai-stg-env -g rg-ipai-stg-odoo-runtime \
+    --query "{state:properties.provisioningState, fqdn:properties.defaultDomain}"
+{
+  "state": "Succeeded",
+  "fqdn": "happycoast-577e3b67.southeastasia.azurecontainerapps.io"
+}
+
+$ az role assignment list --assignee 1aee831f-3813-4eed-b49c-f7665330f0f6 \
+    --scope "/subscriptions/eba824fb-332d-4623-9dfb-2c9f7ee83f4e"
+Contributor
+
+$ az role assignment list --assignee 1aee831f-3813-4eed-b49c-f7665330f0f6 \
+    --scope "/subscriptions/536d8cf6.../registries/acripaiodoo"
+AcrPull
+```
+
+---
+
+*Report generated 2026-04-13 by Claude Code agent session.*
+*Canonical tagging standard: [ssot/azure/tagging-standard.yaml](../../../ssot/azure/tagging-standard.yaml)*
+*Audit tool: [scripts/azure/audit-tags.sh](../../../scripts/azure/audit-tags.sh)*

--- a/web/ipai-landing/src/App.tsx
+++ b/web/ipai-landing/src/App.tsx
@@ -470,6 +470,7 @@ const Footer = ({ setPage }: { setPage: (p: PageId) => void }) => (
         <div>
           <p>&copy; 2026 InsightPulseAI. All rights reserved.</p>
           <p className="mt-2 text-gray-600">Dataverse IT Consultancy &middot; La Fuerza Plaza, 2241 Chino Roces Ave, Makati City 1231, Philippines</p>
+          <p className="mt-2 text-gray-600">InsightPulseAI is a Microsoft Solutions Partner for Business Applications.</p>
         </div>
         <div className="flex gap-8">
           <button onClick={() => setPage('trust')} className="hover:text-white transition-colors">Trust Center</button>
@@ -790,10 +791,20 @@ const HomePage = ({ setPage }: { setPage: (p: PageId) => void }) => (
     </section>
 
     {/* Trust & Governance */}
-    <section className="py-24 px-6 md:px-12 max-w-7xl mx-auto">
+    <section className="py-24 px-6 md:px-12 max-w-7xl mx-auto" aria-labelledby="trust-governance-heading">
       <div className="mb-16">
-        <h2 className="text-3xl md:text-4xl font-bold mb-8 tracking-tight">Trust, governance, and current product posture</h2>
+        <h2 id="trust-governance-heading" className="text-3xl md:text-4xl font-bold mb-8 tracking-tight">Trust, governance, and current product posture</h2>
       </div>
+
+      {/* Microsoft partnership attribution */}
+      <div className="mb-12 p-8 rounded-2xl bg-white border border-gray-100" style={{ boxShadow: SHADOW.shadow4 }} aria-labelledby="microsoft-partner-heading">
+        <h3 id="microsoft-partner-heading" className="text-sm font-bold uppercase tracking-widest text-brand-primary mb-3">Microsoft partnership</h3>
+        <p className="text-lg text-gray-800 leading-relaxed">
+          InsightPulseAI is a Microsoft Solutions Partner for Business Applications.
+          We help organizations modernize business applications, operations, and ERP workflows using Microsoft technologies.
+        </p>
+      </div>
+
       <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {[
           "Role-based access and workflow-aware permissions",


### PR DESCRIPTION
## Summary
Two scopes landing together on the same branch:

### 1. Sponsored staging runtime substrate (deployed live)
Created 4 resources on the **Microsoft Azure Sponsorship** subscription (\`eba824fb-332d-4623-9dfb-2c9f7ee83f4e\`):
- \`rg-ipai-stg-odoo-runtime\`, \`rg-ipai-stg-odoo-data\` — staging RGs
- \`log-ipai-stg\` — Log Analytics
- \`ipai-stg-env\` — ACA managed environment (FQDN: \`happycoast-577e3b67.southeastasia.azurecontainerapps.io\`)

All 4 tagged per [ssot/azure/tagging-standard.yaml](ssot/azure/tagging-standard.yaml).

Full report: [docs/evidence/20260413-sponsored-staging/DEPLOYMENT_REPORT.md](docs/evidence/20260413-sponsored-staging/DEPLOYMENT_REPORT.md)

### 2. Microsoft Solutions Partner attribution (compliant copy)
Microsoft's Partner Brand Guide requires qualifying the designation by **solution area** and explicitly forbids shortening to "Microsoft Solutions Partner" alone.

Landed:
- **Homepage Trust & Governance section** ([web/ipai-landing/src/App.tsx](web/ipai-landing/src/App.tsx)) — new "Microsoft partnership" subsection with richer-variant copy, a11y hygiene (aria-labelledby, proper h3 id)
- **Footer bottom-left** — single-line compliance attribution under company address
- **[docs/brand/microsoft-partner-copy.md](docs/brand/microsoft-partner-copy.md)** — canonical doctrine + 7 paste-ready copy blocks for homepage/footer/about/CTA/email/badge

### Attribution rule (now enforced across the site)
```
✓ InsightPulseAI is a Microsoft Solutions Partner for Business Applications.
✗ InsightPulseAI is a Microsoft Solutions Partner.    ← forbidden
✗ InsightPulseAI is a Microsoft MSP.                   ← forbidden
```

## Known blockers (documented in copy doctrine)
1. **Live \`/features\` page** shows template placeholder copy ("This is the space to describe the product") — source is not in this repo (stale Wix/off-repo host). Owner: unpublish, redirect, or rewrite before leaning harder on partner branding.
2. **Official badge asset** not yet generated from Partner Center → Logo Builder. Owner: download full-color badge, save to \`web/ipai-landing/public/microsoft-partner-badge.png\`, embed per the caption block in the doctrine doc.

## Test plan
- [ ] \`npm run build\` in \`web/ipai-landing/\` succeeds
- [ ] Homepage renders the Microsoft partnership block in the Trust section
- [ ] Footer shows the attribution line under address
- [ ] Doctrine doc renders clean on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)