### PR TITLE
feat(wave-01): ipai_finance_gl + Reconciliation Agent v0 (#523, #524)

### DIFF
--- a/addons/ipai/ipai_finance_gl/README.md
+++ b/addons/ipai/ipai_finance_gl/README.md
@@ -1,0 +1,76 @@
+# ipai_finance_gl
+
+> **D365 Finance General Ledger parity overlay.** Wave-01 Epic #523, Issue: General Ledger and Financial Foundation.
+
+## Purpose
+
+Capture the D365 Finance GL parity surface as queryable records inside Odoo, without re-implementing GL behavior. Odoo CE `account` + OCA finance stack provide the runtime; this module documents the D365 → Odoo mapping for the 7 Wave-01 GL Tasks and exposes a parity-matrix UI.
+
+## Scope
+
+- **In scope:**
+  - D365 GL concept inventory (chart of accounts, main accounts, fiscal calendar, financial dimensions, accounting structures, journals, periodic processes)
+  - Parity records linking each D365 concept → Odoo CE/OCA equivalent
+  - Light extensions only where CE+OCA composition leaves a gap
+  - Parity-status reporting view
+- **Non-goals:**
+  - Re-implementing GL behavior (Odoo CE owns it)
+  - Replacing OCA finance modules
+  - Asset leasing (separate module — `ipai_asset_leasing` candidate)
+  - Tax (separate module — `ipai_bir_tax`)
+  - Subscription billing (separate module candidate)
+
+## Module type
+
+**overlay** — parity tracking record model + light view extension; no CRUD overrides on `account.*` core models.
+
+## Dependencies
+
+- Odoo CE modules: `base`, `account`, `analytic`
+- OCA modules:
+  - `account_financial_report` (OCA/account-financial-reporting)
+  - `account_journal_lock_date` (OCA/account-financial-tools)
+  - `mis_builder` (OCA/mis-builder)
+- Other `ipai_*` modules: none (foundational)
+
+## Installation
+
+```bash
+./scripts/odoo_install.sh -d odoo_dev -m ipai_finance_gl
+```
+
+## User flows
+
+1. **Browse parity matrix:** Finance → Configuration → D365 Parity → GL Parity Map
+2. **Add parity record:** Document a new D365 concept and its Odoo equivalent (with status: covered / partial / gap / out-of-scope)
+3. **Generate parity report:** Export current parity status (CSV/PDF) for stakeholder reviews
+4. **Filter by status:** View all `gap` records to see what still needs Odoo or `ipai_*` work
+
+## Installed components
+
+- **Models:**
+  - `ipai.finance.gl.parity` — parity record (D365 concept ↔ Odoo equivalent + status)
+  - `ipai.finance.gl.parity.category` — taxonomy (chart-of-accounts, fiscal-calendar, journal, etc.)
+- **Views:**
+  - GL parity tree/form/search/kanban
+  - Top-level menu under Finance → Configuration
+- **Security groups:**
+  - `group_ipai_finance_gl_user` (read parity records)
+  - `group_ipai_finance_gl_manager` (manage parity records)
+- **Cron jobs:** none (M2 may add a sync job to refresh from `ssot/benchmarks/parity_matrix.yaml`)
+
+## Upgrade notes
+
+- This is the initial 18.0.1.0.0 release — no upgrade path yet.
+- Dependencies on OCA modules require they are installed first (validated by `addons/oca/`).
+
+## Required documentation
+
+- [Module introspection](docs/MODULE_INTROSPECTION.md) — why this module exists
+- [Technical guide](docs/TECHNICAL_GUIDE.md) — how it's built
+
+## Owner
+
+- Primary: finance-platform team
+- Backup: odoo-platform team
+- ADO: Epic #523 D365 Finance Parity

--- a/addons/ipai/ipai_finance_gl/__manifest__.py
+++ b/addons/ipai/ipai_finance_gl/__manifest__.py
@@ -1,0 +1,60 @@
+{
+    "name": "IPAI Finance — General Ledger Parity Foundation",
+    "version": "18.0.1.0.0",
+    "summary": "D365 Finance GL parity overlay: chart-of-accounts, fiscal calendar, "
+               "financial dimensions, accounting structures, journals, periodic processes.",
+    "description": """
+IPAI Finance GL — Wave-01 D365 Finance Parity (Epic #523)
+==========================================================
+
+Thin overlay on Odoo CE `account` + selected OCA finance modules to capture the
+D365 Finance "General Ledger and Financial Foundation" parity surface as
+explicit, queryable parity-mapping records.
+
+This module does NOT re-implement GL behavior. Odoo CE + OCA already provide the
+runtime; this module documents the D365-to-Odoo parity, exposes a parity matrix
+view, and adds light extensions where CE+OCA composition leaves a gap.
+
+Module type: **overlay** (parity tracking + light extension)
+
+Wave-01 Issue coverage (7 Tasks under Epic #523):
+- Define general-ledger parity scope
+- Define chart-of-accounts and main-account model
+- Define fiscal-calendar model
+- Define financial-dimensions and dimension-set model
+- Define accounting-structure model
+- Define financial-journal model
+- Define periodic financial-process model
+
+Anchors:
+- CLAUDE.md §"Odoo extension and customization doctrine"
+- ssot/benchmarks/parity_matrix.yaml
+- docs/architecture/repo-adoption-register.md §F.1 D365 Finance reference surfaces
+- ADO Boards Epic #523 D365 Finance Parity
+    """,
+    "author": "InsightPulseAI",
+    "website": "https://insightpulseai.com",
+    "license": "LGPL-3",
+    "category": "InsightPulseAI/Finance",
+    "depends": [
+        "base",
+        # Odoo CE 18 baseline
+        "account",
+        "analytic",
+        # OCA finance (selected; per ssot/odoo/module_install_manifest.yaml)
+        "account_financial_report",       # OCA/account-financial-reporting
+        "account_journal_lock_date",      # OCA/account-financial-tools
+        "mis_builder",                    # OCA/mis-builder (for periodic processes)
+    ],
+    "data": [
+        "security/ipai_finance_gl_security.xml",
+        "security/ir.model.access.csv",
+        "data/d365_parity_data.xml",
+        "views/d365_parity_views.xml",
+        "views/menu.xml",
+    ],
+    "demo": [],
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+}

--- a/addons/ipai/ipai_finance_gl/data/d365_parity_data.xml
+++ b/addons/ipai/ipai_finance_gl/data/d365_parity_data.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo noupdate="0">
+
+    <!--
+        Wave-01 GL Parity Categories — D365 Finance General Ledger Foundation
+        Epic #523 — 7 tasks mapped to 7 categories.
+        noupdate="0": refreshed on every module update (seed data, not configuration).
+    -->
+
+    <record id="parity_category_chart_of_accounts" model="ipai.finance.gl.parity.category">
+        <field name="name">Chart of Accounts</field>
+        <field name="code">chart_of_accounts</field>
+        <field name="sequence">10</field>
+        <field name="description">Main account structure, account types, and COA hierarchy mapping between D365 Finance and Odoo.</field>
+        <field name="active">True</field>
+    </record>
+
+    <record id="parity_category_fiscal_calendar" model="ipai.finance.gl.parity.category">
+        <field name="name">Fiscal Calendar</field>
+        <field name="code">fiscal_calendar</field>
+        <field name="sequence">20</field>
+        <field name="description">Fiscal year definition, period setup, and year-end close calendar alignment.</field>
+        <field name="active">True</field>
+    </record>
+
+    <record id="parity_category_financial_dimensions" model="ipai.finance.gl.parity.category">
+        <field name="name">Financial Dimensions</field>
+        <field name="code">financial_dimensions</field>
+        <field name="sequence">30</field>
+        <field name="description">D365 financial dimensions and dimension sets mapped to Odoo analytic accounts and tags.</field>
+        <field name="active">True</field>
+    </record>
+
+    <record id="parity_category_accounting_structure" model="ipai.finance.gl.parity.category">
+        <field name="name">Accounting Structure</field>
+        <field name="code">accounting_structure</field>
+        <field name="sequence">40</field>
+        <field name="description">Account structures, posting rules, and financial reporting tree configuration.</field>
+        <field name="active">True</field>
+    </record>
+
+    <record id="parity_category_financial_journal" model="ipai.finance.gl.parity.category">
+        <field name="name">Financial Journal</field>
+        <field name="code">financial_journal</field>
+        <field name="sequence">50</field>
+        <field name="description">Journal types, journal control, and voucher/entry creation workflows.</field>
+        <field name="active">True</field>
+    </record>
+
+    <record id="parity_category_periodic_process" model="ipai.finance.gl.parity.category">
+        <field name="name">Periodic Financial Process</field>
+        <field name="code">periodic_process</field>
+        <field name="sequence">60</field>
+        <field name="description">Month-end and year-end periodic tasks: accruals, deferrals, closing entries, and balance sheet reports.</field>
+        <field name="active">True</field>
+    </record>
+
+    <record id="parity_category_gl_overall" model="ipai.finance.gl.parity.category">
+        <field name="name">GL Overall</field>
+        <field name="code">gl_overall</field>
+        <field name="sequence">70</field>
+        <field name="description">Cross-cutting GL parity scope, governance, and items that span multiple GL sub-domains.</field>
+        <field name="active">True</field>
+    </record>
+
+</odoo>

--- a/addons/ipai/ipai_finance_gl/docs/MODULE_INTROSPECTION.md
+++ b/addons/ipai/ipai_finance_gl/docs/MODULE_INTROSPECTION.md
@@ -1,0 +1,101 @@
+# MODULE_INTROSPECTION.md — ipai_finance_gl
+
+## Why this module exists
+
+`ipai_finance_gl` captures the D365 Finance "General Ledger and Financial Foundation" parity surface as explicit, queryable records inside Odoo. It exists so that the finance-platform team and stakeholders can see — at a glance — which D365 GL concepts are covered, partially covered, gapped, or out of scope for the current Odoo CE + OCA stack, and link each gap to an ADO task for remediation.
+
+## Business problem
+
+The IPAI platform is displacing D365 Finance for clients migrating to Odoo CE. Stakeholders need a structured parity matrix (not a spreadsheet) to track D365 → Odoo concept mapping across 7 GL wave-01 tasks (chart of accounts, fiscal calendar, financial dimensions, accounting structures, journals, periodic processes, overall GL scope). Without queryable records, the parity state lives in docs only and cannot be filtered, reported, or surfaced in a Pulser agent context.
+
+## CE 18 coverage checked
+
+The following CE 18 models were reviewed as potential native coverage:
+
+| CE Model | Covers |
+|---|---|
+| `account.account` | Chart of accounts — GL accounts |
+| `account.fiscal.year` | Fiscal year/calendar |
+| `account.journal` | Financial journals |
+| `account.analytic.account` | Analytic dimensions (partial financial dimensions proxy) |
+| `account.group` | Account grouping / accounting structures |
+
+CE 18 provides the **runtime** for all GL concepts. It does not provide a parity-tracking data model that maps D365 concepts to Odoo equivalents with status, wave, ADO linkage, and stakeholder-facing views.
+
+## Property-field assessment
+
+Could a property field on `account.account` (or another parent model) solve this requirement?
+
+**No.** Property fields are parent-scoped lightweight metadata for form-level enrichment of existing records (e.g., project-specific task attributes). Parity tracking is metadata *about the mapping between D365 and Odoo* — it is not scoped to a single parent record and has no natural parent model in CE. It requires its own queryable table with status, wave, ADO task linkage, and category taxonomy. A property field cannot carry cross-model D365→Odoo mapping metadata, cannot have SQL uniqueness constraints, cannot be filtered in list/kanban views, and cannot be linked to ADO tasks.
+
+## OCA 18 same-domain coverage checked
+
+| OCA Repo | Modules Reviewed |
+|---|---|
+| `OCA/account-financial-reporting` | `account_financial_report` — financial statement reports; no parity tracking |
+| `OCA/account-financial-tools` | `account_journal_lock_date`, `account_usability` — usability aids; no parity tracking |
+| `OCA/mis-builder` | KPI/MIS reports; no parity tracking |
+| `OCA/account-analytic` | Analytic account management; no parity tracking |
+
+None of these modules provide a D365→Odoo concept mapping or parity-status data model.
+
+## Adjacent OCA modules reviewed
+
+No adjacent OCA domains (sales, HR, project, purchase) provide a parity-tracking concept applicable here. Parity tracking is a novel concern specific to ERP migration overlay modules.
+
+## Why CE + property fields + OCA composition was insufficient
+
+CE 18 provides GL runtime. OCA finance modules provide reporting and tooling. Neither provides a queryable parity-matrix data model. Property fields cannot represent cross-model mapping metadata. No upstream equivalent exists in CE, OCA, or adjacent OCA domains. The requirement — stakeholder-reviewable, filterable, ADO-linked parity records with status, wave, and category taxonomy — is genuinely novel.
+
+## Why custom code is justified
+
+The Wave-01 parity matrix (7 GL task scopes, N D365 concepts each) needs:
+- Queryable status records (`covered` / `partial` / `gap` / `out_of_scope`) for stakeholder review
+- ADO Task linkage (`ado_task_id`) for engineering tracking
+- Wave segmentation for phased delivery reporting
+- Category taxonomy for grouping by GL domain
+- A Pulser-accessible surface for agent-driven parity queries (future M2)
+
+None of these are satisfiable by CE configuration, property fields, or OCA composition alone.
+
+## Module type
+
+**overlay** — adds new models and views; does not override or inherit any `account.*` core models.
+
+## Functional boundaries
+
+**In scope:**
+- `ipai.finance.gl.parity` — parity record model
+- `ipai.finance.gl.parity.category` — category taxonomy model
+- GL parity matrix views (tree, form, search, kanban)
+- 7 seed categories from `d365_parity_data.xml`
+- Security groups (user read-only, manager CRUD)
+
+**Out of scope:**
+- Re-implementing GL behavior (Odoo CE + OCA owns it)
+- AP/AR parity (separate modules: `ipai_finance_ap`, `ipai_finance_ar`)
+- Asset leasing parity (`ipai_asset_leasing` candidate)
+- Tax/BIR parity (`ipai_bir_tax`)
+- Automated sync from `ssot/benchmarks/parity_matrix.yaml` (M2 scope)
+
+## Extension points used
+
+None. This module adds new models only. It does not use `_inherit` on any existing model, override any view, or hook any CRUD method.
+
+## Blast radius
+
+**Low.** Additive only. Uninstalling this module leaves no orphaned references in `account.*` or any other CE/OCA model. No schema changes to existing tables.
+
+## Upgrade risk
+
+**Low.** Initial release (18.0.1.0.0). No existing schema to migrate. OCA dependency modules (`account_financial_report`, `account_journal_lock_date`, `mis_builder`) must be installed and compatible with Odoo 18.0 before this module can be installed.
+
+## Owner
+
+- Primary: finance-platform team
+- Backup: odoo-platform team
+- ADO: Epic #523 D365 Finance Parity
+
+## Retirement / replacement criteria
+
+When D365 Finance GL parity reaches ≥80% `covered` status across all Wave-01 parity records, this module can be marked deprecated and the parity matrix moved to docs-only (`ssot/benchmarks/parity_matrix.yaml`). Retirement requires a deliberate deprecation PR reviewed by the finance-platform team lead.

--- a/addons/ipai/ipai_finance_gl/docs/TECHNICAL_GUIDE.md
+++ b/addons/ipai/ipai_finance_gl/docs/TECHNICAL_GUIDE.md
@@ -1,0 +1,136 @@
+# TECHNICAL_GUIDE.md — ipai_finance_gl
+
+## Architecture
+
+Three layers:
+
+1. **Model layer** — two new models (`ipai.finance.gl.parity`, `ipai.finance.gl.parity.category`) with no inheritance from existing CE models.
+2. **Parity matrix data** — seed XML (`data/d365_parity_data.xml`) populates 7 `ipai.finance.gl.parity.category` records representing the Wave-01 GL taxonomy.
+3. **View layer** — tree / form / search / kanban views for the parity model, plus a top-level menu under Finance → Configuration.
+
+No inherited models. No CRUD overrides. No webhooks or background jobs in v1.
+
+## Models extended
+
+None. This module adds new models only and does not `_inherit` any existing CE or OCA model.
+
+## Fields added
+
+### `ipai.finance.gl.parity`
+
+| Field | Type | Purpose |
+|---|---|---|
+| `name` | `Char` (computed, store=True) | Display name, format: `[GL] <d365_concept>` |
+| `d365_concept` | `Char` (required) | D365 Finance concept name (e.g., "Main Account") |
+| `d365_module` | `Char` | D365 module owning this concept (e.g., "General Ledger") |
+| `d365_doc_url` | `Char` | URL to Microsoft Learn doc for this concept |
+| `category_id` | `Many2one('ipai.finance.gl.parity.category')` | GL taxonomy category |
+| `odoo_module` | `Char` | Odoo CE/OCA module providing coverage (e.g., `account`) |
+| `odoo_model` | `Char` | Odoo model providing coverage (e.g., `account.account`) |
+| `odoo_view_ref` | `Char` | XML ID of the Odoo form view for this model (used in `action_open_odoo_model`) |
+| `status` | `Selection` | Parity status: `covered` / `partial` / `gap` / `out_of_scope` |
+| `status_color` | `Integer` (computed) | Odoo color index for kanban/list decoration: covered=10, partial=2, gap=1, out_of_scope=4 |
+| `notes` | `Html` | Free-form notes (rich text) |
+| `ipai_module_id` | `Many2one('ir.module.module')` | `ipai_*` module bridging this gap (if any) |
+| `wave` | `Char` (default `'Wave-01'`) | Delivery wave for phased parity tracking |
+| `ado_task_id` | `Char` | Azure DevOps task ID for the remediation work item |
+| `active` | `Boolean` (default `True`) | Supports archiving via standard Odoo active pattern |
+
+### `ipai.finance.gl.parity.category`
+
+| Field | Type | Purpose |
+|---|---|---|
+| `name` | `Char` (required) | Human-readable category name |
+| `code` | `Char` (required) | Unique machine key (e.g., `chart_of_accounts`) |
+| `description` | `Text` | Optional longer description |
+| `sequence` | `Integer` (default `10`) | Display ordering |
+| `active` | `Boolean` (default `True`) | Supports archiving |
+
+## Methods overridden
+
+None.
+
+## View inheritance points
+
+None. All views in this module are original (not inheriting from CE or OCA views).
+
+Views defined in `views/d365_parity_views.xml`:
+- `ipai_finance_gl_parity_view_tree`
+- `ipai_finance_gl_parity_view_form`
+- `ipai_finance_gl_parity_view_search`
+- `ipai_finance_gl_parity_view_kanban`
+- `ipai_finance_gl_parity_category_view_tree`
+- `ipai_finance_gl_parity_category_view_form`
+
+## Security model
+
+Two security groups defined in `security/ipai_finance_gl_security.xml`:
+
+| Group XML ID | Name | Permissions |
+|---|---|---|
+| `group_ipai_finance_gl_user` | GL Parity User | Read parity records and categories |
+| `group_ipai_finance_gl_manager` | GL Parity Manager | Full CRUD on parity records and categories |
+
+ACL entries in `security/ir.model.access.csv`:
+
+| Model | User group | R | W | C | D |
+|---|---|---|---|---|---|
+| `ipai.finance.gl.parity` | GL Parity User | ✓ | | | |
+| `ipai.finance.gl.parity` | GL Parity Manager | ✓ | ✓ | ✓ | ✓ |
+| `ipai.finance.gl.parity.category` | GL Parity User | ✓ | | | |
+| `ipai.finance.gl.parity.category` | GL Parity Manager | ✓ | ✓ | ✓ | ✓ |
+
+## Data files loaded
+
+Load order (from `__manifest__.py`):
+
+1. `security/ipai_finance_gl_security.xml` — group definitions
+2. `security/ir.model.access.csv` — ACL entries
+3. `data/d365_parity_data.xml` — 7 seed `ipai.finance.gl.parity.category` records:
+   - `chart_of_accounts` — Chart of Accounts & Main Accounts
+   - `fiscal_calendar` — Fiscal Calendar & Periods
+   - `financial_dimensions` — Financial Dimensions & Dimension Sets
+   - `accounting_structure` — Accounting Structures & Rules
+   - `financial_journal` — Financial Journals
+   - `periodic_process` — Periodic Financial Processes
+   - `gl_overall` — GL Overall Scope
+4. `views/d365_parity_views.xml` — all views
+5. `views/menu.xml` — Finance → Configuration → D365 Parity menu items
+
+## Jobs / cron / queues / webhooks
+
+None in v1. M2 may add a cron job to sync parity status from `ssot/benchmarks/parity_matrix.yaml`.
+
+## External integrations
+
+None in v1. The `ado_task_id` field stores an ADO task ID as a plain `Char` — no live API call to Azure DevOps is made. Future versions may add a clickable URL or a sync action via Azure DevOps MCP.
+
+## Test strategy
+
+Three test files in `tests/`:
+
+| File | Coverage |
+|---|---|
+| `test_parity_category.py` | Category model: defaults, unique code constraint, archiving, ordering |
+| `test_parity_record.py` | Parity model: gap/covered validation constraint, name compute, status_color compute, unique (d365_concept, wave) SQL constraint, `action_open_odoo_model()` |
+| `test_seed_data.py` | Seed data: 7 categories exist post-install with required fields populated |
+
+All test classes are tagged `@tagged('post_install', '-at_install')` and use `TransactionCase` for proper rollback isolation. Run with:
+
+```bash
+odoo-bin -d test_ipai_finance_gl -i ipai_finance_gl --test-enable --stop-after-init
+```
+
+## Upgrade / rollback notes
+
+- **Upgrade**: No existing schema to migrate. Safe to install fresh.
+- **Rollback / uninstall**: Uninstalling drops `ipai_finance_gl_parity` and `ipai_finance_gl_parity_category` tables. No foreign keys exist on any CE/OCA table pointing to these models. Uninstall is safe with no orphaned references.
+- OCA dependency modules must remain installed; uninstalling them while `ipai_finance_gl` is installed will fail the manifest dependency check.
+
+## Known limitations and failure modes
+
+- **GL scope only**: v1 covers only General Ledger. AP, AR, asset, and tax parity need separate `ipai_finance_*` modules.
+- **Manual data entry**: Parity records are entered manually. No automated sync from `ssot/benchmarks/parity_matrix.yaml` until M2.
+- **No drill-through from gap records**: `action_open_odoo_model()` only works when `odoo_view_ref` is explicitly set; gap records (no CE coverage) will always return falsy.
+- **`d365_concept` + `wave` uniqueness is enforced at DB level**: Duplicate records attempted via import will produce an `IntegrityError` rather than a user-friendly `ValidationError`. A `@api.constrains` wrapper can be added in M2 if needed.
+- **`ipai_module_id` is advisory**: The field links to `ir.module.module` for discoverability but no install/uninstall side-effects are triggered.

--- a/addons/ipai/ipai_finance_gl/models/__init__.py
+++ b/addons/ipai/ipai_finance_gl/models/__init__.py
@@ -1,0 +1,3 @@
+# © 2026 InsightPulseAI — License: LGPL-3
+from . import parity_category
+from . import parity_record

--- a/addons/ipai/ipai_finance_gl/models/parity_category.py
+++ b/addons/ipai/ipai_finance_gl/models/parity_category.py
@@ -1,0 +1,73 @@
+# © 2026 InsightPulseAI — License: LGPL-3
+"""
+ipai.finance.gl.parity.category
+--------------------------------
+Taxonomy for D365 Finance GL parity records.
+
+Each category represents a functional grouping of D365 GL concepts
+(e.g. chart-of-accounts, fiscal-calendar, journal, financial-dimensions).
+Categories are referenced by parity records and drive filtering/reporting
+in the parity-matrix view.
+"""
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class FinanceGlParityCategory(models.Model):
+    """Taxonomy grouping for D365 Finance GL parity concepts."""
+
+    _name = "ipai.finance.gl.parity.category"
+    _description = "D365 Finance GL Parity Category"
+    _inherit = ["mail.thread"]
+    _rec_name = "name"
+    _order = "sequence, name"
+
+    # -------------------------------------------------------------------------
+    # Fields
+    # -------------------------------------------------------------------------
+
+    name = fields.Char(
+        string="Category Name",
+        required=True,
+        tracking=True,
+        help="Human-readable name, e.g. 'Chart of Accounts', 'Fiscal Calendar'.",
+    )
+    code = fields.Char(
+        string="Code",
+        required=True,
+        tracking=True,
+        help="Short slug used in data files and exports, e.g. 'chart-of-accounts'.",
+    )
+    description = fields.Text(
+        string="Description",
+        help="Narrative description of the D365 GL functional area this category covers.",
+    )
+    sequence = fields.Integer(
+        string="Sequence",
+        default=10,
+        help="Display ordering within the parity matrix.",
+    )
+    active = fields.Boolean(
+        string="Active",
+        default=True,
+        tracking=True,
+        help="Archived categories are hidden from parity views but retained for history.",
+    )
+
+    # -------------------------------------------------------------------------
+    # SQL constraints
+    # -------------------------------------------------------------------------
+
+    _sql_constraints = [
+        (
+            "name_uniq",
+            "unique(name)",
+            "A parity category with this name already exists. Category names must be unique.",
+        ),
+        (
+            "code_uniq",
+            "unique(code)",
+            "A parity category with this code already exists. Category codes must be unique.",
+        ),
+    ]

--- a/addons/ipai/ipai_finance_gl/models/parity_record.py
+++ b/addons/ipai/ipai_finance_gl/models/parity_record.py
@@ -1,0 +1,260 @@
+# © 2026 InsightPulseAI — License: LGPL-3
+"""
+ipai.finance.gl.parity
+-----------------------
+D365 Finance General Ledger parity record.
+
+Each record maps one D365 GL concept to its Odoo CE/OCA/ipai_* equivalent and
+tracks whether that equivalent is fully covered, partially covered, a gap, or
+explicitly out of scope.
+
+Wave-01 D365 GL scope (Epic #523, 7 Tasks):
+  chart-of-accounts | fiscal-calendar | financial-dimensions
+  accounting-structure | financial-journal | periodic-process | gl-scope-definition
+
+This model does NOT override any account.* behaviour. It is a pure overlay —
+query / reporting / documentation surface only.
+"""
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+# Status → Kanban color index mapping (Odoo color convention)
+_STATUS_COLOR = {
+    "covered": 10,       # green
+    "partial": 2,        # yellow / amber
+    "gap": 1,            # red
+    "out_of_scope": 4,   # grey
+}
+
+
+class FinanceGlParityRecord(models.Model):
+    """D365 Finance GL concept ↔ Odoo equivalent parity record."""
+
+    _name = "ipai.finance.gl.parity"
+    _description = "D365 Finance GL Parity Record"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _rec_name = "name"
+    _order = "category_id, d365_concept"
+
+    # -------------------------------------------------------------------------
+    # Computed name (display only — not stored to avoid stale data)
+    # -------------------------------------------------------------------------
+
+    name = fields.Char(
+        string="Name",
+        compute="_compute_name",
+        store=True,
+        help="Auto-computed as '[d365_module] d365_concept', e.g. '[GL] Main account'.",
+    )
+
+    # -------------------------------------------------------------------------
+    # D365 side
+    # -------------------------------------------------------------------------
+
+    d365_concept = fields.Char(
+        string="D365 Concept",
+        required=True,
+        tracking=True,
+        help="Exact D365 Finance concept name, e.g. 'Main account', 'Fiscal calendar'.",
+    )
+    d365_module = fields.Char(
+        string="D365 Module",
+        tracking=True,
+        help="D365 module abbreviation, e.g. 'GL', 'AP', 'AR', 'FA'.",
+    )
+    d365_doc_url = fields.Char(
+        string="D365 Docs URL",
+        help=(
+            "Link to the Microsoft Learn / dynamics-365-unified-operations-public "
+            "documentation page for this concept."
+        ),
+    )
+
+    # -------------------------------------------------------------------------
+    # Taxonomy
+    # -------------------------------------------------------------------------
+
+    category_id = fields.Many2one(
+        comodel_name="ipai.finance.gl.parity.category",
+        string="Category",
+        required=True,
+        ondelete="restrict",
+        tracking=True,
+        help="Functional grouping, e.g. 'Chart of Accounts', 'Fiscal Calendar'.",
+    )
+
+    # -------------------------------------------------------------------------
+    # Odoo / OCA side
+    # -------------------------------------------------------------------------
+
+    odoo_module = fields.Char(
+        string="Odoo Module",
+        tracking=True,
+        help="CE or OCA module that covers this concept, e.g. 'account', 'OCA/mis-builder'.",
+    )
+    odoo_model = fields.Char(
+        string="Odoo Model",
+        tracking=True,
+        help="Primary Odoo model, e.g. 'account.account', 'account.fiscal.position'.",
+    )
+    odoo_view_ref = fields.Char(
+        string="Odoo View XML ID",
+        help=(
+            "Fully-qualified XML ID used to open the Odoo model view directly, "
+            "e.g. 'account.view_account_form'. Used by action_open_odoo_model()."
+        ),
+    )
+
+    # -------------------------------------------------------------------------
+    # Parity status
+    # -------------------------------------------------------------------------
+
+    status = fields.Selection(
+        selection=[
+            ("covered", "Covered"),
+            ("partial", "Partial"),
+            ("gap", "Gap"),
+            ("out_of_scope", "Out of Scope"),
+        ],
+        string="Status",
+        required=True,
+        default="gap",
+        tracking=True,
+        help=(
+            "covered — Odoo CE/OCA fully satisfies the D365 concept.\n"
+            "partial — Partial coverage; supplementary ipai_* work may be needed.\n"
+            "gap — No Odoo equivalent exists yet.\n"
+            "out_of_scope — Explicitly excluded from parity scope."
+        ),
+    )
+    status_color = fields.Integer(
+        string="Status Color",
+        compute="_compute_status_color",
+        help="Kanban color index derived from status (not stored — display only).",
+    )
+
+    # -------------------------------------------------------------------------
+    # Notes and implementation metadata
+    # -------------------------------------------------------------------------
+
+    notes = fields.Html(
+        string="Implementation Notes",
+        help="Rich-text notes on how the parity is achieved, gaps, or workarounds.",
+    )
+    ipai_module_id = fields.Char(
+        string="IPAI Module",
+        tracking=True,
+        help=(
+            "Name of the thin ipai_* adapter module if one is needed or already exists, "
+            "e.g. 'ipai_finance_gl_dimensions'."
+        ),
+    )
+
+    # -------------------------------------------------------------------------
+    # Wave / project tracking
+    # -------------------------------------------------------------------------
+
+    wave = fields.Char(
+        string="Wave",
+        default="Wave-01",
+        tracking=True,
+        help="Delivery wave this record belongs to, e.g. 'Wave-01'.",
+    )
+    ado_task_id = fields.Char(
+        string="ADO Task ID",
+        help="Azure DevOps Task ID under Epic #523, e.g. '#612'.",
+    )
+    active = fields.Boolean(
+        string="Active",
+        default=True,
+        tracking=True,
+    )
+
+    # -------------------------------------------------------------------------
+    # SQL constraints
+    # -------------------------------------------------------------------------
+
+    _sql_constraints = [
+        (
+            "d365_concept_wave_uniq",
+            "unique(d365_concept, wave)",
+            "A parity record for this D365 concept already exists in the same wave.",
+        ),
+    ]
+
+    # -------------------------------------------------------------------------
+    # Compute methods
+    # -------------------------------------------------------------------------
+
+    @api.depends("d365_module", "d365_concept")
+    def _compute_name(self):
+        """Derive display name as '[MODULE] Concept' or just 'Concept' when no module."""
+        for rec in self:
+            if rec.d365_module:
+                rec.name = f"[{rec.d365_module}] {rec.d365_concept or ''}"
+            else:
+                rec.name = rec.d365_concept or ""
+
+    @api.depends("status")
+    def _compute_status_color(self):
+        """Map parity status to Odoo kanban color index."""
+        for rec in self:
+            rec.status_color = _STATUS_COLOR.get(rec.status, 0)
+
+    # -------------------------------------------------------------------------
+    # Constraint methods
+    # -------------------------------------------------------------------------
+
+    @api.constrains("status", "odoo_module", "odoo_model")
+    def _check_covered_requires_odoo_fields(self):
+        """Enforce that 'covered' status records declare their Odoo module and model."""
+        for rec in self:
+            if rec.status == "covered" and not (rec.odoo_module and rec.odoo_model):
+                raise ValidationError(
+                    _(
+                        "Parity record '%s' has status 'Covered' but is missing "
+                        "Odoo Module and/or Odoo Model. Both fields are required "
+                        "when status is Covered.",
+                        rec.name or rec.d365_concept,
+                    )
+                )
+
+    # -------------------------------------------------------------------------
+    # Action methods
+    # -------------------------------------------------------------------------
+
+    def action_open_odoo_model(self):
+        """Open the related Odoo model view identified by odoo_view_ref.
+
+        Returns a window action dict when odoo_view_ref is set, or raises
+        a UserError with guidance when the field is empty.
+
+        Usage: bound to a button on the parity record form view.
+        """
+        self.ensure_one()
+        if not self.odoo_view_ref:
+            raise ValidationError(
+                _(
+                    "No Odoo View XML ID is configured for '%s'. "
+                    "Set the 'Odoo View XML ID' field to enable direct navigation.",
+                    self.name or self.d365_concept,
+                )
+            )
+        view = self.env.ref(self.odoo_view_ref, raise_if_not_found=False)
+        if not view:
+            raise ValidationError(
+                _(
+                    "The XML ID '%s' could not be resolved. "
+                    "Verify the module containing this view is installed.",
+                    self.odoo_view_ref,
+                )
+            )
+        return {
+            "type": "ir.actions.act_window",
+            "name": self.name,
+            "res_model": view.model,
+            "view_mode": "list,form",
+            "views": [(view.id, view.type)],
+            "target": "current",
+        }

--- a/addons/ipai/ipai_finance_gl/security/ipai_finance_gl_security.xml
+++ b/addons/ipai/ipai_finance_gl/security/ipai_finance_gl_security.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <!-- Module category (custom — allows separate Settings grouping) -->
+    <record id="module_category_ipai_finance_gl" model="ir.module.category">
+        <field name="name">InsightPulseAI / Finance GL</field>
+        <field name="sequence">100</field>
+        <field name="visible">True</field>
+    </record>
+
+    <!-- GL Parity User — read-only access; inherits from account.group_account_user -->
+    <record id="group_ipai_finance_gl_user" model="res.groups">
+        <field name="name">GL Parity User</field>
+        <field name="category_id" ref="module_category_ipai_finance_gl"/>
+        <field name="implied_ids" eval="[(4, ref('account.group_account_user'))]"/>
+        <field name="comment">Read-only access to D365 GL parity records</field>
+    </record>
+
+    <!-- GL Parity Manager — full CRUD; inherits from account.group_account_manager -->
+    <record id="group_ipai_finance_gl_manager" model="res.groups">
+        <field name="name">GL Parity Manager</field>
+        <field name="category_id" ref="module_category_ipai_finance_gl"/>
+        <field name="implied_ids" eval="[(4, ref('account.group_account_manager')), (4, ref('group_ipai_finance_gl_user'))]"/>
+        <field name="comment">Full CRUD access to D365 GL parity records and categories</field>
+    </record>
+
+</odoo>

--- a/addons/ipai/ipai_finance_gl/security/ir.model.access.csv
+++ b/addons/ipai/ipai_finance_gl/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_finance_gl_parity_user,finance.gl.parity.user,model_ipai_finance_gl_parity,ipai_finance_gl.group_ipai_finance_gl_user,1,0,0,0
+access_finance_gl_parity_manager,finance.gl.parity.manager,model_ipai_finance_gl_parity,ipai_finance_gl.group_ipai_finance_gl_manager,1,1,1,1
+access_finance_gl_parity_category_user,finance.gl.parity.category.user,model_ipai_finance_gl_parity_category,ipai_finance_gl.group_ipai_finance_gl_user,1,0,0,0
+access_finance_gl_parity_category_manager,finance.gl.parity.category.manager,model_ipai_finance_gl_parity_category,ipai_finance_gl.group_ipai_finance_gl_manager,1,1,1,1

--- a/addons/ipai/ipai_finance_gl/tests/__init__.py
+++ b/addons/ipai/ipai_finance_gl/tests/__init__.py
@@ -1,0 +1,3 @@
+from . import test_parity_category
+from . import test_parity_record
+from . import test_seed_data

--- a/addons/ipai/ipai_finance_gl/tests/test_parity_category.py
+++ b/addons/ipai/ipai_finance_gl/tests/test_parity_category.py
@@ -1,0 +1,61 @@
+from odoo.exceptions import IntegrityError
+from odoo.tests.common import TransactionCase
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestParityCategory(TransactionCase):
+    """Tests for ipai.finance.gl.parity.category model."""
+
+    def _make_category(self, name, code, **kwargs):
+        vals = {"name": name, "code": code}
+        vals.update(kwargs)
+        return self.env["ipai.finance.gl.parity.category"].create(vals)
+
+    def test_01_create_category_defaults(self):
+        """Creating a category applies default sequence=10 and active=True."""
+        cat = self._make_category("Chart of Accounts", "chart_of_accounts")
+        self.assertEqual(cat.sequence, 10)
+        self.assertTrue(cat.active)
+        self.assertEqual(cat.name, "Chart of Accounts")
+        self.assertEqual(cat.code, "chart_of_accounts")
+
+    def test_02_unique_code_constraint(self):
+        """Creating two categories with the same code raises IntegrityError."""
+        self._make_category("Chart of Accounts", "chart_of_accounts")
+        with self.assertRaises((IntegrityError, Exception)):
+            self._make_category("Chart of Accounts Duplicate", "chart_of_accounts")
+
+    def test_03_archive_does_not_delete(self):
+        """Archiving a category sets active=False but does not delete the record."""
+        cat = self._make_category("Fiscal Calendar", "fiscal_calendar")
+        cat_id = cat.id
+        cat.write({"active": False})
+        # Record must still exist when searched with active_test=False
+        found = self.env["ipai.finance.gl.parity.category"].with_context(
+            active_test=False
+        ).search([("id", "=", cat_id)])
+        self.assertTrue(found)
+        self.assertFalse(found.active)
+
+    def test_04_ordering_by_sequence_then_name(self):
+        """Records are returned ordered by sequence, then name."""
+        self._make_category("Zebra Category", "zebra", sequence=20)
+        self._make_category("Alpha Category", "alpha", sequence=10)
+        self._make_category("Beta Category", "beta", sequence=10)
+        records = self.env["ipai.finance.gl.parity.category"].search(
+            [("code", "in", ["zebra", "alpha", "beta"])]
+        )
+        # sequence 10 records come before sequence 20
+        codes = records.mapped("code")
+        self.assertIn("alpha", codes)
+        self.assertIn("beta", codes)
+        self.assertIn("zebra", codes)
+        zebra_pos = codes.index("zebra")
+        alpha_pos = codes.index("alpha")
+        beta_pos = codes.index("beta")
+        # Both alpha and beta (seq 10) must appear before zebra (seq 20)
+        self.assertLess(alpha_pos, zebra_pos)
+        self.assertLess(beta_pos, zebra_pos)
+        # Within seq 10: alpha < beta alphabetically
+        self.assertLess(alpha_pos, beta_pos)

--- a/addons/ipai/ipai_finance_gl/tests/test_parity_record.py
+++ b/addons/ipai/ipai_finance_gl/tests/test_parity_record.py
@@ -1,0 +1,141 @@
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestParityRecord(TransactionCase):
+    """Tests for ipai.finance.gl.parity model."""
+
+    def setUp(self):
+        super().setUp()
+        self.category = self.env["ipai.finance.gl.parity.category"].create(
+            {
+                "name": "Chart of Accounts",
+                "code": "chart_of_accounts",
+            }
+        )
+
+    def _make_parity(self, d365_concept, status, **kwargs):
+        vals = {
+            "d365_concept": d365_concept,
+            "status": status,
+            "category_id": self.category.id,
+        }
+        vals.update(kwargs)
+        return self.env["ipai.finance.gl.parity"].create(vals)
+
+    def test_01_create_gap_record_no_odoo_module(self):
+        """A parity record with status='gap' does not require odoo_module."""
+        rec = self._make_parity(
+            "Main Account",
+            "gap",
+            d365_module="General Ledger",
+            wave="Wave-01",
+        )
+        self.assertEqual(rec.status, "gap")
+        self.assertFalse(rec.odoo_module)
+        self.assertTrue(rec.id)
+
+    def test_02_covered_without_odoo_module_raises(self):
+        """status='covered' without odoo_module + odoo_model raises ValidationError."""
+        with self.assertRaises(ValidationError):
+            self._make_parity(
+                "Chart of Accounts",
+                "covered",
+                d365_module="General Ledger",
+                wave="Wave-01",
+                # intentionally omitting odoo_module and odoo_model
+            )
+
+    def test_03_covered_with_odoo_module_and_model_succeeds(self):
+        """status='covered' with odoo_module + odoo_model creates record successfully."""
+        rec = self._make_parity(
+            "Chart of Accounts",
+            "covered",
+            d365_module="General Ledger",
+            wave="Wave-01",
+            odoo_module="account",
+            odoo_model="account.account",
+        )
+        self.assertEqual(rec.status, "covered")
+        self.assertEqual(rec.odoo_module, "account")
+        self.assertEqual(rec.odoo_model, "account.account")
+
+    def test_04_name_compute_format(self):
+        """Computed name returns '[GL] <d365_concept>' format."""
+        rec = self._make_parity(
+            "Chart of accounts",
+            "gap",
+            d365_module="General Ledger",
+            wave="Wave-01",
+        )
+        self.assertEqual(rec.name, "[GL] Chart of accounts")
+
+    def test_05_status_color_compute(self):
+        """status_color returns the correct integer per status value."""
+        expected_colors = {
+            "covered": 10,
+            "partial": 2,
+            "gap": 1,
+            "out_of_scope": 4,
+        }
+        for status, expected_color in expected_colors.items():
+            extra = {}
+            if status == "covered":
+                extra = {"odoo_module": "account", "odoo_model": "account.account"}
+            rec = self._make_parity(
+                f"Concept for {status}",
+                status,
+                d365_module="General Ledger",
+                wave=f"Wave-{status}",
+                **extra,
+            )
+            self.assertEqual(
+                rec.status_color,
+                expected_color,
+                msg=f"status_color mismatch for status='{status}'",
+            )
+
+    def test_06_unique_d365_concept_wave_constraint(self):
+        """Creating two parity records with same (d365_concept, wave) raises."""
+        self._make_parity(
+            "Main Account",
+            "gap",
+            d365_module="General Ledger",
+            wave="Wave-01",
+        )
+        with self.assertRaises(Exception):
+            self._make_parity(
+                "Main Account",
+                "partial",
+                d365_module="General Ledger",
+                wave="Wave-01",
+            )
+
+    def test_07_action_open_odoo_model(self):
+        """action_open_odoo_model returns an act_window dict when odoo_view_ref is set,
+        and returns False or falsy when odoo_view_ref is not set."""
+        # With odoo_view_ref set
+        rec_with_ref = self._make_parity(
+            "Account with view ref",
+            "covered",
+            d365_module="General Ledger",
+            wave="Wave-02",
+            odoo_module="account",
+            odoo_model="account.account",
+            odoo_view_ref="account.view_account_form",
+        )
+        action = rec_with_ref.action_open_odoo_model()
+        self.assertIsInstance(action, dict)
+        self.assertEqual(action.get("type"), "ir.actions.act_window")
+
+        # Without odoo_view_ref set
+        rec_no_ref = self._make_parity(
+            "Account without view ref",
+            "gap",
+            d365_module="General Ledger",
+            wave="Wave-03",
+        )
+        result = rec_no_ref.action_open_odoo_model()
+        self.assertFalse(result)

--- a/addons/ipai/ipai_finance_gl/tests/test_seed_data.py
+++ b/addons/ipai/ipai_finance_gl/tests/test_seed_data.py
@@ -1,0 +1,59 @@
+from odoo.tests.common import TransactionCase
+from odoo.tests import tagged
+
+
+# Expected seed category codes, matching d365_parity_data.xml
+_EXPECTED_SEED_CODES = [
+    "chart_of_accounts",
+    "fiscal_calendar",
+    "financial_dimensions",
+    "accounting_structure",
+    "financial_journal",
+    "periodic_process",
+    "gl_overall",
+]
+
+
+@tagged("post_install", "-at_install")
+class TestSeedData(TransactionCase):
+    """Tests that the seed data from d365_parity_data.xml loaded correctly."""
+
+    def test_01_seed_categories_count(self):
+        """Exactly 7 seed categories exist after module installation."""
+        categories = self.env["ipai.finance.gl.parity.category"].search(
+            [("code", "in", _EXPECTED_SEED_CODES)]
+        )
+        self.assertEqual(
+            len(categories),
+            7,
+            msg=(
+                f"Expected 7 seed categories, found {len(categories)}. "
+                f"Codes found: {categories.mapped('code')}"
+            ),
+        )
+
+    def test_02_seed_categories_required_fields_populated(self):
+        """Each seed category has name, code, and sequence populated."""
+        categories = self.env["ipai.finance.gl.parity.category"].search(
+            [("code", "in", _EXPECTED_SEED_CODES)]
+        )
+        self.assertEqual(len(categories), 7, "All 7 seed categories must be present")
+        for cat in categories:
+            self.assertTrue(
+                cat.name,
+                msg=f"Category with code='{cat.code}' is missing a name",
+            )
+            self.assertTrue(
+                cat.code,
+                msg=f"Category id={cat.id} is missing a code",
+            )
+            self.assertIsInstance(
+                cat.sequence,
+                int,
+                msg=f"Category code='{cat.code}' sequence must be an integer",
+            )
+            self.assertGreater(
+                cat.sequence,
+                0,
+                msg=f"Category code='{cat.code}' sequence must be > 0",
+            )

--- a/addons/ipai/ipai_finance_gl/views/d365_parity_views.xml
+++ b/addons/ipai/ipai_finance_gl/views/d365_parity_views.xml
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <!-- ================================================================
+         ipai.finance.gl.parity — List View
+         ================================================================ -->
+    <record id="view_finance_gl_parity_list" model="ir.ui.view">
+        <field name="name">ipai.finance.gl.parity.list</field>
+        <field name="model">ipai.finance.gl.parity</field>
+        <field name="arch" type="xml">
+            <list default_group_by="category_id"
+                  decoration-success="status == 'covered'"
+                  decoration-warning="status == 'partial'"
+                  decoration-danger="status == 'gap'"
+                  decoration-muted="status == 'out_of_scope'">
+                <field name="d365_module" optional="show"/>
+                <field name="d365_concept"/>
+                <field name="category_id"/>
+                <field name="odoo_module" optional="show"/>
+                <field name="odoo_model" optional="show"/>
+                <field name="status" widget="badge"
+                       decoration-success="status == 'covered'"
+                       decoration-warning="status == 'partial'"
+                       decoration-danger="status == 'gap'"
+                       decoration-muted="status == 'out_of_scope'"/>
+                <field name="wave" optional="show"/>
+                <field name="active" optional="hide"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- ================================================================
+         ipai.finance.gl.parity — Form View
+         ================================================================ -->
+    <record id="view_finance_gl_parity_form" model="ir.ui.view">
+        <field name="name">ipai.finance.gl.parity.form</field>
+        <field name="model">ipai.finance.gl.parity</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <field name="status" widget="statusbar"
+                           statusbar_visible="gap,partial,covered,out_of_scope"/>
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="Parity item name"/>
+                        </h1>
+                    </div>
+                    <group>
+                        <group string="D365">
+                            <field name="d365_module"/>
+                            <field name="d365_concept"/>
+                            <field name="d365_doc_url" widget="url"/>
+                            <field name="category_id"/>
+                            <field name="ado_task_id"/>
+                        </group>
+                        <group string="Odoo">
+                            <field name="odoo_module"/>
+                            <field name="odoo_model"/>
+                            <field name="odoo_view_ref"/>
+                            <field name="ipai_module_id"/>
+                            <field name="wave"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Notes">
+                            <field name="notes" widget="html"/>
+                        </page>
+                        <page string="Activity">
+                            <field name="activity_ids" widget="one2many_list"/>
+                        </page>
+                    </notebook>
+                    <div class="o_ipai_finance_gl_actions" attrs="{'invisible': [('odoo_view_ref', '=', False)]}">
+                        <button name="action_open_odoo_model"
+                                type="object"
+                                string="Open Odoo Model"
+                                class="btn-secondary"
+                                invisible="not odoo_view_ref"/>
+                    </div>
+                </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids"/>
+                    <field name="activity_ids"/>
+                    <field name="message_ids"/>
+                </div>
+            </form>
+        </field>
+    </record>
+
+    <!-- ================================================================
+         ipai.finance.gl.parity — Search View
+         ================================================================ -->
+    <record id="view_finance_gl_parity_search" model="ir.ui.view">
+        <field name="name">ipai.finance.gl.parity.search</field>
+        <field name="model">ipai.finance.gl.parity</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="d365_concept"/>
+                <field name="odoo_model"/>
+                <field name="d365_module"/>
+                <field name="category_id"/>
+                <separator/>
+                <filter name="filter_covered" string="Covered" domain="[('status', '=', 'covered')]"/>
+                <filter name="filter_partial" string="Partial" domain="[('status', '=', 'partial')]"/>
+                <filter name="filter_gap" string="Gap" domain="[('status', '=', 'gap')]"/>
+                <filter name="filter_out_of_scope" string="Out of Scope" domain="[('status', '=', 'out_of_scope')]"/>
+                <separator/>
+                <filter name="active_test" string="Archived" domain="[('active', '=', False)]"/>
+                <group expand="0" string="Group By">
+                    <filter name="group_by_category" string="Category" context="{'group_by': 'category_id'}"/>
+                    <filter name="group_by_status" string="Status" context="{'group_by': 'status'}"/>
+                    <filter name="group_by_wave" string="Wave" context="{'group_by': 'wave'}"/>
+                    <filter name="group_by_d365_module" string="D365 Module" context="{'group_by': 'd365_module'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- ================================================================
+         ipai.finance.gl.parity — Kanban View
+         ================================================================ -->
+    <record id="view_finance_gl_parity_kanban" model="ir.ui.view">
+        <field name="name">ipai.finance.gl.parity.kanban</field>
+        <field name="model">ipai.finance.gl.parity</field>
+        <field name="arch" type="xml">
+            <kanban default_group_by="status">
+                <field name="status"/>
+                <field name="status_color"/>
+                <field name="d365_concept"/>
+                <field name="odoo_module"/>
+                <field name="odoo_model"/>
+                <field name="category_id"/>
+                <field name="wave"/>
+                <templates>
+                    <t t-name="card">
+                        <div t-attf-class="o_kanban_record_top oe_kanban_color_#{record.status_color.raw_value}">
+                            <div class="o_kanban_record_headings">
+                                <strong class="o_kanban_record_title">
+                                    <field name="d365_concept"/>
+                                </strong>
+                            </div>
+                            <field name="status" widget="badge"
+                                   decoration-success="status == 'covered'"
+                                   decoration-warning="status == 'partial'"
+                                   decoration-danger="status == 'gap'"
+                                   decoration-muted="status == 'out_of_scope'"/>
+                        </div>
+                        <div class="o_kanban_record_body">
+                            <field name="category_id"/>
+                        </div>
+                        <div class="o_kanban_record_bottom">
+                            <div class="oe_kanban_bottom_left text-muted">
+                                <t t-if="record.odoo_module.raw_value">
+                                    <span><field name="odoo_module"/></span>
+                                    <t t-if="record.odoo_model.raw_value">
+                                        <span> / <field name="odoo_model"/></span>
+                                    </t>
+                                </t>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <!-- ================================================================
+         ipai.finance.gl.parity — Window Action
+         ================================================================ -->
+    <record id="action_finance_gl_parity" model="ir.actions.act_window">
+        <field name="name">GL Parity Map</field>
+        <field name="res_model">ipai.finance.gl.parity</field>
+        <field name="view_mode">list,kanban,form</field>
+        <field name="search_view_id" ref="view_finance_gl_parity_search"/>
+        <field name="context">{'search_default_group_by_category': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No parity items found.
+            </p>
+            <p>
+                Add GL parity map entries to track D365 Finance
+                General Ledger feature coverage in Odoo.
+            </p>
+        </field>
+    </record>
+
+    <!-- ================================================================
+         ipai.finance.gl.parity.category — List View
+         ================================================================ -->
+    <record id="view_finance_gl_parity_category_list" model="ir.ui.view">
+        <field name="name">ipai.finance.gl.parity.category.list</field>
+        <field name="model">ipai.finance.gl.parity.category</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+                <field name="code"/>
+                <field name="description"/>
+                <field name="active" optional="hide"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- ================================================================
+         ipai.finance.gl.parity.category — Form View
+         ================================================================ -->
+    <record id="view_finance_gl_parity_category_form" model="ir.ui.view">
+        <field name="name">ipai.finance.gl.parity.category.form</field>
+        <field name="model">ipai.finance.gl.parity.category</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="Category name"/>
+                        </h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="code"/>
+                            <field name="sequence"/>
+                            <field name="active"/>
+                        </group>
+                    </group>
+                    <group>
+                        <field name="description" placeholder="One-line description of this GL category"/>
+                    </group>
+                </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids"/>
+                    <field name="activity_ids"/>
+                    <field name="message_ids"/>
+                </div>
+            </form>
+        </field>
+    </record>
+
+    <!-- ================================================================
+         ipai.finance.gl.parity.category — Window Action
+         ================================================================ -->
+    <record id="action_finance_gl_parity_category" model="ir.actions.act_window">
+        <field name="name">GL Parity Categories</field>
+        <field name="res_model">ipai.finance.gl.parity.category</field>
+        <field name="view_mode">list,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No categories yet.
+            </p>
+            <p>
+                Create GL parity categories to organise D365 Finance
+                module coverage areas.
+            </p>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/ipai/ipai_finance_gl/views/menu.xml
+++ b/addons/ipai/ipai_finance_gl/views/menu.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <!-- Top-level D365 Parity menu under Finance / Accounting configuration -->
+    <menuitem
+        id="menu_ipai_finance_gl_root"
+        name="D365 Parity"
+        parent="account.menu_finance_configuration"
+        sequence="100"
+        groups="ipai_finance_gl.group_ipai_finance_gl_user"/>
+
+    <!-- GL Parity Map -->
+    <menuitem
+        id="menu_ipai_finance_gl_parity"
+        name="GL Parity Map"
+        parent="menu_ipai_finance_gl_root"
+        action="action_finance_gl_parity"
+        sequence="10"
+        groups="ipai_finance_gl.group_ipai_finance_gl_user"/>
+
+    <!-- GL Parity Categories -->
+    <menuitem
+        id="menu_ipai_finance_gl_parity_categories"
+        name="GL Parity Categories"
+        parent="menu_ipai_finance_gl_root"
+        action="action_finance_gl_parity_category"
+        sequence="20"
+        groups="ipai_finance_gl.group_ipai_finance_gl_manager"/>
+
+</odoo>

--- a/agents/skills/recon_agent/README.md
+++ b/agents/skills/recon_agent/README.md
@@ -1,0 +1,42 @@
+# Pulser Account Reconciliation Agent — Operator Guide
+
+The Pulser Account Reconciliation Agent automates bank statement reconciliation and
+intercompany WHT clearing inside Odoo. It uses a four-specialist HandoffWorkflow
+(BankMatcher → BankClearer / ExceptionHandler, IntercompanyClearer) backed by
+FileCheckpointStorage so runs resume safely when new bank data arrives mid-period.
+
+## When to Invoke
+
+- Monthly: after bank statements are downloaded and before the period is locked
+- Ad-hoc: when an intercompany WHT transaction (e.g. Form 2307) needs clearing
+- Daily incremental: re-invoke with same `company_id` + `period`; checkpoint resumes
+
+## What Approvals to Expect
+
+Every write to Odoo requires explicit approval — there are no silent mutations:
+
+1. **Bank reconciliation** — agent presents: bank line date, amount, partner, matched
+   move line, confidence score, and delta. You approve or reject before it posts.
+2. **Writeoff** — if a delta exists, agent proposes a writeoff account and amount.
+   A second approval is required before the writeoff is posted.
+3. **Intercompany clearing** — agent confirms Form 2307 receipt, then presents the
+   full clearing detail (source company, target company, invoice ID, WHT amount)
+   before requesting approval. Affects two companies simultaneously.
+
+Unmatched items older than 30 days are never auto-cleared — they are escalated to
+Finance Director for manual decision.
+
+## Checkpoint and Log Location
+
+Checkpoints write to `$PULSER_CHECKPOINT_PATH` (default: `/var/lib/pulser/checkpoints`).
+Each workflow run uses the key `reconcile_{company_id}_{period}`.
+
+## Quick Reference
+
+```
+Invoke  : build_reconcile_workflow("dataverse_pasig", "2026-04")
+Test    : pytest agents/tests/test_payment_reconcile_workflow.py -m unit -v
+Source  : agents/workflows/payment_reconcile_workflow.py
+SKILL   : agents/skills/recon_agent/SKILL.md
+Epic    : ADO #524
+```

--- a/agents/skills/recon_agent/SKILL.md
+++ b/agents/skills/recon_agent/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: pulser-recon-agent
+version: 0.1.0
+runtime: microsoft-agent-framework
+epic_id: "524"
+benchmark: D365 Account Reconciliation Agent
+status: v0
+plane: B (Copilot Finance agent)
+author: InsightPulse AI
+tags: [finance, reconciliation, bank, intercompany, hitl]
+---
+
+# Pulser Account Reconciliation Agent — SKILL
+
+## Purpose
+
+Automates bank statement reconciliation and intercompany WHT clearing for Odoo companies.
+Benchmarks against the D365 Account Reconciliation Agent (Plane B: Copilot Finance).
+All mutating actions require explicit human approval before execution.
+
+## Tools
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `get_bank_statement_lines` | read-only | Fetch unreconciled bank statement lines for a period |
+| `get_open_ar_lines` | read-only | Fetch open AR lines (outstanding customer invoices) |
+| `get_open_ap_lines` | read-only | Fetch open AP lines (outstanding vendor bills) |
+| `get_intercompany_transactions` | read-only | Get intercompany transactions between two Odoo companies |
+| `match_bank_line_to_move` | read-only | Propose a match between a bank line and a move line (no post) |
+| `reconcile_bank_line` | **mutating** | Mark a bank line reconciled against an account.move.line |
+| `clear_intercompany_transaction` | **mutating** | Clear an intercompany WHT transaction (affects two companies) |
+
+## Mutating Tool Guardrails
+
+Both mutating tools are decorated with `@tool(approval_mode="always_require")`.
+
+- `reconcile_bank_line` — requires approval before any reconciliation post.
+  If `writeoff_amount > 0`, a second approval is required for the writeoff account.
+- `clear_intercompany_transaction` — requires approval before intercompany clearing.
+  Primary scenario: Dataverse (Pasig) ↔ TBWA\SMP WHT clearing (Form 2307).
+
+No mutating action runs silently. The agent will always surface amounts, dates,
+Odoo record IDs, and a confidence score before requesting approval.
+
+## Inputs
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `company_id` | str | Odoo company xmlid (e.g. `dataverse_pasig`) |
+| `period` | str | ISO period string `YYYY-MM` (e.g. `2026-04`) |
+
+## Outputs
+
+- Matched bank line list with reconciliation status per line
+- Unmatched / low-confidence exceptions list (escalated to Finance Director if > 30 days)
+- Intercompany clearing summary (Dataverse ↔ TBWA\SMP WHT)
+- Checkpoint file per workflow run (FileCheckpointStorage, resumable)
+
+## HITL Contract
+
+All write operations require human-in-the-loop approval:
+
+1. Agent presents match proposal: amounts, dates, Odoo IDs, confidence score
+2. Human approves or rejects
+3. On approval: agent calls mutating tool and confirms result
+4. On rejection: agent routes to ExceptionHandler for human decision
+
+Unmatched items older than 30 days are always escalated — never auto-cleared.
+
+## Failure Modes
+
+| Condition | Behavior |
+|-----------|----------|
+| Low-confidence match (< 95%) | Routed to ExceptionHandler, surfaced for human decision |
+| Unmatched line > 30 days | Escalated to Finance Director |
+| Approval denied | Item added to exceptions report; no state change |
+| Missing bank statement | BankMatcher halts; requests manual import |
+| Missing Form 2307 | IntercompanyClearer blocks clearing until confirmed received |
+
+## How to Invoke
+
+```python
+from agents.workflows.payment_reconcile_workflow import build_reconcile_workflow
+
+workflow = build_reconcile_workflow("dataverse_pasig", "2026-04")
+# Resumes from checkpoint when new bank data arrives
+```
+
+Workflow is durable via `FileCheckpointStorage` — safe to call again when new
+bank data arrives; it resumes from the last checkpoint.
+
+## Test Command
+
+```bash
+pytest agents/tests/test_payment_reconcile_workflow.py -m unit -v
+```
+
+## Anchors
+
+- Implementation: `agents/workflows/payment_reconcile_workflow.py`
+- Tests: `agents/tests/test_payment_reconcile_workflow.py`
+- ADO Epic: [#524 Finance Agents Parity](https://dev.azure.com/insightpulseai/ipai-platform/_workitems/edit/524)
+- Reference adaptation: `docs/architecture/reference-adaptations/finance-recon-agent-v0.md`
+- D365 benchmark: Account Reconciliation Agent (preview, Wave 1)
+- Doctrine: `CLAUDE.md` §"Pulser — canonical classification", Plane B

--- a/agents/tests/test_payment_reconcile_workflow.py
+++ b/agents/tests/test_payment_reconcile_workflow.py
@@ -1,0 +1,276 @@
+"""
+agents/tests/test_payment_reconcile_workflow.py
+
+Unit tests for Pulser Account Reconciliation Workflow.
+D365 benchmark: Account Reconciliation Agent
+Epic: #524 Finance Agents Parity
+
+Tests run without real Azure credentials via unittest.mock stubs.
+"""
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Stub out heavy dependencies before import
+# ---------------------------------------------------------------------------
+
+def _make_agent_framework_stub():
+    """Return a minimal agent_framework stub module tree."""
+    af = types.ModuleType("agent_framework")
+    af_foundry = types.ModuleType("agent_framework.foundry")
+    af_workflows = types.ModuleType("agent_framework.workflows")
+
+    class _Tool:
+        """Minimal @tool decorator stub."""
+        def __init__(self, func=None, *, approval_mode=None):
+            self._approval_mode = approval_mode
+            if func is not None:
+                self._func = func
+                self.__call__ = func
+            else:
+                self._func = None
+
+        def __call__(self, func=None, **kwargs):
+            if callable(func):
+                # Called as @tool (no args)
+                wrapped = _Tool.__new__(_Tool)
+                wrapped._func = func
+                wrapped._approval_mode = None
+                wrapped.__call__ = func
+                wrapped.__name__ = func.__name__
+                wrapped.__doc__ = func.__doc__
+                return wrapped
+            # Called as @tool(approval_mode=...) — return decorator
+            approval = kwargs.get("approval_mode", self._approval_mode)
+            def decorator(f):
+                wrapped = _Tool.__new__(_Tool)
+                wrapped._func = f
+                wrapped._approval_mode = approval
+                wrapped.__call__ = f
+                wrapped.__name__ = f.__name__
+                wrapped.__doc__ = f.__doc__
+                return wrapped
+            return decorator
+
+    tool_instance = _Tool()
+
+    class _Agent:
+        def __init__(self, **kwargs):
+            self.name = kwargs.get("name", "")
+            self.tools = kwargs.get("tools", [])
+
+    class _FileCheckpointStorage:
+        def __init__(self, storage_path=None):
+            self.storage_path = storage_path
+
+    class _HandoffBuilder:
+        def __init__(self, **kwargs):
+            self._kwargs = kwargs
+
+        def with_start_agent(self, agent):
+            self._start = agent
+            return self
+
+        def build(self):
+            workflow = MagicMock()
+            workflow.name = self._kwargs.get("name", "")
+            return workflow
+
+    af.tool = tool_instance
+    af.Agent = _Agent
+    af.FileCheckpointStorage = _FileCheckpointStorage
+
+    af_foundry.FoundryChatClient = MagicMock(return_value=MagicMock())
+    af_workflows.HandoffBuilder = _HandoffBuilder
+
+    af.foundry = af_foundry
+    af.workflows = af_workflows
+
+    return af, af_foundry, af_workflows
+
+
+def _make_azure_identity_stub():
+    azure = types.ModuleType("azure")
+    azure_identity = types.ModuleType("azure.identity")
+    azure_identity.ManagedIdentityCredential = MagicMock(return_value=MagicMock())
+    azure_identity.ChainedTokenCredential = MagicMock(return_value=MagicMock())
+    azure.identity = azure_identity
+    return azure, azure_identity
+
+
+def _make_pydantic_stub():
+    pydantic = types.ModuleType("pydantic")
+    pydantic.Field = MagicMock(return_value=None)
+    return pydantic
+
+
+# Register stubs before the workflow module is imported
+_af, _af_foundry, _af_workflows = _make_agent_framework_stub()
+_azure, _azure_identity = _make_azure_identity_stub()
+_pydantic = _make_pydantic_stub()
+
+sys.modules.setdefault("agent_framework", _af)
+sys.modules.setdefault("agent_framework.foundry", _af_foundry)
+sys.modules.setdefault("agent_framework.workflows", _af_workflows)
+sys.modules.setdefault("azure", _azure)
+sys.modules.setdefault("azure.identity", _azure_identity)
+sys.modules.setdefault("pydantic", _pydantic)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def env_vars():
+    """Inject required env vars so module-level code doesn't raise KeyError."""
+    with patch.dict(os.environ, {
+        "AZURE_CLIENT_ID": "test-client-id",
+        "IPAI_FOUNDRY_ENDPOINT": "https://test.services.ai.azure.com/api/projects/test",
+        "PULSER_CHECKPOINT_PATH": "/tmp/test-pulser-checkpoints",
+    }):
+        yield
+
+
+# Import the module under test AFTER stubs and env vars are in place
+@pytest.fixture(scope="module")
+def workflow_module(env_vars):
+    import importlib
+    import agents.workflows.payment_reconcile_workflow as mod
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestBuildReconWorkflow:
+    """Smoke tests for build_reconcile_workflow factory."""
+
+    def test_returns_workflow_object(self, workflow_module):
+        wf = workflow_module.build_reconcile_workflow("dataverse_pasig", "2026-04")
+        assert wf is not None
+
+    def test_accepts_company_id_and_period(self, workflow_module):
+        wf = workflow_module.build_reconcile_workflow("company_abc", "2026-03")
+        assert wf is not None
+
+    def test_workflow_name_includes_company_and_period(self, workflow_module):
+        wf = workflow_module.build_reconcile_workflow("dataverse_pasig", "2026-05")
+        assert hasattr(wf, "name")
+        assert "dataverse_pasig" in wf.name
+        assert "2026-05" in wf.name
+
+
+@pytest.mark.unit
+class TestReadOnlyToolSignatures:
+    """Verify all read-only tools are callable with expected signatures."""
+
+    def test_get_bank_statement_lines_callable(self, workflow_module):
+        fn = workflow_module.get_bank_statement_lines
+        assert callable(fn) or callable(getattr(fn, "__call__", None))
+
+    def test_get_open_ar_lines_callable(self, workflow_module):
+        fn = workflow_module.get_open_ar_lines
+        assert callable(fn) or callable(getattr(fn, "__call__", None))
+
+    def test_get_open_ap_lines_callable(self, workflow_module):
+        fn = workflow_module.get_open_ap_lines
+        assert callable(fn) or callable(getattr(fn, "__call__", None))
+
+    def test_get_intercompany_transactions_callable(self, workflow_module):
+        fn = workflow_module.get_intercompany_transactions
+        assert callable(fn) or callable(getattr(fn, "__call__", None))
+
+    def test_match_bank_line_to_move_callable(self, workflow_module):
+        fn = workflow_module.match_bank_line_to_move
+        assert callable(fn) or callable(getattr(fn, "__call__", None))
+
+    def test_get_bank_statement_lines_accepts_company_and_period(self, workflow_module):
+        import inspect
+        fn = workflow_module.get_bank_statement_lines
+        func = getattr(fn, "_func", fn)
+        sig = inspect.signature(func)
+        params = list(sig.parameters.keys())
+        assert "company_id" in params
+        assert "period" in params
+
+    def test_get_open_ar_lines_accepts_company_id(self, workflow_module):
+        import inspect
+        fn = workflow_module.get_open_ar_lines
+        func = getattr(fn, "_func", fn)
+        sig = inspect.signature(func)
+        params = list(sig.parameters.keys())
+        assert "company_id" in params
+
+    def test_get_intercompany_accepts_source_target_period(self, workflow_module):
+        import inspect
+        fn = workflow_module.get_intercompany_transactions
+        func = getattr(fn, "_func", fn)
+        sig = inspect.signature(func)
+        params = list(sig.parameters.keys())
+        assert "source_company" in params
+        assert "target_company" in params
+        assert "period" in params
+
+
+@pytest.mark.unit
+class TestMutatingToolApprovalGuardrails:
+    """Verify mutating tools carry approval_mode='always_require'."""
+
+    def test_reconcile_bank_line_has_always_require(self, workflow_module):
+        tool = workflow_module.reconcile_bank_line
+        assert getattr(tool, "_approval_mode", None) == "always_require", (
+            "reconcile_bank_line must declare approval_mode='always_require'"
+        )
+
+    def test_clear_intercompany_transaction_has_always_require(self, workflow_module):
+        tool = workflow_module.clear_intercompany_transaction
+        assert getattr(tool, "_approval_mode", None) == "always_require", (
+            "clear_intercompany_transaction must declare approval_mode='always_require'"
+        )
+
+    def test_reconcile_bank_line_callable(self, workflow_module):
+        fn = workflow_module.reconcile_bank_line
+        assert callable(fn) or callable(getattr(fn, "__call__", None))
+
+    def test_clear_intercompany_callable(self, workflow_module):
+        fn = workflow_module.clear_intercompany_transaction
+        assert callable(fn) or callable(getattr(fn, "__call__", None))
+
+    def test_reconcile_bank_line_signature(self, workflow_module):
+        import inspect
+        fn = workflow_module.reconcile_bank_line
+        func = getattr(fn, "_func", fn)
+        sig = inspect.signature(func)
+        params = list(sig.parameters.keys())
+        assert "bank_line_id" in params
+        assert "move_line_id" in params
+
+    def test_clear_intercompany_signature(self, workflow_module):
+        import inspect
+        fn = workflow_module.clear_intercompany_transaction
+        func = getattr(fn, "_func", fn)
+        sig = inspect.signature(func)
+        params = list(sig.parameters.keys())
+        assert "source_company" in params
+        assert "target_company" in params
+        assert "invoice_id" in params
+        assert "wht_amount" in params
+
+
+@pytest.mark.unit
+class TestReadOnlyToolsLackApprovalGuard:
+    """Read-only tools must NOT have approval_mode set (safety net)."""
+
+    def test_get_bank_statement_lines_no_approval(self, workflow_module):
+        tool = workflow_module.get_bank_statement_lines
+        mode = getattr(tool, "_approval_mode", None)
+        assert mode != "always_require"
+
+    def test_match_bank_line_to_move_no_approval(self, workflow_module):
+        tool = workflow_module.match_bank_line_to_move
+        mode = getattr(tool, "_approval_mode", None)
+        assert mode != "always_require"

--- a/docs/architecture/reference-adaptations/finance-recon-agent-v0.md
+++ b/docs/architecture/reference-adaptations/finance-recon-agent-v0.md
@@ -1,0 +1,60 @@
+# Finance Reconciliation Agent — v0 Reference Adaptation
+
+| Field | Value |
+|-------|-------|
+| Status | v0 shipped 2026-04-14 |
+| ADO Epic | [#524 Finance Agents Parity](https://dev.azure.com/insightpulseai/ipai-platform/_workitems/edit/524) |
+| D365 Benchmark | Account Reconciliation Agent (preview, Wave 1) |
+| Plane | B — Copilot Finance agent (see `feedback_d365_two_plane_doctrine.md`) |
+| Runtime | microsoft-agent-framework (HandoffWorkflow + FileCheckpointStorage) |
+| Model | `claude-sonnet-4-6` via `ipai-copilot-resource` (East US 2) |
+
+## IPAI Implementation
+
+- **Workflow**: `agents/workflows/payment_reconcile_workflow.py`
+- **Skill metadata**: `agents/skills/recon_agent/SKILL.md`
+- **Operator guide**: `agents/skills/recon_agent/README.md`
+- **Tests**: `agents/tests/test_payment_reconcile_workflow.py`
+
+## Wave-01 Issue Task Coverage (Epic #524)
+
+All four tasks under the "Financial Reconciliation Agent" issue in Epic #524
+are covered by this v0 delivery:
+
+| Task | Coverage |
+|------|----------|
+| Define parity scope (bank recon + intercompany WHT) | `payment_reconcile_workflow.py` module docstring + scope section |
+| Define data sources (bank statements, AR/AP, intercompany) | 5 read-only tools: `get_bank_statement_lines`, `get_open_ar_lines`, `get_open_ap_lines`, `get_intercompany_transactions`, `match_bank_line_to_move` |
+| Define workflow + approval gates | HandoffWorkflow with 4 specialist agents; `@tool(approval_mode="always_require")` on both mutating tools |
+| Define UAT + release gating | Unit tests in `agents/tests/test_payment_reconcile_workflow.py`; SKILL.md test command; this adaptation doc |
+
+## D365 Benchmark Alignment
+
+The D365 Account Reconciliation Agent (preview) covers:
+- Automated matching of bank transactions to journal entries
+- Exception surfacing for manual review
+- Intercompany reconciliation
+
+IPAI v0 delivers equivalent scope via:
+- BankMatcher agent (automated matching, confidence scoring)
+- ExceptionHandler agent (low-confidence + unmatched surfacing, 30-day escalation)
+- IntercompanyClearer agent (WHT clearing between Odoo companies)
+- BankClearer agent (approval-gated posting)
+
+## Gaps for v1 (Planned)
+
+| Gap | Notes |
+|-----|-------|
+| Real-time bank feed | v0 uses manual import; v1 will use bank statement API or OCA `account_bank_statement_import` |
+| Multi-currency reconciliation | v0 assumes single currency per period |
+| VAT/WHT clearing generalization | v0 targets Dataverse ↔ TBWA\SMP WHT; v1 will generalize to all intercompany pairs |
+| Multi-tenant company scope expansion | v0 targets `dataverse_pasig`; v1 will accept any `res.company` in the Odoo instance |
+| Databricks analytics lane integration | v0 is Odoo-only; v1 will push matched/unmatched stats to Databricks for Power BI reporting |
+
+## Anchors
+
+- Doctrine: `CLAUDE.md` §"Pulser — canonical classification"
+- Two-plane doctrine: `.claude/projects/memory/feedback_d365_two_plane_doctrine.md`
+- D365 agent parity matrix: `.claude/projects/memory/reference_d365_agent_parity_matrix.md`
+- ADO normalization matrix: `docs/backlog/azdo_normalization_matrix.md`
+- Platform authority split: `ssot/governance/platform-authority-split.yaml`


### PR DESCRIPTION
## Summary
First Wave-01 product code — D365 Finance GL parity overlay + Pulser Reconciliation Agent v0 productization.

(Replaces auto-closed #741 — original base branch was deleted when its parent PR #740 squash-merged.)

## Contents

### `addons/ipai/ipai_finance_gl/` — Wave-01 Epic #523, Issue #527
- 16 files, ~970 lines (manifest + README + 2 models + 4 XML + 4 tests + 2 docs)
- Models: `ipai.finance.gl.parity` (16 fields, mail.thread, status constraint, action_open_odoo_model) + `ipai.finance.gl.parity.category` (mail.thread, unique code constraint)
- Views: list/form/search/kanban + category list/form + menu under Finance/Configuration/D365 Parity
- Security: 2 groups (`group_ipai_finance_gl_user`, `group_ipai_finance_gl_manager`)
- Seed data: 7 Wave-01 GL category records (chart_of_accounts, fiscal_calendar, financial_dimensions, accounting_structure, financial_journal, periodic_process, gl_overall)
- Tests: 13 unit tests
- Docs: `MODULE_INTROSPECTION.md` + `TECHNICAL_GUIDE.md` (REQUIRED per CLAUDE.md doctrine)
- Module type: overlay (parity tracking + light extension; no CRUD overrides on `account.*`)

### `agents/skills/recon_agent/` — Wave-01 Epic #524, Issue #532 v0
- Productization of existing `agents/workflows/payment_reconcile_workflow.py` (204 lines)
- 18 pytest unit tests with `sys.modules` stubs
- SKILL.md + README.md + Epic #524 linkage doc

## Wave-01 task coverage
- ✅ #527: 7/7 GL Tasks structurally covered as parity-record categories
- ✅ #532: 4/4 Reconciliation Agent Tasks artifact-backed

## Verification status (per `verification.md`)
- ✅ Python AST parse on 10 .py files
- ✅ XML parse on 4 .xml files
- ✅ CSV format on 1 access file
- ⏳ Odoo install + 13 unit tests = deferred to CI
- ⏳ pytest run for recon agent = deferred to CI

## Test plan
- [ ] CI runs `scripts/ci/run_odoo_tests.sh -m ipai_finance_gl` against disposable test database
- [ ] CI runs `pytest agents/tests/test_payment_reconcile_workflow.py -m unit`
- [ ] Reviewer verifies module installs: `./scripts/odoo_install.sh -d test_finance_gl -m ipai_finance_gl`
- [ ] Reviewer verifies parity matrix view loads under Finance → Configuration → D365 Parity → GL Parity Map

## Anchors
- ADO: Epic #523 / Issue #527, Epic #524 / Issue #532
- `CLAUDE.md` § "Odoo extension and customization doctrine"
- `ssot/benchmarks/parity_matrix.yaml`
- Memory: `project_delivery_position_20260414.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)