### PR TITLE
infra(c1): managed-identity.bicep → AVM v0.5.0 wrapper

### DIFF
--- a/infra/modules/security/managed-identity.bicep
+++ b/infra/modules/security/managed-identity.bicep
@@ -1,0 +1,39 @@
+// modules/security/managed-identity.bicep
+// Creates: id-{prefix}-{env} (User-Assigned Managed Identity)
+// All ACA containers use this MI for Azure service auth (no API keys)
+//
+// REFACTOR (C step 1, 2026-04-14): wraps Azure Verified Module
+// `avm/res/managed-identity/user-assigned-identity@0.5.0` instead of
+// hand-rolled `Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31`.
+// Wrapper preserves output names (miResourceId / miPrincipalId / miClientId / miName)
+// so that 9+ callers in infra/main.bicep require ZERO changes.
+//
+// Verified zero functional change via `az deployment group what-if` — see PR.
+targetScope = 'resourceGroup'
+
+param prefix   string
+param env      string
+param location string
+param tags     object
+@description('Reserved for backward compatibility. Not used by the AVM module.')
+param deployPrincipalId string = ''
+
+var miName = 'id-${prefix}-${env}'
+
+// AVM module — pinned to v0.5.0 (latest at 2026-04-14)
+module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-identity:0.5.0' = {
+  name: 'avm-mi-${miName}'
+  params: {
+    name:     miName
+    location: location
+    tags:     tags
+    // No federatedIdentityCredentials, no lockType, no roleAssignments at this layer.
+    // Those compose at the consumer layer (Key Vault RBAC, ACA app role assignments).
+  }
+}
+
+// ── Outputs (preserved interface — same names as pre-AVM module) ───────────
+output miResourceId  string = userAssignedIdentity.outputs.resourceId
+output miPrincipalId string = userAssignedIdentity.outputs.principalId
+output miClientId    string = userAssignedIdentity.outputs.clientId
+output miName        string = userAssignedIdentity.outputs.name


### PR DESCRIPTION
## Summary
**Acceleration plan C step 1** — first AVM migration. Replaces hand-rolled `Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31` with `avm/res/managed-identity/user-assigned-identity:0.5.0`.

Wrapper preserves output interface (`miResourceId` / `miPrincipalId` / `miClientId` / `miName`) so 9+ callers in `infra/main.bicep` need ZERO changes.

## What-if validation (acceleration plan gate: zero unintended changes)

Ran against actual production resource `id-ipai-dev` in `rg-ipai-dev-security-sea`:

```
Managed-identity changes: 1
  changeType: Modify
    Delete: properties.isolationScope (before={'isolationScope': 'None'}, after=None)
    [tag deltas are pre-existing session drift, not caused by AVM swap]
```

**Functional delta: ZERO.**
- `properties.isolationScope: 'None'` is the API default value when not specified
- AVM module doesn't emit it; hand-rolled module's older API version (2023-01-31) did emit it
- Both produce functionally identical Managed Identities (same name, location, MI type, principal/client IDs unchanged)

**Tag deltas in what-if** (`tags.costCenter`, `tags.environment`, `tags.product`, etc. → Delete) are **pre-existing session drift** — leftover legacy tag keys from earlier today's tag policy work. They are NOT caused by this AVM swap and would not occur in normal `main.bicep` end-to-end deploy (which passes the canonical 15-tag set).

## Why this is safe to merge

1. ✅ AVM v0.5.0 is the latest published version (verified via `mcr.microsoft.com` tags)
2. ✅ Wrapper preserves all 4 output names — no downstream caller changes
3. ✅ What-if shows zero functional resource changes
4. ✅ Same `miName` derivation (`id-{prefix}-{env}`)
5. ✅ Same param surface (kept `deployPrincipalId` for backward compat — flagged unused; can be removed in follow-up)

## Why this is the right migration to do FIRST

Per acceleration plan + agent audit:
- **Trivial complexity** (single resource, 25-line module)
- **Low blast radius** (only 1 MI in dev; no downstream policy-deny risk)
- **High-leverage proof** — proves the AVM consumption pattern works end-to-end before tackling Key Vault / PostgreSQL / Front Door (steps 2-5)

## Test plan
- [ ] Reviewer compares what-if output (above) vs current state — confirms only `isolationScope` delta
- [ ] Reviewer confirms tag deltas are session drift, not AVM-induced
- [ ] After merge: deploy via `infra/main.bicep` and verify MI is unchanged
- [ ] After merge + verify: proceed to C step 2 (log-analytics dedup ×2 → AVM)

## Locked-in by acceleration plan
- This is the ONLY infra change being proposed in this PR
- Steps C2-C5 (log-analytics, ACR, Key Vault, PostgreSQL) require separate PRs with their own what-if gates
- DO NOT merge if the what-if "isolationScope" delta is unfamiliar — confirm with reviewer first

## Anchors
- `docs/delivery/acceleration-plan-20260414.md` § Active levers
- `ssot/governance/upstream-adoption-register.yaml` (`Azure/bicep-registry-modules` consume_directly)
- `CLAUDE.md` § Engineering Execution Doctrine (reuse upstream first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)