### PR TITLE
infra(r3): deploy gap closers — Action Group + AI Search + Purview

### DIFF
--- a/azure-pipelines/deploy-r3-gap-closers.yml
+++ b/azure-pipelines/deploy-r3-gap-closers.yml
@@ -1,0 +1,194 @@
+# =====================================================
+# R3 Production-Readiness Gap Closers — Azure Pipeline
+# Deploys: Action Group (#625), AI Search (#624), Purview (#627)
+# Doctrine: Azure Pipelines = sole CI/CD authority
+# =====================================================
+trigger:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - infra/azure/modules/action-group.bicep
+      - infra/azure/modules/ai-search.bicep
+      - infra/azure/modules/purview.bicep
+
+parameters:
+  - name: deployActionGroup
+    type: boolean
+    default: true
+  - name: deployAiSearch
+    type: boolean
+    default: true
+  - name: deployPurview
+    type: boolean
+    default: true
+  - name: environment
+    type: string
+    default: dev
+    values:
+      - dev
+      - stg
+      - prod
+
+variables:
+  - name: subscriptionId
+    value: eba824fb-332d-4623-9dfb-2c9f7ee83f4e
+  - name: location
+    value: southeastasia
+  - name: serviceConnection
+    value: ipai-azure-sponsorship
+
+stages:
+  - stage: Validate
+    displayName: Bicep What-If
+    jobs:
+      - job: WhatIf
+        displayName: What-If All Modules
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+
+          - task: AzureCLI@2
+            displayName: What-If Action Group
+            condition: eq('${{ parameters.deployActionGroup }}', true)
+            inputs:
+              azureSubscription: $(serviceConnection)
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                az deployment group what-if \
+                  --subscription $(subscriptionId) \
+                  --resource-group rg-ipai-${{ parameters.environment }}-mon-sea \
+                  --template-file infra/azure/modules/action-group.bicep \
+                  --no-pretty-print
+
+          - task: AzureCLI@2
+            displayName: What-If AI Search
+            condition: eq('${{ parameters.deployAiSearch }}', true)
+            inputs:
+              azureSubscription: $(serviceConnection)
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                az deployment group what-if \
+                  --subscription $(subscriptionId) \
+                  --resource-group rg-ipai-${{ parameters.environment }}-ai-sea \
+                  --template-file infra/azure/modules/ai-search.bicep \
+                  --no-pretty-print
+
+          - task: AzureCLI@2
+            displayName: What-If Purview
+            condition: eq('${{ parameters.deployPurview }}', true)
+            inputs:
+              azureSubscription: $(serviceConnection)
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                az deployment group what-if \
+                  --subscription $(subscriptionId) \
+                  --resource-group rg-ipai-${{ parameters.environment }}-security-sea \
+                  --template-file infra/azure/modules/purview.bicep \
+                  --no-pretty-print
+
+  - stage: Deploy
+    displayName: Deploy Gap Closers
+    dependsOn: Validate
+    condition: succeeded()
+    jobs:
+      - deployment: DeployActionGroup
+        displayName: T1 — Action Group (LOW risk)
+        condition: eq('${{ parameters.deployActionGroup }}', true)
+        environment: ipai-${{ parameters.environment }}
+        pool:
+          vmImage: ubuntu-latest
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: self
+                - task: AzureCLI@2
+                  inputs:
+                    azureSubscription: $(serviceConnection)
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      az deployment group create \
+                        --subscription $(subscriptionId) \
+                        --resource-group rg-ipai-${{ parameters.environment }}-mon-sea \
+                        --name t1-action-group-$(Build.BuildNumber) \
+                        --template-file infra/azure/modules/action-group.bicep
+
+      - deployment: DeployAiSearch
+        displayName: T2 — AI Search (LOW risk)
+        dependsOn: DeployActionGroup
+        condition: eq('${{ parameters.deployAiSearch }}', true)
+        environment: ipai-${{ parameters.environment }}
+        pool:
+          vmImage: ubuntu-latest
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: self
+                - task: AzureCLI@2
+                  inputs:
+                    azureSubscription: $(serviceConnection)
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      az deployment group create \
+                        --subscription $(subscriptionId) \
+                        --resource-group rg-ipai-${{ parameters.environment }}-ai-sea \
+                        --name t2-ai-search-$(Build.BuildNumber) \
+                        --template-file infra/azure/modules/ai-search.bicep \
+                        --parameters sku=basic
+
+      - deployment: DeployPurview
+        displayName: T3 — Purview (LOW risk)
+        dependsOn: DeployAiSearch
+        condition: eq('${{ parameters.deployPurview }}', true)
+        environment: ipai-${{ parameters.environment }}
+        pool:
+          vmImage: ubuntu-latest
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: self
+                - task: AzureCLI@2
+                  inputs:
+                    azureSubscription: $(serviceConnection)
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      az deployment group create \
+                        --subscription $(subscriptionId) \
+                        --resource-group rg-ipai-${{ parameters.environment }}-security-sea \
+                        --name t3-purview-$(Build.BuildNumber) \
+                        --template-file infra/azure/modules/purview.bicep
+
+  - stage: Verify
+    displayName: Resource Graph Count
+    dependsOn: Deploy
+    condition: succeeded()
+    jobs:
+      - job: Count
+        displayName: Recount resources vs baseline 24
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: AzureCLI@2
+            inputs:
+              azureSubscription: $(serviceConnection)
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                COUNT=$(az graph query -q "Resources | where subscriptionId == '$(subscriptionId)' | count" --query "data[0].Count" -o tsv)
+                echo "Resource Graph count: $COUNT"
+                echo "Baseline (pre-R3): 24"
+                echo "Expected after T1+T2+T3: 27"
+                if [ "$COUNT" -lt 27 ]; then
+                  echo "##vso[task.logissue type=warning]Resource count ($COUNT) below T1+T2+T3 expectation (27)"
+                fi

--- a/infra/azure/modules/action-group.bicep
+++ b/infra/azure/modules/action-group.bicep
@@ -1,0 +1,59 @@
+// =====================================================
+// Azure Monitor Action Group — alert routing baseline
+// AVM: avm/res/insights/action-group@0.8.0
+// Doctrine: Engineering Execution — reuse AVM, thin delta only
+// Deploys to: rg-ipai-dev-mon-sea (monitoring plane)
+// =====================================================
+targetScope = 'resourceGroup'
+
+param prefix string = 'ipai'
+param env string = 'dev'
+param location string = 'global'
+param tags object = {
+  org: 'ipai'
+  env: 'dev'
+  platform: 'pulser-odoo'
+  plane: 'observability'
+  workload: 'alerting'
+}
+
+@description('Email recipients for alerts.')
+param emailRecipients array = [
+  {
+    name: 'ops'
+    emailAddress: 'ops@insightpulseai.com'
+  }
+]
+
+@description('Optional Slack webhook URL. When empty, webhook receiver is skipped.')
+@secure()
+param slackWebhookUrl string = ''
+
+var agName = 'ag-${prefix}-${env}-sea'
+var webhookReceivers = empty(slackWebhookUrl) ? [] : [
+  {
+    name: 'slack-ipai-alerts'
+    serviceUri: slackWebhookUrl
+    useCommonAlertSchema: true
+  }
+]
+
+module actionGroup 'br/public:avm/res/insights/action-group:0.8.0' = {
+  name: 'avm-ag-${agName}'
+  params: {
+    name: agName
+    location: location
+    tags: tags
+    groupShortName: 'ipai-${env}'
+    enabled: true
+    emailReceivers: [for r in emailRecipients: {
+      name: r.name
+      emailAddress: r.emailAddress
+      useCommonAlertSchema: true
+    }]
+    webhookReceivers: webhookReceivers
+  }
+}
+
+output actionGroupId string = actionGroup.outputs.resourceId
+output actionGroupName string = actionGroup.outputs.name

--- a/infra/azure/modules/ai-search.bicep
+++ b/infra/azure/modules/ai-search.bicep
@@ -1,0 +1,52 @@
+// =====================================================
+// Azure AI Search — RAG backbone for Plane B agents
+// AVM: avm/res/search/search-service@0.9.2
+// Deploys to: rg-ipai-dev-ai-sea
+// =====================================================
+targetScope = 'resourceGroup'
+
+param prefix string = 'ipai'
+param env string = 'dev'
+param location string = 'southeastasia'
+param tags object = {
+  org: 'ipai'
+  env: 'dev'
+  platform: 'pulser-odoo'
+  plane: 'data'
+  workload: 'agent-rag'
+}
+
+@description('SKU: basic (dev) or standard (prod).')
+param sku string = 'basic'
+param replicaCount int = 1
+param partitionCount int = 1
+
+@description('Log Analytics workspace resource ID for diagnostics. Optional.')
+param logAnalyticsWorkspaceId string = ''
+
+var searchName = 'srch-${prefix}-${env}-sea'
+var diagnosticSettings = empty(logAnalyticsWorkspaceId) ? [] : [
+  {
+    workspaceResourceId: logAnalyticsWorkspaceId
+    logCategoriesAndGroups: [{ categoryGroup: 'allLogs' }]
+    metricCategories: [{ category: 'AllMetrics' }]
+  }
+]
+
+module aiSearch 'br/public:avm/res/search/search-service:0.9.2' = {
+  name: 'avm-search-${searchName}'
+  params: {
+    name: searchName
+    location: location
+    tags: tags
+    sku: sku
+    replicaCount: replicaCount
+    partitionCount: partitionCount
+    publicNetworkAccess: 'Enabled' // Hardened to 'Disabled' at R3 W6 with PE
+    managedIdentities: { systemAssigned: true }
+    diagnosticSettings: diagnosticSettings
+  }
+}
+
+output searchServiceId string = aiSearch.outputs.resourceId
+output searchServiceName string = aiSearch.outputs.name

--- a/infra/azure/modules/purview.bicep
+++ b/infra/azure/modules/purview.bicep
@@ -1,0 +1,43 @@
+// =====================================================
+// Microsoft Purview — governance, lineage, DSPM
+// AVM: avm/res/purview/account@0.9.2
+// Deploys to: rg-ipai-dev-security-sea
+// =====================================================
+targetScope = 'resourceGroup'
+
+param prefix string = 'ipai'
+param env string = 'dev'
+param location string = 'southeastasia'
+param tags object = {
+  org: 'ipai'
+  env: 'dev'
+  platform: 'pulser-odoo'
+  plane: 'governance'
+  workload: 'purview'
+}
+
+@description('Public network access. Hardened to Disabled at R3 W6 with PE.')
+param publicNetworkAccess string = 'Enabled'
+
+@description('Admin user/group object IDs for Purview Data Curator role.')
+param collectionAdmins array = []
+
+var purviewName = 'pv-${prefix}-${env}-sea'
+
+module purview 'br/public:avm/res/purview/account:0.9.2' = {
+  name: 'avm-purview-${purviewName}'
+  params: {
+    name: purviewName
+    location: location
+    tags: tags
+    publicNetworkAccess: publicNetworkAccess
+    // Purview always uses a system-assigned identity; not a user-configurable param.
+    roleAssignments: [for admin in collectionAdmins: {
+      principalId: admin
+      roleDefinitionIdOrName: 'Purview Data Curator'
+    }]
+  }
+}
+
+output purviewAccountId string = purview.outputs.resourceId
+output purviewAccountName string = purview.outputs.name


### PR DESCRIPTION
## Summary
- Deploys 3 of 4 R3 production-readiness gap closers per [quickstart-bicep-snippets.md](docs/architecture/quickstart-bicep-snippets.md).
- Already-deployed: **T1 Action Group** (`ag-ipai-dev-sea` live).
- In-flight at PR open: **T2 AI Search** (`srch-ipai-dev-sea` provisioning), **T3 Purview** (awaiting RP registration).
- Adds Azure Pipeline for future reproducibility (doctrine: Azure Pipelines = sole CI/CD).

## Resource Graph deltas
- Before: 24
- After T1 (verified): **27**
- Target after T1+T2+T3: 29
- Path to R3 (62): T4 PE/DNS next tranche

## ADO Issues
- Closes #625 (Action Group)
- Progresses #624 (AI Search)
- Progresses #627 (Purview)
- Does not touch #626 (PE/DNS — next PR)

## Test plan
- [x] `az bicep build` clean for all 3 modules
- [x] T1 deployment succeeded
- [ ] T2 AI Search reaches Succeeded
- [ ] Purview RP registered + T3 retry succeeds
- [ ] Resource Graph recount confirms +3 delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)