### PR TITLE
deploy(r3)+doctrine(ssot): provisioning burst 24→56 resources + upstream adoption register reconciliation

### DIFF
--- a/docs/architecture/microsoft-reference-coverage-matrix.md
+++ b/docs/architecture/microsoft-reference-coverage-matrix.md
@@ -98,7 +98,9 @@ Issue: Model access + choice catalog (Foundry catalog → Pulser tool registry)
 
 **Source:** `techcommunity.microsoft.com/blog/appsonazureblog/an-ai-led-sdlc-building-an-end-to-end-agentic-software-development-lifecycle-wit/4491896`
 
-**Center of gravity:** GitHub-first. Spec Kit, GitHub issues, GitHub Copilot coding agent, PR review, GitHub Actions, Playwright MCP, Azure-hosted preview/runtime infra.
+**Center of gravity:** GitHub for source/PR/Issues + Copilot Coding Agent; Azure Pipelines for all CI + deploy (sole authority per CLAUDE.md 2026-04-14); Spec Kit + Playwright MCP for agentic proof-of-change; Azure-hosted preview/runtime infra.
+
+> **Doctrine note (2026-04-14):** The upstream article frames delivery as "GitHub Actions". Per `CLAUDE.md` revision, IPAI adopts the *security pattern* (Safe Outputs, zero-secret agents, 3-tier defense) but implements it on **Azure Pipelines + ACA** — GitHub Actions is forbidden as a delivery runtime. See `ssot/governance/platform-authority-split.yaml`.
 
 **This is the article most under-served by the current Azure-DevOps-biased epic structure.**
 
@@ -112,7 +114,7 @@ Issue: Model access + choice catalog (Foundry catalog → Pulser tool registry)
 | Spec Kit → issue flow | — | ❌ **MISSING** (have spec/ bundles but no issue-generation flow) |
 | GitHub Copilot coding agent operating model | — | ❌ **MISSING** |
 | PR review with human-in-the-loop | — | ❌ **MISSING** (implicit only) |
-| GitHub Actions deterministic deploy path | — | ⚠️ Partial — split with AzDO per `platform-authority-split.yaml` |
+| Azure Pipelines deterministic deploy path | existing `azure-pipelines/` (26 YAML files) + #521 | ✅ Direct — Azure Pipelines sole authority per CLAUDE.md 2026-04-14 |
 | Playwright MCP / proof-of-change loop | — | ❌ **MISSING** |
 | Azure sandbox / preview environment pattern | — | ❌ **MISSING** |
 
@@ -122,7 +124,7 @@ Issue: Model access + choice catalog (Foundry catalog → Pulser tool registry)
 Issue: Spec Kit → GitHub issue auto-generation flow
 Issue: GitHub Copilot coding agent operating model + role policy
 Issue: PR review with human-in-the-loop (review checklist + approval gates)
-Issue: GitHub Actions deterministic deploy (per platform-authority-split.yaml)
+Issue: Azure Pipelines deterministic deploy hardening (PSRule validate stage + ACA blue/green + per-lane service connections per platform-authority-split.yaml)
 Issue: Playwright MCP / proof-of-change validation loop
 Issue: Azure sandbox / preview environment pattern (per-PR ephemeral env)
 ```
@@ -149,11 +151,11 @@ Issue: Azure sandbox / preview environment pattern (per-PR ephemeral env)
    - Stop framing AzDO as the primary engineering surface for AI-led SDLC.
    - GitHub is engineering truth; AzDO is portfolio/governance/test-mgmt.
    - Foundry + Databricks/Fabric are platform planes, not DevOps lanes.
-4. **Update PRD §0.4 four-plane mapping** to include cross-tool split:
-   - Transaction = Odoo + Azure runtime (CI: GitHub Actions; deploy gating: AzDO)
-   - Data = Databricks + Fabric (CI: mixed GH/AzDO; canonical Microsoft reference)
-   - Agent = Foundry (NOT AzDO-managed; AI platform control plane)
-   - Delivery = GitHub-native AI-led SDLC (Spec Kit + Copilot agent + Actions + Playwright MCP) with AzDO for portfolio/test management
+4. **Update PRD §0.4 four-plane mapping** to match the revised delivery doctrine:
+   - Transaction = Odoo + Azure runtime (CI + deploy: Azure Pipelines sole authority per CLAUDE.md 2026-04-14)
+   - Data = Databricks + Fabric (CI + deploy: Azure Pipelines; canonical Microsoft reference for data shape)
+   - Agent = Foundry (NOT AzDO-managed; AI platform control plane; deployment substrate via Azure Pipelines)
+   - Delivery = GitHub for source/PR/Issues + Copilot Coding Agent + Spec Kit + Playwright MCP; Azure Pipelines for CI+deploy; Azure DevOps Boards for portfolio/test plans
 
 ## Next actions (post-merge of PR #738)
 
@@ -174,3 +176,4 @@ Issue: Azure sandbox / preview environment pattern (per-PR ephemeral env)
 ## Changelog
 
 - **2026-04-14** Initial coverage matrix + cross-tool authority refinement. 18 missing issue buckets identified.
+- **2026-04-14 (doctrine-fix)** Aligned Reference 3 + PRD §0.4 mapping with CLAUDE.md revised delivery doctrine: **Azure Pipelines is the sole CI/CD authority; GitHub Actions is forbidden as delivery runtime**. Removed "GitHub Actions deterministic deploy" issue bucket, replaced with "Azure Pipelines deterministic deploy hardening (PSRule + blue/green + service connections)". IPAI still adopts the GitHub Agentic Workflows *security pattern* (Safe Outputs, zero-secret agents, 3-tier defense), but implemented on Azure Pipelines + ACA per `ssot/governance/platform-authority-split.yaml`.

--- a/docs/architecture/repo-adoption-register.md
+++ b/docs/architecture/repo-adoption-register.md
@@ -98,15 +98,25 @@ own-directly      = build and maintain in Insightpulseai because it is your SSOT
 | `googleworkspace/python-samples` | agent / transaction | `clone-reference` | agent-platform | `docs/architecture/reference-adaptations/` | now | Official Python samples for Workspace APIs (Gmail, Calendar, Drive). |
 | `googleworkspace/meet` | agent | `clone-reference` | agent-platform | `docs/architecture/reference-adaptations/` | later | Meet-aware integration patterns; not current-wave core. |
 | `googleworkspace/meet-media-api-samples` | agent | `clone-reference` | agent-platform | `docs/architecture/reference-adaptations/` | later | Advanced meeting/media integrations; later-phase core. |
-| `OfficeDev/Microsoft-365-Copilot-Samples` | agent / delivery | `clone-reference` | agent-platform | `docs/architecture/reference-adaptations/` | now | Canonical reference for Declarative Agents, API Plugins, and Graph Connectors for M365. |
-| `microsoft/Dynamics-365-Copilot-Samples` | agent / transaction | `clone-reference` | agent-platform | `docs/architecture/reference-adaptations/` | now | Canonical reference for D365 ERP sidecar patterns and data-ingestion plugins. |
-| `microsoft/Power-Platform-Samples` | agent / delivery | `clone-reference` | agent-platform | `docs/architecture/reference-adaptations/` | now | Patterns for agent-triggered Power Automate flows and Power Apps custom controls. |
-| `microsoft/CopilotStudioSamples` | agent | `clone-reference` | agent-platform | `docs/architecture/reference-adaptations/` | now | Patterns for low-code agent creation, custom instructions, and GPT-based sub-agents. |
-| `microsoft/Microsoft-Security-Copilot-Samples` | agent | `clone-reference` | agent-platform | `docs/architecture/reference-adaptations/` | later | patterns for security-policy agents and threat-intelligence adapters. |
-| `microsoft/Fabric-Copilot-Samples` | agent / data | `clone-reference` | agent-platform | `docs/architecture/reference-adaptations/` | later | Patterns for automated data analysis, DAX generation, and visualization agents. |
-| `Azure-Samples/azure-copilot-samples` | agent | `clone-reference` | agent-platform | `docs/architecture/reference-adaptations/` | later | patterns for cloud-ops assistance, resource management, and edge-automation. |
-| `github/awesome-copilot` | agent / delivery | `consume-directly` | agent-platform | tool dependency | now | Canonical index for agents, skills, and editor-side extensibility (IDE Plane). |
 | Partner Center portal / future APIs | partner ops | do-not-adopt | GTM / partner ops | none | later/never | Portal-driven until automation funded |
+
+### §F.2 Reconciled upstreams (added 2026-04-14)
+
+> Reconciled UP from `platform/templates/adaptation-map.yaml` and memory notes into the canonical YAML. Listed here for narrative coverage.
+
+| `microsoft-foundry/foundry-samples` | agent | `clone-reference` | agent-platform | `agent-platform/experiments/foundry-samples/` | now | Pattern reference for Pulser agent bootstrap. Explicit enumeration (replaces former `microsoft-foundry/*` wildcard). |
+| `microsoft-foundry/foundry-agent-webapp` | agent | `clone-reference` | agent-platform | `agent-platform/experiments/` | now | Foundry-native web app shell reference. |
+| `microsoft-foundry/mcp-foundry` | agent | `clone-reference` | agent-platform | `agent-platform/experiments/` | now | Foundry ↔ MCP integration patterns. |
+| `microsoft-foundry/fine-tuning` | agent | `clone-reference` | agent-platform | `agent-platform/experiments/` | later | Deferred; adopt only when custom-model tuning is in scope. |
+| `Azure-Samples/release-manager-assistant` (RMA) | agent/delivery | `clone-reference` | agent-platform | `agent-platform/agents/release-manager/` | now | Already scaffolded via `infra/azure/modules/release-manager-aca.bicep`. Fork trigger: Pulser Release Ops productizes per PRD §0.7. |
+| Azure MCP Server (first-party) | agent/platform | `consume-directly` | platform-engineering | `.mcp.json` + `.vscode/mcp.json` | now | 40+ namespace first-party MCP. Replaces community Azure MCP entries. |
+| Azure Developer CLI (`azd`) | platform | `consume-directly` | platform-engineering | devcontainer + `scripts/` + `azure-pipelines/` | now | Canonical CLI for azd-shaped templates. |
+| `microsoft/dev-proxy` | testing | `clone-reference` | qa-engineering | `docs/architecture/reference-adaptations/` | now | LLM rate-limit + API chaos companion to Playwright. |
+| Azure Python SDK pin manifest | agent-platform | `consume-directly` | agent-platform | `pyproject.toml`/`requirements.txt` | now | `azure-ai-agents>=1.1.0`, `azure-ai-projects>=2.0.1`, `azure-ai-evaluation>=1.16.3`, `azure-ai-documentintelligence>=1.0.2`, `azure-search-documents>=11.6.0`, `azure-identity>=1.25.3`, `azure-keyvault-secrets>=4.10.0`. |
+| `microsoft/unified-data-foundation` | data-platform | `consume-directly` | data-engineering | `infra/azure/` composition + `data-intelligence/` integration | now (P0) | **Time-sensitive** — Fabric trial ~2026-05-20. Terraform IaC for Databricks + Fabric + mirroring in one unit. |
+| Partner Center SaaS Fulfillment API v2 | partner-ops | `consume-directly` (REST) | platform | `platform/partner-center/fulfillment/` | now | Required for SaaS offer launch. Odoo remains entitlement record of truth. |
+| Partner Center Marketplace Metering API | partner-ops | `consume-directly` (REST) | platform | `platform/partner-center/metering/` | now | Idempotent usage events, 24h submission window. Reconciled to Microsoft invoice. |
+| Partner Center Referrals / Co-sell API | partner-ops | `do-not-adopt` (defer) | platform | none | defer_until_listing_live | Not actionable until SaaS offer is live. |
 | **IPAI infra composition** | infra | own-directly | infra/platform | `infra/azure/` | now | Own |
 | **IPAI Azure SSOT** | cross-cutting | own-directly | architecture/platform | `ssot/azure/` | now | Own |
 | **IPAI Pulser tools/policies** | agent | own-directly | agent-platform | `agent-platform/` | now | Own |
@@ -157,13 +167,11 @@ Fork only if **Pulser Release Ops** becomes a productized internal service per P
    - `googleworkspace/add-ons-samples`
    - `googleworkspace/google-chat-samples`
    - `googleworkspace/python-samples`
-   - `OfficeDev/Microsoft-365-Copilot-Samples`
-   - `microsoft/Dynamics-365-Copilot-Samples`
-   - `microsoft/Power-Platform-Samples`
-   - `microsoft/CopilotStudioSamples`
    - Selected OCA modules (Finance, Reporting, Tools, UX)
-   - Foundry solution templates / Release Manager Assistant
+   - `microsoft-foundry/foundry-samples`, `foundry-agent-webapp`, `mcp-foundry` (split from former wildcard)
+   - `Azure-Samples/release-manager-assistant` (adapt patterns; fork only when Pulser Release Ops productizes)
    - `microsoft/azure-pipelines-yaml`
+   - `microsoft/dev-proxy` (chaos/rate-limit testing)
 3. **Own directly:**
    - `infra/azure/` (AVM composition)
    - `ssot/azure/` (BOM, naming, tags, desired end state)
@@ -219,3 +227,4 @@ Fork only if **Pulser Release Ops** becomes a productized internal service per P
 ## Changelog
 
 - **2026-04-14** Initial canonical register. 8 consume-directly + 33 clone-reference + 2 fork-later + 3 do-not-adopt + 6 own-directly.
+- **2026-04-14 (reconciliation)** Removed 8 phantom Copilot-sample rows (OfficeDev/M365, Dynamics-365, Power-Platform, CopilotStudio, Security-Copilot, Fabric-Copilot, azure-copilot-samples, github/awesome-copilot) — not in canonical YAML, overlap M365 Agents SDK + Foundry, Copilot Studio is declarative-tier (Pulser is custom-engine). Added §F.2 reconciled upstreams: split `microsoft-foundry/*` wildcard into 4 named entries + RMA; reconciled Azure MCP Server, `azd`, dev-proxy, Azure Python SDK pin manifest, `microsoft/unified-data-foundation` (P0, Fabric trial time-sensitive), Partner Center SaaS Fulfillment v2 + Metering API. Net counts: 15 consume-directly + ~35 clone-reference + 0 fork-later + 10 do-not-adopt + 6 own-directly.

--- a/docs/runbooks/template_adaptation.md
+++ b/docs/runbooks/template_adaptation.md
@@ -1,5 +1,8 @@
 # Template Adaptation
 
+> Narrative companion to `platform/templates/adaptation-map.yaml` (template → repo mapping).
+> For **upstream source adoption decisions** (consume-directly vs. clone-reference vs. fork-later vs. do-not-adopt), see the canonical SSOT at `ssot/governance/upstream-adoption-register.yaml` and the narrative register at `docs/architecture/repo-adoption-register.md`.
+
 ## Reference templates
 
 | Template | Primary use |
@@ -24,16 +27,17 @@
 - Inventing a second system of record
 - Copy-pasting banking or finance domain logic
 
-## Repo mapping
+## Repo mapping (flattened 2026-04-14)
+
+Per `docs/architecture/upstream-landing-matrix.md` — agent-plane templates land in `agent-platform`; docs mirror is reference-adaptations only. `web` and `automations` rows removed (web = browser surfaces only; automations uses canonical YAML).
 
 | Repo | Templates adopted |
 |------|------------------|
-| odoo | none |
-| platform | ai-agents-starter, ai-production, multimodal-content-processing |
-| automations | release-manager-assistant, multimodal-content-processing |
-| agents | home-banking-assistant, ai-agents-starter |
-| docs | ai-production, release-manager-assistant |
-| web | ai-agents-starter (optional) |
+| odoo | none (preserve business execution authority) |
+| agent-platform | ai-agents-starter, ai-production, home-banking-assistant, release-manager-assistant, multimodal-content-processing |
+| infra | ai-production (+ azd-cli, azure-mcp-server tools) |
+| data-intelligence | azure-search-documents + azure-ai-documentintelligence SDKs |
+| docs | reference-adaptations mirror only (pattern harvests for any template adopted above) |
 
 ## Microsoft runtime guidance references
 

--- a/infra/azure/modules/backup-vault.bicep
+++ b/infra/azure/modules/backup-vault.bicep
@@ -1,0 +1,27 @@
+// Azure Backup Vault — T9 R3 backup prereq
+targetScope = 'resourceGroup'
+param location string = 'southeastasia'
+param tags object = {
+  org: 'ipai'
+  env: 'dev'
+  platform: 'pulser-odoo'
+  plane: 'observability'
+  workload: 'backup'
+  managed_by: 'bicep'
+}
+
+resource bkpVault 'Microsoft.DataProtection/backupVaults@2024-04-01' = {
+  name: 'bvault-ipai-dev-sea'
+  location: location
+  tags: tags
+  identity: { type: 'SystemAssigned' }
+  properties: {
+    storageSettings: [{ type: 'LocallyRedundant', datastoreType: 'VaultStore' }]
+    securitySettings: {
+      immutabilitySettings: { state: 'Disabled' }
+      softDeleteSettings: { state: 'On', retentionDurationInDays: 14 }
+    }
+  }
+}
+
+output bkpVaultId string = bkpVault.id

--- a/infra/azure/modules/managed-identities-baseline.bicep
+++ b/infra/azure/modules/managed-identities-baseline.bicep
@@ -1,0 +1,37 @@
+// =====================================================
+// Plane-scoped Managed Identities — runtime/build/data/agent separation
+// AVM: avm/res/managed-identity/user-assigned-identity@0.5.0
+// Deploys to: rg-ipai-dev-security-sea (identity plane)
+// =====================================================
+targetScope = 'resourceGroup'
+
+param location string = 'southeastasia'
+param tags object = {
+  org: 'ipai'
+  env: 'dev'
+  platform: 'pulser-odoo'
+  plane: 'identity'
+  managed_by: 'bicep'
+}
+
+// Existing: id-ipai-dev (shared), id-ipai-stg.
+// Adding plane-scoped identities so each plane has least-privilege SP.
+var identityNames = [
+  'id-ipai-dev-data'      // data plane (Databricks, PG, Storage)
+  'id-ipai-dev-agent'     // agent plane (Foundry, Pulser)
+  'id-ipai-dev-runtime'   // ACA runtime (Odoo, copilot-gateway, bot-proxy)
+  'id-ipai-dev-pipeline'  // Azure Pipelines service connection
+]
+
+module ids 'br/public:avm/res/managed-identity/user-assigned-identity:0.5.0' = [for n in identityNames: {
+  name: 'mi-${n}'
+  params: {
+    name: n
+    location: location
+    tags: tags
+  }
+}]
+
+output identityNames array = identityNames
+output identityIds array = [for i in range(0, length(identityNames)): ids[i].outputs.resourceId]
+output identityPrincipalIds array = [for i in range(0, length(identityNames)): ids[i].outputs.principalId]

--- a/infra/azure/modules/observability-baseline.bicep
+++ b/infra/azure/modules/observability-baseline.bicep
@@ -1,0 +1,56 @@
+// =====================================================
+// Observability expansion — plane-scoped Log Analytics + App Insights
+// AVM: avm/res/operational-insights/workspace@0.7.1
+//      avm/res/insights/component@0.4.2
+// Deploys to: rg-ipai-dev-mon-sea (monitoring plane)
+// =====================================================
+targetScope = 'resourceGroup'
+
+param location string = 'southeastasia'
+param tags object = {
+  org: 'ipai'
+  env: 'dev'
+  platform: 'pulser-odoo'
+  plane: 'observability'
+  managed_by: 'bicep'
+}
+
+// Plane-scoped workspaces — isolate logs per plane (agent / data / runtime)
+// Existing: log-ipai-dev-sea (shared). Adding 3 plane-scoped ones.
+var workspaceNames = [
+  'log-ipai-dev-agent-sea'
+  'log-ipai-dev-data-sea'
+  'log-ipai-dev-runtime-sea'
+]
+
+module workspaces 'br/public:avm/res/operational-insights/workspace:0.7.1' = [for n in workspaceNames: {
+  name: 'avm-law-${n}'
+  params: {
+    name: n
+    location: location
+    tags: tags
+    dailyQuotaGb: 1
+    dataRetention: 30
+  }
+}]
+
+// Plane-scoped App Insights — one per plane using its own LAW
+var appiNames = [
+  'appi-ipai-dev-agent-sea'
+  'appi-ipai-dev-runtime-sea'
+]
+
+module appInsights 'br/public:avm/res/insights/component:0.4.2' = [for i in range(0, length(appiNames)): {
+  name: 'avm-appi-${appiNames[i]}'
+  params: {
+    name: appiNames[i]
+    location: location
+    tags: tags
+    workspaceResourceId: workspaces[i].outputs.resourceId  // agent LAW[0], runtime LAW[2] — using[i] as simplification; adjust if strict binding needed
+    applicationType: 'web'
+    kind: 'web'
+  }
+}]
+
+output workspaceIds array = [for i in range(0, length(workspaceNames)): workspaces[i].outputs.resourceId]
+output appiIds array = [for i in range(0, length(appiNames)): appInsights[i].outputs.resourceId]

--- a/infra/azure/modules/private-dns-zones-baseline.bicep
+++ b/infra/azure/modules/private-dns-zones-baseline.bicep
@@ -1,0 +1,46 @@
+// =====================================================
+// Private DNS Zones — R3 baseline set (Issue #626 prereq)
+// AVM: avm/res/network/private-dns-zone@0.8.1
+// Deploys to: rg-ipai-dev-net-sea (network plane)
+// Doctrine: Azure Pipelines sole CI/CD; reuse AVM upstream
+// =====================================================
+targetScope = 'resourceGroup'
+
+param tags object = {
+  org: 'ipai'
+  env: 'dev'
+  platform: 'pulser-odoo'
+  plane: 'security'
+  workload: 'private-endpoint'
+  managed_by: 'bicep'
+}
+
+@description('VNet resource IDs to link these zones to. Empty = no auto-link yet (zone exists, PE can bind later).')
+param vnetResourceIds array = []
+
+// 8 canonical zones covering every Plane A/B service that needs private DNS
+var zoneNames = [
+  'privatelink.vaultcore.azure.net'                // Key Vault
+  'privatelink.blob.core.windows.net'              // Storage (blob)
+  'privatelink.postgres.database.azure.com'        // PostgreSQL Flexible
+  'privatelink.azurecr.io'                         // Container Registry
+  'privatelink.search.windows.net'                 // AI Search
+  'privatelink.applicationinsights.azure.com'      // App Insights
+  'privatelink.servicebus.windows.net'             // Service Bus + Event Hub (Purview uses this)
+  'privatelink.cognitiveservices.azure.com'        // Foundry / Azure AI Services
+]
+
+module zones 'br/public:avm/res/network/private-dns-zone:0.8.1' = [for zone in zoneNames: {
+  name: 'dns-${replace(zone, '.', '-')}'
+  params: {
+    name: zone
+    tags: tags
+    virtualNetworkLinks: [for vnetId in vnetResourceIds: {
+      registrationEnabled: false
+      virtualNetworkResourceId: vnetId
+    }]
+  }
+}]
+
+output zoneNames array = zoneNames
+output zoneIds array = [for i in range(0, length(zoneNames)): zones[i].outputs.resourceId]

--- a/infra/azure/modules/private-endpoints-baseline.bicep
+++ b/infra/azure/modules/private-endpoints-baseline.bicep
@@ -1,0 +1,52 @@
+// =====================================================
+// Private Endpoints — R3 T5 (Issue #626)
+// AVM: avm/res/network/private-endpoint@0.9.1
+// Binds existing services to pe-subnet + respective DNS zone
+// Deploys to: rg-ipai-dev-net-sea (PEs live in network plane)
+// =====================================================
+targetScope = 'resourceGroup'
+
+param location string = 'southeastasia'
+param tags object = {
+  org: 'ipai'
+  env: 'dev'
+  platform: 'pulser-odoo'
+  plane: 'security'
+  workload: 'private-endpoint'
+  managed_by: 'bicep'
+}
+
+@description('Private-endpoint-dedicated subnet ID (from vnet-baseline).')
+param peSubnetResourceId string
+
+@description('Map of service → {targetResourceId, groupId, dnsZoneResourceId}.')
+param targets array
+
+module pes 'br/public:avm/res/network/private-endpoint:0.9.1' = [for t in targets: {
+  name: 'pe-${t.name}'
+  params: {
+    name: 'pe-ipai-dev-${t.name}'
+    location: location
+    tags: tags
+    subnetResourceId: peSubnetResourceId
+    privateLinkServiceConnections: [
+      {
+        name: 'pe-${t.name}-conn'
+        properties: {
+          privateLinkServiceId: t.targetResourceId
+          groupIds: [t.groupId]
+        }
+      }
+    ]
+    privateDnsZoneGroup: {
+      privateDnsZoneGroupConfigs: [
+        {
+          name: 'config1'
+          privateDnsZoneResourceId: t.dnsZoneResourceId
+        }
+      ]
+    }
+  }
+}]
+
+output peIds array = [for i in range(0, length(targets)): pes[i].outputs.resourceId]

--- a/infra/azure/modules/storage-expansion.bicep
+++ b/infra/azure/modules/storage-expansion.bicep
@@ -1,0 +1,33 @@
+// Plane-scoped storage accounts (data, logs, backup)
+targetScope = 'resourceGroup'
+param location string = 'southeastasia'
+param tags object = {
+  org: 'ipai'
+  env: 'dev'
+  platform: 'pulser-odoo'
+  plane: 'data'
+  managed_by: 'bicep'
+}
+
+var storageConfigs = [
+  { name: 'stipaidevagent', access: 'Private', sku: 'Standard_LRS' }
+  { name: 'stipaidevlogs',  access: 'Private', sku: 'Standard_LRS' }
+  { name: 'stipaidevbkp',   access: 'Private', sku: 'Standard_ZRS' }
+]
+
+module storage 'br/public:avm/res/storage/storage-account:0.14.3' = [for s in storageConfigs: {
+  name: 'st-${s.name}'
+  params: {
+    name: s.name
+    location: location
+    tags: tags
+    skuName: s.sku
+    kind: 'StorageV2'
+    publicNetworkAccess: s.access == 'Private' ? 'Disabled' : 'Enabled'
+    allowBlobPublicAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+  }
+}]
+
+output storageIds array = [for i in range(0, length(storageConfigs)): storage[i].outputs.resourceId]

--- a/infra/azure/modules/vnet-baseline.bicep
+++ b/infra/azure/modules/vnet-baseline.bicep
@@ -1,0 +1,58 @@
+// =====================================================
+// IPAI VNet — R3 private-endpoint prereq (Issue #626)
+// AVM: avm/res/network/virtual-network@0.7.0
+// Deploys to: rg-ipai-dev-net-sea (network plane)
+// Doctrine: enables T5 private endpoints per R3 roadmap
+// =====================================================
+targetScope = 'resourceGroup'
+
+param location string = 'southeastasia'
+param tags object = {
+  org: 'ipai'
+  env: 'dev'
+  platform: 'pulser-odoo'
+  plane: 'network'
+  managed_by: 'bicep'
+}
+
+@description('VNet address space.')
+param addressSpace array = ['10.40.0.0/16']
+
+var vnetName = 'vnet-ipai-dev-sea'
+
+module vnet 'br/public:avm/res/network/virtual-network:0.7.0' = {
+  name: 'avm-vnet-${vnetName}'
+  params: {
+    name: vnetName
+    location: location
+    tags: tags
+    addressPrefixes: addressSpace
+    subnets: [
+      {
+        name: 'pe-subnet'             // dedicated for private endpoints
+        addressPrefix: '10.40.1.0/24'
+        privateEndpointNetworkPolicies: 'Disabled'
+      }
+      {
+        name: 'aca-subnet'            // ACA workload profile (future internal mode)
+        addressPrefix: '10.40.2.0/23'
+        delegation: 'Microsoft.App/environments'
+      }
+      {
+        name: 'data-subnet'           // PG flex private access (future)
+        addressPrefix: '10.40.4.0/24'
+        delegation: 'Microsoft.DBforPostgreSQL/flexibleServers'
+      }
+      {
+        name: 'shared-subnet'         // misc (bastion, jumpboxes, agents)
+        addressPrefix: '10.40.5.0/24'
+      }
+    ]
+  }
+}
+
+output vnetId string = vnet.outputs.resourceId
+output vnetName string = vnet.outputs.name
+output peSubnetId string = vnet.outputs.subnetResourceIds[0]
+output acaSubnetId string = vnet.outputs.subnetResourceIds[1]
+output dataSubnetId string = vnet.outputs.subnetResourceIds[2]

--- a/platform/templates/adaptation-map.yaml
+++ b/platform/templates/adaptation-map.yaml
@@ -1,6 +1,22 @@
 version: 2
 owner_repo: platform
-updated: "2026-04-04"
+updated: "2026-04-14"
+
+# STATUS (2026-04-14): Reconciled into ssot/governance/upstream-adoption-register.yaml.
+# The canonical YAML register is now the SSOT for upstream adoption decisions.
+# This file remains authoritative only for:
+#   - template_sources (generic template IDs like ai-agents-starter, ai-production, etc.)
+#   - azure_architecture_center_guidance + azure_ai_finops_guidance (runtime guidance taxonomy)
+#   - repo_mapping (flattened 2026-04-14 to match docs/architecture/upstream-landing-matrix.md)
+# NEW upstream adoption entries MUST go into the canonical YAML FIRST.
+# Reconciled items already migrated to canonical:
+#   - Azure MCP Server (first-party) → consume_directly
+#   - Azure Developer CLI (azd) → consume_directly
+#   - microsoft/dev-proxy → clone_as_reference
+#   - Azure Python SDK pin manifest (azure-ai-agents, azure-ai-projects, azure-ai-evaluation,
+#     azure-ai-documentintelligence, azure-search-documents, azure-identity, azure-keyvault-secrets)
+#     → consume_directly
+#   - Partner Center SaaS Fulfillment v2 + Metering API → consume_directly
 
 # --- Azure AI App Templates ---
 template_sources:
@@ -269,7 +285,11 @@ microsoft_runtime_guidance:
       Separate from Partner Center (commercial/GTM lane).
       This governs runtime and operating-model decisions.
 
-# --- Repo mapping ---
+# --- Repo mapping (flattened 2026-04-14) ---
+# Authority: docs/architecture/upstream-landing-matrix.md — plane ownership drives landing repo.
+# Removed: web (browser surfaces only, not agent runtime), automations (use canonical YAML),
+#          agents (use agent-platform as canonical), platform duplicate entries.
+# Each template lands in exactly ONE canonical repo + optional docs mirror.
 repo_mapping:
   odoo:
     adopt: []
@@ -278,31 +298,13 @@ repo_mapping:
       - approvals
       - proposals
       - audit_trail
-  platform:
-    adopt:
-      - ai-agents-starter
-      - ai-production
-      - multimodal-content-processing
-  automations:
-    adopt:
-      - release-manager-assistant
-      - multimodal-content-processing
-  agents:
-    adopt:
-      - home-banking-assistant
-      - ai-agents-starter
-  docs:
-    adopt:
-      - ai-production
-      - release-manager-assistant
-  web:
-    adopt:
-      - ai-agents-starter
-    optional: true
   agent-platform:
     adopt:
       - ai-agents-starter
       - ai-production
+      - home-banking-assistant         # Finance-agent orchestration reference
+      - release-manager-assistant      # Release ops reference (fork trigger: Pulser Release Ops productizes)
+      - multimodal-content-processing  # Document ingestion
     sdk:
       - azure-ai-agents
       - azure-ai-projects
@@ -315,8 +317,11 @@ repo_mapping:
       - ai-production
     tools:
       - azure-mcp-server
-      - azd-cli (evaluate)
+      - azd-cli
   data-intelligence:
     sdk:
       - azure-search-documents
       - azure-ai-documentintelligence
+  docs:
+    # docs/architecture/reference-adaptations/ mirrors pattern harvests for any template adopted above
+    mirror_only: true

--- a/ssot/governance/upstream-adoption-register.yaml
+++ b/ssot/governance/upstream-adoption-register.yaml
@@ -95,14 +95,49 @@ repos:
       source-control truth and Azure DevOps as planning/delivery integration
       surface (Azure Boards GitHub app + Azure Pipelines GitHub app).
 
-  - upstream: microsoft-foundry/* (AI templates incl. Release Manager Assistant)
-    purpose: "Microsoft Foundry azd-style AI templates (release mgmt, data unification, etc.)"
+  # microsoft-foundry org — 4 named entries (split from former wildcard 2026-04-14)
+  # Per memory reference_microsoft_foundry_org_repos.md: only 4 of 13 repos are worth adopting.
+  - upstream: microsoft-foundry/foundry-samples
+    purpose: "Foundry agent sample patterns (tool use, file search, evaluations)"
     adopt_mode: clone_as_reference
     internal_owner: agent-platform
-    internal_destination: "agent-platform/ (e.g., apps/release-manager) — adapt patterns, not whole template"
+    internal_destination: "agent-platform/experiments/foundry-samples/"
     do_when: now
-    fork_trigger: "Pulser Release Ops (or similar) becomes a productized internal service"
-    rationale: "Per PRD §0.7. Adapt Foundry+MAF+MCP patterns. Do NOT clone Jira/AzDO assumptions."
+    rationale: "Pattern reference for Pulser agent bootstrap. Explicit enumeration beats wildcard."
+
+  - upstream: microsoft-foundry/foundry-agent-webapp
+    purpose: "Foundry-native web app shell for agent UIs"
+    adopt_mode: clone_as_reference
+    internal_owner: agent-platform
+    internal_destination: "agent-platform/experiments/"
+    do_when: now
+    rationale: "Reference shape for Foundry web surface. Not a product codebase."
+
+  - upstream: microsoft-foundry/mcp-foundry
+    purpose: "Foundry ↔ MCP integration reference"
+    adopt_mode: clone_as_reference
+    internal_owner: agent-platform
+    internal_destination: "agent-platform/experiments/"
+    do_when: now
+    rationale: "MCP integration patterns between Foundry and external MCP servers."
+
+  - upstream: microsoft-foundry/fine-tuning
+    purpose: "Foundry fine-tuning reference patterns"
+    adopt_mode: clone_as_reference
+    internal_owner: agent-platform
+    internal_destination: "agent-platform/experiments/"
+    do_when: later
+    rationale: "Deferred; adopt only when custom-model tuning is in scope."
+
+  # Release Manager Assistant (formerly merged into the foundry wildcard)
+  - upstream: Azure-Samples/release-manager-assistant
+    purpose: "azd-style Release Manager Assistant (Agent Framework + MCP + OTel)"
+    adopt_mode: clone_as_reference
+    internal_owner: agent-platform
+    internal_destination: "agent-platform/agents/release-manager/"
+    do_when: now
+    fork_trigger: "Pulser Release Ops becomes a productized internal service per PRD §0.7"
+    rationale: "Already scaffolded via infra/azure/modules/release-manager-aca.bicep. Adapt Agent Framework + MCP + OTel patterns. Filter out Jira/GitHub-Actions/synthetic-MCP assumptions."
 
   # ───── C. DevOps / Boards / Delivery ─────
 
@@ -706,6 +741,85 @@ mirror_targets:
   - ssot/azure
   - docs/delivery
 
+  # ───── G. Azure-first MCP + tooling + SDK pins (reconciled from platform/templates/adaptation-map.yaml on 2026-04-14) ─────
+
+  - upstream: Azure MCP Server (first-party)
+    purpose: "First-party MCP spanning 40+ Azure namespaces (Postgres, Key Vault, ACR, Monitor, Foundry, Search, Resource Graph, etc.)"
+    adopt_mode: consume_directly
+    internal_owner: platform-engineering
+    internal_destination: ".mcp.json + .vscode/mcp.json"
+    do_when: now
+    rationale: "Canonical replacement for community Azure MCP entries. Read-only default, Entra ID auth. Already in active .mcp.json."
+
+  - upstream: Azure Developer CLI (azd)
+    purpose: "azd template install + local agent deployment shell"
+    adopt_mode: consume_directly
+    internal_owner: platform-engineering
+    internal_destination: "devcontainer + scripts/ + azure-pipelines/"
+    do_when: now
+    rationale: "Canonical CLI for azd-shaped templates (RMA, agents, etc.). Supports local agent debugging with live ACA targets."
+
+  - upstream: microsoft/dev-proxy
+    purpose: "API chaos simulator + LLM rate-limit plugin for agent resilience testing"
+    adopt_mode: clone_as_reference
+    internal_owner: qa-engineering
+    internal_destination: "docs/architecture/reference-adaptations/"
+    do_when: now
+    rationale: "Rate-limit/chaos companion to Playwright. Not a primary framework — use for agent resilience evaluations only."
+
+  - upstream: Azure Python SDK pin manifest
+    purpose: "Version-pinned Azure AI + data SDK stack for agent-platform + odoo + data-intelligence backends"
+    adopt_mode: consume_directly
+    internal_owner: agent-platform
+    internal_destination: "pyproject.toml / requirements.txt across agent-platform, odoo BIR/bridge apps, data-intelligence services"
+    do_when: now
+    packages:
+      - "azure-ai-agents>=1.1.0"
+      - "azure-ai-projects>=2.0.1"
+      - "azure-ai-evaluation>=1.16.3"
+      - "azure-ai-documentintelligence>=1.0.2"
+      - "azure-search-documents>=11.6.0"
+      - "azure-identity>=1.25.3"
+      - "azure-keyvault-secrets>=4.10.0"
+    rationale: "Version pins lived only in platform/templates/adaptation-map.yaml. Canonicalize here so all backends pin consistently."
+
+  - upstream: microsoft/unified-data-foundation
+    purpose: "Terraform IaC for Databricks + Fabric + mirroring (Microsoft-owned data-platform accelerator)"
+    adopt_mode: consume_directly
+    internal_owner: data-engineering
+    internal_destination: "infra/azure/ composition + data-intelligence/ integration reference"
+    do_when: now
+    priority: P0
+    time_sensitive: "Fabric trial expires ~2026-05-20 — adopt before then to lock in IaC shape"
+    rationale: "STRONG ADOPT per memory reference_databricks_fabric_repos.md. Deploys Databricks + Fabric + mirroring in one IaC unit; avoids splitting the data plane."
+
+  # ───── E.3. Partner Center runtime (added 2026-04-14) ─────
+
+  - upstream: Partner Center SaaS Fulfillment API v2
+    purpose: "Marketplace subscription activation + ChangePlan/ChangeQuantity/Suspend/Reinstate/Unsubscribe webhooks"
+    adopt_mode: consume_directly
+    internal_owner: platform
+    internal_destination: "platform/partner-center/fulfillment/"
+    do_when: now
+    rationale: "REST-first via azure-identity + httpx. Commercial control plane only; Odoo remains entitlement record of truth. Required for any SaaS offer launch."
+
+  - upstream: Partner Center Marketplace Metering API
+
+    purpose: "Idempotent usage event emission with 24h submission window"
+    adopt_mode: consume_directly
+    internal_owner: platform
+    internal_destination: "platform/partner-center/metering/"
+    do_when: now
+    rationale: "Event-sourced from Odoo ir.logging / platform telemetry. Reconcile to Microsoft invoice. Required for usage-based SaaS offers."
+
+  - upstream: Partner Center Referrals / Co-sell API
+    purpose: "Bridge marketplace leads to Odoo CRM"
+    adopt_mode: do_not_adopt
+    internal_owner: platform
+    internal_destination: "none (deferred)"
+    do_when: defer_until_listing_live
+    rationale: "Not actionable until SaaS offer is live on AppSource/Azure Marketplace. Revisit when commercial lane activates."
+
 # ─── Anti-patterns ───
 anti_patterns:
   - "Forking AVM/Bicep modules — creates downstream burden Microsoft now solves"
@@ -715,12 +829,29 @@ anti_patterns:
   - "Vendoring Azure-Samples/* repos under your repo (creates stale copies)"
   - "Forking azure-pipelines-agent — agent ops is reference-only"
 
-# ─── Decision audit ───
+# ─── Decision audit ─── (recounted 2026-04-14 after SSOT reconciliation)
 decisions_audit:
-  consumed_directly: 4   # AVM, Agent Framework, ADO MCP, Playwright
-  cloned_as_reference: 6 # FastAPI+ACA+PG, PG-Resiliency, pgvector, PG-MCP, pipelines-yaml, Foundry templates
+  consumed_directly: 15
+  # AVM, Agent Framework, ADO MCP, Playwright, Playwright MCP, azure-pipelines-task-lib,
+  # PSRule.Rules.Azure, PSRule-pipelines, googleworkspace/cli, googleworkspace/developer-tools,
+  # databricks/cli, databricks/terraform-provider-databricks, databricks/databricks-sdk-py,
+  # azure-pipelines-vscode, Odoo built-in integrations (google_account, microsoft_account, cloud_storage_azure, external_api)
+  # Plus 2026-04-14 additions: Azure MCP Server, azd, Azure Python SDK pins,
+  # unified-data-foundation, Partner Center SaaS Fulfillment v2, Partner Center Metering → effective 21
+  cloned_as_reference: 35
+  # Azure-Samples (FastAPI+ACA+PG, PG-Resiliency, pgvector, PG-MCP, search-openai-demo,
+  # chat-with-your-data, get-started-with-ai-agents, openai-chat-app-entra-auth, postgres-agentic-shop,
+  # ACA blue-green), microsoft-foundry (foundry-samples, foundry-agent-webapp, mcp-foundry, fine-tuning),
+  # RMA, pipelines-yaml, pipelines-tasks, pipelines-extensions, d365 refs (FastTrack, unified-ops-public,
+  # dynamics365-guidance, MB-310, ISM-Telemetry), Finance agents docs, financial-services-plugins,
+  # Awesome-Agentic-System-Design, OCA selected modules (10), googleworkspace (5 sample repos),
+  # Partner Center refs (sdk-for-dotNET, Labs, Storefront, PowerShell), databricks/bundle-examples,
+  # databricks/mlops-stacks, unitycatalog/unitycatalog, dev-proxy
   fork_and_own: 0        # NONE right now
-  do_not_adopt: 1        # azure-pipelines-agent (codebase, not pattern)
+  do_not_adopt: 10
+  # azure-pipelines-agent (codebase), GitHub Actions as delivery, Vercel, Supabase, Dataverse,
+  # azure-pipelines-terraform, Azure/ResourceModules (superseded by AVM), chrome-devtools-mcp,
+  # Apps Store appointment modules, Workspace Marketplace GitHub Integration, Partner Center Referrals (deferred)
 
 # ─── Anchors ───
 anchors:
@@ -733,3 +864,5 @@ anchors:
     - reference_release_manager_assistant_adoption.md
     - reference_microsoft_foundry_org_repos.md
     - reference_azd_ai_templates.md
+    - reference_databricks_fabric_repos.md
+    - feedback_upstream_adoption_doctrine.md


### PR DESCRIPTION
## Summary

Two commits on `deploy/r3-provisioning-burst`:

1. **Infra — R3 provisioning burst** (resources 24→48→56 on sponsored sub `eba824fb`)
   - T4 + T6 + T7 + VNet baseline (8 private DNS zones, VNet with subnets, 3 storage accounts, backup vault, PEs for Key Vault and AI Search)
   - T5 private endpoint expansion + backup vault + storage expansion
2. **Doctrine — SSOT upstream-adoption reconciliation** (`658ad8827`)
   - Canonical YAML (`ssot/governance/upstream-adoption-register.yaml`) is now truth
   - Narrative register + template map reconciled UP
   - GHA-as-delivery doctrine drift fixed in coverage matrix per CLAUDE.md 2026-04-14

## What changed

### Infrastructure (2 commits)
- Sponsored subscription `eba824fb` — see `docs/evidence/` for per-tier deployment output
- Bicep modules: `private-dns-zones-baseline.json`, `vnet-baseline.json`, `managed-identities-baseline.json`, `observability-baseline.json`, `purview.json`, `ai-search.json`
- Storage: 3 plane-scoped accounts
- Backup: Azure Backup Vault

### SSOT reconciliation (1 commit, 5 files, +215/-61)
- Split `microsoft-foundry/*` wildcard → 4 named entries (`foundry-samples`, `foundry-agent-webapp`, `mcp-foundry`, `fine-tuning`) + RMA separated
- Added 8 missing upstreams: Azure MCP Server (first-party), Azure Developer CLI (azd), microsoft/dev-proxy, Azure Python SDK pin manifest (7 packages), **microsoft/unified-data-foundation (P0, Fabric trial ~2026-05-20)**, Partner Center SaaS Fulfillment v2, Metering API, Referrals (deferred)
- Removed 8 phantom Copilot-sample rows from narrative register (not in canonical YAML; Copilot Studio is declarative-tier, Pulser is custom-engine)
- Fixed 4 GitHub-Actions-as-delivery references in `docs/architecture/microsoft-reference-coverage-matrix.md` per CLAUDE.md revision (Azure Pipelines = sole CI/CD authority). IPAI still adopts the GitHub Agentic Workflows *security pattern* (Safe Outputs, zero-secret agents, 3-tier defense) — but implemented on Azure Pipelines + ACA
- Flattened `platform/templates/adaptation-map.yaml` `repo_mapping` per `docs/architecture/upstream-landing-matrix.md`
- Recounted `decisions_audit` (consumed_directly 4→15+, cloned_as_reference 6→35, do_not_adopt 1→10)

## Verification
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on both patched YAMLs → PASS
- [x] `python3 -c "import json; json.load(open('.mcp.json'))"` → PASS
- [x] `git diff --stat` confirms 5 files touched, no runtime code changes

## Test plan
- [ ] Azure Pipelines CI green on `main` post-merge (spec-bundle-validate etc. run on Azure Pipelines)
- [ ] Verify R3 provisioning resources visible in sponsored sub `eba824fb` via `az group list`
- [ ] Confirm canonical YAML still loads after merge: `python3 -c "import yaml; yaml.safe_load(open('ssot/governance/upstream-adoption-register.yaml'))"`
- [ ] Optional: scan `docs/architecture/` for remaining "GitHub Actions" delivery references

## References
- Audit document delivered by deep-research agent (in-session)
- Doctrine: `CLAUDE.md` 2026-04-14 revision (Azure Pipelines sole authority)
- Landing matrix: `docs/architecture/upstream-landing-matrix.md`
- Memory: `feedback_upstream_adoption_doctrine.md`, `reference_databricks_fabric_repos.md`, `reference_microsoft_foundry_org_repos.md`