### PR TITLE
docs(data-model): consolidate data model — master index + CDM contract + D365 mappings

### DIFF
--- a/docs/architecture/data-model-index.md
+++ b/docs/architecture/data-model-index.md
@@ -1,0 +1,277 @@
+# IPAI Data Model — Master Index
+
+> **Locked:** 2026-04-16
+> **Authority:** this file is the single entry point for IPAI's data model across all 8 components.
+> **Companion to:** [`canonical-platform-architecture.md`](./canonical-platform-architecture.md) §1 (8-component architecture).
+>
+> **Rule:** if you're looking for "where is X modeled", start here. If the answer is "planned — no schema yet", see §5.
+
+---
+
+## 1. Component → data-model file map
+
+Maps the 8 canonical components to their data-model artifacts.
+
+| # | Component (per canonical arch) | Data-model file(s) |
+|---|---|---|
+| 1.1 | Odoo 18 CE + OCA | [`data-model-erd.md`](./data-model-erd.md) §1 (schema), [`ODOO_CANONICAL_SCHEMA.dbml`](../data-model/ODOO_CANONICAL_SCHEMA.dbml), [`odata-to-odoo-mapping.md`](./odata-to-odoo-mapping.md), [`d365-to-odoo-mapping.md`](../research/d365-to-odoo-mapping.md), [`d365-data-model-inventory.md`](../research/d365-data-model-inventory.md) |
+| 1.2 | PostgreSQL Flex (`pg-ipai-odoo`) | [`data-model-erd.md`](./data-model-erd.md) §0–2 (DBMS + 3 schemas: `public` / `ops` / `platform`) |
+| 1.3 | Azure AI Foundry (`ipai-copilot-resource`) | §3 inline below — Foundry is stateless; deployments + connections documented via `ssot/ai/` |
+| 1.4 | MAF Agent Platform (6 agents) | [`data-model-erd.md`](./data-model-erd.md) §2 `ops` schema (agent runs + events); §3 inline below for Cosmos session state |
+| 1.5 | Databricks (`dbw-ipai-dev`) | §4 inline below — UC `ppm` catalog tables; DLT pipeline definitions live at [`infra/databricks/`](../../infra/databricks/) |
+| 1.6 | Unity Catalog | §4 inline below — catalog/schema/table RBAC + tags |
+| 1.7 | Microsoft Fabric (`fcipaidev`) | §5 inline below — mirror source tables + Fabric Data Agent surface |
+| 1.8 | ADLS Gen2 (`stipaidevlake`) | [`cdm-and-analytics-bridge.md`](./cdm-and-analytics-bridge.md), [`cdm-odoo-mapping.md`](./cdm-odoo-mapping.md), [`cdm-entity-map.yaml`](../../platform/contracts/cdm-entity-map.yaml) |
+
+**Cross-plane:** [`data-model-erd.md`](./data-model-erd.md) §4 (data flow) + §6 inline below.
+
+---
+
+## 2. File catalog — 8 data-model artifacts, 3,515 lines
+
+| File | Lines | Format | Role |
+|---|---|---|---|
+| [`data-model-erd.md`](./data-model-erd.md) | 709 | Markdown | Canonical ERD — PG schemas, tables, multitenancy, access rules |
+| [`ODOO_CANONICAL_SCHEMA.dbml`](../data-model/ODOO_CANONICAL_SCHEMA.dbml) | 664 | DBML | Renderable Odoo schema (dbdiagram.io) |
+| [`odata-to-odoo-mapping.md`](./odata-to-odoo-mapping.md) | 510 | Markdown | D365 OData entity → Odoo ORM mapping |
+| [`cdm-entity-map.yaml`](../../platform/contracts/cdm-entity-map.yaml) | 438 | YAML (machine-readable) | CDM entity ↔ Odoo model contract; consumed by DLT pipelines |
+| [`d365-to-odoo-mapping.md`](../research/d365-to-odoo-mapping.md) | 382 | Markdown | D365 Finance + Project Ops → Odoo CE+OCA+`ipai_*` mapping |
+| [`d365-data-model-inventory.md`](../research/d365-data-model-inventory.md) | 284 | Markdown | D365 entity catalog for displacement tracking |
+| [`cdm-odoo-mapping.md`](./cdm-odoo-mapping.md) | 273 | Markdown | CDM ↔ Odoo narrative mapping (companion to YAML) |
+| [`cdm-and-analytics-bridge.md`](./cdm-and-analytics-bridge.md) | 255 | Markdown | PG → ADLS CDM bridge (Bronze/Silver/Gold) |
+
+---
+
+## 3. Component 1.3 + 1.4 — Foundry + MAF Agent Platform data shape
+
+### 3.1 Foundry `ipai-copilot-resource`
+
+Foundry itself is **stateless**. No IPAI-owned data persists inside Foundry. What is modeled:
+
+- **Model deployments** — declared in `ssot/ai/models.yaml` (reflects `az cognitiveservices account deployment list` state)
+- **Connections** — declared in `ssot/ai/connections.yaml`
+- **Agent definitions** — declared in `ssot/ai/agents.yaml`
+
+These are *infrastructure state*, not data-plane. They show up in `ssot/` not `docs/architecture/`.
+
+### 3.2 MAF Agent Platform — state split
+
+Per [`canonical-platform-architecture.md`](./canonical-platform-architecture.md) §5 decision #7:
+
+```
+Agent session state       = cosmos-ipai-dev (Cosmos DB)
+Agent audit trail         = pg-ipai-odoo.platform.ops.run_events
+Two stores, two purposes.
+```
+
+**Cosmos DB `cosmos-ipai-dev` container layout (proposed — not yet deployed):**
+
+| Container | Partition key | TTL | Contents |
+|---|---|---|---|
+| `sessions` | `/tenant_id` | 7 days sliding | Active user-agent sessions: conversation turns, scratchpad state, working memory |
+| `tool_calls` | `/session_id` | 7 days sliding | Tool-call traces tied to a session (input, output, latency) for mid-session replay |
+| `artifacts` | `/session_id` | 24 hours | Ephemeral artifacts generated mid-session (drafts, renderings) before persist-to-Odoo |
+
+**Rule:** Cosmos is the *ephemeral* plane. Nothing load-bearing to audit or truth lives there. Anything that must survive session expiry gets written to Odoo (truth) or `platform.ops.*` (audit) before session end.
+
+**PG `platform.ops.*` schema** (detailed in [`data-model-erd.md`](./data-model-erd.md) §2):
+
+```sql
+platform.ops.runs          -- one row per agent invocation (run_id, agent_id, tenant_id, started_at, ended_at, status)
+platform.ops.run_events    -- append-only event log per run (input, tool call, tool response, output, errors)
+platform.ops.tool_catalog  -- allowlist of tools per agent
+platform.ops.feature_flags -- per-tenant runtime toggles
+platform.ops.tenants       -- tenant registry (used by public schema company_id FK)
+```
+
+---
+
+## 4. Component 1.5 + 1.6 — Databricks + Unity Catalog
+
+### 4.1 UC catalog structure
+
+Per [`databricks-ipai-grounded.md`](../skills/databricks-ipai-grounded.md):
+
+```
+ppm                              ← catalog (one per env in target state: ppm-dev, ppm-stg, ppm-prod)
+├── bronze                       ← raw Odoo exports, minimally transformed
+├── silver                       ← cleaned, type-conformed, joined
+├── gold                         ← domain aggregates (the consumer layer)
+├── metrics                      ← (planned) pre-computed metric tables for dashboards
+└── features                     ← (planned) ML feature store
+```
+
+### 4.2 Gold-layer tables (planned — not yet populated)
+
+These are the tables that business users + Power BI + Fabric mirror will read. Names locked here so downstream consumers can reference before tables exist.
+
+| Table | Source (Bronze → Silver) | Grain | Consumers |
+|---|---|---|---|
+| `ppm.gold.finance_gl_trial_balance` | `account.move.line` | account × period × company | CFO dashboard, close agent |
+| `ppm.gold.finance_ap_aging` | `account.move` where `move_type='in_invoice'` | vendor × aging bucket × company | AP dashboard, payment planning |
+| `ppm.gold.finance_ar_aging` | `account.move` where `move_type='out_invoice'` | customer × aging bucket × company | AR collections agent |
+| `ppm.gold.finance_cash_position` | `account.move.line` on liquidity accounts | day × account × company | Treasury dashboard |
+| `ppm.gold.ops_project_burn` | `project.task` + `account.analytic.line` | project × week | PPM dashboard, project manager |
+| `ppm.gold.ops_agent_run_summary` | `platform.ops.runs` + `run_events` | day × agent × tenant × outcome | Ops dashboard, Pulser QA |
+| `ppm.gold.compliance_bir_filing_status` | `ipai.bir.*` models | filing × period × form-type | Tax Guru dashboard, compliance agent |
+
+### 4.3 Tag contract on UC objects
+
+Every `ppm.*.*` table MUST carry tags matching the mandatory tag set per [`ssot/azure/tagging-standard.yaml`](../../ssot/azure/tagging-standard.yaml): `owner`, `sensitivity`, `tenant_scope`, `freshness_sla`, `source_repo`. Tags enforced by Databricks Asset Bundle templates.
+
+---
+
+## 5. Component 1.7 — Fabric Mirror source tables
+
+Per [`fabric-mirroring-target-state.md`](./fabric-mirroring-target-state.md) §2: Fabric Database Mirroring from PG is **GA** for PG Flex.
+
+### 5.1 Mirror scope — Phase 1 tables
+
+Starting narrow — only operational truth, not derived data:
+
+| PG table | Why mirrored | Consumers |
+|---|---|---|
+| `public.account_move` | Invoice/journal header — operational truth of every financial transaction | Power BI Direct Lake, Fabric Data Agent |
+| `public.account_move_line` | Journal lines — enables GL analysis | Same |
+| `public.account_payment` | Payment events | Same |
+| `public.account_bank_statement_line` | Bank statement truth | Bank-recon agent, finance dashboards |
+| `public.res_partner` | Master data for customer/vendor | Joined analytics |
+| `public.res_company` | Multitenancy boundary | Tenant-aware dashboards |
+| `public.project_project` + `project.task` | PPM analytics | PPM dashboard |
+
+### 5.2 What is NOT mirrored (and why)
+
+- `ops.*` and `platform.*` schemas — these are agent-plane operational state; they land in Databricks via Lakehouse Federation, not Fabric mirror. Double-mirror is forbidden (per `canonical-platform-architecture.md` §3.4).
+- Odoo `ir.*` tables (Odoo internals) — no analytics value.
+- Audit log entries that already flow to `platform.ops.run_events` — agent events are Databricks-side, not Fabric-mirrored.
+
+### 5.3 Fabric Data Agent surface
+
+Per `canonical-platform-architecture.md` §1.7, Fabric exposes a **Fabric Data Agent** endpoint so M365 Copilot can query Odoo data via Fabric without touching PG. The data agent reads the Phase-1 mirror + UC `ppm.gold.*` via OneLake shortcuts.
+
+---
+
+## 6. Cross-plane data flow — entity-level
+
+The authoritative flow per `canonical-platform-architecture.md` §3, at entity granularity:
+
+### 6.1 Write path — user action to durable truth
+
+```
+User action on Odoo UI / MAF agent tool call via ipai-odoo-mcp
+      │
+      ▼
+Odoo ORM (public.account_move, public.res_partner, public.project_task, etc.)
+      │  (triggers + constraints + Odoo business rules)
+      ▼
+pg-ipai-odoo.public.<table>  ← SoR row persisted
+      │
+      │  (concurrent audit write)
+      ▼
+pg-ipai-odoo.platform.ops.runs / run_events  ← audit row written before session end
+      │
+      │  (Fabric Database Mirroring, ~15s cadence, Phase-1 tables only)
+      ▼
+Fabric OneLake Delta (mirrored source tables)
+```
+
+### 6.2 Analytics path — truth to consumable insight
+
+```
+pg-ipai-odoo.public.*  ──(Databricks Lakehouse Federation, zero-copy read)──▶ Databricks DLT
+                                                                                    │
+                                                                                    ▼
+                                                                    ADLS stipaidevlake/bronze/*
+                                                                                    │
+                                                                                    ▼
+                                                                    ADLS stipaidevlake/silver/*
+                                                                                    │
+                                                                                    ▼
+                                                                    ADLS stipaidevlake/gold/*
+                                                                                    │
+                                                                          (UC registration + RLS/CLS)
+                                                                                    │
+                                                                                    ▼
+                                                                        Unity Catalog ppm.gold.*
+                                                                                    │
+                                                               ┌────────────────────┴────────────────────┐
+                                                               ▼                                          ▼
+                                                  Fabric (OneLake shortcut)              Power BI (Direct Lake via UC)
+                                                               │
+                                                               ▼
+                                                  Fabric Data Agent (for M365 Copilot)
+```
+
+### 6.3 Agent path — user question to action
+
+```
+User question via Teams/Web/Copilot
+      │
+      ▼
+Pulser router agent (ACA)
+      │  consults ssot/ai/agents.yaml for routing policy
+      ▼
+Specialist agent (tax-guru / bank-recon / ap-invoice / doc-intel / finance-close) — on ACA
+      │  reads session state from cosmos-ipai-dev.sessions (if mid-conversation)
+      │
+      ├──▶ Foundry (ipai-copilot-resource) for inference  [gpt-4.1 today]
+      │
+      ├──▶ ipai-odoo-mcp (canonical Odoo tool path) for CRUD on public.* models
+      │         │
+      │         ▼
+      │      pg-ipai-odoo.public.*  (mutation goes through Odoo business rules)
+      │
+      └──▶ writes run_event row to pg-ipai-odoo.platform.ops.run_events
+```
+
+---
+
+## 7. Open gaps (as of 2026-04-16)
+
+Tracked here to prevent future "I thought this was documented":
+
+| Gap | Current status | Owner | Deadline |
+|---|---|---|---|
+| `cosmos-ipai-dev` not yet deployed | Documented in this doc §3.2 as proposed shape; schema-ready when deployed | platform | Deploy before first MAF agent hits production |
+| UC `ppm.gold.*` tables not yet populated | Schema names + grains locked in §4.2; DLT pipelines pending | data | Wave-2 Finance (R2 target 2026-07-14) |
+| Fabric mirror not yet wired | Source table list locked in §5.1; Fabric capacity trial expires ~2026-05-20 | data | F-SKU procurement gate 2026-05-01 |
+| `ssot/ai/agents.yaml` + `models.yaml` + `connections.yaml` not yet populated | Referenced in §3.1 but not yet written | platform | When 715-123420 deploy blocker clears |
+| Frontier model deployments (gpt-5.4, o3-pro, Sora 2, gpt-image-1.5) | Approved + quota granted; deploy fails with `715-123420` — MS-acknowledged bug per [microsoft/microsoft-foundry-for-vscode#515](https://github.com/microsoft/microsoft-foundry-for-vscode/issues/515) | ops | Support ticket pending |
+
+---
+
+## 8. Mutation rules (what changes where)
+
+Non-negotiable:
+
+1. **Odoo schema (`public.*`)** mutates ONLY via Odoo migrations (`addons/<module>/migrations/`) or the ORM at runtime. No ad-hoc DDL.
+2. **`ops.*` and `platform.*`** mutate via `agent-platform/migrations/` or `migrations/odoo/`. Append-only where possible.
+3. **UC `ppm.*.*`** tables mutate via Databricks Asset Bundle deploys from `infra/databricks/`. No portal clicks.
+4. **CDM entity map** (`platform/contracts/cdm-entity-map.yaml`) is PR-only; code changes consuming it (DLT pipelines) must not precede the YAML update.
+5. **Fabric Mirror + UC shortcut configs** committed as IaC under `infra/fabric/` when we adopt `microsoft/unified-data-foundation` — see #753.
+
+---
+
+## 9. References
+
+Internal (all linked above):
+- [`canonical-platform-architecture.md`](./canonical-platform-architecture.md) — 8-component architecture
+- [`data-model-erd.md`](./data-model-erd.md) — canonical ERD
+- [`fabric-mirroring-target-state.md`](./fabric-mirroring-target-state.md)
+- [`databricks-one-and-workspace-operating-model.md`](./databricks-one-and-workspace-operating-model.md)
+- [`cdm-and-analytics-bridge.md`](./cdm-and-analytics-bridge.md)
+- [`cdm-odoo-mapping.md`](./cdm-odoo-mapping.md)
+- [`cdm-entity-map.yaml`](../../platform/contracts/cdm-entity-map.yaml)
+- [`odata-to-odoo-mapping.md`](./odata-to-odoo-mapping.md)
+- [`d365-to-odoo-mapping.md`](../research/d365-to-odoo-mapping.md)
+- [`d365-data-model-inventory.md`](../research/d365-data-model-inventory.md)
+- [`ODOO_CANONICAL_SCHEMA.dbml`](../data-model/ODOO_CANONICAL_SCHEMA.dbml)
+
+External (Microsoft Learn):
+- [Common Data Model folder format](https://learn.microsoft.com/common-data-model/data-lake)
+- [Unity Catalog](https://learn.microsoft.com/azure/databricks/data-governance/unity-catalog/)
+- [Fabric Database Mirroring from Azure Postgres Flex](https://learn.microsoft.com/fabric/mirroring/azure-database-postgresql)
+
+---
+
+*Last updated: 2026-04-16*

--- a/docs/research/d365-data-model-inventory.md
+++ b/docs/research/d365-data-model-inventory.md
@@ -1,0 +1,284 @@
+# D365 Finance + Project Operations + Finance Agents — Data Model Inventory
+
+> Complete entity catalog for competitive/parity analysis against IPAI (Odoo CE 18 + OCA + `ipai_*`).
+> Sources: Microsoft Learn documentation for D365 Finance, D365 Project Operations (Core + Integrated with ERP), and Microsoft Copilot Finance agents.
+> Compiled 2026-04-15.
+
+**Purpose:** map what TBWA\SMP Finance (or any D365 customer) actually gets for
+$210 (Finance) + $135 (Project Operations) per user/month, and where IPAI's
+Odoo+OCA+`ipai_*` layer needs to reach for true parity.
+
+---
+
+## 1. D365 Finance — core data model
+
+### 1.1 General Ledger (GL)
+
+| Entity | Purpose | Odoo equivalent |
+|---|---|---|
+| `MainAccount` | Chart of accounts | `account.account` |
+| `LedgerChartOfAccounts` | CoA container | — (implicit) |
+| `Ledger` | Ledger per legal entity | `res.company` |
+| `LedgerJournalTable` | Journal header | `account.move` |
+| `LedgerJournalTrans` | Journal line | `account.move.line` |
+| `GeneralJournalEntry` | Posted GJE header | `account.move` (posted state) |
+| `GeneralJournalAccountEntry` | GJE account line | `account.move.line` |
+| `FinancialDimension` | Dim catalog (cost center, project, department) | `account.analytic.account`, tag system |
+| `DimensionAttributeValueCombination` | Dim combination | `account.analytic.distribution` |
+| `FiscalCalendar` / `FiscalYear` / `FiscalPeriod` | Calendar structure | `account.fiscal.year`, period is implicit |
+| `Currency` / `CurrencyExchangeRate` / `ExchangeRateType` | FX | `res.currency`, `res.currency.rate` |
+| `LegalEntity` / `CompanyInfo` | Tenant company | `res.company` |
+
+### 1.2 Accounts Payable (AP)
+
+| Entity | Purpose | Odoo equivalent |
+|---|---|---|
+| `VendGroup` / `VendTable` | Vendor master | `res.partner` with `supplier_rank > 0` |
+| `VendorInvoice` / `VendInvoiceJour` / `VendInvoiceTrans` | AP invoice header/line | `account.move` (type=in_invoice) |
+| `VendInvoiceInfoTable` | Pending (pre-posting) invoice | `account.move` (state=draft) |
+| `PurchTable` / `PurchLine` | PO header/line | `purchase.order` / `purchase.order.line` |
+| `VendorPaymentJournal` / `VendPayment` | Payment run | `account.payment` |
+| `MatchingReason` / `InvoiceMatching` / `VendMatching` | 2/3-way matching | OCA `account_invoice_three_way_match` |
+| `VendorSettlement` | Invoice↔payment settlement | `account.partial.reconcile` |
+| `VendInvoiceCapture` | Invoice capture (OCR) | `ipai_*` with Document Intelligence or OCA `account_invoice_import*` |
+| `BankRemittance` / `PaymentProposal` | Payment proposal | `account.payment.register` |
+
+### 1.3 Accounts Receivable (AR)
+
+| Entity | Purpose | Odoo equivalent |
+|---|---|---|
+| `CustGroup` / `CustTable` | Customer master | `res.partner` with `customer_rank > 0` |
+| `SalesTable` / `SalesLine` | Sales order header/line | `sale.order` / `sale.order.line` |
+| `CustInvoiceJour` / `CustInvoiceTrans` | Customer invoice | `account.move` (type=out_invoice) |
+| `CustPaymentJournal` / `CustPayment` | Customer payment | `account.payment` |
+| `CustCollectionLetter` / `CollectionLetterAgingPeriod` | Dunning letter | OCA `account_followup_*`, `account_credit_control` |
+| `CustInterestJournal` / `Interest` | Interest on overdue | OCA `account_invoice_interest` |
+| `CreditLimit` / `CustCreditLimit` | Credit limit | `res.partner.credit_limit`, OCA `account_credit_limit_advanced` |
+| `SubscriptionBilling` / `BillingSchedule` / `RecurringBillingLine` | Subscription billing | OCA `subscription_*` / `contract` |
+| `CreditTransactionLimit` | Credit mgmt rules | OCA `account_credit_control_*` |
+
+### 1.4 Cash & Bank Management
+
+| Entity | Purpose | Odoo equivalent |
+|---|---|---|
+| `BankAccountTable` | Bank account master | `res.partner.bank` + `account.journal` (type=bank) |
+| `BankStatementTable` / `BankStatementDocument` | Bank statement | `account.bank.statement` |
+| `BankStatementLine` | Statement line | `account.bank.statement.line` |
+| `BankReconciliation` / `AdvancedBankReconciliation` | Reconciliation | `account.reconciliation`, OCA `account_reconciliation_widget` |
+| `MatchBankDocumentLine` | Matched pair | `account.partial.reconcile` |
+| `CashFlowForecast` / `CashFlowForecastCalc` | Cash flow forecast | OCA `account_cash_flow_forecast` |
+| `BankParameters` / `BankNegativePaymAmount` | Bank controls | `account.journal` config |
+
+### 1.5 Fixed Assets
+
+| Entity | Purpose | Odoo equivalent |
+|---|---|---|
+| `AssetTable` | Asset master | `account.asset` |
+| `AssetBook` | Depreciation book per asset | `account.asset` (multiple valuation books via `account_asset_multibook` OCA) |
+| `AssetGroup` | Asset group | `account.asset.group` |
+| `AssetTrans` | Asset transactions | `account.move.line` linked to asset |
+| `AssetDepreciationJournal` | Depreciation run | `account.asset.depreciation.line` |
+| `AssetDepreciationProfile` / `AssetDepreciationMethod` | Dep method | `account.asset.profile` |
+| `AssetAcquisition` / `AssetDisposal` | Acquisition / disposal events | `account.asset` state transitions |
+| `AssetRevaluation` | Revaluation | OCA `account_asset_management_revaluation` |
+
+### 1.6 Asset Leasing
+
+| Entity | Purpose | Odoo equivalent |
+|---|---|---|
+| `Lease` | Lease master | OCA `account_asset_leasing` or `ipai_lease_*` |
+| `LeaseBook` | Lease valuation book | part of OCA |
+| `LeasePayment` / `LeaseSchedule` | Payment schedule | OCA |
+| `LeaseTransaction` | Lease posting | `account.move.line` |
+| `LeaseModification` | Amendment | OCA |
+| `RightOfUseAsset` / `LeaseLiability` | ROU asset + liability (IFRS 16) | OCA `account_asset_leasing_*` |
+
+### 1.7 Budgeting
+
+| Entity | Purpose | Odoo equivalent |
+|---|---|---|
+| `BudgetPlan` / `BudgetPlanScenario` | Budget plan + scenarios | `account.budget.post` / `crossovered.budget` |
+| `BudgetControl` / `BudgetControlConfiguration` | Budget control policy | OCA `account_budget_activity` |
+| `BudgetSource` / `BudgetSourceTracking` | Budget funding source | OCA |
+| `BudgetTransaction` | Budget commitment/reservation | OCA `budget_manager` |
+| `PositionBudget` / `PositionForecasting` | HR position budget | OCA `hr_budget` |
+
+### 1.8 Cost Accounting
+
+| Entity | Purpose | Odoo equivalent |
+|---|---|---|
+| `CostElement` / `CostElementDimension` | Cost element taxonomy | `account.analytic.account` + tags |
+| `CostCenter` / `CostObject` | Cost center + object | `account.analytic.account` |
+| `CostAllocationRule` / `OverheadCalculation` | Allocation rules | OCA `account_analytic_distribution_rule` |
+| `CostEntry` / `CostTrans` | Cost posting | `account.analytic.line` |
+| `CostingSheet` / `CostingVersion` | Costing sheet | `product.cost.structure` (OCA) |
+
+### 1.9 Tax
+
+| Entity | Purpose | Odoo equivalent |
+|---|---|---|
+| `TaxGroup` / `TaxItemGroup` | Tax group + item | `account.tax.group` |
+| `TaxTable` | Tax master | `account.tax` |
+| `TaxTrans` | Tax transaction | `account.move.line.tax_line_id` |
+| `TaxAuthority` / `TaxJurisdiction` | Authority + jurisdiction | `res.partner` (tax authority) |
+| `SalesTaxReport` / `ElectronicTaxReport` / `VATReport` | Tax reporting | `account.tax.report`, Odoo localization modules |
+| `TaxRegistration` / `TaxCertificate` | Tax reg & cert | Odoo l10n_* modules |
+| `ElectronicInvoiceConfiguration` / `EDocument` | E-invoicing | OCA `account_e_invoice_*`, `ipai_*` for PH BIR |
+
+### 1.10 Financial Reporting & Insights
+
+| Entity | Purpose | Odoo equivalent |
+|---|---|---|
+| `FinancialReport` / `FinancialReportRowDefinition` | Financial report definition | `account.financial.html.report` (OCA) |
+| `TrialBalance` / `TrialBalanceAccountBalance` | TB | OCA `account_financial_report` |
+| `PowerBIEmbeddedReport` | Embedded PBI | IPAI Power BI integration |
+| `PaymentPrediction` / `PaymentDelayPrediction` | ML customer payment prediction | IPAI `ipai_finance_insights_*` (needs build) |
+| `CustomerPaymentPrediction` | AR risk score | same |
+| `BudgetProposalPrediction` | Budget variance ML | same |
+
+### 1.11 Public Sector (optional module)
+
+| Entity | Purpose | Odoo equivalent |
+|---|---|---|
+| `FundClass` / `FundType` / `Fund` | Fund accounting | OCA `account_fund_accounting` |
+| `DerivedFinancialHierarchy` | Fund hierarchy | OCA |
+| `BudgetRegisterEntry` | Public sector budget | OCA |
+| `AppropriationAccount` | Appropriation tracking | OCA |
+
+---
+
+## 2. D365 Project Operations — core data model
+
+### 2.1 Project Operations Core (Dataverse / CDS entities, `msdyn_*` prefix)
+
+| Entity | Purpose | Odoo equivalent |
+|---|---|---|
+| `Lead` / `Opportunity` | CRM lead + oppty | `crm.lead` |
+| `Quote` / `QuoteDetail` | Quote header + line | `sale.order` (state=draft/quote) |
+| `SalesOrder` / `SalesOrderDetail` | Order header + line | `sale.order` |
+| `Invoice` / `InvoiceDetail` | Project invoice | `account.move` + link to `project.project` |
+| `PriceList` / `PriceListItem` | Price list | `product.pricelist` / `product.pricelist.item` |
+| `msdyn_project` | Project | `project.project` |
+| `msdyn_projecttask` | Task / WBS node | `project.task` + OCA `project_wbs` |
+| `msdyn_projectteammember` | Team member | `project.project.allowed_user_ids` |
+| `msdyn_projectstage` / `msdyn_milestone` | Stage + milestone | `project.stage` |
+| `msdyn_bookableresource` | Bookable resource | `hr.employee` + `resource.resource` |
+| `msdyn_resourcerequirement` | Resource requirement | OCA `project_resource_requirement` |
+| `msdyn_resourceassignment` | Resource assignment | `project.task.user_ids` + workload |
+| `msdyn_resourcebookingrequest` | Booking request | — (not core in Odoo) |
+| `msdyn_timeentry` | Time entry | `account.analytic.line` (timesheet) |
+| `msdyn_expense` / `msdyn_expensecategory` | Expense record | `hr.expense` / `hr.expense.category` |
+| `msdyn_projectapproval` | Approval record | OCA `project_approval` + `ipai_*` for PH |
+| `msdyn_actualpendingjournaltransaction` | Pending actuals | — (Odoo posts immediately) |
+| `msdyn_actual` | Posted actual | `account.analytic.line` |
+| `msdyn_estimatelineitem` | Estimate line | OCA `project_timeline` |
+
+### 2.2 Project Operations Integrated with ERP (F&O entities, `Proj*` prefix)
+
+| Entity | Purpose | Odoo equivalent |
+|---|---|---|
+| `ProjTable` | Project master | `project.project` |
+| `ProjPlan` / `ProjWBS` / `ProjActivity` | Plan + WBS + activity | `project.task` hierarchy |
+| `ProjTransBudget` | Project budget transaction | OCA `project_budget` |
+| `ProjTransPosting` | Project posting | `account.analytic.line` |
+| `ProjJournalTable` / `ProjJournalTrans` | Project journal | `account.move` + analytic |
+| `ProjEmplTrans` | Time transaction | `account.analytic.line` (type=timesheet) |
+| `ProjCostTrans` | Cost transaction | `account.analytic.line` |
+| `ProjRevenueTrans` | Revenue transaction | `account.analytic.line` + `account.move.line` |
+| `ProjInvoiceJour` / `ProjInvoiceTable` / `ProjInvoiceLine` | Project invoice | `account.move` linked to project |
+| `ProjInvoiceProposal` / `ProjInvoiceProposalLine` | Invoice proposal | OCA `project_invoicing` |
+| `ProjFundingSource` / `ProjContract` | Funding + contract | OCA `project_contract` |
+| `ProjSubContract` | Subcontract | OCA `project_subcontract` |
+| `ProjWorkerAllocation` | Worker allocation | `hr.employee` + `resource.resource` |
+| `ProjRevenueRecognition` / `ProjPercentComplete` | POC / rev rec | OCA `project_pm_revenue_recognition` |
+| `ProjExpenseTrans` | Expense txn | `hr.expense` |
+| `ProjForecast*` (multiple) | Forecast records (cost, hours, revenue) | OCA `project_forecast` |
+
+---
+
+## 3. Microsoft Copilot Finance agents — data access model
+
+### 3.1 Financial Reconciliation agent
+
+| Entity / Data surface | Purpose | Source |
+|---|---|---|
+| `FinancialReconciliation_RunInstance` | Run instance per reconciliation job | D365 F&O |
+| `ReconciliationLineItem` / `ReconciliationMatch` | Line + match record | D365 F&O (bank recon, GL recon) |
+| `ReconciliationRule` | Rule for auto-matching | D365 config |
+| `ReconciliationException` | Unmatched item | D365 F&O |
+| Excel range bindings | Excel-hosted data (operator works in Excel) | M365 Graph API |
+| Prompt/response telemetry | Conversation history | Copilot runtime |
+
+Data handling per Microsoft: agent reads from F&O ledger + GL + subledgers + bank statements; writes go through F&O data-entity endpoints with the operator's credentials; results surface inline in Excel or Outlook.
+
+### 3.2 Collections in Outlook agent
+
+| Entity / Data surface | Purpose |
+|---|---|
+| `CollectionsSuggestion` | Agent-generated follow-up suggestion |
+| `CollectionEmailDraft` | Drafted customer email |
+| `CustInvoiceAgingBucket` | Aging bucket reads from AR |
+| `CustContact` | Customer contact lookup |
+| `ContactConversationHistory` | Prior correspondence |
+| `FollowUpTask` | Outlook task created by agent |
+
+Agent surface: Outlook email + Teams chat (shown earlier in your screenshots). Reads: AR aging, customer contacts, prior emails. Writes: drafts emails, creates follow-up tasks, logs activities back to CRM/F&O.
+
+### 3.3 Data handling summary (from MS Learn "Data handling in Finance agents")
+
+- Agents read via the Common Data Service (Dataverse) + F&O data-entity endpoints.
+- Operator auth flows via Entra ID; least-privilege role assignments apply.
+- Agent prompts and responses are logged for audit.
+- Data never leaves the customer's Microsoft tenancy boundary (per Microsoft's data-residency commitment).
+- Fine-tuning on customer data is not performed (per current Copilot doctrine).
+
+---
+
+## 4. IPAI parity gap — what needs a thin `ipai_*` layer
+
+Running this catalog against what Odoo CE 18 + OCA already provides:
+
+### Areas where Odoo+OCA already covers ≥80% of D365 functionality
+- GL, AP, AR (core)
+- Bank reconciliation (via OCA `account_reconciliation_widget`)
+- Fixed Assets (OCA `account_asset_management*`)
+- Project management, WBS, time entry, expense (core + OCA `project_*`)
+- Cost accounting via analytic accounting
+- CRM (lead → opportunity → quote → order)
+
+### Areas where OCA is partial and `ipai_*` delta needed
+- **PH-specific BIR compliance** (2307, 2550M, SAWT, QAP, SLSP, 1601-C, 1601-E) — `ipai_bir_tax_compliance`
+- **Philippine expense liquidation + OR/CWT** — `ipai_expense_liquidation` (already in repo per prior memory)
+- **Finance insights ML predictions** (customer payment, budget variance) — `ipai_finance_insights_*` (build)
+- **Subscription billing with PH tax complexity** — OCA `subscription` + `ipai_*` for 2307/CWT overlays
+- **E-invoicing for BIR-compliant electronic OR** — `ipai_einvoice_ph`
+- **Rev rec for services/project billing (ASC 606 / PFRS 15)** — OCA `project_pm_revenue_recognition` + `ipai_*` for PH GAAP
+
+### Areas where D365 leads but IPAI should NOT chase
+- **Asset Leasing full IFRS 16 ROU/liability posting workflows** — unless a customer needs it, skip
+- **Public sector fund accounting** — not IPAI's market
+- **Electronic Invoicing (generic engine)** — OCA covers EU/LATAM; IPAI only needs PH overlay
+- **Regulatory configuration service (RCS)** — D365 enterprise-only; not worth cloning
+
+### The pitch structure
+
+For a TBWA\SMP Finance-sized customer (11 users), D365 Finance ($210) + Project Operations ($135) = **$45,540/year** for feature coverage that Odoo CE + ~15 OCA modules + 3-4 `ipai_*` modules delivers at **zero license cost**, with **PH-native BIR compliance** that D365 doesn't ship.
+
+---
+
+## 5. Pulser agent binding implications
+
+Given the data model, here is which Pulser agent should own which D365-equivalent capability:
+
+| D365 capability | Pulser agent | Primary data source (IPAI) |
+|---|---|---|
+| Financial Reconciliation agent | `pulser-finance` | `account.bank.statement`, `account.move.line` via PG MCP |
+| Collections in Outlook | `pulser-finance` | `account.move` (overdue AR), `res.partner` via PG MCP |
+| BIR filing (no D365 equivalent) | `pulser-finance` | `ipai_bir_tax_compliance` + PG MCP + Code Interpreter + Browser Automation |
+| Project cost roll-up | `pulser-finance` | `account.analytic.line`, `project.project` via PG MCP |
+| Resource booking suggestions | `pulser-ops` or a future `pulser-projects` | `hr.employee`, `resource.resource` |
+| Payment prediction | `pulser-finance` | AR aging + ML (build via Azure ML or in-Foundry) |
+
+---
+
+*Compiled 2026-04-15. Living document — append as Microsoft releases new modules or as IPAI maps additional entities.*

--- a/docs/research/d365-to-odoo-mapping.md
+++ b/docs/research/d365-to-odoo-mapping.md
@@ -1,0 +1,382 @@
+# D365 → Odoo 18 CE + OCA + `ipai_*` — Full Data Model & Business Logic Mapping
+
+> Canonical mapping for every D365 Finance, Project Operations, and Finance Agents
+> entity + business process to its Odoo 18 CE implementation.
+> Doctrine per `CLAUDE.md`: CE → OCA → thin `ipai_*` delta. Never fork core.
+> Companion: `docs/research/d365-data-model-inventory.md` (entity catalog only).
+> Compiled 2026-04-15.
+
+---
+
+## 0. Stack doctrine
+
+Every mapping follows the 3-layer order:
+
+| Layer | Scope | Examples |
+|---|---|---|
+| 1. Odoo CE 18 | Built-in models + workflows | `account.move`, `project.project`, `hr.expense` |
+| 2. OCA | Vetted community extensions | `account_asset_management`, `account_budget_oca`, `project_wbs` |
+| 3. `ipai_*` | PH-specific / bridge / overlay only | `ipai_bir_tax_compliance`, `ipai_expense_liquidation` |
+
+**Rule:** if a mapping requires only Layer 1+2, never build Layer 3.
+
+---
+
+## 1. D365 Finance → Odoo mapping
+
+### 1.1 General Ledger
+
+| D365 entity | D365 process | Odoo CE model | OCA ext | `ipai_*` | Business logic alignment |
+|---|---|---|---|---|---|
+| `MainAccount` | Define CoA | `account.account` | `account_financial_report` (report structure) | — | CE supports hierarchical CoA; `internal_group` + `internal_type` cover D365's `MainAccountType` |
+| `Ledger` | Ledger per LE | `res.company` + `account.journal` | `account_consolidation` (multi-entity) | — | One Odoo company = one Ledger; multi-company enabled by `multi_company_ids` |
+| `LedgerJournalTable` | Journal header | `account.move` | — | — | CE's `account.move` is the universal journal header (covers GL, AP, AR, bank) |
+| `LedgerJournalTrans` | Journal line | `account.move.line` | — | — | CE supports debit/credit + dimensions via `analytic_distribution` |
+| `FinancialDimension` | Cost center, project, dept dims | `account.analytic.account` + `account.analytic.plan` | `account_analytic_distribution_rule` | — | CE 18 supports multiple analytic plans (matches D365's multi-dim) |
+| `DimensionAttributeValueCombination` | Dim combination | `account.analytic.distribution` (JSON) | — | — | CE 18 stores distributions as JSON on move lines |
+| `FiscalCalendar` / `FiscalYear` / `FiscalPeriod` | Calendar structure | `account.fiscal.year` + period derived | — | — | CE uses continuous fiscal year with period locks via `fiscalyear_lock_date` / `tax_lock_date` |
+| `Currency` | Multi-currency | `res.currency` | — | — | CE has full multi-currency |
+| `CurrencyExchangeRate` | FX rates | `res.currency.rate` | `currency_rate_update` (auto-fetch) | — | OCA `currency_rate_update` auto-pulls from BSP, ECB, etc. |
+
+**Business process — Period close:**
+- D365: period-end close wizard, consolidation, FX revaluation, year-end carry-forward
+- Odoo: `fiscalyear_lock_date` + `tax_lock_date` + `account_closing` (OCA) covers equivalent workflow
+- `ipai_*` delta: none — CE+OCA sufficient
+
+### 1.2 Accounts Payable
+
+| D365 entity | D365 process | Odoo CE model | OCA ext | `ipai_*` | Alignment |
+|---|---|---|---|---|---|
+| `VendTable` | Vendor master | `res.partner` (supplier_rank>0) | `partner_firstname`, `partner_contact_*` | — | CE unifies customer+vendor partner; flag via `supplier_rank` |
+| `PurchTable` / `PurchLine` | PO header/line | `purchase.order` / `purchase.order.line` | `purchase_*` series | — | Full purchase module in CE |
+| `VendorInvoice` / `VendInvoiceTrans` | AP invoice | `account.move` (move_type=in_invoice) | — | — | — |
+| `VendInvoiceInfoTable` | Pending invoice | `account.move` (state=draft) | `account_invoice_pending_to_post` | — | Draft = pending; post = approved |
+| `MatchingReason` / `InvoiceMatching` | 2/3-way match | — | `account_invoice_three_way_match` | — | OCA adds receipt+invoice+PO matching |
+| `VendorPaymentJournal` | Payment run | `account.payment` + `account.batch.payment` | `account_banking_sepa_credit_transfer`, `account_payment_partner` | — | SEPA/ACH/local via OCA |
+| `VendorSettlement` | Invoice↔payment | `account.partial.reconcile` | — | — | Auto-reconciliation on payment register |
+| `VendInvoiceCapture` | OCR invoice capture | — | `account_invoice_import_ocr` | `ipai_apiscan` (Document Intelligence bridge) | OCA has Tesseract-based; `ipai_*` wires Azure Document Intelligence |
+| `BankRemittance` | Payment remittance | `account.payment` with journal | `account_banking_mandate`, `account_banking_sepa_direct_debit` | — | — |
+
+**Business process — Invoice approval + payment:**
+1. Vendor submits invoice → `account.move` (draft, in_invoice)
+2. 3-way match: PO + receipt + invoice via OCA `account_invoice_three_way_match`
+3. Tiered approval via OCA `base_tier_validation`
+4. Post → state=posted
+5. Batch payment proposal via OCA `account_payment_order`
+6. Payment run → `account.payment` + bank file generated
+7. Reconciliation auto-matches on bank statement import
+
+### 1.3 Accounts Receivable
+
+| D365 entity | D365 process | Odoo CE model | OCA ext | `ipai_*` | Alignment |
+|---|---|---|---|---|---|
+| `CustTable` | Customer master | `res.partner` (customer_rank>0) | — | — | — |
+| `SalesTable` / `SalesLine` | Sales order | `sale.order` / `sale.order.line` | `sale_order_*` series | — | Full sale module in CE |
+| `CustInvoiceJour` / `CustInvoiceTrans` | Customer invoice | `account.move` (move_type=out_invoice) | — | — | — |
+| `CustPayment` | Customer payment | `account.payment` | `account_payment_partner` | — | — |
+| `CustCollectionLetter` | Dunning letter | — | `account_credit_control` (primary), `account_followup_*` | `ipai_collections_ph` (optional) | OCA provides policy engine; `ipai_*` only if PH-specific tone/language |
+| `CustInterestJournal` | Overdue interest | — | `account_invoice_interest` | — | OCA |
+| `CreditLimit` / `CustCreditLimit` | Credit limit | `res.partner.credit_limit` | `account_credit_control_advanced`, `sale_order_credit_limit` | — | CE 18 has basic; OCA extends with hold-release |
+| `SubscriptionBilling` | Subscription billing | — (Enterprise-only `sale_subscription`) | `contract` (OCA — full replacement) | `ipai_subscription_ph_tax` | Use OCA `contract` — avoids EE |
+| `CreditTransactionLimit` | Block order on limit | — | `sale_order_credit_limit_oca` | — | Block-at-quote pattern |
+
+**Business process — Order-to-cash:**
+1. Lead → Opportunity (`crm.lead`) → Quote (`sale.order` state=draft)
+2. Credit check via OCA `sale_order_credit_limit_oca` blocks over-limit orders
+3. Order confirmed → `sale.order` state=sale
+4. Delivery/service → `stock.picking` OR timesheet hours (project-based billing)
+5. Invoice → `account.move` (out_invoice)
+6. Dunning cycle via OCA `account_credit_control` runs on aging buckets
+7. Payment received → `account.payment` + auto-reconciliation
+8. For PH: `ipai_bir_tax_compliance` auto-generates BIR 2307 when customer withholds tax
+
+### 1.4 Cash & Bank Management
+
+| D365 entity | D365 process | Odoo CE model | OCA ext | `ipai_*` | Alignment |
+|---|---|---|---|---|---|
+| `BankAccountTable` | Bank account | `account.journal` (type=bank) + `res.partner.bank` | — | — | — |
+| `BankStatementTable` / `BankStatementLine` | Statement header/line | `account.bank.statement` / `account.bank.statement.line` | `account_bank_statement_import_*` (CAMT53, OFX, MT940) | `ipai_bank_sync_ph` (BPI/BDO/Metrobank/Unionbank connectors) | CE has import framework; PH banks need custom parsers |
+| `BankReconciliation` | Auto-reconciliation | `account.reconciliation` widget | `account_reconciliation_widget_*` | — | CE 18 has modern reconciliation widget |
+| `CashFlowForecast` | Cash flow forecast | — | `account_cash_flow_forecast`, `account_cash_flow_report` | — | — |
+| `MatchBankDocumentLine` | Matched pair | `account.partial.reconcile` | — | — | — |
+
+**Business process — Bank reconciliation:**
+1. Statement imported (manual upload or OCA auto-fetch)
+2. Auto-match via `ir.model.reconcile.model` rules
+3. Manual review on unmatched
+4. Post → updates GL via journal entry
+5. Cash flow forecast computed from open invoices + payment patterns
+
+### 1.5 Fixed Assets
+
+| D365 entity | D365 process | Odoo CE model | OCA ext | `ipai_*` | Alignment |
+|---|---|---|---|---|---|
+| `AssetTable` | Asset master | — (EE-only in CE) | `account_asset_management` (full replacement) | — | Use OCA; never EE |
+| `AssetBook` | Multi-valuation book | — | `account_asset_management_multibook` | — | — |
+| `AssetGroup` | Asset category | — | `account.asset.profile` | — | OCA's `profile` = D365's `AssetGroup` |
+| `AssetDepreciationJournal` | Depreciation run | — | `account_asset_management` (`account.asset.depreciation.line.run`) | — | Monthly cron + manual run |
+| `AssetDepreciationMethod` | Dep method | — | OCA (SL, DB, units-of-prod, custom) | — | All major methods supported |
+| `AssetRevaluation` | Revaluation | — | `account_asset_management_revaluation` | — | — |
+| `AssetDisposal` | Disposal | — | `account_asset_management` (removal flow) | — | — |
+
+**Business process — Asset lifecycle:**
+1. Acquisition via AP invoice → auto-create asset via OCA link (`account_asset_create_from_invoice`)
+2. Monthly depreciation via cron → posts journal entries
+3. Revaluation event → `account_asset_management_revaluation`
+4. Disposal → calculate gain/loss, post, remove from register
+5. `ipai_*` delta: none — OCA covers IFRS + PFRS
+
+### 1.6 Asset Leasing (IFRS 16)
+
+| D365 entity | Odoo CE model | OCA ext | `ipai_*` | Alignment |
+|---|---|---|---|---|
+| `Lease` | — | `account_asset_leasing` (OCA lease-wg) | `ipai_lease_ph` (if PH PFRS 16 specifics needed) | OCA covers ROU + liability |
+| `LeaseBook` | — | `account_asset_leasing` | — | — |
+| `LeasePayment` / `LeaseSchedule` | — | `account_asset_leasing` payment schedule | — | — |
+| `LeaseModification` | — | `account_asset_leasing_modification` | — | — |
+
+**Business process — IFRS 16 lease:**
+1. Lease created → OCA generates ROU asset + lease liability on commencement
+2. Monthly: interest expense on liability + depreciation on ROU
+3. Modification: reassessment of liability + adjustment to ROU
+4. Termination: derecognition with gain/loss
+
+### 1.7 Budgeting
+
+| D365 entity | Odoo CE model | OCA ext | `ipai_*` | Alignment |
+|---|---|---|---|---|
+| `BudgetPlan` | `crossovered.budget` (CE has basic) | `account_budget_oca` (preferred full feature) | — | OCA is superior; use it |
+| `BudgetPlanScenario` | — | `account_budget_oca` scenarios | — | — |
+| `BudgetControl` | — | `account_budget_activity`, `budget_control` | — | Commitment + reservation |
+| `BudgetTransaction` | — | `budget_manager` | — | — |
+| `PositionBudget` | — | `hr_employee_firstname` + `hr_budget` | — | HR position cost planning |
+
+**Business process — Budget cycle:**
+1. Create budget plan per period + analytic plan
+2. Allocate amounts per account + analytic
+3. Post commitments on PO / expense approval (reservation pattern)
+4. Actual vs budget report via OCA `account_financial_report`
+5. Variance analysis + reforecast
+
+### 1.8 Cost Accounting
+
+| D365 entity | Odoo CE model | OCA ext | `ipai_*` | Alignment |
+|---|---|---|---|---|
+| `CostElement` | `account.analytic.account` | — | — | Analytic account IS the cost element |
+| `CostCenter` / `CostObject` | `account.analytic.account` (grouping) | `account_analytic_distribution_rule` | — | — |
+| `CostAllocationRule` | — | `account_analytic_distribution_rule` | — | Rule-based distribution |
+| `OverheadCalculation` | — | `account_analytic_*_overhead` | — | — |
+| `CostingSheet` | `product.cost.structure` | OCA `product_cost_structure` | — | Product cost hierarchy |
+
+### 1.9 Tax (PH-critical section)
+
+| D365 entity | Odoo CE model | OCA ext | `ipai_*` | Alignment |
+|---|---|---|---|---|
+| `TaxGroup` | `account.tax.group` | — | — | — |
+| `TaxTable` | `account.tax` | — | — | — |
+| `TaxTrans` | `account.move.line.tax_line_id` / `tax_ids` | — | — | — |
+| `TaxAuthority` / `TaxJurisdiction` | `res.partner` (tagged as tax authority) | — | — | — |
+| `SalesTaxReport` | — | `l10n_ph` reports | `ipai_bir_tax_compliance` | `l10n_ph` covers basic; `ipai_*` adds BIR forms + DAT gen |
+| BIR Form 2307 (Certificate of Creditable Tax Withheld) | — | — | `ipai_expense_liquidation` (already in repo), `ipai_bir_tax_compliance` | PH-specific; no CE/OCA equivalent |
+| BIR Form 2550M (Monthly VAT Declaration) | — | — | `ipai_bir_tax_compliance` | Custom |
+| BIR Form SAWT (Summary Alphalist Withholding Tax) | — | — | `ipai_bir_tax_compliance` | DAT file output via Code Interpreter |
+| BIR Form QAP (Quarterly Alphabetical List of Payees) | — | — | `ipai_bir_tax_compliance` | Custom |
+| BIR Form SLSP (Summary List of Sales & Purchases) | — | — | `ipai_bir_tax_compliance` | DAT file output |
+| BIR Form 1601-C (Compensation Withholding) | — | — | `ipai_bir_tax_compliance` | Custom |
+| BIR Form 1601-E (Expanded Withholding) | — | — | `ipai_bir_tax_compliance` | Custom |
+| eFPS/eBIRForms submission | — | — | `ipai_bir_tax_compliance` + Foundry Browser Automation | Replaces D365's ElectronicInvoicing engine |
+
+**Business process — Monthly BIR close:**
+1. Period close triggers `ipai_bir_tax_compliance.generate_2550m()` → reads `account.move.line` where tax is VAT
+2. Code Interpreter (Foundry tool) generates 2550M PDF + validated DAT
+3. Cross-check against `sale.order` / `purchase.order` for VAT basis
+4. Browser Automation submits to eBIRForms portal
+5. Submission receipt stored in `ipai_bir_filing_runs` audit table (Odoo, not Supabase)
+6. 2307 auto-generated per vendor payment when CWT applies
+
+### 1.10 Financial Reporting
+
+| D365 entity | Odoo CE model | OCA ext | `ipai_*` | Alignment |
+|---|---|---|---|---|
+| `FinancialReport` (TB, BS, IS) | `account.financial.html.report` | `account_financial_report` (OCA) | — | OCA provides full suite |
+| `PowerBIEmbeddedReport` | — | — | Power BI integration (not a module, connection config) | Power BI semantic model connects to Odoo PG via service account |
+| `PaymentPrediction` (ML) | — | — | `ipai_finance_insights_payment` (build) | Azure ML model trained on AR aging patterns |
+| `CustomerPaymentPrediction` | — | — | same as above | — |
+| `BudgetProposalPrediction` | — | — | `ipai_finance_insights_budget` (build) | — |
+
+---
+
+## 2. D365 Project Operations → Odoo mapping
+
+### 2.1 Project Operations Core (Dataverse entities)
+
+| D365 entity | Odoo CE model | OCA ext | `ipai_*` | Business logic alignment |
+|---|---|---|---|---|
+| `Lead` | `crm.lead` | — | — | — |
+| `Opportunity` | `crm.lead` (stage=opportunity) | — | — | Odoo uses single `crm.lead` with stages |
+| `Quote` | `sale.order` (state=sent/draft) | — | — | — |
+| `SalesOrder` | `sale.order` (state=sale) | — | — | — |
+| `Invoice` (project-linked) | `account.move` linked to `project.project` | `sale_project` (CE), `account_analytic_sale` (OCA) | — | — |
+| `PriceList` / `PriceListItem` | `product.pricelist` / `product.pricelist.item` | — | — | CE has full pricelist with variants + rules |
+| `msdyn_project` | `project.project` | — | — | — |
+| `msdyn_projecttask` | `project.task` | `project_wbs`, `project_timeline` | — | CE has hierarchical tasks; OCA adds WBS and Gantt |
+| `msdyn_projectteammember` | `project.project.allowed_user_ids` / `hr.employee` | — | — | — |
+| `msdyn_projectstage` | `project.task.type` (kanban stage) | — | — | — |
+| `msdyn_milestone` | `project.milestone` | — | — | CE 18 has native `project.milestone` |
+| `msdyn_bookableresource` | `hr.employee` + `resource.resource` | `resource_booking` | — | OCA adds booking calendar |
+| `msdyn_resourcerequirement` | — | `project_resource_requirement` | — | OCA |
+| `msdyn_resourceassignment` | `project.task.user_ids` + `account.analytic.line` | — | — | — |
+| `msdyn_resourcebookingrequest` | — | `resource_booking` | — | OCA |
+| `msdyn_timeentry` | `account.analytic.line` (type=timesheet) | `sale_timesheet`, `project_timesheet_*` | — | CE has full timesheet via `hr_timesheet` |
+| `msdyn_expense` | `hr.expense` | `hr_expense_*` | `ipai_expense_liquidation` | CE + PH overlay |
+| `msdyn_expensecategory` | `hr.expense.category` (product) | — | — | — |
+| `msdyn_projectapproval` | — | `base_tier_validation`, `project_approval` | — | OCA |
+| `msdyn_actual` | `account.analytic.line` (posted) | — | — | — |
+| `msdyn_actualpendingjournaltransaction` | — | `account_analytic_pending` | — | Odoo typically posts immediately; OCA adds pending state |
+| `msdyn_estimatelineitem` | `project.task.planned_hours` | `project_timeline` | — | CE has basic estimates; OCA adds line-item |
+
+### 2.2 Project Operations Integrated with ERP (F&O `Proj*` entities)
+
+| D365 entity | Odoo CE model | OCA ext | `ipai_*` | Alignment |
+|---|---|---|---|---|
+| `ProjTable` | `project.project` | — | — | — |
+| `ProjPlan` / `ProjWBS` | `project.task` hierarchy | `project_wbs`, `project_hierarchy` | — | OCA adds formal WBS codes |
+| `ProjActivity` | `project.task` | `project_activity_task` (OCA) | — | — |
+| `ProjTransBudget` | — | `project_budget`, `account_budget_oca` | — | — |
+| `ProjTransPosting` | `account.analytic.line` | — | — | — |
+| `ProjJournalTable` / `ProjJournalTrans` | `account.move` + analytic | — | — | — |
+| `ProjEmplTrans` (time) | `account.analytic.line` (type=timesheet) | `hr_timesheet_sheet` (if needed) | — | — |
+| `ProjCostTrans` | `account.analytic.line` (cost) | — | — | — |
+| `ProjRevenueTrans` | `account.analytic.line` + `account.move.line` | `project_pm_revenue_recognition` | — | OCA adds formal rev rec |
+| `ProjInvoiceJour` / `ProjInvoiceLine` | `account.move` linked to project | `project_sale_invoice` | — | — |
+| `ProjInvoiceProposal` | `sale.order` → `account.move.line` preview | `project_invoicing`, `sale_project_invoice_policy` | — | OCA adds invoice proposal workflow |
+| `ProjFundingSource` / `ProjContract` | `project.project.partner_id` + `project.contract` (OCA) | `project_contract`, `project_funding` | — | — |
+| `ProjSubContract` | `purchase.order` linked to project | `project_purchase_link` | — | — |
+| `ProjWorkerAllocation` | `resource.resource` + `project.task.user_ids` | `resource_allocation` | — | — |
+| `ProjPercentComplete` / `ProjRevenueRecognition` | — | `project_pm_revenue_recognition` | `ipai_project_rev_rec_ph` (PFRS 15 nuances) | OCA + optional PH overlay |
+| `ProjForecast*` | — | `project_forecast_*`, `project_forecast_line` | — | OCA comprehensive forecast |
+| `ProjExpenseTrans` | `hr.expense` linked to project | — | — | — |
+
+**Business process — Project lifecycle (services/agency):**
+1. Opportunity won → `sale.order` created with project template
+2. Project auto-created with WBS via OCA `project_wbs_template`
+3. Resources allocated via `resource.resource` + `project.task.user_ids`
+4. Time entered via `account.analytic.line` (timesheet)
+5. Expenses captured via `hr.expense` + `ipai_expense_liquidation`
+6. Percentage-of-completion computed via OCA `project_pm_revenue_recognition`
+7. Invoice proposal generated based on contract terms
+8. Customer invoice posted + AR aging begins
+9. Project close: variance analysis, final cost+revenue
+
+---
+
+## 3. Microsoft Copilot Finance agents → Pulser agents
+
+### 3.1 Financial Reconciliation agent
+
+| D365 Copilot surface | Pulser equivalent | Tool stack | Storage |
+|---|---|---|---|
+| Excel-hosted reconciliation | `pulser-finance` agent | PG MCP (read `account.bank.statement`, `account.move.line`) + Code Interpreter (match logic) + AI Search (rule grounding) | `stipaidevagent` (output Excel) |
+| Auto-matching rules | `account.reconciliation.model` + agent-suggested new rules | Agent reads historical matches, proposes rule updates | — |
+| Unmatched queue | `account.bank.statement.line` where `is_reconciled=False` | PG MCP query + agent prioritization | — |
+| Operator corrections | Human-in-loop on agent suggestions | Via Odoo UI; agent logs corrections to `ops.reconciliation_feedback` (Postgres `ops` schema) | — |
+
+**Business process — Reconciliation with Pulser:**
+1. Bank statement imported → `account.bank.statement.line` records in draft
+2. `pulser-finance` agent invoked via schedule or on-demand
+3. Agent queries open statement lines via PG MCP
+4. For each line: searches `account.move.line` for candidate matches, runs fuzzy match, scores confidence
+5. Auto-matches high-confidence pairs → creates `account.partial.reconcile`
+6. Low-confidence pairs → flagged for human review in Odoo UI
+7. Operator decision logged as preference data for future DPO fine-tuning
+
+### 3.2 Collections in Outlook agent
+
+| D365 Copilot surface | Pulser equivalent | Tool stack | Storage |
+|---|---|---|---|
+| Outlook email draft | `pulser-finance` skill `ar_collections` | Azure AI Search (customer history), PG MCP (`account.move` overdue, `res.partner`), Foundry MCP (model eval), `stipaidevagent` (email template) | — |
+| AR aging bucket read | PG MCP query on `account.move` where `invoice_date_due < today` | — | — |
+| Customer contact lookup | PG MCP query on `res.partner` + `res.partner.title` | — | — |
+| Follow-up task creation | `mail.activity` on `res.partner` | Odoo activity model, not Outlook | — |
+| Email logging | `mail.mail` + `mail.message` linked to partner + invoice | Odoo mail infrastructure | — |
+
+**Business process — Collections with Pulser:**
+1. Daily cron triggers `ar_collections` skill
+2. Agent queries overdue invoices via PG MCP, grouped by customer
+3. For each customer: reads prior follow-up history + payment patterns
+4. Drafts tiered email (1st reminder / 2nd / final demand) based on aging bucket
+5. Pushes draft to Odoo as `mail.activity` for AR clerk approval
+6. On approval: `mail.mail.send()` via Odoo's `ir.mail_server` (Zoho SMTP)
+7. Agent logs activity, schedules next-step follow-up
+
+---
+
+## 4. Gaps where `ipai_*` thin layer is required
+
+After CE + OCA, these are the only modules `ipai_*` needs to build:
+
+| Module | Scope | Why OCA/CE insufficient |
+|---|---|---|
+| `ipai_bir_tax_compliance` | All BIR forms (2307, 2550M, SAWT, QAP, SLSP, 1601-C, 1601-E, 1702) + DAT + PDF + eBIRForms submission | No OCA module covers PH BIR; tax authority-specific |
+| `ipai_expense_liquidation` (already in repo) | PH expense liquidation + OR/CWT handling | CE `hr.expense` + OCA doesn't handle PH OR requirements or 2307 overlay |
+| `ipai_bank_sync_ph` | BPI/BDO/Metrobank/Unionbank bank statement connectors | OCA has CAMT/OFX; PH banks use proprietary file formats |
+| `ipai_subscription_ph_tax` | Subscription billing with 2307/CWT overlay | OCA `contract` is generic; PH tax overlay needed |
+| `ipai_einvoice_ph` | BIR-compliant e-OR generation (when BIR mandate lands) | OCA e-invoice generic; BIR e-OR spec is PH-specific |
+| `ipai_finance_insights_payment` | Customer payment prediction ML | No OCA equivalent; `ipai_*` bridges to Azure ML / Foundry |
+| `ipai_finance_insights_budget` | Budget variance prediction ML | Same |
+| `ipai_project_rev_rec_ph` (optional) | PFRS 15 specifics beyond OCA `project_pm_revenue_recognition` | Only if customer needs strict PFRS 15; otherwise OCA alone |
+| `ipai_apiscan` (OCR bridge) | Wire Azure Document Intelligence to AP invoice capture | OCA `account_invoice_import_ocr` uses Tesseract; Azure DI is more accurate for PH receipts |
+| `ipai_lease_ph` (optional) | PFRS 16 specifics beyond OCA `account_asset_leasing` | Only if needed; OCA first |
+
+**No other `ipai_*` modules should exist for the D365 parity use case.**
+
+---
+
+## 5. D365 features IPAI explicitly does NOT chase
+
+| D365 feature | Why skip |
+|---|---|
+| Regulatory Configuration Service (RCS) | Enterprise-only; localization maintained in open OCA modules for IPAI markets |
+| Public sector fund accounting | Not IPAI's market (TBWA\SMP, W9, PrismaLab — all private sector) |
+| IoT-integrated asset management | Out of scope |
+| Retail commerce (D365 Commerce) | Different product category |
+| Mobile workspace SDK | Odoo web responsive + iOS wrapper per `docs/skills/ios-native-wrapper.md` cover this |
+| Electronic Invoicing generic engine | OCA covers EU/LATAM; PH-specific is small `ipai_einvoice_ph` |
+
+---
+
+## 6. Pulser agent ↔ Odoo model binding summary
+
+| Pulser agent | Primary Odoo models | Write posture | Tools |
+|---|---|---|---|
+| `pulser-finance` | `account.move`, `account.move.line`, `account.payment`, `account.bank.statement*`, `res.partner`, `account.analytic.line`, `hr.expense` | Read-first; writes via Odoo JSON-RPC with operator approval | PG MCP, Code Interpreter, Browser Automation, Azure AI Search, Document Intelligence, File Search |
+| `pulser-ops` | `ir.cron`, `ir.module.module`, `ir.logging` (read); Azure resources (write via Azure MCP) | Read Odoo; mutate Azure only | Azure MCP, ADO MCP, Foundry MCP, GitHub MCP |
+| `pulser-research` | `ir.attachment`, `mail.message`, `project.project.description` | Read-only | AI Search, Bing Search, File Search, GitHub MCP |
+
+---
+
+## 7. Migration / onboarding flow (D365 → IPAI)
+
+For a customer migrating off D365 Finance + Project Operations to IPAI:
+
+1. **Chart of accounts** → export D365 `MainAccount` + `FinancialDimension` → import to `account.account` + `account.analytic.plan`
+2. **Master data** → vendors + customers from D365 → `res.partner` (tagged supplier_rank / customer_rank)
+3. **Open items** → AR/AP open invoices → `account.move` with opening balance journal
+4. **Asset register** → D365 `AssetTable` + `AssetBook` → OCA `account.asset` with historical depreciation pre-loaded
+5. **Project masters** → D365 `msdyn_project` / `ProjTable` → `project.project` with WBS via `project_wbs`
+6. **Time & expense history** → archive in Odoo as historical analytic lines or keep in D365 read-only during transition
+7. **BIR history** → new system starts clean; historical DAT files retained in `stipaidevagent`
+8. **Cutover** → parallel run 30 days, reconciliation of GL/AR/AP, then switch
+
+---
+
+## 8. Related
+
+- `docs/research/d365-data-model-inventory.md` — entity catalog (this file's source)
+- `CLAUDE.md` §"Odoo extension and customization doctrine" — CE → OCA → `ipai_*` rule
+- Memory: `feedback_odoo_module_selection_doctrine`, `feedback_no_custom_default`
+- Runbook: `docs/runbooks/foundry-connections-and-tools.md`
+
+---
+
+*Compiled 2026-04-15. Living document — update as Odoo 18 CE / OCA / `ipai_*` modules ship.*

--- a/platform/contracts/cdm-entity-map.yaml
+++ b/platform/contracts/cdm-entity-map.yaml
@@ -1,0 +1,438 @@
+# SSOT — Odoo ↔ Common Data Model entity mapping
+# Canonical machine-readable version of docs/architecture/cdm-odoo-mapping.md
+# Consumed by: data-intelligence/pipelines/odoo_cdm_export.py (Databricks DLT)
+# Mutation rule: PR-only. Code changes must not precede a YAML update.
+
+schema_version: "1.0.0"
+last_updated: "2026-04-15"
+owner: "platform"
+
+adoption_posture:
+  cdm_schema: adopt_as_projection_target   # entity names + attrs + relationships
+  cdm_folder_format_adls: adopt             # stipaidevlake/gold/ is CDM-formatted
+  cdm_naming_in_platform_contracts: adopt   # canonical cross-system reference
+  dataverse_as_backing_store: reject        # Odoo is SOR
+  cdm_shape_in_pg_ipai_odoo_public: reject  # never rename Odoo models
+  cdm_semantic_model_views_in_fabric: adopt # projection layer only
+
+output_layout:
+  root: "abfss://gold@stipaidevlake.dfs.core.windows.net/"
+  manifest_file: "manifest.cdm.json"
+  per_entity:
+    layout: "<EntityName>/<EntityName>.cdm.json + partitions/"
+    format: parquet
+    compression: snappy
+    partition_column: date-based on created_at or transaction_date
+
+# =============================================================================
+# CORE BUSINESS ENTITIES — CDM standard
+# =============================================================================
+entities:
+
+  - cdm: Account
+    odoo_model: res.partner
+    discriminator: is_company = true
+    attributes:
+      - {cdm: name, odoo: name}
+      - {cdm: accountNumber, odoo: ref}
+      - {cdm: taxRegistrationNumber, odoo: vat, note: "PH TIN"}
+      - {cdm: primaryEmailAddress, odoo: email}
+      - {cdm: primaryPhone, odoo: phone}
+      - {cdm: websiteUrl, odoo: website}
+      - {cdm: addressLine1, odoo: street}
+      - {cdm: addressLine2, odoo: street2}
+      - {cdm: city, odoo: city}
+      - {cdm: stateOrProvince, odoo: state_id.name}
+      - {cdm: postalCode, odoo: zip}
+      - {cdm: country, odoo: country_id.name}
+      - {cdm: currency, odoo: property_account_receivable_id.currency_id.name}
+
+  - cdm: Contact
+    odoo_model: res.partner
+    discriminator: is_company = false
+    attributes:
+      - {cdm: firstName, odoo: firstname, note: "via OCA partner_firstname"}
+      - {cdm: lastName, odoo: lastname, note: "via OCA partner_firstname"}
+      - {cdm: fullName, odoo: name}
+      - {cdm: parentAccountId, odoo: parent_id}
+      - {cdm: emailAddress1, odoo: email}
+      - {cdm: telephone1, odoo: phone}
+      - {cdm: jobTitle, odoo: function}
+
+  - cdm: Lead
+    odoo_model: crm.lead
+    discriminator: type = 'lead'
+    attributes:
+      - {cdm: leadName, odoo: name}
+      - {cdm: companyName, odoo: partner_name}
+      - {cdm: contactName, odoo: contact_name}
+      - {cdm: emailAddress1, odoo: email_from}
+      - {cdm: leadSourceCode, odoo: source_id.name}
+
+  - cdm: Opportunity
+    odoo_model: crm.lead
+    discriminator: type = 'opportunity'
+    attributes:
+      - {cdm: opportunityName, odoo: name}
+      - {cdm: parentAccountId, odoo: partner_id}
+      - {cdm: estimatedValue, odoo: expected_revenue}
+      - {cdm: probability, odoo: probability}
+      - {cdm: statusCode, odoo: stage_id.name}
+
+  - cdm: Product
+    odoo_model: product.template
+    attributes:
+      - {cdm: name, odoo: name}
+      - {cdm: productNumber, odoo: default_code}
+      - {cdm: description, odoo: description}
+      - {cdm: price, odoo: list_price}
+      - {cdm: productCategoryId, odoo: categ_id}
+
+  - cdm: ProductCategory
+    odoo_model: product.category
+    attributes:
+      - {cdm: name, odoo: name}
+      - {cdm: parentCategoryId, odoo: parent_id}
+
+  - cdm: BusinessUnit
+    odoo_model: res.company
+    attributes:
+      - {cdm: name, odoo: name}
+      - {cdm: currency, odoo: currency_id.name}
+      - {cdm: country, odoo: country_id.name}
+
+  - cdm: Employee
+    odoo_model: hr.employee
+    attributes:
+      - {cdm: fullName, odoo: name}
+      - {cdm: jobTitle, odoo: job_id.name}
+      - {cdm: departmentId, odoo: department_id}
+      - {cdm: emailAddress, odoo: work_email}
+
+  - cdm: Case
+    odoo_model: helpdesk.ticket
+    attributes:
+      - {cdm: title, odoo: name}
+      - {cdm: customerId, odoo: partner_id}
+      - {cdm: stageCode, odoo: stage_id.name}
+      - {cdm: description, odoo: description}
+
+  - cdm: Campaign
+    odoo_model: utm.campaign
+    attributes:
+      - {cdm: name, odoo: name}
+      - {cdm: stageCode, odoo: stage_id.name}
+
+  - cdm: PriceList
+    odoo_model: product.pricelist
+    attributes:
+      - {cdm: name, odoo: name}
+      - {cdm: currency, odoo: currency_id.name}
+
+  - cdm: Currency
+    odoo_model: res.currency
+    attributes:
+      - {cdm: currencyCode, odoo: name}
+      - {cdm: exchangeRate, odoo: rate}
+      - {cdm: symbol, odoo: symbol}
+
+  - cdm: TaxCode
+    odoo_model: account.tax
+    attributes:
+      - {cdm: name, odoo: name}
+      - {cdm: rate, odoo: amount}
+      - {cdm: taxUsageType, odoo: type_tax_use}
+
+  - cdm: BankAccount
+    odoo_model: res.partner.bank
+    joined_with: account.journal
+    attributes:
+      - {cdm: accountNumber, odoo: acc_number}
+      - {cdm: bankName, odoo: bank_id.name}
+      - {cdm: ownerAccountId, odoo: partner_id}
+
+# =============================================================================
+# SALES + PROCUREMENT
+# =============================================================================
+
+  - cdm: Quote
+    odoo_model: sale.order
+    discriminator: state IN ('draft', 'sent')
+    attributes:
+      - {cdm: quoteNumber, odoo: name}
+      - {cdm: customerId, odoo: partner_id}
+      - {cdm: totalAmount, odoo: amount_total}
+      - {cdm: quoteDate, odoo: date_order}
+
+  - cdm: SalesOrder
+    odoo_model: sale.order
+    discriminator: state IN ('sale', 'done')
+    attributes:
+      - {cdm: salesOrderNumber, odoo: name}
+      - {cdm: customerId, odoo: partner_id}
+      - {cdm: totalAmount, odoo: amount_total}
+      - {cdm: orderDate, odoo: date_order}
+      - {cdm: statusCode, odoo: state}
+
+  - cdm: SalesOrderLine
+    odoo_model: sale.order.line
+    attributes:
+      - {cdm: salesOrderId, odoo: order_id}
+      - {cdm: productId, odoo: product_id}
+      - {cdm: quantity, odoo: product_uom_qty}
+      - {cdm: unitPrice, odoo: price_unit}
+      - {cdm: lineTotal, odoo: price_subtotal}
+
+  - cdm: PurchaseOrder
+    odoo_model: purchase.order
+    discriminator: state IN ('purchase', 'done')
+    attributes:
+      - {cdm: purchaseOrderNumber, odoo: name}
+      - {cdm: vendorId, odoo: partner_id}
+      - {cdm: totalAmount, odoo: amount_total}
+      - {cdm: orderDate, odoo: date_order}
+
+  - cdm: PurchaseOrderLine
+    odoo_model: purchase.order.line
+    attributes:
+      - {cdm: purchaseOrderId, odoo: order_id}
+      - {cdm: productId, odoo: product_id}
+      - {cdm: quantity, odoo: product_qty}
+      - {cdm: unitPrice, odoo: price_unit}
+
+# =============================================================================
+# FINANCE / GL
+# =============================================================================
+
+  - cdm: Invoice
+    odoo_model: account.move
+    discriminator: move_type = 'out_invoice'
+    aliases: [CustomerInvoice]
+    attributes:
+      - {cdm: invoiceNumber, odoo: name}
+      - {cdm: customerId, odoo: partner_id}
+      - {cdm: invoiceDate, odoo: invoice_date}
+      - {cdm: dueDate, odoo: invoice_date_due}
+      - {cdm: paymentDate, odoo: payment_date}
+      - {cdm: totalAmount, odoo: amount_total}
+      - {cdm: currencyCode, odoo: currency_id.name}
+      - {cdm: statusCode, odoo: state}
+
+  - cdm: CustomerRefund
+    odoo_model: account.move
+    discriminator: move_type = 'out_refund'
+
+  - cdm: VendorInvoice
+    odoo_model: account.move
+    discriminator: move_type = 'in_invoice'
+    aliases: [Bill]
+    attributes:
+      - {cdm: invoiceNumber, odoo: ref}
+      - {cdm: vendorId, odoo: partner_id}
+      - {cdm: invoiceDate, odoo: invoice_date}
+      - {cdm: totalAmount, odoo: amount_total}
+
+  - cdm: InvoiceLine
+    odoo_model: account.move.line
+    discriminator: "move_id.move_type IN ('out_invoice','in_invoice','out_refund','in_refund')"
+    attributes:
+      - {cdm: invoiceId, odoo: move_id}
+      - {cdm: accountId, odoo: account_id}
+      - {cdm: debit, odoo: debit}
+      - {cdm: credit, odoo: credit}
+      - {cdm: balance, odoo: balance}
+      - {cdm: analyticDistribution, odoo: analytic_distribution}
+
+  - cdm: Journal
+    odoo_model: account.journal
+    aliases: [LedgerJournal]
+    attributes:
+      - {cdm: journalCode, odoo: code}
+      - {cdm: journalName, odoo: name}
+      - {cdm: journalType, odoo: type}
+
+  - cdm: GeneralLedgerAccount
+    odoo_model: account.account
+    attributes:
+      - {cdm: accountCode, odoo: code}
+      - {cdm: accountName, odoo: name}
+      - {cdm: accountType, odoo: account_type}
+
+  - cdm: GeneralLedger
+    odoo_model: account.move.line
+    discriminator: move_id.state = 'posted'
+    aliases: [GeneralJournalAccountEntry]
+
+  - cdm: Payment
+    odoo_model: account.payment
+    attributes:
+      - {cdm: paymentNumber, odoo: name}
+      - {cdm: partnerId, odoo: partner_id}
+      - {cdm: amount, odoo: amount}
+      - {cdm: paymentDate, odoo: date}
+      - {cdm: journalId, odoo: journal_id}
+
+  - cdm: BankStatement
+    odoo_model: account.bank.statement
+
+  - cdm: BankStatementLine
+    odoo_model: account.bank.statement.line
+    attributes:
+      - {cdm: statementId, odoo: statement_id}
+      - {cdm: lineDate, odoo: date}
+      - {cdm: amount, odoo: amount}
+      - {cdm: isReconciled, odoo: is_reconciled}
+      - {cdm: paymentReference, odoo: payment_ref}
+
+  - cdm: Budget
+    odoo_model: account.budget
+    alternative_odoo: account_budget_oca  # OCA module preferred
+
+  - cdm: BudgetLine
+    odoo_model: account.budget.line
+
+  - cdm: FinancialDimension
+    odoo_model: account.analytic.plan
+
+  - cdm: DimensionValue
+    odoo_model: account.analytic.account
+
+  - cdm: FiscalYear
+    odoo_model: account.fiscal.year
+
+  - cdm: Project
+    odoo_model: project.project
+
+  - cdm: ProjectTask
+    odoo_model: project.task
+
+  - cdm: TimeEntry
+    odoo_model: account.analytic.line
+    discriminator: project_id IS NOT NULL
+    attributes:
+      - {cdm: employeeId, odoo: employee_id}
+      - {cdm: projectId, odoo: project_id}
+      - {cdm: taskId, odoo: task_id}
+      - {cdm: hours, odoo: unit_amount}
+      - {cdm: entryDate, odoo: date}
+
+  - cdm: ExpenseReport
+    odoo_model: hr.expense.sheet
+
+  - cdm: ExpenseTransaction
+    odoo_model: hr.expense
+    attributes:
+      - {cdm: employeeId, odoo: employee_id}
+      - {cdm: reportId, odoo: sheet_id}
+      - {cdm: expenseDate, odoo: date}
+      - {cdm: amount, odoo: total_amount}
+
+# =============================================================================
+# IPAI-SPECIFIC CDM EXTENSIONS (PH BIR — no CDM standard equivalent)
+# =============================================================================
+ipai_extensions:
+
+  - cdm: IPAI_BIRFiling
+    extends: null   # no CDM parent; fully custom
+    odoo_model: ipai_bir_filing_run
+    attributes:
+      - {cdm: filingId, odoo: id}
+      - {cdm: formType, odoo: form_type}
+      - {cdm: period, odoo: period}
+      - {cdm: companyTin, odoo: company_tin}
+      - {cdm: branchSuffix, odoo: branch_suffix}
+      - {cdm: state, odoo: state}
+      - {cdm: submissionDate, odoo: submission_date}
+      - {cdm: birReferenceNo, odoo: bir_reference_no}
+
+  - cdm: IPAI_BIRFormLine
+    extends: null
+    odoo_model: ipai_bir_2307_line
+    attributes:
+      - {cdm: filingRunId, odoo: filing_run_id}
+      - {cdm: moveId, odoo: move_id}
+      - {cdm: vendorId, odoo: partner_id}
+      - {cdm: atcCode, odoo: atc_code}
+      - {cdm: amountPaid, odoo: amount_paid}
+      - {cdm: withholdingAmount, odoo: withholding_amount}
+      - {cdm: rate, odoo: rate}
+
+  - cdm: IPAI_ATCCode
+    extends: TaxCode  # CDM parent exists
+    odoo_model: account.tax
+    discriminator: "country_id.code = 'PH' AND atc_code IS NOT NULL"
+    attributes:
+      - {cdm: atcCode, odoo: atc_code, note: "custom field on account.tax"}
+      - {cdm: description, odoo: name}
+      - {cdm: rate, odoo: amount}
+
+  - cdm: IPAI_TINNumber
+    extends: null
+    odoo_model: res.partner
+    attributes:
+      - {cdm: partnerId, odoo: id}
+      - {cdm: tinBase, odoo: "vat (parsed NNN-NNN-NNN portion)"}
+      - {cdm: tinBranchSuffix, odoo: "branch_suffix (custom field)"}
+      - {cdm: fullTin, odoo: "computed: vat || '-' || branch_suffix"}
+
+  - cdm: IPAI_ExpenseLiquidation
+    extends: ExpenseReport   # CDM parent
+    odoo_model: ipai_expense_liquidation
+    attributes:
+      - {cdm: expenseId, odoo: expense_id}
+      - {cdm: phOrNumber, odoo: ph_or_number}
+      - {cdm: orCwtRequired, odoo: or_cwt_required}
+      - {cdm: cwtAmount, odoo: cwt_amount}
+      - {cdm: atcCode, odoo: atc_code}
+      - {cdm: birReceiptNumber, odoo: bir_receipt_number}
+
+  - cdm: IPAI_EWTRate
+    extends: TaxCode
+    odoo_model: account.tax
+    discriminator: "country_id.code = 'PH' AND type_tax_use = 'purchase'"
+
+  - cdm: IPAI_AuditEvent
+    extends: null
+    odoo_model: null   # lives in platform.audit_event (Postgres, not Odoo)
+    source_schema: platform
+    attributes:
+      - {cdm: eventId, pg_column: id}
+      - {cdm: occurredAt, pg_column: occurred_at}
+      - {cdm: actorKind, pg_column: actor_kind}
+      - {cdm: resourceType, pg_column: resource_type}
+      - {cdm: action, pg_column: action}
+      - {cdm: beforeState, pg_column: before_state}
+      - {cdm: afterState, pg_column: after_state}
+
+# =============================================================================
+# SKIP list — entities NOT projected to CDM
+# =============================================================================
+skip_from_cdm_export:
+  - ops.agent_run        # operational; not analytical
+  - ops.agent_message    # too high-volume; privacy concerns
+  - ops.tool_call        # same
+  - ops.agent_conversation
+  - "stock.*"            # inventory not in IPAI v1 scope
+  - "mrp.*"              # manufacturing not in scope
+  - "pos.*"              # point-of-sale not in scope
+  - "ir.*"               # Odoo internal models
+  - "res.users"          # auth data — Entra is SOR for identity
+
+# =============================================================================
+# Fabric Data Agent exposure
+# =============================================================================
+fabric_data_agent:
+  enabled: false   # gated on Issue 26 (CDM export pipeline) + Fabric capacity
+  expose_entities:
+    - Invoice
+    - VendorInvoice
+    - Payment
+    - BankStatementLine
+    - ExpenseReport
+    - SalesOrder
+    - PurchaseOrder
+    - Project
+    - TimeEntry
+    - IPAI_BIRFiling
+    - IPAI_ExpenseLiquidation
+  mcp_endpoint: "https://fcipaidev.fabric.microsoft.com/mcp"   # placeholder, provisioned in Phase 2


### PR DESCRIPTION
## Summary

Closes the 4 data-model gaps flagged against PR #765 (merged). Single-doc entry point + 3 previously-uncommitted data-model artifacts brought under version control.

**New: `docs/architecture/data-model-index.md`** — master index mapping the 8 canonical components to their data-model file(s), closing these gaps inline:

| Gap (per PR #765 review) | Closed by |
|---|---|
| No Cosmos entity schema | §3.2 — 3 containers (`sessions` / `tool_calls` / `artifacts`) + partition keys + TTLs |
| No UC `ppm.gold.*` catalog | §4.2 — 7 gold-layer tables named + grains locked (finance, ops, compliance) |
| No Fabric Mirror table list | §5.1 — Phase-1 scope locked (7 operational tables; `ops.*`/`platform.*` explicitly excluded per anti-pattern) |
| No single index tying files to components | §1 — full component-to-file matrix |

**Now tracked (previously uncommitted):**
- `platform/contracts/cdm-entity-map.yaml` (438 lines) — machine-readable CDM entity contract consumed by DLT pipelines
- `docs/research/d365-to-odoo-mapping.md` (382 lines) — D365 Finance + Project Operations → Odoo CE+OCA+`ipai_*` mapping
- `docs/research/d365-data-model-inventory.md` (284 lines) — D365 entity catalog for displacement tracking

## Data-model surface — total

| Committed in this PR | Lines |
|---|---|
| data-model-index.md (new) | ~350 |
| cdm-entity-map.yaml (was untracked) | 438 |
| d365-to-odoo-mapping.md (was untracked) | 382 |
| d365-data-model-inventory.md (was untracked) | 284 |
| **Subtotal this PR** | **~1,454** |
| **Pre-existing (already on main)** | **3,515** |
| **Total IPAI data-model surface** | **~4,969 lines** |

## Open gaps tracked in §7 of the index

Not fixed by this PR — tracked for future work:

- Cosmos `cosmos-ipai-dev` not yet deployed (schema locked, ready to deploy)
- UC `ppm.gold.*` tables not yet populated (Wave-2 Finance target R2 = 2026-07-14)
- Fabric mirror not yet wired (F-SKU procurement gate 2026-05-01)
- `ssot/ai/agents.yaml` + `models.yaml` + `connections.yaml` not yet populated
- Frontier model deployments blocked on MS-acknowledged bug 715-123420 ([microsoft/microsoft-foundry-for-vscode#515](https://github.com/microsoft/microsoft-foundry-for-vscode/issues/515))

## Issues addressed / supported

- Supports #685 — Day-1 go-live product bundle (data model is a Day-1 prerequisite)
- Supports #688 — PPM bridge implementation (gold-layer tables named in §4.2)
- Supports #689 — finance-close module (`ppm.gold.finance_*` tables named)
- Supports #690 — TaxPulse bridge (`ppm.gold.compliance_bir_filing_status` named)
- Supports #754 — Pulser delivery governance epic (Cosmos + PG `platform.ops.*` split locked)

## Test plan

- [ ] Markdown renders cleanly on GitHub; all internal links resolve
- [ ] Cross-refs to `canonical-platform-architecture.md` (on main) resolve
- [ ] `cdm-entity-map.yaml` parses as valid YAML (lint: `yq eval . platform/contracts/cdm-entity-map.yaml`)
- [ ] §2 file catalog line counts match actual file sizes
- [ ] §5.1 Fabric Mirror table list is a strict subset of `public.*` (no `ops.*` or `platform.*` inclusions)

## Not in scope

- Populating `ssot/ai/*.yaml` — requires frontier-model deploy unblock first
- Deploying Cosmos `cosmos-ipai-dev` — separate infra PR
- Writing DLT pipelines for `ppm.gold.*` — Wave-2 Finance scope
- Opening PRs for the 3 files that are still uncommitted on other branches (different scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)