### PR TITLE
ssot(data-model): 5-layer canonical model stack — ORM + DBML + CDM + UC + physical

### DIFF
--- a/docs/data-model/bounded-contexts/finance_accounting.dbml
+++ b/docs/data-model/bounded-contexts/finance_accounting.dbml
@@ -1,0 +1,336 @@
+// ============================================================
+// IPAI Finance/Accounting — Odoo CE 18 bounded context
+// Generated: 2026-04-15
+// Scope: account_*, hr_expense* tables in Odoo CE 18 PostgreSQL schema
+// Cross-context spine refs: res_partner, res_company, res_currency,
+//   product_product — defined in global_spine.dbml; referenced here
+//   with dotted notation per DBML cross-schema convention.
+// ============================================================
+
+Project "IPAI Finance/Accounting — Odoo CE 18 bounded context" {
+  database_type: "PostgreSQL"
+  Note: '''
+    Bounded context: Finance & Accounting
+    Source: Odoo CE 18.0 ORM / PostgreSQL schema
+    Owner: IPAI Engineering
+    Spine dependencies: res_partner, res_company, res_currency, product_product
+    Related bounded contexts: project (analytic), hr (expenses), inventory (product)
+    Last reviewed: 2026-04-15
+  '''
+}
+
+// ============================================================
+// CHART OF ACCOUNTS
+// ============================================================
+
+Table account_account {
+  id               integer       [pk, increment, not null]
+  code             varchar       [not null, note: "e.g. 101000"]
+  name             varchar       [not null]
+  account_type     varchar       [not null, note: "asset_receivable|asset_cash|asset_current|asset_non_current|asset_prepayments|asset_fixed|liability_payable|liability_credit_card|liability_current|liability_non_current|equity|equity_unaffected|income|income_other|expense|expense_depreciation|expense_direct_cost|off_balance"]
+  company_id       integer       [not null, ref: > res_company.id]
+  currency_id      integer       [ref: > res_currency.id, note: "optional; forces currency on journal items"]
+  reconcile        boolean       [not null, default: false, note: "true for AR/AP accounts"]
+  deprecated       boolean       [not null, default: false]
+  group_id         integer       [ref: > account_group.id]
+
+  Note: "Chart of accounts entry. account_type drives P&L vs balance sheet placement."
+}
+
+Table account_group {
+  id               integer       [pk, increment, not null]
+  name             varchar       [not null]
+  code_prefix_start varchar      [note: "e.g. 1"]
+  code_prefix_end   varchar      [note: "e.g. 1999"]
+  company_id       integer       [not null, ref: > res_company.id]
+  parent_id        integer       [ref: > account_group.id, note: "self-referential hierarchy"]
+
+  Note: "Account groups used for financial report grouping."
+}
+
+// ============================================================
+// JOURNALS
+// ============================================================
+
+Table account_journal {
+  id                    integer   [pk, increment, not null]
+  name                  varchar   [not null]
+  code                  varchar   [not null, note: "Short code e.g. INV, BILL, BNK1"]
+  type                  varchar   [not null, note: "sale|purchase|cash|bank|general"]
+  company_id            integer   [not null, ref: > res_company.id]
+  default_account_id    integer   [ref: > account_account.id, note: "Default debit/credit account"]
+  currency_id           integer   [ref: > res_currency.id, note: "Forces foreign currency on journal entries"]
+
+  Note: "Journals partition accounting entries by business flow (sales, purchases, bank, cash, misc)."
+}
+
+// ============================================================
+// JOURNAL ENTRIES (MOVES)
+// ============================================================
+
+Table account_move {
+  id               integer       [pk, increment, not null]
+  name             varchar       [note: "Sequence number e.g. INV/2026/00001; / for drafts"]
+  state            varchar       [not null, note: "draft|posted|cancel"]
+  move_type        varchar       [not null, note: "entry|out_invoice|in_invoice|out_refund|in_refund|out_receipt|in_receipt"]
+  journal_id       integer       [not null, ref: > account_journal.id]
+  company_id       integer       [not null, ref: > res_company.id]
+  partner_id       integer       [ref: > res_partner.id]
+  currency_id      integer       [not null, ref: > res_currency.id]
+  date             date          [not null, note: "Accounting date"]
+  invoice_date     date          [note: "Document date (invoices/bills only)"]
+  amount_total     numeric       [not null, default: 0, note: "Total in document currency"]
+  amount_residual  numeric       [not null, default: 0, note: "Remaining amount to pay"]
+  payment_state    varchar       [note: "not_paid|in_payment|paid|partial|reversed|invoicing_legacy"]
+
+  Note: "Central accounting document — covers journal entries, vendor bills, customer invoices, credit/debit notes, and receipts."
+}
+
+// ============================================================
+// JOURNAL ENTRY LINES
+// ============================================================
+
+Table account_move_line {
+  id                    integer   [pk, increment, not null]
+  move_id               integer   [not null, ref: > account_move.id]
+  account_id            integer   [not null, ref: > account_account.id]
+  partner_id            integer   [ref: > res_partner.id]
+  product_id            integer   [ref: > product_product.id]
+  name                  varchar   [note: "Line label / description"]
+  quantity              numeric   [not null, default: 1]
+  price_unit            numeric   [not null, default: 0]
+  debit                 numeric   [not null, default: 0]
+  credit                numeric   [not null, default: 0]
+  balance               numeric   [not null, default: 0, note: "debit - credit; computed"]
+  amount_currency       numeric   [not null, default: 0, note: "Amount in line currency when different from company currency"]
+  currency_id           integer   [not null, ref: > res_currency.id]
+  analytic_distribution jsonb     [note: "Map of account_analytic_account.id (as text) -> percentage, e.g. {\"42\": 100.0}"]
+  company_id            integer   [not null, ref: > res_company.id]
+
+  Note: "One debit or credit line within an account_move. tax_ids is a many2many via account_move_line_account_tax_rel (not modelled as column)."
+}
+
+// Many-to-many: account_move_line <-> account_tax
+Table account_move_line_account_tax_rel {
+  account_move_line_id  integer   [not null, ref: > account_move_line.id]
+  account_tax_id        integer   [not null, ref: > account_tax.id]
+
+  indexes {
+    (account_move_line_id, account_tax_id) [pk]
+  }
+
+  Note: "Junction table for tax_ids M2M on account_move_line."
+}
+
+// ============================================================
+// TAXES
+// ============================================================
+
+Table account_tax {
+  id               integer       [pk, increment, not null]
+  name             varchar       [not null]
+  type_tax_use     varchar       [not null, note: "sale|purchase|none"]
+  amount_type      varchar       [not null, note: "percent|fixed|group|division"]
+  amount           numeric       [not null, default: 0, note: "Rate (e.g. 12 for 12%) or fixed amount"]
+  company_id       integer       [not null, ref: > res_company.id]
+
+  Note: "Tax definition. Group taxes reference child taxes via account_tax_filiation_rel (not expanded here)."
+}
+
+// ============================================================
+// PAYMENTS
+// ============================================================
+
+Table account_payment {
+  id               integer       [pk, increment, not null]
+  partner_id       integer       [ref: > res_partner.id]
+  amount           numeric       [not null, default: 0]
+  currency_id      integer       [not null, ref: > res_currency.id]
+  date             date          [not null]
+  journal_id       integer       [not null, ref: > account_journal.id]
+  payment_type     varchar       [not null, note: "inbound|outbound|transfer"]
+  partner_type     varchar       [note: "customer|supplier"]
+  move_id          integer       [ref: > account_move.id, note: "Generated journal entry"]
+  state            varchar       [not null, note: "draft|posted|sent|reconciled|cancelled"]
+
+  Note: "Customer receipts and vendor payments. Generates an account_move on posting."
+}
+
+// ============================================================
+// BANK STATEMENTS
+// ============================================================
+
+Table account_bank_statement {
+  id                  integer     [pk, increment, not null]
+  name                varchar     [not null, note: "Reference / statement number"]
+  date                date        [not null]
+  journal_id          integer     [not null, ref: > account_journal.id]
+  company_id          integer     [not null, ref: > res_company.id]
+  balance_start       numeric     [not null, default: 0]
+  balance_end_real    numeric     [not null, default: 0, note: "Closing balance as per bank document"]
+
+  Note: "Bank or cash statement imported or entered manually. Lines are matched/reconciled against journal entries."
+}
+
+Table account_bank_statement_line {
+  id               integer       [pk, increment, not null]
+  statement_id     integer       [not null, ref: > account_bank_statement.id]
+  move_id          integer       [not null, ref: > account_move.id, note: "Created automatically; holds the accounting entry"]
+  partner_id       integer       [ref: > res_partner.id]
+  amount           numeric       [not null, default: 0]
+  date             date          [not null]
+  payment_ref      varchar       [note: "Bank memo / reference text"]
+  account_number   varchar       [note: "Counterparty account number from bank feed"]
+
+  Note: "Individual transaction line from a bank statement."
+}
+
+// ============================================================
+// ANALYTIC ACCOUNTING
+// ============================================================
+
+Table account_analytic_plan {
+  id               integer       [pk, increment, not null]
+  name             varchar       [not null]
+  parent_id        integer       [ref: > account_analytic_plan.id, note: "Self-referential hierarchy; NULL for root plans"]
+  company_id       integer       [ref: > res_company.id, note: "NULL = shared across companies"]
+
+  Note: "Analytic plan groups analytic accounts into a named dimension (e.g. Projects, Departments, Cost Centres)."
+}
+
+Table account_analytic_account {
+  id               integer       [pk, increment, not null]
+  name             varchar       [not null]
+  code             varchar
+  company_id       integer       [ref: > res_company.id]
+  partner_id       integer       [ref: > res_partner.id]
+  plan_id          integer       [not null, ref: > account_analytic_plan.id]
+
+  Note: "Analytic account (cost centre / project / department). Referenced via analytic_distribution jsonb on move lines."
+}
+
+Table account_analytic_line {
+  id                   integer    [pk, increment, not null]
+  name                 varchar    [not null]
+  date                 date       [not null]
+  amount               numeric    [not null, default: 0]
+  unit_amount          numeric    [not null, default: 0, note: "Hours or quantity"]
+  account_id           integer    [not null, ref: > account_analytic_account.id, note: "Analytic account (cost centre)"]
+  general_account_id   integer    [ref: > account_account.id, note: "GL account counterpart"]
+  move_line_id         integer    [ref: > account_move_line.id, note: "Source journal item; NULL for timesheets"]
+  partner_id           integer    [ref: > res_partner.id]
+  company_id           integer    [not null, ref: > res_company.id]
+  project_id           integer    [ref: > project_project.id, note: "Cross-context ref to project bounded context"]
+
+  Note: "Analytic distribution line. Created automatically from account_move_line.analytic_distribution or from timesheets."
+}
+
+// ============================================================
+// FISCAL YEAR (used for lock dates and period configuration)
+// ============================================================
+
+Table account_fiscal_year {
+  id               integer       [pk, increment, not null]
+  name             varchar       [not null]
+  date_from        date          [not null]
+  date_to          date          [not null]
+  company_id       integer       [not null, ref: > res_company.id]
+
+  Note: "Fiscal year definition used for lock-date enforcement and period-based reporting."
+}
+
+// ============================================================
+// EXPENSES
+// ============================================================
+
+Table hr_expense {
+  id                    integer   [pk, increment, not null]
+  name                  varchar   [not null, note: "Expense description"]
+  employee_id           integer   [not null, ref: > hr_employee.id, note: "Cross-context ref to HR bounded context"]
+  product_id            integer   [not null, ref: > product_product.id]
+  unit_amount           numeric   [not null, default: 0, note: "Price per unit (or total when qty=1)"]
+  quantity              numeric   [not null, default: 1]
+  total_amount          numeric   [not null, default: 0, note: "unit_amount * quantity (computed)"]
+  state                 varchar   [not null, note: "draft|reported|approved|done|refused"]
+  sheet_id              integer   [ref: > hr_expense_sheet.id]
+  company_id            integer   [not null, ref: > res_company.id]
+  account_id            integer   [ref: > account_account.id]
+  analytic_distribution jsonb     [note: "Map of account_analytic_account.id (as text) -> percentage"]
+
+  Note: "Individual employee expense line. Grouped into hr_expense_sheet for approval and posting."
+}
+
+Table hr_expense_sheet {
+  id               integer       [pk, increment, not null]
+  name             varchar       [not null]
+  employee_id      integer       [not null, ref: > hr_employee.id]
+  state            varchar       [not null, note: "draft|submit|approve|post|done|cancel"]
+  company_id       integer       [not null, ref: > res_company.id]
+  journal_id       integer       [not null, ref: > account_journal.id]
+  account_move_id  integer       [ref: > account_move.id, note: "Journal entry created on posting"]
+  total_amount     numeric       [not null, default: 0]
+
+  Note: "Expense report grouping one or more hr_expense lines. Approval → posting creates account_move."
+}
+
+// ============================================================
+// RECONCILIATION MODELS (bank matching rules)
+// ============================================================
+
+Table account_reconcile_model {
+  id                   integer    [pk, increment, not null]
+  name                 varchar    [not null]
+  rule_type            varchar    [not null, note: "writeoff_button|writeoff_suggestion|invoice_matching"]
+  company_id           integer    [not null, ref: > res_company.id]
+
+  Note: "Automated bank reconciliation rule. match_journal_ids is a M2M to account_journal (via account_reconcile_model_journal_rel); not expanded as column here."
+}
+
+// Many-to-many: account_reconcile_model <-> account_journal (match_journal_ids)
+Table account_reconcile_model_journal_rel {
+  reconcile_model_id   integer   [not null, ref: > account_reconcile_model.id]
+  journal_id           integer   [not null, ref: > account_journal.id]
+
+  indexes {
+    (reconcile_model_id, journal_id) [pk]
+  }
+
+  Note: "Junction table for match_journal_ids M2M on account_reconcile_model."
+}
+
+// ============================================================
+// CROSS-CONTEXT SPINE STUBS
+// These tables live in the global spine bounded context.
+// Declared here as stubs to satisfy Ref targets within this file.
+// Full definitions: docs/data-model/bounded-contexts/global_spine.dbml
+// ============================================================
+
+Table res_company {
+  id   integer [pk]
+  Note: "Global spine — see global_spine.dbml"
+}
+
+Table res_partner {
+  id   integer [pk]
+  Note: "Global spine — see global_spine.dbml"
+}
+
+Table res_currency {
+  id   integer [pk]
+  Note: "Global spine — see global_spine.dbml"
+}
+
+Table product_product {
+  id   integer [pk]
+  Note: "Inventory/product bounded context — see inventory.dbml"
+}
+
+Table hr_employee {
+  id   integer [pk]
+  Note: "HR bounded context — see hr.dbml"
+}
+
+Table project_project {
+  id   integer [pk]
+  Note: "Project bounded context — see project.dbml"
+}

--- a/docs/data-model/bounded-contexts/hr_workforce.dbml
+++ b/docs/data-model/bounded-contexts/hr_workforce.dbml
@@ -1,0 +1,128 @@
+Project "IPAI HR/Workforce — Odoo CE 18 bounded context" {
+  database_type: 'PostgreSQL'
+  Note: 'Bounded context: Employees, departments, contracts, attendance, leaves, and recruitment. Source: Odoo CE 18 models hr.employee, hr.contract, hr.attendance, hr.leave, hr.applicant.'
+}
+
+Table hr_employee {
+  id             integer  [pk, increment]
+  name           varchar  [not null]
+  user_id        integer  [ref: > res_users.id, note: 'linked portal/internal user']
+  company_id     integer  [not null, ref: > res_company.id]
+  department_id  integer  [ref: > hr_department.id]
+  job_id         integer  [ref: > hr_job.id]
+  job_title      varchar
+  work_email     varchar
+  work_phone     varchar
+  resource_id    integer  [not null, ref: > resource_resource.id]
+  parent_id      integer  [ref: > hr_employee.id, note: 'manager (self-ref)']
+  coach_id       integer  [ref: > hr_employee.id, note: 'coach (self-ref)']
+  active         boolean
+}
+
+Table hr_department {
+  id             integer  [pk, increment]
+  name           varchar  [not null]
+  company_id     integer  [not null, ref: > res_company.id]
+  parent_id      integer  [ref: > hr_department.id, note: 'parent department (self-ref)']
+  manager_id     integer  [ref: > hr_employee.id]
+  complete_name  varchar  [note: 'computed hierarchical label']
+}
+
+Table hr_job {
+  id                  integer  [pk, increment]
+  name                varchar  [not null]
+  department_id       integer  [ref: > hr_department.id]
+  company_id          integer  [ref: > res_company.id]
+  no_of_recruitment   integer
+}
+
+Table hr_contract {
+  id             integer   [pk, increment]
+  name           varchar   [not null]
+  employee_id    integer   [not null, ref: > hr_employee.id]
+  department_id  integer   [ref: > hr_department.id]
+  job_id         integer   [ref: > hr_job.id]
+  company_id     integer   [not null, ref: > res_company.id]
+  state          varchar   [not null, note: 'draft, open, close, cancel']
+  date_start     date      [not null]
+  date_end       date
+  wage           numeric   [not null]
+  struct_id      integer   [ref: > hr_payroll_structure.id]
+}
+
+Table hr_payroll_structure {
+  id          integer  [pk, increment]
+  name        varchar  [not null]
+  company_id  integer  [ref: > res_company.id]
+}
+
+Table hr_attendance {
+  id            integer   [pk, increment]
+  employee_id   integer   [not null, ref: > hr_employee.id]
+  check_in      timestamp [not null]
+  check_out     timestamp
+  worked_hours  float     [note: 'computed']
+}
+
+Table hr_leave {
+  id                 integer   [pk, increment]
+  employee_id        integer   [not null, ref: > hr_employee.id]
+  holiday_status_id  integer   [not null, ref: > hr_leave_type.id]
+  date_from          timestamp [not null]
+  date_to            timestamp [not null]
+  number_of_days     float
+  state              varchar   [not null, note: 'draft, confirm, validate1, validate, refuse']
+  company_id         integer   [not null, ref: > res_company.id]
+}
+
+Table hr_leave_type {
+  id                     integer  [pk, increment]
+  name                   varchar  [not null]
+  company_id             integer  [ref: > res_company.id]
+  requires_allocation    varchar  [note: 'yes, no']
+  leave_validation_type  varchar  [note: 'no_validation, time_off, both']
+}
+
+Table hr_applicant {
+  id               integer  [pk, increment]
+  partner_name     varchar
+  partner_id       integer  [ref: > res_partner.id]
+  job_id           integer  [ref: > hr_job.id]
+  department_id    integer  [ref: > hr_department.id]
+  stage_id         integer  [ref: > hr_recruitment_stage.id]
+  user_id          integer  [ref: > res_users.id]
+  priority         varchar  [note: '0 normal, 1 good, 2 very good, 3 excellent']
+  salary_expected  numeric
+  salary_proposed  numeric
+  company_id       integer  [ref: > res_company.id]
+}
+
+Table hr_recruitment_stage {
+  id        integer  [pk, increment]
+  name      varchar  [not null]
+  sequence  integer
+  fold      boolean
+}
+
+Table resource_resource {
+  id          integer  [pk, increment]
+  name        varchar  [not null]
+  company_id  integer  [ref: > res_company.id]
+  user_id     integer  [ref: > res_users.id]
+}
+
+// Shared dimension stubs
+Table res_partner {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_users {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_company {
+  id    integer  [pk]
+  name  varchar
+}

--- a/docs/data-model/bounded-contexts/platform_identity_tenant_ai.dbml
+++ b/docs/data-model/bounded-contexts/platform_identity_tenant_ai.dbml
@@ -1,0 +1,249 @@
+// ============================================================
+// IPAI Platform / Identity / Tenant / AI Overlay
+// Bounded-context: Platform, Identity, Tenant, AI (ops + platform schemas)
+//
+// Scope: Thin IPAI layer on top of Odoo CE 18.
+//   - ops.*     — agent runtime, tenancy, feature flags, tool catalog
+//   - platform.* — cross-cutting audit
+//   - public.*  — Odoo-owned schema (referenced only, never modified here)
+//
+// NOT included in PG schemas:
+//   - cosmos.*  — Azure Cosmos DB document collections (documented below
+//                 as comments; not relational tables)
+//
+// Cross-schema FK note:
+//   ops.tenants.company_id → public.res_company(id)
+//   public schema is owned by Odoo; treat as read-only external reference.
+// ============================================================
+
+Project "IPAI Platform / Identity / Tenant / AI Overlay" {
+  database_type: 'PostgreSQL'
+  Note: '''
+    Schema: ops + platform (IPAI-owned)
+    Odoo public schema is referenced but never modified by these models.
+    Cosmos DB collections are documented as comments (document store, not relational).
+    Runtime: Azure Container Apps + PostgreSQL 16 (pg-ipai-odoo)
+    Auth: Entra ID (OIDC) — no custom ipai_auth_oidc module; wired via standard
+          Odoo OIDC config + infra env vars per no-custom-identity doctrine.
+  '''
+}
+
+// ============================================================
+// OPS SCHEMA
+// ============================================================
+
+Table ops.tenants {
+  id          serial        [pk, increment, note: "Internal tenant surrogate key"]
+  name        varchar       [not null, note: "Human-readable tenant name"]
+  code        varchar       [unique, not null, note: "Short slug, e.g. ipai / w9 / tbwa"]
+  company_id  int           [not null, ref: > public.res_company.id, note: "Odoo company this tenant maps to"]
+  entra_tenant_id varchar   [null, note: "Azure Entra external tenant GUID; null for single-tenant deployments"]
+  active      boolean       [not null, default: true]
+  created_at  timestamp     [not null, default: `now()`]
+
+  Note: '''
+    One ops.tenant = one res.company in Odoo.
+    entra_tenant_id is populated only for multi-tenant SaaS lanes.
+    Self-hosted single-tenant: leave null, rely on Odoo built-in OIDC config.
+  '''
+}
+
+Table ops.runs {
+  id              uuid          [pk, default: `gen_random_uuid()`, note: "Stable run identifier; shared with Cosmos session"]
+  agent_id        varchar       [not null, note: "Logical agent identifier, e.g. pulser/tax-guru/recon-agent"]
+  tenant_id       int           [not null, ref: > ops.tenants.id, note: "Owning tenant"]
+  session_id      varchar       [not null, note: "Cosmos session_id for cross-store correlation"]
+  started_at      timestamp     [not null, default: `now()`]
+  ended_at        timestamp     [null]
+  status          varchar       [not null, note: "running | completed | failed | cancelled"]
+  input_summary   text          [null, note: "Sanitised (Safe Outputs) summary of user input"]
+  output_summary  text          [null, note: "Sanitised summary of agent response"]
+  model_used      varchar       [null, note: "e.g. gpt-4.1, claude-sonnet-4-6"]
+  tokens_in       int           [null]
+  tokens_out      int           [null]
+  create_date     timestamp     [not null, default: `now()`]
+
+  indexes {
+    (tenant_id, started_at) [name: "idx_runs_tenant_started"]
+    (agent_id, status)      [name: "idx_runs_agent_status"]
+    session_id              [name: "idx_runs_session"]
+  }
+
+  Note: '''
+    Append-only. Updates allowed only to: ended_at, status, output_summary,
+    tokens_in, tokens_out.
+    input_summary / output_summary must pass Safe Outputs subsystem before write.
+  '''
+}
+
+Table ops.run_events {
+  id           bigserial     [pk, increment]
+  run_id       uuid          [not null, ref: > ops.runs.id, note: "Parent run"]
+  event_type   varchar       [not null, note: "input | tool_call | tool_response | output | error | guardrail"]
+  payload      jsonb         [not null, note: "Sanitised event payload; secrets stripped by Safe Outputs"]
+  timestamp    timestamp     [not null, default: `now()`]
+  sequence_num int           [not null, note: "Monotonic sequence within a run; used for ordered replay"]
+
+  indexes {
+    (run_id, sequence_num) [name: "idx_run_events_run_seq", unique]
+    (run_id, event_type)   [name: "idx_run_events_type"]
+  }
+
+  Note: '''
+    Append-only. No deletes, no updates.
+    Payload is post-Safe-Outputs (filtered / moderated / secret-stripped).
+    guardrail events record policy violations caught by Content Safety middleware.
+  '''
+}
+
+Table ops.tool_catalog {
+  id          serial        [pk, increment]
+  agent_id    varchar       [not null, note: "Agent this tool is registered for; '*' = shared across all agents"]
+  tool_name   varchar       [not null, note: "Canonical MCP / Foundry tool name"]
+  tool_type   varchar       [not null, note: "mcp | foundry | cli | odoo_rpc"]
+  endpoint    varchar       [null, note: "MCP server URI or Foundry tool endpoint; null for cli/odoo_rpc"]
+  allowed     boolean       [not null, default: true, note: "Runtime allow-flag; false = tool blocked without manifest change"]
+  create_date timestamp     [not null, default: `now()`]
+
+  indexes {
+    (agent_id, tool_name) [name: "idx_tool_catalog_agent_tool", unique]
+  }
+
+  Note: '''
+    MCP allowlist SSOT. Pulser agents may only call tools present here with allowed=true.
+    No dynamic tool acquisition permitted (Agentic Workflow Security Doctrine).
+    Changes require PR + Azure Pipelines gate.
+  '''
+}
+
+Table ops.feature_flags {
+  id          serial        [pk, increment]
+  flag_name   varchar       [unique, not null, note: "e.g. pulser.recon_agent.v2 / finance.bir_2307.auto_file"]
+  tenant_id   int           [null, ref: > ops.tenants.id, note: "Null = global flag; non-null = tenant-scoped override"]
+  enabled     boolean       [not null, default: false]
+  value       jsonb         [null, note: "Optional structured config for the flag"]
+  description text          [null]
+
+  indexes {
+    (flag_name, tenant_id) [name: "idx_feature_flags_name_tenant"]
+  }
+
+  Note: '''
+    Global flags: tenant_id IS NULL, flag_name unique globally.
+    Tenant overrides: tenant_id IS NOT NULL; take precedence over global row.
+    Evaluated at agent dispatch time; cached per-session in Cosmos scratchpad.
+  '''
+}
+
+// ============================================================
+// PLATFORM SCHEMA
+// ============================================================
+
+Table platform.audit_log {
+  id             bigserial     [pk, increment]
+  actor          varchar       [not null, note: "UPN or agent_id of the acting principal"]
+  action         varchar       [not null, note: "e.g. CREATE / UPDATE / DELETE / APPROVE / INVOKE"]
+  resource_type  varchar       [not null, note: "e.g. ops.runs / account.move / res.partner"]
+  resource_id    varchar       [not null, note: "String-cast PK of the affected resource"]
+  before_state   jsonb         [null,  note: "Snapshot before mutation; null for CREATE"]
+  after_state    jsonb         [null,  note: "Snapshot after mutation; null for DELETE"]
+  timestamp      timestamp     [not null, default: `now()`]
+  tenant_id      int           [not null, ref: > ops.tenants.id]
+
+  indexes {
+    (tenant_id, timestamp)        [name: "idx_audit_log_tenant_ts"]
+    (resource_type, resource_id)  [name: "idx_audit_log_resource"]
+    actor                         [name: "idx_audit_log_actor"]
+  }
+
+  Note: '''
+    Append-only. No updates, no deletes (ADO Issue #623 — audit traceability).
+    Covers IPAI platform mutations; Odoo native chatter covers ERP-level changes.
+    before_state / after_state are post-Safe-Outputs snapshots (secrets stripped).
+  '''
+}
+
+// ============================================================
+// EXTERNAL REFERENCE ONLY — public schema (Odoo-owned)
+// Included here solely to define the cross-schema FK target.
+// Do NOT create, alter, or drop anything in public.* from IPAI migrations.
+// ============================================================
+
+Table public.res_company {
+  id    int   [pk, note: "Odoo-managed company ID — external reference only"]
+
+  Note: '''
+    Odoo CE 18 native table. IPAI must never run DDL against this table.
+    ops.tenants.company_id references this as a logical FK;
+    enforced at application layer, not as a DB-level constraint,
+    to avoid cross-schema FK dependency on Odoo migrations.
+  '''
+}
+
+// ============================================================
+// REFS
+// ============================================================
+
+// ops.runs → ops.tenants
+Ref: ops.runs.tenant_id > ops.tenants.id
+
+// ops.run_events → ops.runs
+Ref: ops.run_events.run_id > ops.runs.id
+
+// ops.feature_flags → ops.tenants (nullable tenant-scoped override)
+Ref: ops.feature_flags.tenant_id > ops.tenants.id
+
+// platform.audit_log → ops.tenants
+Ref: platform.audit_log.tenant_id > ops.tenants.id
+
+// Cross-schema: ops.tenants → public.res_company (Odoo-owned; app-level only)
+Ref: ops.tenants.company_id > public.res_company.id
+
+// ============================================================
+// COSMOS DB — DOCUMENT COLLECTIONS (not PG tables)
+// Documented here for bounded-context completeness.
+// These are Azure Cosmos DB for NoSQL containers, NOT PostgreSQL tables.
+// Partition keys and TTL are Cosmos-native concepts.
+// Correlate to PG via: session_id ↔ ops.runs.session_id
+//                       run_id    ↔ ops.runs.id
+// ============================================================
+
+// cosmos.sessions
+// ---------------
+// Container:     sessions
+// Partition key: tenant_id
+// TTL:           7 days
+// Fields:
+//   session_id          string  — correlates to ops.runs.session_id
+//   agent_id            string  — correlates to ops.runs.agent_id
+//   conversation_turns  array   — ordered array of {role, content, timestamp}
+//   scratchpad          object  — ephemeral agent working memory (feature flags cache,
+//                                 intermediate reasoning, tool state)
+//   ttl                 int     — document TTL override in seconds (default: 604800 = 7d)
+//
+// cosmos.tool_calls
+// -----------------
+// Container:     tool_calls
+// Partition key: session_id
+// TTL:           7 days
+// Fields:
+//   call_id     string  — unique call identifier
+//   tool_name   string  — matches ops.tool_catalog.tool_name
+//   input       object  — raw tool input (pre-Safe-Outputs; store only after filter pass)
+//   output      object  — raw tool output (pre-Safe-Outputs; store only after filter pass)
+//   latency_ms  int     — wall-clock latency
+//   ttl         int     — document TTL override (default: 604800 = 7d)
+//
+// cosmos.artifacts
+// ----------------
+// Container:     artifacts
+// Partition key: session_id
+// TTL:           24 hours (86400 seconds)
+// Fields:
+//   artifact_id  string  — unique artifact identifier
+//   type         string  — e.g. pdf / xlsx / json / image
+//   content      blob    — base64-encoded or Cosmos attachment reference
+//   ttl          int     — document TTL override (default: 86400 = 24h)
+//
+// Note: Artifacts with longer retention must be promoted to Azure Blob Storage
+//       and referenced by URL. Cosmos is ephemeral session scratch only.

--- a/docs/data-model/bounded-contexts/projects_services.dbml
+++ b/docs/data-model/bounded-contexts/projects_services.dbml
@@ -1,0 +1,103 @@
+Project "IPAI Projects/Services — Odoo CE 18 bounded context" {
+  database_type: 'PostgreSQL'
+  Note: 'Bounded context: Project management, tasks, milestones, and status updates. Source: Odoo CE 18 models project.project, project.task, project.milestone, project.update.'
+}
+
+Table project_project {
+  id                   integer   [pk, increment]
+  name                 varchar   [not null]
+  active               boolean
+  company_id           integer   [ref: > res_company.id]
+  partner_id           integer   [ref: > res_partner.id]
+  user_id              integer   [ref: > res_users.id]
+  date_start           date
+  date                 date      [note: 'planned end date']
+  allow_timesheets     boolean
+  analytic_account_id  integer   [ref: > account_analytic_account.id]
+  label_tasks          varchar   [note: 'custom label for task stages column']
+  task_count           integer   [note: 'computed, stored']
+}
+
+Table project_task {
+  id              integer   [pk, increment]
+  name            varchar   [not null]
+  project_id      integer   [ref: > project_project.id]
+  stage_id        integer   [ref: > project_task_type.id]
+  partner_id      integer   [ref: > res_partner.id]
+  date_deadline   date
+  kanban_state    varchar   [note: 'normal, blocked, done']
+  priority        varchar   [note: '0 normal, 1 high']
+  parent_id       integer   [ref: > project_task.id, note: 'subtask parent (self-ref)']
+  company_id      integer   [ref: > res_company.id]
+  description     text
+  planned_hours   float
+  effective_hours float      [note: 'computed from timesheets']
+  Note: 'user_ids is M2M via project_task_user_rel join table'
+}
+
+Table project_task_user_rel {
+  task_id  integer  [not null, ref: > project_task.id]
+  user_id  integer  [not null, ref: > res_users.id]
+  indexes {
+    (task_id, user_id) [pk]
+  }
+}
+
+Table project_task_type {
+  id        integer  [pk, increment]
+  name      varchar  [not null]
+  sequence  integer
+  fold      boolean
+  Note: 'project_ids is M2M via project_task_type_rel join table'
+}
+
+Table project_task_type_rel {
+  type_id     integer  [not null, ref: > project_task_type.id]
+  project_id  integer  [not null, ref: > project_project.id]
+  indexes {
+    (type_id, project_id) [pk]
+  }
+}
+
+Table project_milestone {
+  id            integer  [pk, increment]
+  name          varchar  [not null]
+  project_id    integer  [not null, ref: > project_project.id]
+  deadline      date
+  is_reached    boolean
+  reached_date  date
+}
+
+Table project_update {
+  id          integer   [pk, increment]
+  name        varchar   [not null]
+  project_id  integer   [not null, ref: > project_project.id]
+  status      varchar   [not null, note: 'on_track, at_risk, off_track, on_hold']
+  date        date
+  description text
+  progress    integer   [note: '0–100 percent']
+}
+
+Table account_analytic_account {
+  id          integer  [pk, increment]
+  name        varchar  [not null]
+  code        varchar
+  company_id  integer  [ref: > res_company.id]
+  active      boolean
+}
+
+// Shared dimension stubs
+Table res_partner {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_users {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_company {
+  id    integer  [pk]
+  name  varchar
+}

--- a/docs/data-model/bounded-contexts/purchase_inventory_mrp.dbml
+++ b/docs/data-model/bounded-contexts/purchase_inventory_mrp.dbml
@@ -1,0 +1,159 @@
+Project "IPAI Purchase/Inventory/MRP — Odoo CE 18 bounded context" {
+  database_type: 'PostgreSQL'
+  Note: 'Bounded context: Purchase orders, warehouse/inventory, stock movements. Source: Odoo CE 18 models purchase.order, stock.*, uom.*.'
+}
+
+Table purchase_order {
+  id              integer   [pk, increment]
+  name            varchar   [not null]
+  state           varchar   [not null, note: 'draft, sent, to approve, purchase, done, cancel']
+  partner_id      integer   [not null, ref: > res_partner.id]
+  date_order      timestamp
+  date_planned    timestamp
+  currency_id     integer   [not null, ref: > res_currency.id]
+  amount_total    numeric   [not null]
+  company_id      integer   [not null, ref: > res_company.id]
+  picking_type_id integer   [ref: > stock_picking_type.id]
+}
+
+Table purchase_order_line {
+  id              integer  [pk, increment]
+  order_id        integer  [not null, ref: > purchase_order.id]
+  product_id      integer  [not null, ref: > product_product.id]
+  name            varchar  [not null]
+  product_qty     numeric  [not null]
+  price_unit      numeric  [not null]
+  price_subtotal  numeric
+  date_planned    timestamp
+  product_uom     integer  [ref: > uom_uom.id]
+  Note: 'taxes_id is M2M via purchase_order_line_tax_rel join table'
+}
+
+Table purchase_order_line_tax_rel {
+  order_line_id  integer  [not null, ref: > purchase_order_line.id]
+  tax_id         integer  [not null, ref: > account_tax.id]
+  indexes {
+    (order_line_id, tax_id) [pk]
+  }
+}
+
+Table stock_warehouse {
+  id              integer  [pk, increment]
+  name            varchar  [not null]
+  code            varchar  [not null]
+  company_id      integer  [not null, ref: > res_company.id]
+  lot_stock_id    integer  [ref: > stock_location.id]
+  partner_id      integer  [ref: > res_partner.id]
+}
+
+Table stock_location {
+  id             integer  [pk, increment]
+  name           varchar  [not null]
+  complete_name  varchar
+  usage          varchar  [not null, note: 'internal, customer, supplier, transit, production, inventory']
+  company_id     integer  [ref: > res_company.id]
+  location_id    integer  [ref: > stock_location.id, note: 'parent location (self-ref)']
+}
+
+Table stock_picking_type {
+  id           integer  [pk, increment]
+  name         varchar  [not null]
+  code         varchar  [note: 'incoming, outgoing, internal']
+  warehouse_id integer  [ref: > stock_warehouse.id]
+  company_id   integer  [ref: > res_company.id]
+}
+
+Table stock_picking {
+  id              integer   [pk, increment]
+  name            varchar   [not null]
+  origin          varchar
+  state           varchar   [not null, note: 'draft, waiting, confirmed, assigned, done, cancel']
+  picking_type_id integer   [not null, ref: > stock_picking_type.id]
+  partner_id      integer   [ref: > res_partner.id]
+  location_id     integer   [not null, ref: > stock_location.id]
+  location_dest_id integer  [not null, ref: > stock_location.id]
+  scheduled_date  timestamp
+  date_done       timestamp
+  company_id      integer   [not null, ref: > res_company.id]
+}
+
+Table stock_move {
+  id               integer  [pk, increment]
+  name             varchar  [not null]
+  product_id       integer  [not null, ref: > product_product.id]
+  product_uom_qty  numeric  [not null]
+  quantity         numeric
+  picking_id       integer  [ref: > stock_picking.id]
+  location_id      integer  [not null, ref: > stock_location.id]
+  location_dest_id integer  [not null, ref: > stock_location.id]
+  state            varchar  [not null, note: 'draft, cancel, waiting, confirmed, partially_available, assigned, done']
+  company_id       integer  [not null, ref: > res_company.id]
+}
+
+Table stock_move_line {
+  id               integer  [pk, increment]
+  move_id          integer  [ref: > stock_move.id]
+  product_id       integer  [not null, ref: > product_product.id]
+  qty_done         numeric
+  lot_id           integer  [ref: > stock_lot.id]
+  location_id      integer  [not null, ref: > stock_location.id]
+  location_dest_id integer  [not null, ref: > stock_location.id]
+  picking_id       integer  [ref: > stock_picking.id]
+}
+
+Table stock_quant {
+  id                   integer  [pk, increment]
+  product_id           integer  [not null, ref: > product_product.id]
+  location_id          integer  [not null, ref: > stock_location.id]
+  quantity             numeric  [not null]
+  reserved_quantity    numeric
+  lot_id               integer  [ref: > stock_lot.id]
+  company_id           integer  [not null, ref: > res_company.id]
+}
+
+Table stock_lot {
+  id          integer  [pk, increment]
+  name        varchar  [not null]
+  product_id  integer  [not null, ref: > product_product.id]
+  company_id  integer  [not null, ref: > res_company.id]
+}
+
+Table uom_category {
+  id    integer  [pk, increment]
+  name  varchar  [not null]
+}
+
+Table uom_uom {
+  id           integer  [pk, increment]
+  name         varchar  [not null]
+  category_id  integer  [not null, ref: > uom_category.id]
+  factor       float
+  rounding     float
+  active       boolean
+}
+
+// Shared dimension stubs
+Table res_partner {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_company {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_currency {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table product_product {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table account_tax {
+  id    integer  [pk]
+  name  varchar
+}

--- a/docs/data-model/bounded-contexts/sales_crm.dbml
+++ b/docs/data-model/bounded-contexts/sales_crm.dbml
@@ -1,0 +1,162 @@
+Project "IPAI Sales/CRM — Odoo CE 18 bounded context" {
+  database_type: 'PostgreSQL'
+  Note: 'Bounded context: Sales and CRM pipeline. Source: Odoo CE 18 models crm.lead, sale.order, product.pricelist.'
+}
+
+Table crm_lead {
+  id                integer     [pk, increment]
+  name              varchar     [not null]
+  type              varchar     [not null, note: 'lead or opportunity']
+  partner_id        integer     [ref: > res_partner.id]
+  partner_name      varchar
+  contact_name      varchar
+  email_from        varchar
+  phone             varchar
+  expected_revenue  numeric
+  probability       float
+  stage_id          integer     [not null, ref: > crm_stage.id]
+  team_id           integer     [ref: > crm_team.id]
+  user_id           integer     [ref: > res_users.id]
+  company_id        integer     [ref: > res_company.id]
+  date_deadline     date
+  source_id         integer     [ref: > utm_source.id]
+  medium_id         integer     [ref: > utm_medium.id]
+  campaign_id       integer     [ref: > utm_campaign.id]
+  create_date       timestamp
+  write_date        timestamp
+}
+
+Table crm_stage {
+  id        integer  [pk, increment]
+  name      varchar  [not null]
+  sequence  integer
+  is_won    boolean
+  fold      boolean
+}
+
+Table crm_team {
+  id          integer  [pk, increment]
+  name        varchar  [not null]
+  company_id  integer  [ref: > res_company.id]
+  user_id     integer  [ref: > res_users.id]
+}
+
+Table utm_source {
+  id    integer  [pk, increment]
+  name  varchar  [not null]
+}
+
+Table utm_medium {
+  id    integer  [pk, increment]
+  name  varchar  [not null]
+}
+
+Table utm_campaign {
+  id    integer  [pk, increment]
+  name  varchar  [not null]
+}
+
+Table sale_order {
+  id                  integer   [pk, increment]
+  name                varchar   [not null]
+  state               varchar   [not null, note: 'draft, sent, sale, done, cancel']
+  partner_id          integer   [not null, ref: > res_partner.id]
+  partner_invoice_id  integer   [not null, ref: > res_partner.id]
+  partner_shipping_id integer   [not null, ref: > res_partner.id]
+  date_order          timestamp
+  validity_date       date
+  pricelist_id        integer   [ref: > product_pricelist.id]
+  currency_id         integer   [not null, ref: > res_currency.id]
+  amount_untaxed      numeric   [not null]
+  amount_tax          numeric   [not null]
+  amount_total        numeric   [not null]
+  company_id          integer   [not null, ref: > res_company.id]
+  user_id             integer   [ref: > res_users.id]
+  team_id             integer   [ref: > crm_team.id]
+  invoice_status      varchar   [note: 'upselling, invoiced, to invoice, nothing']
+}
+
+Table sale_order_line {
+  id               integer  [pk, increment]
+  order_id         integer  [not null, ref: > sale_order.id]
+  product_id       integer  [ref: > product_product.id]
+  name             varchar  [not null]
+  product_uom_qty  numeric  [not null]
+  price_unit       numeric  [not null]
+  discount         float
+  price_subtotal   numeric
+  price_total      numeric
+  product_uom      integer  [ref: > uom_uom.id]
+  company_id       integer  [ref: > res_company.id]
+  Note: 'tax_id is M2M via sale_order_line_tax_rel join table'
+}
+
+Table sale_order_line_tax_rel {
+  order_line_id  integer  [not null, ref: > sale_order_line.id]
+  tax_id         integer  [not null, ref: > account_tax.id]
+  indexes {
+    (order_line_id, tax_id) [pk]
+  }
+}
+
+Table product_pricelist {
+  id          integer  [pk, increment]
+  name        varchar  [not null]
+  currency_id integer  [not null, ref: > res_currency.id]
+  company_id  integer  [ref: > res_company.id]
+  active      boolean
+}
+
+Table product_pricelist_item {
+  id              integer  [pk, increment]
+  pricelist_id    integer  [not null, ref: > product_pricelist.id]
+  product_tmpl_id integer  [ref: > product_template.id]
+  product_id      integer  [ref: > product_product.id]
+  min_quantity    numeric
+  fixed_price     numeric
+  percent_price   float
+  compute_price   varchar  [note: 'fixed, percentage, formula']
+  date_start      date
+  date_end        date
+}
+
+// Shared dimension stubs (defined canonically in finance_accounting.dbml)
+Table res_partner {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_users {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_company {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_currency {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table product_product {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table product_template {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table uom_uom {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table account_tax {
+  id    integer  [pk]
+  name  varchar
+}

--- a/docs/data-model/bounded-contexts/website_marketing.dbml
+++ b/docs/data-model/bounded-contexts/website_marketing.dbml
@@ -1,0 +1,166 @@
+Project "IPAI Website/Marketing/Productivity — Odoo CE 18 bounded context" {
+  database_type: 'PostgreSQL'
+  Note: 'Bounded context: Website CMS, email marketing, calendar, events, and surveys. Source: Odoo CE 18 models website, mass_mailing.*, calendar.event, event.event, survey.survey.'
+}
+
+Table website {
+  id               integer  [pk, increment]
+  name             varchar  [not null]
+  domain           varchar
+  company_id       integer  [not null, ref: > res_company.id]
+  default_lang_id  integer  [ref: > res_lang.id]
+  homepage_url     varchar
+}
+
+Table res_lang {
+  id    integer  [pk, increment]
+  name  varchar  [not null]
+  code  varchar  [not null]
+}
+
+Table website_page {
+  id            integer   [pk, increment]
+  name          varchar   [not null]
+  url           varchar   [not null]
+  website_id    integer   [ref: > website.id]
+  is_published  boolean
+  date_publish  timestamp
+}
+
+Table website_menu {
+  id          integer  [pk, increment]
+  name        varchar  [not null]
+  url         varchar
+  page_id     integer  [ref: > website_page.id]
+  parent_id   integer  [ref: > website_menu.id, note: 'parent menu item (self-ref)']
+  website_id  integer  [not null, ref: > website.id]
+  sequence    integer
+}
+
+Table mailing_contact {
+  id            integer  [pk, increment]
+  name          varchar  [not null]
+  email         varchar
+  company_name  varchar
+  country_id    integer  [ref: > res_country.id]
+  Note: 'tag_ids M2M via mailing_contact_tag_rel; list_ids M2M via mailing_contact_list_rel'
+}
+
+Table mailing_contact_tag_rel {
+  contact_id  integer  [not null, ref: > mailing_contact.id]
+  tag_id      integer  [not null, ref: > mailing_tag.id]
+  indexes {
+    (contact_id, tag_id) [pk]
+  }
+}
+
+Table mailing_contact_list_rel {
+  contact_id  integer  [not null, ref: > mailing_contact.id]
+  list_id     integer  [not null, ref: > mailing_list.id]
+  indexes {
+    (contact_id, list_id) [pk]
+  }
+}
+
+Table mailing_tag {
+  id    integer  [pk, increment]
+  name  varchar  [not null]
+}
+
+Table mailing_list {
+  id             integer  [pk, increment]
+  name           varchar  [not null]
+  active         boolean
+  contact_count  integer  [note: 'computed']
+}
+
+Table mailing_mailing {
+  id                integer  [pk, increment]
+  subject           varchar  [not null]
+  body_html         text
+  mailing_type      varchar  [not null, note: 'mail, sms']
+  state             varchar  [not null, note: 'draft, in_queue, sending, done']
+  mailing_model_id  integer  [ref: > ir_model.id, note: 'target Odoo model']
+  sent              integer
+  delivered         integer
+  opened            integer
+  clicked           integer
+  bounced           integer
+  Note: 'contact_list_ids M2M via mailing_mailing_list_rel join table'
+}
+
+Table mailing_mailing_list_rel {
+  mailing_id  integer  [not null, ref: > mailing_mailing.id]
+  list_id     integer  [not null, ref: > mailing_list.id]
+  indexes {
+    (mailing_id, list_id) [pk]
+  }
+}
+
+Table ir_model {
+  id     integer  [pk, increment]
+  name   varchar  [not null]
+  model  varchar  [not null]
+}
+
+Table calendar_event {
+  id          integer   [pk, increment]
+  name        varchar   [not null]
+  start       timestamp [not null]
+  stop        timestamp [not null]
+  user_id     integer   [ref: > res_users.id]
+  description text
+  location    varchar
+  allday      boolean
+  Note: 'partner_ids M2M via calendar_event_res_partner_rel join table'
+}
+
+Table calendar_event_res_partner_rel {
+  event_id    integer  [not null, ref: > calendar_event.id]
+  partner_id  integer  [not null, ref: > res_partner.id]
+  indexes {
+    (event_id, partner_id) [pk]
+  }
+}
+
+Table event_event {
+  id               integer   [pk, increment]
+  name             varchar   [not null]
+  date_begin       timestamp [not null]
+  date_end         timestamp [not null]
+  company_id       integer   [ref: > res_company.id]
+  organizer_id     integer   [ref: > res_partner.id]
+  seats_max        integer
+  seats_available  integer   [note: 'computed']
+  state            varchar   [not null, note: 'draft, confirm, done, cancel']
+}
+
+Table survey_survey {
+  id            integer  [pk, increment]
+  title         varchar  [not null]
+  state         varchar  [not null, note: 'draft, open, closed']
+  scoring_type  varchar  [note: 'no_scoring, scoring_with_answers, scoring_without_answers']
+  access_mode   varchar  [note: 'public, token, users']
+}
+
+Table res_country {
+  id    integer  [pk, increment]
+  name  varchar  [not null]
+  code  varchar  [not null]
+}
+
+// Shared dimension stubs
+Table res_partner {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_users {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_company {
+  id    integer  [pk]
+  name  varchar
+}

--- a/docs/data-model/global_spine.dbml
+++ b/docs/data-model/global_spine.dbml
@@ -1,0 +1,243 @@
+Project ipai_global_spine {
+  database_type: 'PostgreSQL'
+  Note: 'IPAI Global Spine — Odoo CE 18 cross-domain anchors'
+}
+
+// ─── Currency & Country ──────────────────────────────────────────────────────
+
+Table res_currency {
+  id integer [pk, increment]
+  name varchar(3) [not null]
+  symbol varchar(4) [not null]
+  active boolean [not null, default: true]
+}
+
+Table res_country {
+  id integer [pk, increment]
+  name varchar [not null]
+  code varchar(2)
+}
+
+// ─── Unit of Measure ─────────────────────────────────────────────────────────
+
+Table uom_uom {
+  id integer [pk, increment]
+  name varchar [not null]
+  category_id integer [not null]
+  factor float8 [not null, default: 1.0]
+  uom_type varchar [not null]
+}
+
+// ─── Company & Partner ───────────────────────────────────────────────────────
+
+Table res_company {
+  id integer [pk, increment]
+  name varchar [not null]
+  partner_id integer [not null]
+  currency_id integer [not null]
+  parent_id integer
+}
+
+Table res_partner {
+  id integer [pk, increment]
+  name varchar
+  email varchar
+  phone varchar
+  is_company boolean [default: false]
+  company_id integer
+  parent_id integer
+  supplier_rank integer [not null, default: 0]
+  customer_rank integer [not null, default: 0]
+  vat varchar
+  create_uid integer
+  write_uid integer
+  create_date timestamptz
+  write_date timestamptz
+}
+
+// ─── Users & Groups ──────────────────────────────────────────────────────────
+
+Table res_users {
+  id integer [pk, increment]
+  login varchar [not null]
+  partner_id integer [not null]
+  company_id integer [not null]
+  active boolean [not null, default: true]
+}
+
+Table res_groups {
+  id integer [pk, increment]
+  name varchar [not null]
+  category_id integer
+}
+
+Table res_groups_users_rel {
+  gid integer [not null]
+  uid integer [not null]
+
+  indexes {
+    (gid, uid) [pk]
+  }
+}
+
+// ─── IR Framework ────────────────────────────────────────────────────────────
+
+Table ir_module_module {
+  id integer [pk, increment]
+  name varchar [not null]
+  state varchar [not null]
+  shortdesc varchar
+  author varchar
+}
+
+Table ir_model {
+  id integer [pk, increment]
+  name varchar [not null]
+  model varchar [not null]
+  state varchar [not null, default: 'base']
+  transient boolean [not null, default: false]
+}
+
+Table ir_model_fields {
+  id integer [pk, increment]
+  name varchar [not null]
+  field_description varchar
+  model_id integer [not null]
+  ttype varchar [not null]
+  relation varchar
+}
+
+Table ir_model_access {
+  id integer [pk, increment]
+  name varchar [not null]
+  model_id integer [not null]
+  group_id integer
+  perm_read boolean [not null, default: false]
+  perm_write boolean [not null, default: false]
+  perm_create boolean [not null, default: false]
+  perm_unlink boolean [not null, default: false]
+}
+
+Table ir_rule {
+  id integer [pk, increment]
+  name varchar [not null]
+  model_id integer [not null]
+  domain_force text
+  global_rule boolean [not null, default: false]
+}
+
+Table ir_attachment {
+  id integer [pk, increment]
+  name varchar [not null]
+  res_model varchar
+  res_id integer
+  type varchar [not null, default: 'binary']
+  mimetype varchar
+  datas text
+  store_fname varchar
+}
+
+Table ir_sequence {
+  id integer [pk, increment]
+  name varchar [not null]
+  code varchar
+  prefix varchar
+  suffix varchar
+  number_next integer [not null, default: 1]
+}
+
+// ─── Mail ─────────────────────────────────────────────────────────────────────
+
+Table mail_message {
+  id integer [pk, increment]
+  subject varchar
+  body text
+  message_type varchar [not null]
+  model varchar
+  res_id integer
+  author_id integer
+  date timestamptz [not null]
+}
+
+Table mail_activity {
+  id integer [pk, increment]
+  res_model varchar [not null]
+  res_id integer [not null]
+  activity_type_id integer [not null]
+  user_id integer [not null]
+  date_deadline date [not null]
+  summary varchar
+}
+
+// ─── Product ─────────────────────────────────────────────────────────────────
+
+Table product_category {
+  id integer [pk, increment]
+  name varchar [not null]
+  parent_id integer
+  complete_name varchar
+}
+
+Table product_template {
+  id integer [pk, increment]
+  name varchar [not null]
+  type varchar [not null, default: 'consu']
+  categ_id integer [not null]
+  list_price float8 [not null, default: 1.0]
+  uom_id integer [not null]
+}
+
+Table product_product {
+  id integer [pk, increment]
+  product_tmpl_id integer [not null]
+  default_code varchar
+  barcode varchar
+  active boolean [not null, default: true]
+}
+
+// ─── References ──────────────────────────────────────────────────────────────
+
+// res_company
+Ref: res_company.partner_id > res_partner.id
+Ref: res_company.currency_id > res_currency.id
+Ref: res_company.parent_id > res_company.id
+
+// res_partner
+Ref: res_partner.company_id > res_company.id
+Ref: res_partner.parent_id > res_partner.id
+Ref: res_partner.create_uid > res_users.id
+Ref: res_partner.write_uid > res_users.id
+
+// res_users
+Ref: res_users.partner_id > res_partner.id
+Ref: res_users.company_id > res_company.id
+
+// res_groups_users_rel (M2M join)
+Ref: res_groups_users_rel.gid > res_groups.id
+Ref: res_groups_users_rel.uid > res_users.id
+
+// ir_model_fields
+Ref: ir_model_fields.model_id > ir_model.id
+
+// ir_model_access
+Ref: ir_model_access.model_id > ir_model.id
+Ref: ir_model_access.group_id > res_groups.id
+
+// ir_rule
+Ref: ir_rule.model_id > ir_model.id
+
+// mail_message
+Ref: mail_message.author_id > res_partner.id
+
+// mail_activity
+Ref: mail_activity.user_id > res_users.id
+
+// product_category
+Ref: product_category.parent_id > product_category.id
+
+// product_template
+Ref: product_template.categ_id > product_category.id
+Ref: product_template.uom_id > uom_uom.id
+
+// product_product
+Ref: product_product.product_tmpl_id > product_template.id

--- a/docs/data-model/oca_extension_map.yaml
+++ b/docs/data-model/oca_extension_map.yaml
@@ -1,0 +1,368 @@
+# OCA Extension Map — Odoo CE 18
+# Locked: 2026-04-16
+# Authority: this file maps OCA modules to the bounded contexts they extend.
+# Per CLAUDE.md doctrine: Config → CE → OCA → ipai_* (last resort)
+#
+# Maturity levels per OCA: beta | production/stable | mature
+# Adoption: baseline (always install) | optional (install when needed) | reference (pattern only)
+# Source: https://odoo-community.org/list-of-must-have-oca-modules
+
+schema_version: 1
+last_updated: "2026-04-16"
+
+extension_lanes:
+
+  # =========================================================================
+  # Base / Server Tools
+  # =========================================================================
+  oca_base:
+    repo: OCA/server-tools
+    extends: spine
+    modules:
+      - name: base_technical_user
+        maturity: production/stable
+        adoption: baseline
+        extends_model: res.users
+        purpose: service account for automated actions
+
+      - name: base_user_role
+        maturity: production/stable
+        adoption: baseline
+        extends_model: res.users + res.groups
+        purpose: simplified role-based access
+
+      - name: module_auto_update
+        maturity: production/stable
+        adoption: baseline
+        extends_model: ir.module.module
+        purpose: auto-detect and update changed modules
+
+  oca_server_ux:
+    repo: OCA/server-ux
+    extends: spine
+    modules:
+      - name: date_range
+        maturity: mature
+        adoption: baseline
+        purpose: reusable date range objects (fiscal periods, reporting)
+
+      - name: base_tier_validation
+        maturity: production/stable
+        adoption: baseline
+        purpose: multi-level approval workflows
+
+  # =========================================================================
+  # Accounting / Finance
+  # =========================================================================
+  oca_accounting:
+    repo: OCA/account-financial-reporting
+    extends: finance
+    modules:
+      - name: account_financial_report
+        maturity: mature
+        adoption: baseline
+        extends_model: account.move.line
+        purpose: trial balance, general ledger, aged partner balance reports
+
+  oca_account_tools:
+    repo: OCA/account-financial-tools
+    extends: finance
+    modules:
+      - name: account_lock_date_update
+        maturity: production/stable
+        adoption: baseline
+        extends_model: res.company
+        purpose: wizard to update lock dates
+
+      - name: account_move_name_sequence
+        maturity: production/stable
+        adoption: optional
+        extends_model: account.move
+        purpose: customizable journal entry naming
+
+      - name: account_asset_management
+        maturity: mature
+        adoption: baseline
+        extends_model: account.move
+        purpose: fixed asset depreciation (EE parity)
+
+  oca_account_reconcile:
+    repo: OCA/account-reconcile
+    extends: finance
+    modules:
+      - name: account_reconcile_oca
+        maturity: production/stable
+        adoption: baseline
+        extends_model: account.bank.statement.line
+        purpose: enhanced bank reconciliation (EE parity)
+
+  oca_account_payment:
+    repo: OCA/account-payment
+    extends: finance
+    modules:
+      - name: account_payment_order
+        maturity: mature
+        adoption: baseline
+        extends_model: account.payment
+        purpose: batch payment processing
+
+  oca_currency:
+    repo: OCA/currency
+    extends: finance
+    modules:
+      - name: currency_rate_update
+        maturity: mature
+        adoption: baseline
+        extends_model: res.currency.rate
+        purpose: auto-fetch exchange rates (BSP, ECB, etc.)
+
+  oca_budget:
+    repo: OCA/account-budgeting
+    extends: finance
+    modules:
+      - name: account_budget_oca
+        maturity: production/stable
+        adoption: baseline
+        extends_model: account.analytic.account
+        purpose: budget management (EE parity)
+
+  # =========================================================================
+  # Sales / CRM
+  # =========================================================================
+  oca_sales:
+    repo: OCA/sale-workflow
+    extends: sales_crm
+    modules:
+      - name: sale_order_line_sequence
+        maturity: production/stable
+        adoption: optional
+        extends_model: sale.order.line
+        purpose: manual line ordering
+
+      - name: sale_order_type
+        maturity: production/stable
+        adoption: optional
+        extends_model: sale.order
+        purpose: order type classification
+
+  oca_crm:
+    repo: OCA/crm
+    extends: sales_crm
+    modules:
+      - name: crm_stage_probability
+        maturity: production/stable
+        adoption: optional
+        extends_model: crm.lead
+        purpose: stage-based win probability
+
+  # =========================================================================
+  # Purchase / Stock / Logistics
+  # =========================================================================
+  oca_purchase:
+    repo: OCA/purchase-workflow
+    extends: purchase_inventory
+    modules:
+      - name: purchase_order_approved
+        maturity: production/stable
+        adoption: baseline
+        extends_model: purchase.order
+        purpose: approval workflow for POs
+
+  oca_stock:
+    repo: OCA/stock-logistics-workflow
+    extends: purchase_inventory
+    modules:
+      - name: stock_no_negative
+        maturity: production/stable
+        adoption: baseline
+        extends_model: stock.quant
+        purpose: prevent negative stock
+
+  oca_bank_statement:
+    repo: OCA/bank-statement-import
+    extends: finance
+    modules:
+      - name: account_statement_import
+        maturity: mature
+        adoption: baseline
+        extends_model: account.bank.statement
+        purpose: bank statement file import (CSV, OFX, QIF, CAMT)
+
+  # =========================================================================
+  # Project / Services
+  # =========================================================================
+  oca_project:
+    repo: OCA/project
+    extends: projects
+    modules:
+      - name: project_task_default_stage
+        maturity: production/stable
+        adoption: optional
+        extends_model: project.task.type
+        purpose: default stages per project
+
+      - name: project_timeline
+        maturity: production/stable
+        adoption: optional
+        extends_model: project.task
+        purpose: Gantt-like timeline view
+
+  oca_timesheet:
+    repo: OCA/timesheet
+    extends: projects
+    modules:
+      - name: hr_timesheet_sheet
+        maturity: mature
+        adoption: baseline
+        extends_model: account.analytic.line
+        purpose: timesheet approval workflow (EE parity)
+
+  # =========================================================================
+  # HR / Workforce
+  # =========================================================================
+  oca_hr:
+    repo: OCA/hr
+    extends: hr
+    modules:
+      - name: hr_employee_document
+        maturity: production/stable
+        adoption: optional
+        extends_model: hr.employee
+        purpose: document management per employee
+
+  oca_payroll:
+    repo: OCA/payroll
+    extends: hr
+    modules:
+      - name: hr_payroll_community
+        maturity: production/stable
+        adoption: optional
+        extends_model: hr.contract
+        purpose: payroll computation (EE parity)
+
+  # =========================================================================
+  # Partner / Contact
+  # =========================================================================
+  oca_partner:
+    repo: OCA/partner-contact
+    extends: spine
+    modules:
+      - name: partner_firstname
+        maturity: mature
+        adoption: baseline
+        extends_model: res.partner
+        purpose: split first/last name on contacts
+
+      - name: partner_contact_gender
+        maturity: production/stable
+        adoption: optional
+        extends_model: res.partner
+
+      - name: partner_contact_nationality
+        maturity: production/stable
+        adoption: optional
+        extends_model: res.partner
+
+  # =========================================================================
+  # Website / Marketing
+  # =========================================================================
+  oca_website:
+    repo: OCA/website
+    extends: website_marketing
+    modules:
+      - name: website_legal_page
+        maturity: production/stable
+        adoption: optional
+        extends_model: website
+        purpose: legal/privacy page management
+
+  # =========================================================================
+  # Connector / Queue / Integration
+  # =========================================================================
+  oca_connector:
+    repo: OCA/connector
+    extends: platform
+    modules:
+      - name: connector
+        maturity: mature
+        adoption: reference
+        purpose: generic connector framework (pattern reference only)
+
+  oca_queue:
+    repo: OCA/queue
+    extends: platform
+    modules:
+      - name: queue_job
+        maturity: mature
+        adoption: baseline
+        purpose: async background job execution (critical for agent workloads)
+
+      - name: queue_job_cron_jobrunner
+        maturity: production/stable
+        adoption: baseline
+        purpose: cron-based job runner for containerized deploys
+
+  # =========================================================================
+  # Localization — PH
+  # =========================================================================
+  oca_l10n_ph:
+    repo: OCA/l10n-philippines
+    extends: finance
+    modules:
+      - name: l10n_ph
+        maturity: beta
+        adoption: optional
+        purpose: PH chart of accounts + fiscal localization
+        note: "Verify 18.0 readiness before adopting"
+
+# =============================================================================
+# ipai_* bridge/overlay modules (thin deltas only)
+# =============================================================================
+ipai_extensions:
+  - name: ipai_bir_tax_compliance
+    extends: finance
+    extends_model: account.move + account.tax
+    purpose: PH BIR 2307/2316/1601C/1701Q computation + filing
+    type: bridge
+
+  - name: ipai_expense_liquidation
+    extends: finance
+    extends_model: hr.expense.sheet
+    purpose: PH expense liquidation workflow (cash advance → liquidation)
+    type: bridge
+
+  - name: ipai_ar_collections
+    extends: finance
+    extends_model: account.move (out_invoice)
+    purpose: AR aging + collection agent surface
+    type: overlay
+
+  - name: ipai_finance_ppm
+    extends: projects
+    extends_model: project.project + account.analytic.line
+    purpose: Clarity PPM-like portfolio management overlay
+    type: overlay
+
+  - name: ipai_odoo_copilot
+    extends: platform
+    extends_model: mail.message (chat surface)
+    purpose: Pulser chat widget + skill router + Foundry integration
+    type: overlay
+
+  - name: ipai_web_branding
+    extends: website_marketing
+    extends_model: web.login template
+    purpose: login page branding (Entra + Google OAuth buttons)
+    type: overlay
+
+# =============================================================================
+# Rules
+# =============================================================================
+rules:
+  - "OCA modules listed as 'baseline' should be installed in every environment"
+  - "OCA modules listed as 'optional' are installed only when the use case demands"
+  - "OCA modules listed as 'reference' are pattern references, not installed"
+  - "ipai_* modules must have MODULE_INTROSPECTION.md + TECHNICAL_GUIDE.md per CLAUDE.md doctrine"
+  - "Every module that extends a core model must declare extends_model"
+  - "Maturity level must match OCA's published classification at time of adoption"
+  - "No EE modules — OCA parity modules replace EE functionality"

--- a/docs/data-model/orm_registry.yaml
+++ b/docs/data-model/orm_registry.yaml
@@ -1,0 +1,989 @@
+# orm_registry.yaml
+# Canonical ORM model registry for Odoo CE 18 + OCA + ipai_* modules.
+# SSOT for data-model bounded context. Machine-readable. Do not hand-edit generated fields.
+# Last updated: 2026-04-15
+# Maintainer: ipai-platform / data-model worktree
+
+models:
+
+  # ──────────────────────────────────────────────
+  # SPINE (15 models)
+  # ──────────────────────────────────────────────
+
+  - model: res.partner
+    table: res_partner
+    type: Model
+    owning_module: base
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - format.address.mixin
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company (optional company_id); user-own for portal contacts
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: res.users
+    table: res_users
+    type: Model
+    owning_module: base
+    inherits_from:
+      - res.partner
+    delegates_via:
+      res.partner: partner_id
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: user-own; groups-based visibility; portal vs internal split
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: res.company
+    table: res_company
+    type: Model
+    owning_module: base
+    inherits_from:
+      - mail.thread
+    delegates_via:
+      res.partner: partner_id
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; user sees only their own companies
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: res.groups
+    table: res_groups
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global (no per-record rules); access controlled by group membership
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: res.currency
+    table: res_currency
+    type: Model
+    owning_module: base
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: global read; write restricted to base.group_system
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: res.country
+    table: res_country
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global read; write restricted to admin
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: ir.module.module
+    table: ir_module_module
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global; managed by Odoo upgrade framework only
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: ir.model
+    table: ir_model
+    type: Model
+    owning_module: base
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: global read; write restricted to base.group_system
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: ir.model.fields
+    table: ir_model_fields
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global read; write restricted to base.group_system
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: ir.model.access
+    table: ir_model_access
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global; enforced by ORM on every CRUD call
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: ir.rule
+    table: ir_rule
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global; rules evaluated at query-time by ORM
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: ir.attachment
+    table: ir_attachment
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: user-own for private attachments; public for website assets
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: ir.sequence
+    table: ir_sequence
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: mail.message
+    table: mail_message
+    type: Model
+    owning_module: mail
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: user-own; follower-based visibility; internal messages restricted
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: mail.activity
+    table: mail_activity
+    type: Model
+    owning_module: mail
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: user-own (assigned user); manager sees all
+    source_domain: spine
+    extension_policy: core_ce
+
+  # ──────────────────────────────────────────────
+  # FINANCE (15 models)
+  # ──────────────────────────────────────────────
+
+  - model: account.account
+    table: account_account
+    type: Model
+    owning_module: account
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.journal
+    table: account_journal
+    type: Model
+    owning_module: account
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.move
+    table: account_move
+    type: Model
+    owning_module: account
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; portal access for own invoices
+    source_domain: finance
+    extension_policy: oca_baseline
+
+  - model: account.move.line
+    table: account_move_line
+    type: Model
+    owning_module: account
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; inherits parent move visibility
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.tax
+    table: account_tax
+    type: Model
+    owning_module: account
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company
+    source_domain: finance
+    extension_policy: oca_baseline
+
+  - model: account.payment
+    table: account_payment
+    type: Model
+    owning_module: account
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via:
+      account.move: move_id
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.bank.statement
+    table: account_bank_statement
+    type: Model
+    owning_module: account
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; journal-level access
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.bank.statement.line
+    table: account_bank_statement_line
+    type: Model
+    owning_module: account
+    inherits_from: []
+    delegates_via:
+      account.move: move_id
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; inherits parent statement visibility
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.analytic.account
+    table: account_analytic_account
+    type: Model
+    owning_module: analytic
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; plan-scoped
+    source_domain: finance
+    extension_policy: oca_baseline
+
+  - model: account.analytic.line
+    table: account_analytic_line
+    type: Model
+    owning_module: analytic
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; user-own for timesheets
+    source_domain: finance
+    extension_policy: oca_baseline
+
+  - model: account.analytic.plan
+    table: account_analytic_plan
+    type: Model
+    owning_module: analytic
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.fiscal.year
+    table: account_fiscal_year
+    type: Model
+    owning_module: account
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: hr.expense
+    table: hr_expense
+    type: Model
+    owning_module: hr_expense
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: user-own; manager sees all; multi-company
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: hr.expense.sheet
+    table: hr_expense_sheet
+    type: Model
+    owning_module: hr_expense
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: user-own; manager sees all; multi-company
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.reconcile.model
+    table: account_reconcile_model
+    type: Model
+    owning_module: account
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; journal-restricted
+    source_domain: finance
+    extension_policy: core_ce
+
+  # ──────────────────────────────────────────────
+  # SALES / CRM (8 models)
+  # ──────────────────────────────────────────────
+
+  - model: crm.lead
+    table: crm_lead
+    type: Model
+    owning_module: crm
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - utm.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: user-own; team-based visibility; multi-company
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  - model: sale.order
+    table: sale_order
+    type: Model
+    owning_module: sale
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - portal.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: user-own; portal access for own orders; multi-company
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  - model: sale.order.line
+    table: sale_order_line
+    type: Model
+    owning_module: sale
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; inherits parent order visibility
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  - model: product.template
+    table: product_template
+    type: Model
+    owning_module: product
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - image.mixin
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: global read; write restricted to product managers
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  - model: product.product
+    table: product_product
+    type: Model
+    owning_module: product
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via:
+      product.template: product_tmpl_id
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: global read; write restricted to product managers
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  - model: product.pricelist
+    table: product_pricelist
+    type: Model
+    owning_module: product
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; currency-scoped
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  - model: product.pricelist.item
+    table: product_pricelist_item
+    type: Model
+    owning_module: product
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; inherits parent pricelist visibility
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  - model: product.category
+    table: product_category
+    type: Model
+    owning_module: product
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  # ──────────────────────────────────────────────
+  # PURCHASE / INVENTORY (10 models)
+  # ──────────────────────────────────────────────
+
+  - model: purchase.order
+    table: purchase_order
+    type: Model
+    owning_module: purchase
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - portal.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: user-own; portal access for vendors; multi-company
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: purchase.order.line
+    table: purchase_order_line
+    type: Model
+    owning_module: purchase
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; inherits parent order visibility
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: stock.picking
+    table: stock_picking
+    type: Model
+    owning_module: stock
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; warehouse-scoped
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: stock.move
+    table: stock_move
+    type: Model
+    owning_module: stock
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; inherits parent picking visibility
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: stock.move.line
+    table: stock_move_line
+    type: Model
+    owning_module: stock
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; inherits parent move visibility
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: stock.quant
+    table: stock_quant
+    type: Model
+    owning_module: stock
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; location-scoped
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: stock.location
+    table: stock_location
+    type: Model
+    owning_module: stock
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; internal vs external location visibility
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: stock.warehouse
+    table: stock_warehouse
+    type: Model
+    owning_module: stock
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; one warehouse per company minimum
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: uom.uom
+    table: uom_uom
+    type: Model
+    owning_module: uom
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global read; write restricted to inventory managers
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: uom.category
+    table: uom_category
+    type: Model
+    owning_module: uom
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  # ──────────────────────────────────────────────
+  # PROJECTS (5 models)
+  # ──────────────────────────────────────────────
+
+  - model: project.project
+    table: project_project
+    type: Model
+    owning_module: project
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - rating.mixin
+    delegates_via:
+      account.analytic.account: analytic_account_id
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; visibility field (followers/all employees/portal)
+    source_domain: projects
+    extension_policy: core_ce
+
+  - model: project.task
+    table: project_task
+    type: Model
+    owning_module: project
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - rating.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; project visibility cascade; user-own personal tasks
+    source_domain: projects
+    extension_policy: core_ce
+
+  - model: project.task.type
+    table: project_task_type
+    type: Model
+    owning_module: project
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: global; shared across projects unless project-scoped
+    source_domain: projects
+    extension_policy: core_ce
+
+  - model: project.milestone
+    table: project_milestone
+    type: Model
+    owning_module: project
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; project-scoped
+    source_domain: projects
+    extension_policy: core_ce
+
+  - model: project.update
+    table: project_update
+    type: Model
+    owning_module: project
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; project-scoped
+    source_domain: projects
+    extension_policy: core_ce
+
+  # ──────────────────────────────────────────────
+  # HR (8 models)
+  # ──────────────────────────────────────────────
+
+  - model: hr.employee
+    table: hr_employee
+    type: Model
+    owning_module: hr
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - image.mixin
+    delegates_via:
+      hr.employee.public: employee_id
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; user-own (limited fields); HR manager sees all
+    source_domain: hr
+    extension_policy: core_ce
+
+  - model: hr.department
+    table: hr_department
+    type: Model
+    owning_module: hr
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company
+    source_domain: hr
+    extension_policy: core_ce
+
+  - model: hr.job
+    table: hr_job
+    type: Model
+    owning_module: hr
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company
+    source_domain: hr
+    extension_policy: core_ce
+
+  - model: hr.contract
+    table: hr_contract
+    type: Model
+    owning_module: hr_contract
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; HR manager only (sensitive pay data)
+    source_domain: hr
+    extension_policy: core_ce
+
+  - model: hr.attendance
+    table: hr_attendance
+    type: Model
+    owning_module: hr_attendance
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; user-own; kiosk mode bypass
+    source_domain: hr
+    extension_policy: core_ce
+
+  - model: hr.leave
+    table: hr_leave
+    type: Model
+    owning_module: hr_holidays
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; user-own; manager approval flow
+    source_domain: hr
+    extension_policy: core_ce
+
+  - model: hr.leave.type
+    table: hr_leave_type
+    type: Model
+    owning_module: hr_holidays
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company
+    source_domain: hr
+    extension_policy: core_ce
+
+  - model: hr.applicant
+    table: hr_applicant
+    type: Model
+    owning_module: hr_recruitment
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - utm.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; recruiter-own; hiring manager visibility
+    source_domain: hr
+    extension_policy: core_ce
+
+  # ──────────────────────────────────────────────
+  # PLATFORM / OVERLAY (6 models)
+  # ──────────────────────────────────────────────
+
+  - model: ops.runs
+    table: ops_runs
+    type: Model
+    owning_module: ipai_platform_ops
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: global; append-only enforced at application layer
+    source_domain: platform
+    extension_policy: ipai_bridge
+
+  - model: ops.run_events
+    table: ops_run_events
+    type: Model
+    owning_module: ipai_platform_ops
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global; append-only enforced at application layer
+    source_domain: platform
+    extension_policy: ipai_bridge
+
+  - model: ops.tool_catalog
+    table: ops_tool_catalog
+    type: Model
+    owning_module: ipai_platform_ops
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: global read; write restricted to platform admins
+    source_domain: platform
+    extension_policy: ipai_bridge
+
+  - model: ops.feature_flags
+    table: ops_feature_flags
+    type: Model
+    owning_module: ipai_platform_ops
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; write restricted to platform admins
+    source_domain: platform
+    extension_policy: ipai_bridge
+
+  - model: ops.tenants
+    table: ops_tenants
+    type: Model
+    owning_module: ipai_platform_ops
+    inherits_from:
+      - mail.thread
+    delegates_via:
+      res.company: company_id
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: global; tenant isolation enforced at application layer
+    source_domain: platform
+    extension_policy: ipai_overlay
+
+  - model: ipai.bir.tax.compliance.register
+    table: ipai_bir_tax_compliance_register
+    type: Model
+    owning_module: ipai_bir_2307
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; PH BIR-sensitive; accountant and tax manager only
+    source_domain: platform
+    extension_policy: ipai_overlay

--- a/evidence/schema/README.md
+++ b/evidence/schema/README.md
@@ -1,0 +1,19 @@
+# Physical Schema Snapshot
+
+This directory holds generated physical schema from a live reference database.
+NOT hand-authored — generated via:
+
+```bash
+pg_dump -s -n public -n ops -n platform \
+  -h pg-ipai-odoo.postgres.database.azure.com \
+  -U ipaiadmin -d odoo_dev \
+  > evidence/schema/odoo_reference_schema.sql
+```
+
+Status: BLOCKED on PG auth (ipaiadmin password not in KV).
+Unblock: reset password via Azure Portal → pg-ipai-odoo → Compute + storage → Admin password.
+
+Once generated, also export as DBML:
+```bash
+sql2dbml evidence/schema/odoo_reference_schema.sql --postgres > evidence/schema/odoo_reference_schema.dbml
+```

--- a/ssot/lakehouse/unity-catalog-map.yaml
+++ b/ssot/lakehouse/unity-catalog-map.yaml
@@ -1,0 +1,216 @@
+# SSOT — Unity Catalog Governance Map
+# Locked: 2026-04-16
+# Authority: this file governs the analytics and AI projection in Databricks UC.
+# UC is the GOVERNANCE/DISCOVERY/ACCESS layer, NOT the OLTP schema.
+# OLTP truth = Odoo ORM (ssot/odoo/orm-registry.yaml).
+#
+# Reference: https://www.databricks.com/product/unity-catalog
+# Companion: docs/architecture/databricks-one-and-workspace-operating-model.md
+
+schema_version: 1
+last_updated: "2026-04-16"
+workspace: dbw-ipai-dev
+workspace_url: "https://adb-7405608559466577.17.azuredatabricks.net"
+
+catalogs:
+
+  ppm:
+    description: "IPAI Finance / PPM / Operations analytics catalog"
+    schemas:
+
+      bronze:
+        description: "Raw Odoo exports, minimally transformed"
+        objects:
+          - object_name: account_move_raw
+            object_type: table
+            source_domain: finance
+            source_model: account.move
+            owner: data
+            classification: confidential
+            policy_class: multi-company
+            lineage_required: true
+            quality_monitoring_class: freshness + completeness
+            business_semantics_binding: null
+            shareability: internal
+
+          - object_name: res_partner_raw
+            object_type: table
+            source_domain: spine
+            source_model: res.partner
+            owner: data
+            classification: confidential
+            policy_class: multi-company
+            lineage_required: true
+            quality_monitoring_class: completeness
+            shareability: internal
+
+          - object_name: project_task_raw
+            object_type: table
+            source_domain: projects
+            source_model: project.task
+            owner: data
+            classification: internal
+            policy_class: multi-company
+            lineage_required: true
+            quality_monitoring_class: freshness
+            shareability: internal
+
+      silver:
+        description: "Cleaned, type-conformed, joined"
+        objects:
+          - object_name: account_move_cleaned
+            object_type: table
+            source_domain: finance
+            owner: data
+            classification: confidential
+            lineage_required: true
+            quality_monitoring_class: accuracy + completeness
+            shareability: internal
+
+          - object_name: res_partner_cleaned
+            object_type: table
+            source_domain: spine
+            owner: data
+            classification: confidential
+            lineage_required: true
+            quality_monitoring_class: dedup + completeness
+            shareability: internal
+
+      gold:
+        description: "Domain aggregates — the consumer layer for BI + Fabric + agents"
+        objects:
+          - object_name: finance_gl_trial_balance
+            object_type: table
+            source_domain: finance
+            owner: data
+            classification: confidential
+            policy_class: multi-company + row-level
+            lineage_required: true
+            quality_monitoring_class: accuracy + timeliness
+            business_semantics_binding: cdm.JournalLine aggregated
+            shareability: internal
+
+          - object_name: finance_ap_aging
+            object_type: table
+            source_domain: finance
+            owner: data
+            classification: confidential
+            policy_class: multi-company
+            lineage_required: true
+            quality_monitoring_class: accuracy
+            business_semantics_binding: cdm.VendorInvoice aged
+            shareability: internal
+
+          - object_name: finance_ar_aging
+            object_type: table
+            source_domain: finance
+            owner: data
+            classification: confidential
+            policy_class: multi-company
+            lineage_required: true
+            quality_monitoring_class: accuracy
+            business_semantics_binding: cdm.Invoice aged
+            shareability: internal
+
+          - object_name: finance_cash_position
+            object_type: table
+            source_domain: finance
+            owner: data
+            classification: confidential
+            policy_class: multi-company
+            lineage_required: true
+            quality_monitoring_class: timeliness
+            business_semantics_binding: cdm.Payment + cdm.BankStatementLine
+            shareability: internal
+
+          - object_name: ops_project_burn
+            object_type: table
+            source_domain: projects
+            owner: data
+            classification: internal
+            policy_class: multi-company
+            lineage_required: true
+            quality_monitoring_class: completeness
+            business_semantics_binding: cdm.Project + cdm.ProjectTask
+            shareability: internal
+
+          - object_name: ops_agent_run_summary
+            object_type: table
+            source_domain: platform
+            owner: platform
+            classification: internal
+            policy_class: tenant-scoped
+            lineage_required: true
+            quality_monitoring_class: completeness
+            business_semantics_binding: cdm.AgentRun
+            shareability: internal
+
+          - object_name: compliance_bir_filing_status
+            object_type: table
+            source_domain: finance
+            owner: data
+            classification: restricted
+            policy_class: tenant-scoped + regulated
+            lineage_required: true
+            quality_monitoring_class: accuracy + audit
+            business_semantics_binding: ipai.bir.tax.compliance.register
+            shareability: internal
+
+          # --- CDM entity projections (denormalized for BI) ---
+          - object_name: cdm_account
+            object_type: table
+            source_domain: spine
+            owner: data
+            classification: confidential
+            lineage_required: true
+            business_semantics_binding: cdm.Account
+            shareability: partner
+
+          - object_name: cdm_invoice
+            object_type: table
+            source_domain: finance
+            owner: data
+            classification: confidential
+            lineage_required: true
+            business_semantics_binding: cdm.Invoice
+            shareability: partner
+
+          - object_name: cdm_payment
+            object_type: table
+            source_domain: finance
+            owner: data
+            classification: confidential
+            lineage_required: true
+            business_semantics_binding: cdm.Payment
+            shareability: partner
+
+      metrics:
+        description: "Pre-computed metric tables for dashboards (planned)"
+        objects: []
+
+      features:
+        description: "ML feature store (planned)"
+        objects: []
+
+# =============================================================================
+# Governance rules
+# =============================================================================
+governance:
+  access_control: "UC RBAC — catalog/schema/table-level GRANT. No direct PG access from analytics users."
+  lineage: "UC lineage tracks Bronze → Silver → Gold. Source = Odoo PG via Lakehouse Federation."
+  quality: "DLT expectations on Silver + Gold tables. Freshness SLA per table."
+  discovery: "UC tags on every object: owner, sensitivity, tenant_scope, freshness_sla, source_repo"
+  audit: "UC audit log enabled. All access logged."
+  sharing: "OneLake shortcuts for Fabric; partner shareability via UC managed sharing."
+
+# =============================================================================
+# Rules
+# =============================================================================
+rules:
+  - "UC governs curated analytical/AI assets, NOT raw OLTP tables"
+  - "Every UC object must have: source_domain, owner, classification, lineage_required"
+  - "Gold-layer objects must have business_semantics_binding (CDM or domain-specific)"
+  - "policy_class determines row/column-level security model"
+  - "shareability determines cross-tenant/partner data sharing scope"
+  - "No direct Odoo PG connection from UC users — Lakehouse Federation is the read path"
+  - "Bronze/Silver are internal-only; Gold + CDM projections can be partner-shared"

--- a/ssot/odoo/domains/finance.dbml
+++ b/ssot/odoo/domains/finance.dbml
@@ -1,0 +1,336 @@
+// ============================================================
+// IPAI Finance/Accounting — Odoo CE 18 bounded context
+// Generated: 2026-04-15
+// Scope: account_*, hr_expense* tables in Odoo CE 18 PostgreSQL schema
+// Cross-context spine refs: res_partner, res_company, res_currency,
+//   product_product — defined in global_spine.dbml; referenced here
+//   with dotted notation per DBML cross-schema convention.
+// ============================================================
+
+Project "IPAI Finance/Accounting — Odoo CE 18 bounded context" {
+  database_type: "PostgreSQL"
+  Note: '''
+    Bounded context: Finance & Accounting
+    Source: Odoo CE 18.0 ORM / PostgreSQL schema
+    Owner: IPAI Engineering
+    Spine dependencies: res_partner, res_company, res_currency, product_product
+    Related bounded contexts: project (analytic), hr (expenses), inventory (product)
+    Last reviewed: 2026-04-15
+  '''
+}
+
+// ============================================================
+// CHART OF ACCOUNTS
+// ============================================================
+
+Table account_account {
+  id               integer       [pk, increment, not null]
+  code             varchar       [not null, note: "e.g. 101000"]
+  name             varchar       [not null]
+  account_type     varchar       [not null, note: "asset_receivable|asset_cash|asset_current|asset_non_current|asset_prepayments|asset_fixed|liability_payable|liability_credit_card|liability_current|liability_non_current|equity|equity_unaffected|income|income_other|expense|expense_depreciation|expense_direct_cost|off_balance"]
+  company_id       integer       [not null, ref: > res_company.id]
+  currency_id      integer       [ref: > res_currency.id, note: "optional; forces currency on journal items"]
+  reconcile        boolean       [not null, default: false, note: "true for AR/AP accounts"]
+  deprecated       boolean       [not null, default: false]
+  group_id         integer       [ref: > account_group.id]
+
+  Note: "Chart of accounts entry. account_type drives P&L vs balance sheet placement."
+}
+
+Table account_group {
+  id               integer       [pk, increment, not null]
+  name             varchar       [not null]
+  code_prefix_start varchar      [note: "e.g. 1"]
+  code_prefix_end   varchar      [note: "e.g. 1999"]
+  company_id       integer       [not null, ref: > res_company.id]
+  parent_id        integer       [ref: > account_group.id, note: "self-referential hierarchy"]
+
+  Note: "Account groups used for financial report grouping."
+}
+
+// ============================================================
+// JOURNALS
+// ============================================================
+
+Table account_journal {
+  id                    integer   [pk, increment, not null]
+  name                  varchar   [not null]
+  code                  varchar   [not null, note: "Short code e.g. INV, BILL, BNK1"]
+  type                  varchar   [not null, note: "sale|purchase|cash|bank|general"]
+  company_id            integer   [not null, ref: > res_company.id]
+  default_account_id    integer   [ref: > account_account.id, note: "Default debit/credit account"]
+  currency_id           integer   [ref: > res_currency.id, note: "Forces foreign currency on journal entries"]
+
+  Note: "Journals partition accounting entries by business flow (sales, purchases, bank, cash, misc)."
+}
+
+// ============================================================
+// JOURNAL ENTRIES (MOVES)
+// ============================================================
+
+Table account_move {
+  id               integer       [pk, increment, not null]
+  name             varchar       [note: "Sequence number e.g. INV/2026/00001; / for drafts"]
+  state            varchar       [not null, note: "draft|posted|cancel"]
+  move_type        varchar       [not null, note: "entry|out_invoice|in_invoice|out_refund|in_refund|out_receipt|in_receipt"]
+  journal_id       integer       [not null, ref: > account_journal.id]
+  company_id       integer       [not null, ref: > res_company.id]
+  partner_id       integer       [ref: > res_partner.id]
+  currency_id      integer       [not null, ref: > res_currency.id]
+  date             date          [not null, note: "Accounting date"]
+  invoice_date     date          [note: "Document date (invoices/bills only)"]
+  amount_total     numeric       [not null, default: 0, note: "Total in document currency"]
+  amount_residual  numeric       [not null, default: 0, note: "Remaining amount to pay"]
+  payment_state    varchar       [note: "not_paid|in_payment|paid|partial|reversed|invoicing_legacy"]
+
+  Note: "Central accounting document — covers journal entries, vendor bills, customer invoices, credit/debit notes, and receipts."
+}
+
+// ============================================================
+// JOURNAL ENTRY LINES
+// ============================================================
+
+Table account_move_line {
+  id                    integer   [pk, increment, not null]
+  move_id               integer   [not null, ref: > account_move.id]
+  account_id            integer   [not null, ref: > account_account.id]
+  partner_id            integer   [ref: > res_partner.id]
+  product_id            integer   [ref: > product_product.id]
+  name                  varchar   [note: "Line label / description"]
+  quantity              numeric   [not null, default: 1]
+  price_unit            numeric   [not null, default: 0]
+  debit                 numeric   [not null, default: 0]
+  credit                numeric   [not null, default: 0]
+  balance               numeric   [not null, default: 0, note: "debit - credit; computed"]
+  amount_currency       numeric   [not null, default: 0, note: "Amount in line currency when different from company currency"]
+  currency_id           integer   [not null, ref: > res_currency.id]
+  analytic_distribution jsonb     [note: "Map of account_analytic_account.id (as text) -> percentage, e.g. {\"42\": 100.0}"]
+  company_id            integer   [not null, ref: > res_company.id]
+
+  Note: "One debit or credit line within an account_move. tax_ids is a many2many via account_move_line_account_tax_rel (not modelled as column)."
+}
+
+// Many-to-many: account_move_line <-> account_tax
+Table account_move_line_account_tax_rel {
+  account_move_line_id  integer   [not null, ref: > account_move_line.id]
+  account_tax_id        integer   [not null, ref: > account_tax.id]
+
+  indexes {
+    (account_move_line_id, account_tax_id) [pk]
+  }
+
+  Note: "Junction table for tax_ids M2M on account_move_line."
+}
+
+// ============================================================
+// TAXES
+// ============================================================
+
+Table account_tax {
+  id               integer       [pk, increment, not null]
+  name             varchar       [not null]
+  type_tax_use     varchar       [not null, note: "sale|purchase|none"]
+  amount_type      varchar       [not null, note: "percent|fixed|group|division"]
+  amount           numeric       [not null, default: 0, note: "Rate (e.g. 12 for 12%) or fixed amount"]
+  company_id       integer       [not null, ref: > res_company.id]
+
+  Note: "Tax definition. Group taxes reference child taxes via account_tax_filiation_rel (not expanded here)."
+}
+
+// ============================================================
+// PAYMENTS
+// ============================================================
+
+Table account_payment {
+  id               integer       [pk, increment, not null]
+  partner_id       integer       [ref: > res_partner.id]
+  amount           numeric       [not null, default: 0]
+  currency_id      integer       [not null, ref: > res_currency.id]
+  date             date          [not null]
+  journal_id       integer       [not null, ref: > account_journal.id]
+  payment_type     varchar       [not null, note: "inbound|outbound|transfer"]
+  partner_type     varchar       [note: "customer|supplier"]
+  move_id          integer       [ref: > account_move.id, note: "Generated journal entry"]
+  state            varchar       [not null, note: "draft|posted|sent|reconciled|cancelled"]
+
+  Note: "Customer receipts and vendor payments. Generates an account_move on posting."
+}
+
+// ============================================================
+// BANK STATEMENTS
+// ============================================================
+
+Table account_bank_statement {
+  id                  integer     [pk, increment, not null]
+  name                varchar     [not null, note: "Reference / statement number"]
+  date                date        [not null]
+  journal_id          integer     [not null, ref: > account_journal.id]
+  company_id          integer     [not null, ref: > res_company.id]
+  balance_start       numeric     [not null, default: 0]
+  balance_end_real    numeric     [not null, default: 0, note: "Closing balance as per bank document"]
+
+  Note: "Bank or cash statement imported or entered manually. Lines are matched/reconciled against journal entries."
+}
+
+Table account_bank_statement_line {
+  id               integer       [pk, increment, not null]
+  statement_id     integer       [not null, ref: > account_bank_statement.id]
+  move_id          integer       [not null, ref: > account_move.id, note: "Created automatically; holds the accounting entry"]
+  partner_id       integer       [ref: > res_partner.id]
+  amount           numeric       [not null, default: 0]
+  date             date          [not null]
+  payment_ref      varchar       [note: "Bank memo / reference text"]
+  account_number   varchar       [note: "Counterparty account number from bank feed"]
+
+  Note: "Individual transaction line from a bank statement."
+}
+
+// ============================================================
+// ANALYTIC ACCOUNTING
+// ============================================================
+
+Table account_analytic_plan {
+  id               integer       [pk, increment, not null]
+  name             varchar       [not null]
+  parent_id        integer       [ref: > account_analytic_plan.id, note: "Self-referential hierarchy; NULL for root plans"]
+  company_id       integer       [ref: > res_company.id, note: "NULL = shared across companies"]
+
+  Note: "Analytic plan groups analytic accounts into a named dimension (e.g. Projects, Departments, Cost Centres)."
+}
+
+Table account_analytic_account {
+  id               integer       [pk, increment, not null]
+  name             varchar       [not null]
+  code             varchar
+  company_id       integer       [ref: > res_company.id]
+  partner_id       integer       [ref: > res_partner.id]
+  plan_id          integer       [not null, ref: > account_analytic_plan.id]
+
+  Note: "Analytic account (cost centre / project / department). Referenced via analytic_distribution jsonb on move lines."
+}
+
+Table account_analytic_line {
+  id                   integer    [pk, increment, not null]
+  name                 varchar    [not null]
+  date                 date       [not null]
+  amount               numeric    [not null, default: 0]
+  unit_amount          numeric    [not null, default: 0, note: "Hours or quantity"]
+  account_id           integer    [not null, ref: > account_analytic_account.id, note: "Analytic account (cost centre)"]
+  general_account_id   integer    [ref: > account_account.id, note: "GL account counterpart"]
+  move_line_id         integer    [ref: > account_move_line.id, note: "Source journal item; NULL for timesheets"]
+  partner_id           integer    [ref: > res_partner.id]
+  company_id           integer    [not null, ref: > res_company.id]
+  project_id           integer    [ref: > project_project.id, note: "Cross-context ref to project bounded context"]
+
+  Note: "Analytic distribution line. Created automatically from account_move_line.analytic_distribution or from timesheets."
+}
+
+// ============================================================
+// FISCAL YEAR (used for lock dates and period configuration)
+// ============================================================
+
+Table account_fiscal_year {
+  id               integer       [pk, increment, not null]
+  name             varchar       [not null]
+  date_from        date          [not null]
+  date_to          date          [not null]
+  company_id       integer       [not null, ref: > res_company.id]
+
+  Note: "Fiscal year definition used for lock-date enforcement and period-based reporting."
+}
+
+// ============================================================
+// EXPENSES
+// ============================================================
+
+Table hr_expense {
+  id                    integer   [pk, increment, not null]
+  name                  varchar   [not null, note: "Expense description"]
+  employee_id           integer   [not null, ref: > hr_employee.id, note: "Cross-context ref to HR bounded context"]
+  product_id            integer   [not null, ref: > product_product.id]
+  unit_amount           numeric   [not null, default: 0, note: "Price per unit (or total when qty=1)"]
+  quantity              numeric   [not null, default: 1]
+  total_amount          numeric   [not null, default: 0, note: "unit_amount * quantity (computed)"]
+  state                 varchar   [not null, note: "draft|reported|approved|done|refused"]
+  sheet_id              integer   [ref: > hr_expense_sheet.id]
+  company_id            integer   [not null, ref: > res_company.id]
+  account_id            integer   [ref: > account_account.id]
+  analytic_distribution jsonb     [note: "Map of account_analytic_account.id (as text) -> percentage"]
+
+  Note: "Individual employee expense line. Grouped into hr_expense_sheet for approval and posting."
+}
+
+Table hr_expense_sheet {
+  id               integer       [pk, increment, not null]
+  name             varchar       [not null]
+  employee_id      integer       [not null, ref: > hr_employee.id]
+  state            varchar       [not null, note: "draft|submit|approve|post|done|cancel"]
+  company_id       integer       [not null, ref: > res_company.id]
+  journal_id       integer       [not null, ref: > account_journal.id]
+  account_move_id  integer       [ref: > account_move.id, note: "Journal entry created on posting"]
+  total_amount     numeric       [not null, default: 0]
+
+  Note: "Expense report grouping one or more hr_expense lines. Approval → posting creates account_move."
+}
+
+// ============================================================
+// RECONCILIATION MODELS (bank matching rules)
+// ============================================================
+
+Table account_reconcile_model {
+  id                   integer    [pk, increment, not null]
+  name                 varchar    [not null]
+  rule_type            varchar    [not null, note: "writeoff_button|writeoff_suggestion|invoice_matching"]
+  company_id           integer    [not null, ref: > res_company.id]
+
+  Note: "Automated bank reconciliation rule. match_journal_ids is a M2M to account_journal (via account_reconcile_model_journal_rel); not expanded as column here."
+}
+
+// Many-to-many: account_reconcile_model <-> account_journal (match_journal_ids)
+Table account_reconcile_model_journal_rel {
+  reconcile_model_id   integer   [not null, ref: > account_reconcile_model.id]
+  journal_id           integer   [not null, ref: > account_journal.id]
+
+  indexes {
+    (reconcile_model_id, journal_id) [pk]
+  }
+
+  Note: "Junction table for match_journal_ids M2M on account_reconcile_model."
+}
+
+// ============================================================
+// CROSS-CONTEXT SPINE STUBS
+// These tables live in the global spine bounded context.
+// Declared here as stubs to satisfy Ref targets within this file.
+// Full definitions: docs/data-model/bounded-contexts/global_spine.dbml
+// ============================================================
+
+Table res_company {
+  id   integer [pk]
+  Note: "Global spine — see global_spine.dbml"
+}
+
+Table res_partner {
+  id   integer [pk]
+  Note: "Global spine — see global_spine.dbml"
+}
+
+Table res_currency {
+  id   integer [pk]
+  Note: "Global spine — see global_spine.dbml"
+}
+
+Table product_product {
+  id   integer [pk]
+  Note: "Inventory/product bounded context — see inventory.dbml"
+}
+
+Table hr_employee {
+  id   integer [pk]
+  Note: "HR bounded context — see hr.dbml"
+}
+
+Table project_project {
+  id   integer [pk]
+  Note: "Project bounded context — see project.dbml"
+}

--- a/ssot/odoo/domains/hr.dbml
+++ b/ssot/odoo/domains/hr.dbml
@@ -1,0 +1,128 @@
+Project "IPAI HR/Workforce — Odoo CE 18 bounded context" {
+  database_type: 'PostgreSQL'
+  Note: 'Bounded context: Employees, departments, contracts, attendance, leaves, and recruitment. Source: Odoo CE 18 models hr.employee, hr.contract, hr.attendance, hr.leave, hr.applicant.'
+}
+
+Table hr_employee {
+  id             integer  [pk, increment]
+  name           varchar  [not null]
+  user_id        integer  [ref: > res_users.id, note: 'linked portal/internal user']
+  company_id     integer  [not null, ref: > res_company.id]
+  department_id  integer  [ref: > hr_department.id]
+  job_id         integer  [ref: > hr_job.id]
+  job_title      varchar
+  work_email     varchar
+  work_phone     varchar
+  resource_id    integer  [not null, ref: > resource_resource.id]
+  parent_id      integer  [ref: > hr_employee.id, note: 'manager (self-ref)']
+  coach_id       integer  [ref: > hr_employee.id, note: 'coach (self-ref)']
+  active         boolean
+}
+
+Table hr_department {
+  id             integer  [pk, increment]
+  name           varchar  [not null]
+  company_id     integer  [not null, ref: > res_company.id]
+  parent_id      integer  [ref: > hr_department.id, note: 'parent department (self-ref)']
+  manager_id     integer  [ref: > hr_employee.id]
+  complete_name  varchar  [note: 'computed hierarchical label']
+}
+
+Table hr_job {
+  id                  integer  [pk, increment]
+  name                varchar  [not null]
+  department_id       integer  [ref: > hr_department.id]
+  company_id          integer  [ref: > res_company.id]
+  no_of_recruitment   integer
+}
+
+Table hr_contract {
+  id             integer   [pk, increment]
+  name           varchar   [not null]
+  employee_id    integer   [not null, ref: > hr_employee.id]
+  department_id  integer   [ref: > hr_department.id]
+  job_id         integer   [ref: > hr_job.id]
+  company_id     integer   [not null, ref: > res_company.id]
+  state          varchar   [not null, note: 'draft, open, close, cancel']
+  date_start     date      [not null]
+  date_end       date
+  wage           numeric   [not null]
+  struct_id      integer   [ref: > hr_payroll_structure.id]
+}
+
+Table hr_payroll_structure {
+  id          integer  [pk, increment]
+  name        varchar  [not null]
+  company_id  integer  [ref: > res_company.id]
+}
+
+Table hr_attendance {
+  id            integer   [pk, increment]
+  employee_id   integer   [not null, ref: > hr_employee.id]
+  check_in      timestamp [not null]
+  check_out     timestamp
+  worked_hours  float     [note: 'computed']
+}
+
+Table hr_leave {
+  id                 integer   [pk, increment]
+  employee_id        integer   [not null, ref: > hr_employee.id]
+  holiday_status_id  integer   [not null, ref: > hr_leave_type.id]
+  date_from          timestamp [not null]
+  date_to            timestamp [not null]
+  number_of_days     float
+  state              varchar   [not null, note: 'draft, confirm, validate1, validate, refuse']
+  company_id         integer   [not null, ref: > res_company.id]
+}
+
+Table hr_leave_type {
+  id                     integer  [pk, increment]
+  name                   varchar  [not null]
+  company_id             integer  [ref: > res_company.id]
+  requires_allocation    varchar  [note: 'yes, no']
+  leave_validation_type  varchar  [note: 'no_validation, time_off, both']
+}
+
+Table hr_applicant {
+  id               integer  [pk, increment]
+  partner_name     varchar
+  partner_id       integer  [ref: > res_partner.id]
+  job_id           integer  [ref: > hr_job.id]
+  department_id    integer  [ref: > hr_department.id]
+  stage_id         integer  [ref: > hr_recruitment_stage.id]
+  user_id          integer  [ref: > res_users.id]
+  priority         varchar  [note: '0 normal, 1 good, 2 very good, 3 excellent']
+  salary_expected  numeric
+  salary_proposed  numeric
+  company_id       integer  [ref: > res_company.id]
+}
+
+Table hr_recruitment_stage {
+  id        integer  [pk, increment]
+  name      varchar  [not null]
+  sequence  integer
+  fold      boolean
+}
+
+Table resource_resource {
+  id          integer  [pk, increment]
+  name        varchar  [not null]
+  company_id  integer  [ref: > res_company.id]
+  user_id     integer  [ref: > res_users.id]
+}
+
+// Shared dimension stubs
+Table res_partner {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_users {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_company {
+  id    integer  [pk]
+  name  varchar
+}

--- a/ssot/odoo/domains/inventory_mrp.dbml
+++ b/ssot/odoo/domains/inventory_mrp.dbml
@@ -1,0 +1,159 @@
+Project "IPAI Purchase/Inventory/MRP — Odoo CE 18 bounded context" {
+  database_type: 'PostgreSQL'
+  Note: 'Bounded context: Purchase orders, warehouse/inventory, stock movements. Source: Odoo CE 18 models purchase.order, stock.*, uom.*.'
+}
+
+Table purchase_order {
+  id              integer   [pk, increment]
+  name            varchar   [not null]
+  state           varchar   [not null, note: 'draft, sent, to approve, purchase, done, cancel']
+  partner_id      integer   [not null, ref: > res_partner.id]
+  date_order      timestamp
+  date_planned    timestamp
+  currency_id     integer   [not null, ref: > res_currency.id]
+  amount_total    numeric   [not null]
+  company_id      integer   [not null, ref: > res_company.id]
+  picking_type_id integer   [ref: > stock_picking_type.id]
+}
+
+Table purchase_order_line {
+  id              integer  [pk, increment]
+  order_id        integer  [not null, ref: > purchase_order.id]
+  product_id      integer  [not null, ref: > product_product.id]
+  name            varchar  [not null]
+  product_qty     numeric  [not null]
+  price_unit      numeric  [not null]
+  price_subtotal  numeric
+  date_planned    timestamp
+  product_uom     integer  [ref: > uom_uom.id]
+  Note: 'taxes_id is M2M via purchase_order_line_tax_rel join table'
+}
+
+Table purchase_order_line_tax_rel {
+  order_line_id  integer  [not null, ref: > purchase_order_line.id]
+  tax_id         integer  [not null, ref: > account_tax.id]
+  indexes {
+    (order_line_id, tax_id) [pk]
+  }
+}
+
+Table stock_warehouse {
+  id              integer  [pk, increment]
+  name            varchar  [not null]
+  code            varchar  [not null]
+  company_id      integer  [not null, ref: > res_company.id]
+  lot_stock_id    integer  [ref: > stock_location.id]
+  partner_id      integer  [ref: > res_partner.id]
+}
+
+Table stock_location {
+  id             integer  [pk, increment]
+  name           varchar  [not null]
+  complete_name  varchar
+  usage          varchar  [not null, note: 'internal, customer, supplier, transit, production, inventory']
+  company_id     integer  [ref: > res_company.id]
+  location_id    integer  [ref: > stock_location.id, note: 'parent location (self-ref)']
+}
+
+Table stock_picking_type {
+  id           integer  [pk, increment]
+  name         varchar  [not null]
+  code         varchar  [note: 'incoming, outgoing, internal']
+  warehouse_id integer  [ref: > stock_warehouse.id]
+  company_id   integer  [ref: > res_company.id]
+}
+
+Table stock_picking {
+  id              integer   [pk, increment]
+  name            varchar   [not null]
+  origin          varchar
+  state           varchar   [not null, note: 'draft, waiting, confirmed, assigned, done, cancel']
+  picking_type_id integer   [not null, ref: > stock_picking_type.id]
+  partner_id      integer   [ref: > res_partner.id]
+  location_id     integer   [not null, ref: > stock_location.id]
+  location_dest_id integer  [not null, ref: > stock_location.id]
+  scheduled_date  timestamp
+  date_done       timestamp
+  company_id      integer   [not null, ref: > res_company.id]
+}
+
+Table stock_move {
+  id               integer  [pk, increment]
+  name             varchar  [not null]
+  product_id       integer  [not null, ref: > product_product.id]
+  product_uom_qty  numeric  [not null]
+  quantity         numeric
+  picking_id       integer  [ref: > stock_picking.id]
+  location_id      integer  [not null, ref: > stock_location.id]
+  location_dest_id integer  [not null, ref: > stock_location.id]
+  state            varchar  [not null, note: 'draft, cancel, waiting, confirmed, partially_available, assigned, done']
+  company_id       integer  [not null, ref: > res_company.id]
+}
+
+Table stock_move_line {
+  id               integer  [pk, increment]
+  move_id          integer  [ref: > stock_move.id]
+  product_id       integer  [not null, ref: > product_product.id]
+  qty_done         numeric
+  lot_id           integer  [ref: > stock_lot.id]
+  location_id      integer  [not null, ref: > stock_location.id]
+  location_dest_id integer  [not null, ref: > stock_location.id]
+  picking_id       integer  [ref: > stock_picking.id]
+}
+
+Table stock_quant {
+  id                   integer  [pk, increment]
+  product_id           integer  [not null, ref: > product_product.id]
+  location_id          integer  [not null, ref: > stock_location.id]
+  quantity             numeric  [not null]
+  reserved_quantity    numeric
+  lot_id               integer  [ref: > stock_lot.id]
+  company_id           integer  [not null, ref: > res_company.id]
+}
+
+Table stock_lot {
+  id          integer  [pk, increment]
+  name        varchar  [not null]
+  product_id  integer  [not null, ref: > product_product.id]
+  company_id  integer  [not null, ref: > res_company.id]
+}
+
+Table uom_category {
+  id    integer  [pk, increment]
+  name  varchar  [not null]
+}
+
+Table uom_uom {
+  id           integer  [pk, increment]
+  name         varchar  [not null]
+  category_id  integer  [not null, ref: > uom_category.id]
+  factor       float
+  rounding     float
+  active       boolean
+}
+
+// Shared dimension stubs
+Table res_partner {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_company {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_currency {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table product_product {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table account_tax {
+  id    integer  [pk]
+  name  varchar
+}

--- a/ssot/odoo/domains/marketing_productivity_websites.dbml
+++ b/ssot/odoo/domains/marketing_productivity_websites.dbml
@@ -1,0 +1,166 @@
+Project "IPAI Website/Marketing/Productivity — Odoo CE 18 bounded context" {
+  database_type: 'PostgreSQL'
+  Note: 'Bounded context: Website CMS, email marketing, calendar, events, and surveys. Source: Odoo CE 18 models website, mass_mailing.*, calendar.event, event.event, survey.survey.'
+}
+
+Table website {
+  id               integer  [pk, increment]
+  name             varchar  [not null]
+  domain           varchar
+  company_id       integer  [not null, ref: > res_company.id]
+  default_lang_id  integer  [ref: > res_lang.id]
+  homepage_url     varchar
+}
+
+Table res_lang {
+  id    integer  [pk, increment]
+  name  varchar  [not null]
+  code  varchar  [not null]
+}
+
+Table website_page {
+  id            integer   [pk, increment]
+  name          varchar   [not null]
+  url           varchar   [not null]
+  website_id    integer   [ref: > website.id]
+  is_published  boolean
+  date_publish  timestamp
+}
+
+Table website_menu {
+  id          integer  [pk, increment]
+  name        varchar  [not null]
+  url         varchar
+  page_id     integer  [ref: > website_page.id]
+  parent_id   integer  [ref: > website_menu.id, note: 'parent menu item (self-ref)']
+  website_id  integer  [not null, ref: > website.id]
+  sequence    integer
+}
+
+Table mailing_contact {
+  id            integer  [pk, increment]
+  name          varchar  [not null]
+  email         varchar
+  company_name  varchar
+  country_id    integer  [ref: > res_country.id]
+  Note: 'tag_ids M2M via mailing_contact_tag_rel; list_ids M2M via mailing_contact_list_rel'
+}
+
+Table mailing_contact_tag_rel {
+  contact_id  integer  [not null, ref: > mailing_contact.id]
+  tag_id      integer  [not null, ref: > mailing_tag.id]
+  indexes {
+    (contact_id, tag_id) [pk]
+  }
+}
+
+Table mailing_contact_list_rel {
+  contact_id  integer  [not null, ref: > mailing_contact.id]
+  list_id     integer  [not null, ref: > mailing_list.id]
+  indexes {
+    (contact_id, list_id) [pk]
+  }
+}
+
+Table mailing_tag {
+  id    integer  [pk, increment]
+  name  varchar  [not null]
+}
+
+Table mailing_list {
+  id             integer  [pk, increment]
+  name           varchar  [not null]
+  active         boolean
+  contact_count  integer  [note: 'computed']
+}
+
+Table mailing_mailing {
+  id                integer  [pk, increment]
+  subject           varchar  [not null]
+  body_html         text
+  mailing_type      varchar  [not null, note: 'mail, sms']
+  state             varchar  [not null, note: 'draft, in_queue, sending, done']
+  mailing_model_id  integer  [ref: > ir_model.id, note: 'target Odoo model']
+  sent              integer
+  delivered         integer
+  opened            integer
+  clicked           integer
+  bounced           integer
+  Note: 'contact_list_ids M2M via mailing_mailing_list_rel join table'
+}
+
+Table mailing_mailing_list_rel {
+  mailing_id  integer  [not null, ref: > mailing_mailing.id]
+  list_id     integer  [not null, ref: > mailing_list.id]
+  indexes {
+    (mailing_id, list_id) [pk]
+  }
+}
+
+Table ir_model {
+  id     integer  [pk, increment]
+  name   varchar  [not null]
+  model  varchar  [not null]
+}
+
+Table calendar_event {
+  id          integer   [pk, increment]
+  name        varchar   [not null]
+  start       timestamp [not null]
+  stop        timestamp [not null]
+  user_id     integer   [ref: > res_users.id]
+  description text
+  location    varchar
+  allday      boolean
+  Note: 'partner_ids M2M via calendar_event_res_partner_rel join table'
+}
+
+Table calendar_event_res_partner_rel {
+  event_id    integer  [not null, ref: > calendar_event.id]
+  partner_id  integer  [not null, ref: > res_partner.id]
+  indexes {
+    (event_id, partner_id) [pk]
+  }
+}
+
+Table event_event {
+  id               integer   [pk, increment]
+  name             varchar   [not null]
+  date_begin       timestamp [not null]
+  date_end         timestamp [not null]
+  company_id       integer   [ref: > res_company.id]
+  organizer_id     integer   [ref: > res_partner.id]
+  seats_max        integer
+  seats_available  integer   [note: 'computed']
+  state            varchar   [not null, note: 'draft, confirm, done, cancel']
+}
+
+Table survey_survey {
+  id            integer  [pk, increment]
+  title         varchar  [not null]
+  state         varchar  [not null, note: 'draft, open, closed']
+  scoring_type  varchar  [note: 'no_scoring, scoring_with_answers, scoring_without_answers']
+  access_mode   varchar  [note: 'public, token, users']
+}
+
+Table res_country {
+  id    integer  [pk, increment]
+  name  varchar  [not null]
+  code  varchar  [not null]
+}
+
+// Shared dimension stubs
+Table res_partner {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_users {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_company {
+  id    integer  [pk]
+  name  varchar
+}

--- a/ssot/odoo/domains/platform_identity_pulser.dbml
+++ b/ssot/odoo/domains/platform_identity_pulser.dbml
@@ -1,0 +1,249 @@
+// ============================================================
+// IPAI Platform / Identity / Tenant / AI Overlay
+// Bounded-context: Platform, Identity, Tenant, AI (ops + platform schemas)
+//
+// Scope: Thin IPAI layer on top of Odoo CE 18.
+//   - ops.*     — agent runtime, tenancy, feature flags, tool catalog
+//   - platform.* — cross-cutting audit
+//   - public.*  — Odoo-owned schema (referenced only, never modified here)
+//
+// NOT included in PG schemas:
+//   - cosmos.*  — Azure Cosmos DB document collections (documented below
+//                 as comments; not relational tables)
+//
+// Cross-schema FK note:
+//   ops.tenants.company_id → public.res_company(id)
+//   public schema is owned by Odoo; treat as read-only external reference.
+// ============================================================
+
+Project "IPAI Platform / Identity / Tenant / AI Overlay" {
+  database_type: 'PostgreSQL'
+  Note: '''
+    Schema: ops + platform (IPAI-owned)
+    Odoo public schema is referenced but never modified by these models.
+    Cosmos DB collections are documented as comments (document store, not relational).
+    Runtime: Azure Container Apps + PostgreSQL 16 (pg-ipai-odoo)
+    Auth: Entra ID (OIDC) — no custom ipai_auth_oidc module; wired via standard
+          Odoo OIDC config + infra env vars per no-custom-identity doctrine.
+  '''
+}
+
+// ============================================================
+// OPS SCHEMA
+// ============================================================
+
+Table ops.tenants {
+  id          serial        [pk, increment, note: "Internal tenant surrogate key"]
+  name        varchar       [not null, note: "Human-readable tenant name"]
+  code        varchar       [unique, not null, note: "Short slug, e.g. ipai / w9 / tbwa"]
+  company_id  int           [not null, ref: > public.res_company.id, note: "Odoo company this tenant maps to"]
+  entra_tenant_id varchar   [null, note: "Azure Entra external tenant GUID; null for single-tenant deployments"]
+  active      boolean       [not null, default: true]
+  created_at  timestamp     [not null, default: `now()`]
+
+  Note: '''
+    One ops.tenant = one res.company in Odoo.
+    entra_tenant_id is populated only for multi-tenant SaaS lanes.
+    Self-hosted single-tenant: leave null, rely on Odoo built-in OIDC config.
+  '''
+}
+
+Table ops.runs {
+  id              uuid          [pk, default: `gen_random_uuid()`, note: "Stable run identifier; shared with Cosmos session"]
+  agent_id        varchar       [not null, note: "Logical agent identifier, e.g. pulser/tax-guru/recon-agent"]
+  tenant_id       int           [not null, ref: > ops.tenants.id, note: "Owning tenant"]
+  session_id      varchar       [not null, note: "Cosmos session_id for cross-store correlation"]
+  started_at      timestamp     [not null, default: `now()`]
+  ended_at        timestamp     [null]
+  status          varchar       [not null, note: "running | completed | failed | cancelled"]
+  input_summary   text          [null, note: "Sanitised (Safe Outputs) summary of user input"]
+  output_summary  text          [null, note: "Sanitised summary of agent response"]
+  model_used      varchar       [null, note: "e.g. gpt-4.1, claude-sonnet-4-6"]
+  tokens_in       int           [null]
+  tokens_out      int           [null]
+  create_date     timestamp     [not null, default: `now()`]
+
+  indexes {
+    (tenant_id, started_at) [name: "idx_runs_tenant_started"]
+    (agent_id, status)      [name: "idx_runs_agent_status"]
+    session_id              [name: "idx_runs_session"]
+  }
+
+  Note: '''
+    Append-only. Updates allowed only to: ended_at, status, output_summary,
+    tokens_in, tokens_out.
+    input_summary / output_summary must pass Safe Outputs subsystem before write.
+  '''
+}
+
+Table ops.run_events {
+  id           bigserial     [pk, increment]
+  run_id       uuid          [not null, ref: > ops.runs.id, note: "Parent run"]
+  event_type   varchar       [not null, note: "input | tool_call | tool_response | output | error | guardrail"]
+  payload      jsonb         [not null, note: "Sanitised event payload; secrets stripped by Safe Outputs"]
+  timestamp    timestamp     [not null, default: `now()`]
+  sequence_num int           [not null, note: "Monotonic sequence within a run; used for ordered replay"]
+
+  indexes {
+    (run_id, sequence_num) [name: "idx_run_events_run_seq", unique]
+    (run_id, event_type)   [name: "idx_run_events_type"]
+  }
+
+  Note: '''
+    Append-only. No deletes, no updates.
+    Payload is post-Safe-Outputs (filtered / moderated / secret-stripped).
+    guardrail events record policy violations caught by Content Safety middleware.
+  '''
+}
+
+Table ops.tool_catalog {
+  id          serial        [pk, increment]
+  agent_id    varchar       [not null, note: "Agent this tool is registered for; '*' = shared across all agents"]
+  tool_name   varchar       [not null, note: "Canonical MCP / Foundry tool name"]
+  tool_type   varchar       [not null, note: "mcp | foundry | cli | odoo_rpc"]
+  endpoint    varchar       [null, note: "MCP server URI or Foundry tool endpoint; null for cli/odoo_rpc"]
+  allowed     boolean       [not null, default: true, note: "Runtime allow-flag; false = tool blocked without manifest change"]
+  create_date timestamp     [not null, default: `now()`]
+
+  indexes {
+    (agent_id, tool_name) [name: "idx_tool_catalog_agent_tool", unique]
+  }
+
+  Note: '''
+    MCP allowlist SSOT. Pulser agents may only call tools present here with allowed=true.
+    No dynamic tool acquisition permitted (Agentic Workflow Security Doctrine).
+    Changes require PR + Azure Pipelines gate.
+  '''
+}
+
+Table ops.feature_flags {
+  id          serial        [pk, increment]
+  flag_name   varchar       [unique, not null, note: "e.g. pulser.recon_agent.v2 / finance.bir_2307.auto_file"]
+  tenant_id   int           [null, ref: > ops.tenants.id, note: "Null = global flag; non-null = tenant-scoped override"]
+  enabled     boolean       [not null, default: false]
+  value       jsonb         [null, note: "Optional structured config for the flag"]
+  description text          [null]
+
+  indexes {
+    (flag_name, tenant_id) [name: "idx_feature_flags_name_tenant"]
+  }
+
+  Note: '''
+    Global flags: tenant_id IS NULL, flag_name unique globally.
+    Tenant overrides: tenant_id IS NOT NULL; take precedence over global row.
+    Evaluated at agent dispatch time; cached per-session in Cosmos scratchpad.
+  '''
+}
+
+// ============================================================
+// PLATFORM SCHEMA
+// ============================================================
+
+Table platform.audit_log {
+  id             bigserial     [pk, increment]
+  actor          varchar       [not null, note: "UPN or agent_id of the acting principal"]
+  action         varchar       [not null, note: "e.g. CREATE / UPDATE / DELETE / APPROVE / INVOKE"]
+  resource_type  varchar       [not null, note: "e.g. ops.runs / account.move / res.partner"]
+  resource_id    varchar       [not null, note: "String-cast PK of the affected resource"]
+  before_state   jsonb         [null,  note: "Snapshot before mutation; null for CREATE"]
+  after_state    jsonb         [null,  note: "Snapshot after mutation; null for DELETE"]
+  timestamp      timestamp     [not null, default: `now()`]
+  tenant_id      int           [not null, ref: > ops.tenants.id]
+
+  indexes {
+    (tenant_id, timestamp)        [name: "idx_audit_log_tenant_ts"]
+    (resource_type, resource_id)  [name: "idx_audit_log_resource"]
+    actor                         [name: "idx_audit_log_actor"]
+  }
+
+  Note: '''
+    Append-only. No updates, no deletes (ADO Issue #623 — audit traceability).
+    Covers IPAI platform mutations; Odoo native chatter covers ERP-level changes.
+    before_state / after_state are post-Safe-Outputs snapshots (secrets stripped).
+  '''
+}
+
+// ============================================================
+// EXTERNAL REFERENCE ONLY — public schema (Odoo-owned)
+// Included here solely to define the cross-schema FK target.
+// Do NOT create, alter, or drop anything in public.* from IPAI migrations.
+// ============================================================
+
+Table public.res_company {
+  id    int   [pk, note: "Odoo-managed company ID — external reference only"]
+
+  Note: '''
+    Odoo CE 18 native table. IPAI must never run DDL against this table.
+    ops.tenants.company_id references this as a logical FK;
+    enforced at application layer, not as a DB-level constraint,
+    to avoid cross-schema FK dependency on Odoo migrations.
+  '''
+}
+
+// ============================================================
+// REFS
+// ============================================================
+
+// ops.runs → ops.tenants
+Ref: ops.runs.tenant_id > ops.tenants.id
+
+// ops.run_events → ops.runs
+Ref: ops.run_events.run_id > ops.runs.id
+
+// ops.feature_flags → ops.tenants (nullable tenant-scoped override)
+Ref: ops.feature_flags.tenant_id > ops.tenants.id
+
+// platform.audit_log → ops.tenants
+Ref: platform.audit_log.tenant_id > ops.tenants.id
+
+// Cross-schema: ops.tenants → public.res_company (Odoo-owned; app-level only)
+Ref: ops.tenants.company_id > public.res_company.id
+
+// ============================================================
+// COSMOS DB — DOCUMENT COLLECTIONS (not PG tables)
+// Documented here for bounded-context completeness.
+// These are Azure Cosmos DB for NoSQL containers, NOT PostgreSQL tables.
+// Partition keys and TTL are Cosmos-native concepts.
+// Correlate to PG via: session_id ↔ ops.runs.session_id
+//                       run_id    ↔ ops.runs.id
+// ============================================================
+
+// cosmos.sessions
+// ---------------
+// Container:     sessions
+// Partition key: tenant_id
+// TTL:           7 days
+// Fields:
+//   session_id          string  — correlates to ops.runs.session_id
+//   agent_id            string  — correlates to ops.runs.agent_id
+//   conversation_turns  array   — ordered array of {role, content, timestamp}
+//   scratchpad          object  — ephemeral agent working memory (feature flags cache,
+//                                 intermediate reasoning, tool state)
+//   ttl                 int     — document TTL override in seconds (default: 604800 = 7d)
+//
+// cosmos.tool_calls
+// -----------------
+// Container:     tool_calls
+// Partition key: session_id
+// TTL:           7 days
+// Fields:
+//   call_id     string  — unique call identifier
+//   tool_name   string  — matches ops.tool_catalog.tool_name
+//   input       object  — raw tool input (pre-Safe-Outputs; store only after filter pass)
+//   output      object  — raw tool output (pre-Safe-Outputs; store only after filter pass)
+//   latency_ms  int     — wall-clock latency
+//   ttl         int     — document TTL override (default: 604800 = 7d)
+//
+// cosmos.artifacts
+// ----------------
+// Container:     artifacts
+// Partition key: session_id
+// TTL:           24 hours (86400 seconds)
+// Fields:
+//   artifact_id  string  — unique artifact identifier
+//   type         string  — e.g. pdf / xlsx / json / image
+//   content      blob    — base64-encoded or Cosmos attachment reference
+//   ttl          int     — document TTL override (default: 86400 = 24h)
+//
+// Note: Artifacts with longer retention must be promoted to Azure Blob Storage
+//       and referenced by URL. Cosmos is ephemeral session scratch only.

--- a/ssot/odoo/domains/sales.dbml
+++ b/ssot/odoo/domains/sales.dbml
@@ -1,0 +1,162 @@
+Project "IPAI Sales/CRM — Odoo CE 18 bounded context" {
+  database_type: 'PostgreSQL'
+  Note: 'Bounded context: Sales and CRM pipeline. Source: Odoo CE 18 models crm.lead, sale.order, product.pricelist.'
+}
+
+Table crm_lead {
+  id                integer     [pk, increment]
+  name              varchar     [not null]
+  type              varchar     [not null, note: 'lead or opportunity']
+  partner_id        integer     [ref: > res_partner.id]
+  partner_name      varchar
+  contact_name      varchar
+  email_from        varchar
+  phone             varchar
+  expected_revenue  numeric
+  probability       float
+  stage_id          integer     [not null, ref: > crm_stage.id]
+  team_id           integer     [ref: > crm_team.id]
+  user_id           integer     [ref: > res_users.id]
+  company_id        integer     [ref: > res_company.id]
+  date_deadline     date
+  source_id         integer     [ref: > utm_source.id]
+  medium_id         integer     [ref: > utm_medium.id]
+  campaign_id       integer     [ref: > utm_campaign.id]
+  create_date       timestamp
+  write_date        timestamp
+}
+
+Table crm_stage {
+  id        integer  [pk, increment]
+  name      varchar  [not null]
+  sequence  integer
+  is_won    boolean
+  fold      boolean
+}
+
+Table crm_team {
+  id          integer  [pk, increment]
+  name        varchar  [not null]
+  company_id  integer  [ref: > res_company.id]
+  user_id     integer  [ref: > res_users.id]
+}
+
+Table utm_source {
+  id    integer  [pk, increment]
+  name  varchar  [not null]
+}
+
+Table utm_medium {
+  id    integer  [pk, increment]
+  name  varchar  [not null]
+}
+
+Table utm_campaign {
+  id    integer  [pk, increment]
+  name  varchar  [not null]
+}
+
+Table sale_order {
+  id                  integer   [pk, increment]
+  name                varchar   [not null]
+  state               varchar   [not null, note: 'draft, sent, sale, done, cancel']
+  partner_id          integer   [not null, ref: > res_partner.id]
+  partner_invoice_id  integer   [not null, ref: > res_partner.id]
+  partner_shipping_id integer   [not null, ref: > res_partner.id]
+  date_order          timestamp
+  validity_date       date
+  pricelist_id        integer   [ref: > product_pricelist.id]
+  currency_id         integer   [not null, ref: > res_currency.id]
+  amount_untaxed      numeric   [not null]
+  amount_tax          numeric   [not null]
+  amount_total        numeric   [not null]
+  company_id          integer   [not null, ref: > res_company.id]
+  user_id             integer   [ref: > res_users.id]
+  team_id             integer   [ref: > crm_team.id]
+  invoice_status      varchar   [note: 'upselling, invoiced, to invoice, nothing']
+}
+
+Table sale_order_line {
+  id               integer  [pk, increment]
+  order_id         integer  [not null, ref: > sale_order.id]
+  product_id       integer  [ref: > product_product.id]
+  name             varchar  [not null]
+  product_uom_qty  numeric  [not null]
+  price_unit       numeric  [not null]
+  discount         float
+  price_subtotal   numeric
+  price_total      numeric
+  product_uom      integer  [ref: > uom_uom.id]
+  company_id       integer  [ref: > res_company.id]
+  Note: 'tax_id is M2M via sale_order_line_tax_rel join table'
+}
+
+Table sale_order_line_tax_rel {
+  order_line_id  integer  [not null, ref: > sale_order_line.id]
+  tax_id         integer  [not null, ref: > account_tax.id]
+  indexes {
+    (order_line_id, tax_id) [pk]
+  }
+}
+
+Table product_pricelist {
+  id          integer  [pk, increment]
+  name        varchar  [not null]
+  currency_id integer  [not null, ref: > res_currency.id]
+  company_id  integer  [ref: > res_company.id]
+  active      boolean
+}
+
+Table product_pricelist_item {
+  id              integer  [pk, increment]
+  pricelist_id    integer  [not null, ref: > product_pricelist.id]
+  product_tmpl_id integer  [ref: > product_template.id]
+  product_id      integer  [ref: > product_product.id]
+  min_quantity    numeric
+  fixed_price     numeric
+  percent_price   float
+  compute_price   varchar  [note: 'fixed, percentage, formula']
+  date_start      date
+  date_end        date
+}
+
+// Shared dimension stubs (defined canonically in finance_accounting.dbml)
+Table res_partner {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_users {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_company {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_currency {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table product_product {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table product_template {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table uom_uom {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table account_tax {
+  id    integer  [pk]
+  name  varchar
+}

--- a/ssot/odoo/domains/services.dbml
+++ b/ssot/odoo/domains/services.dbml
@@ -1,0 +1,103 @@
+Project "IPAI Projects/Services — Odoo CE 18 bounded context" {
+  database_type: 'PostgreSQL'
+  Note: 'Bounded context: Project management, tasks, milestones, and status updates. Source: Odoo CE 18 models project.project, project.task, project.milestone, project.update.'
+}
+
+Table project_project {
+  id                   integer   [pk, increment]
+  name                 varchar   [not null]
+  active               boolean
+  company_id           integer   [ref: > res_company.id]
+  partner_id           integer   [ref: > res_partner.id]
+  user_id              integer   [ref: > res_users.id]
+  date_start           date
+  date                 date      [note: 'planned end date']
+  allow_timesheets     boolean
+  analytic_account_id  integer   [ref: > account_analytic_account.id]
+  label_tasks          varchar   [note: 'custom label for task stages column']
+  task_count           integer   [note: 'computed, stored']
+}
+
+Table project_task {
+  id              integer   [pk, increment]
+  name            varchar   [not null]
+  project_id      integer   [ref: > project_project.id]
+  stage_id        integer   [ref: > project_task_type.id]
+  partner_id      integer   [ref: > res_partner.id]
+  date_deadline   date
+  kanban_state    varchar   [note: 'normal, blocked, done']
+  priority        varchar   [note: '0 normal, 1 high']
+  parent_id       integer   [ref: > project_task.id, note: 'subtask parent (self-ref)']
+  company_id      integer   [ref: > res_company.id]
+  description     text
+  planned_hours   float
+  effective_hours float      [note: 'computed from timesheets']
+  Note: 'user_ids is M2M via project_task_user_rel join table'
+}
+
+Table project_task_user_rel {
+  task_id  integer  [not null, ref: > project_task.id]
+  user_id  integer  [not null, ref: > res_users.id]
+  indexes {
+    (task_id, user_id) [pk]
+  }
+}
+
+Table project_task_type {
+  id        integer  [pk, increment]
+  name      varchar  [not null]
+  sequence  integer
+  fold      boolean
+  Note: 'project_ids is M2M via project_task_type_rel join table'
+}
+
+Table project_task_type_rel {
+  type_id     integer  [not null, ref: > project_task_type.id]
+  project_id  integer  [not null, ref: > project_project.id]
+  indexes {
+    (type_id, project_id) [pk]
+  }
+}
+
+Table project_milestone {
+  id            integer  [pk, increment]
+  name          varchar  [not null]
+  project_id    integer  [not null, ref: > project_project.id]
+  deadline      date
+  is_reached    boolean
+  reached_date  date
+}
+
+Table project_update {
+  id          integer   [pk, increment]
+  name        varchar   [not null]
+  project_id  integer   [not null, ref: > project_project.id]
+  status      varchar   [not null, note: 'on_track, at_risk, off_track, on_hold']
+  date        date
+  description text
+  progress    integer   [note: '0–100 percent']
+}
+
+Table account_analytic_account {
+  id          integer  [pk, increment]
+  name        varchar  [not null]
+  code        varchar
+  company_id  integer  [ref: > res_company.id]
+  active      boolean
+}
+
+// Shared dimension stubs
+Table res_partner {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_users {
+  id    integer  [pk]
+  name  varchar
+}
+
+Table res_company {
+  id    integer  [pk]
+  name  varchar
+}

--- a/ssot/odoo/global-spine.dbml
+++ b/ssot/odoo/global-spine.dbml
@@ -1,0 +1,243 @@
+Project ipai_global_spine {
+  database_type: 'PostgreSQL'
+  Note: 'IPAI Global Spine — Odoo CE 18 cross-domain anchors'
+}
+
+// ─── Currency & Country ──────────────────────────────────────────────────────
+
+Table res_currency {
+  id integer [pk, increment]
+  name varchar(3) [not null]
+  symbol varchar(4) [not null]
+  active boolean [not null, default: true]
+}
+
+Table res_country {
+  id integer [pk, increment]
+  name varchar [not null]
+  code varchar(2)
+}
+
+// ─── Unit of Measure ─────────────────────────────────────────────────────────
+
+Table uom_uom {
+  id integer [pk, increment]
+  name varchar [not null]
+  category_id integer [not null]
+  factor float8 [not null, default: 1.0]
+  uom_type varchar [not null]
+}
+
+// ─── Company & Partner ───────────────────────────────────────────────────────
+
+Table res_company {
+  id integer [pk, increment]
+  name varchar [not null]
+  partner_id integer [not null]
+  currency_id integer [not null]
+  parent_id integer
+}
+
+Table res_partner {
+  id integer [pk, increment]
+  name varchar
+  email varchar
+  phone varchar
+  is_company boolean [default: false]
+  company_id integer
+  parent_id integer
+  supplier_rank integer [not null, default: 0]
+  customer_rank integer [not null, default: 0]
+  vat varchar
+  create_uid integer
+  write_uid integer
+  create_date timestamptz
+  write_date timestamptz
+}
+
+// ─── Users & Groups ──────────────────────────────────────────────────────────
+
+Table res_users {
+  id integer [pk, increment]
+  login varchar [not null]
+  partner_id integer [not null]
+  company_id integer [not null]
+  active boolean [not null, default: true]
+}
+
+Table res_groups {
+  id integer [pk, increment]
+  name varchar [not null]
+  category_id integer
+}
+
+Table res_groups_users_rel {
+  gid integer [not null]
+  uid integer [not null]
+
+  indexes {
+    (gid, uid) [pk]
+  }
+}
+
+// ─── IR Framework ────────────────────────────────────────────────────────────
+
+Table ir_module_module {
+  id integer [pk, increment]
+  name varchar [not null]
+  state varchar [not null]
+  shortdesc varchar
+  author varchar
+}
+
+Table ir_model {
+  id integer [pk, increment]
+  name varchar [not null]
+  model varchar [not null]
+  state varchar [not null, default: 'base']
+  transient boolean [not null, default: false]
+}
+
+Table ir_model_fields {
+  id integer [pk, increment]
+  name varchar [not null]
+  field_description varchar
+  model_id integer [not null]
+  ttype varchar [not null]
+  relation varchar
+}
+
+Table ir_model_access {
+  id integer [pk, increment]
+  name varchar [not null]
+  model_id integer [not null]
+  group_id integer
+  perm_read boolean [not null, default: false]
+  perm_write boolean [not null, default: false]
+  perm_create boolean [not null, default: false]
+  perm_unlink boolean [not null, default: false]
+}
+
+Table ir_rule {
+  id integer [pk, increment]
+  name varchar [not null]
+  model_id integer [not null]
+  domain_force text
+  global_rule boolean [not null, default: false]
+}
+
+Table ir_attachment {
+  id integer [pk, increment]
+  name varchar [not null]
+  res_model varchar
+  res_id integer
+  type varchar [not null, default: 'binary']
+  mimetype varchar
+  datas text
+  store_fname varchar
+}
+
+Table ir_sequence {
+  id integer [pk, increment]
+  name varchar [not null]
+  code varchar
+  prefix varchar
+  suffix varchar
+  number_next integer [not null, default: 1]
+}
+
+// ─── Mail ─────────────────────────────────────────────────────────────────────
+
+Table mail_message {
+  id integer [pk, increment]
+  subject varchar
+  body text
+  message_type varchar [not null]
+  model varchar
+  res_id integer
+  author_id integer
+  date timestamptz [not null]
+}
+
+Table mail_activity {
+  id integer [pk, increment]
+  res_model varchar [not null]
+  res_id integer [not null]
+  activity_type_id integer [not null]
+  user_id integer [not null]
+  date_deadline date [not null]
+  summary varchar
+}
+
+// ─── Product ─────────────────────────────────────────────────────────────────
+
+Table product_category {
+  id integer [pk, increment]
+  name varchar [not null]
+  parent_id integer
+  complete_name varchar
+}
+
+Table product_template {
+  id integer [pk, increment]
+  name varchar [not null]
+  type varchar [not null, default: 'consu']
+  categ_id integer [not null]
+  list_price float8 [not null, default: 1.0]
+  uom_id integer [not null]
+}
+
+Table product_product {
+  id integer [pk, increment]
+  product_tmpl_id integer [not null]
+  default_code varchar
+  barcode varchar
+  active boolean [not null, default: true]
+}
+
+// ─── References ──────────────────────────────────────────────────────────────
+
+// res_company
+Ref: res_company.partner_id > res_partner.id
+Ref: res_company.currency_id > res_currency.id
+Ref: res_company.parent_id > res_company.id
+
+// res_partner
+Ref: res_partner.company_id > res_company.id
+Ref: res_partner.parent_id > res_partner.id
+Ref: res_partner.create_uid > res_users.id
+Ref: res_partner.write_uid > res_users.id
+
+// res_users
+Ref: res_users.partner_id > res_partner.id
+Ref: res_users.company_id > res_company.id
+
+// res_groups_users_rel (M2M join)
+Ref: res_groups_users_rel.gid > res_groups.id
+Ref: res_groups_users_rel.uid > res_users.id
+
+// ir_model_fields
+Ref: ir_model_fields.model_id > ir_model.id
+
+// ir_model_access
+Ref: ir_model_access.model_id > ir_model.id
+Ref: ir_model_access.group_id > res_groups.id
+
+// ir_rule
+Ref: ir_rule.model_id > ir_model.id
+
+// mail_message
+Ref: mail_message.author_id > res_partner.id
+
+// mail_activity
+Ref: mail_activity.user_id > res_users.id
+
+// product_category
+Ref: product_category.parent_id > product_category.id
+
+// product_template
+Ref: product_template.categ_id > product_category.id
+Ref: product_template.uom_id > uom_uom.id
+
+// product_product
+Ref: product_product.product_tmpl_id > product_template.id

--- a/ssot/odoo/oca-extension-map.yaml
+++ b/ssot/odoo/oca-extension-map.yaml
@@ -1,0 +1,368 @@
+# OCA Extension Map — Odoo CE 18
+# Locked: 2026-04-16
+# Authority: this file maps OCA modules to the bounded contexts they extend.
+# Per CLAUDE.md doctrine: Config → CE → OCA → ipai_* (last resort)
+#
+# Maturity levels per OCA: beta | production/stable | mature
+# Adoption: baseline (always install) | optional (install when needed) | reference (pattern only)
+# Source: https://odoo-community.org/list-of-must-have-oca-modules
+
+schema_version: 1
+last_updated: "2026-04-16"
+
+extension_lanes:
+
+  # =========================================================================
+  # Base / Server Tools
+  # =========================================================================
+  oca_base:
+    repo: OCA/server-tools
+    extends: spine
+    modules:
+      - name: base_technical_user
+        maturity: production/stable
+        adoption: baseline
+        extends_model: res.users
+        purpose: service account for automated actions
+
+      - name: base_user_role
+        maturity: production/stable
+        adoption: baseline
+        extends_model: res.users + res.groups
+        purpose: simplified role-based access
+
+      - name: module_auto_update
+        maturity: production/stable
+        adoption: baseline
+        extends_model: ir.module.module
+        purpose: auto-detect and update changed modules
+
+  oca_server_ux:
+    repo: OCA/server-ux
+    extends: spine
+    modules:
+      - name: date_range
+        maturity: mature
+        adoption: baseline
+        purpose: reusable date range objects (fiscal periods, reporting)
+
+      - name: base_tier_validation
+        maturity: production/stable
+        adoption: baseline
+        purpose: multi-level approval workflows
+
+  # =========================================================================
+  # Accounting / Finance
+  # =========================================================================
+  oca_accounting:
+    repo: OCA/account-financial-reporting
+    extends: finance
+    modules:
+      - name: account_financial_report
+        maturity: mature
+        adoption: baseline
+        extends_model: account.move.line
+        purpose: trial balance, general ledger, aged partner balance reports
+
+  oca_account_tools:
+    repo: OCA/account-financial-tools
+    extends: finance
+    modules:
+      - name: account_lock_date_update
+        maturity: production/stable
+        adoption: baseline
+        extends_model: res.company
+        purpose: wizard to update lock dates
+
+      - name: account_move_name_sequence
+        maturity: production/stable
+        adoption: optional
+        extends_model: account.move
+        purpose: customizable journal entry naming
+
+      - name: account_asset_management
+        maturity: mature
+        adoption: baseline
+        extends_model: account.move
+        purpose: fixed asset depreciation (EE parity)
+
+  oca_account_reconcile:
+    repo: OCA/account-reconcile
+    extends: finance
+    modules:
+      - name: account_reconcile_oca
+        maturity: production/stable
+        adoption: baseline
+        extends_model: account.bank.statement.line
+        purpose: enhanced bank reconciliation (EE parity)
+
+  oca_account_payment:
+    repo: OCA/account-payment
+    extends: finance
+    modules:
+      - name: account_payment_order
+        maturity: mature
+        adoption: baseline
+        extends_model: account.payment
+        purpose: batch payment processing
+
+  oca_currency:
+    repo: OCA/currency
+    extends: finance
+    modules:
+      - name: currency_rate_update
+        maturity: mature
+        adoption: baseline
+        extends_model: res.currency.rate
+        purpose: auto-fetch exchange rates (BSP, ECB, etc.)
+
+  oca_budget:
+    repo: OCA/account-budgeting
+    extends: finance
+    modules:
+      - name: account_budget_oca
+        maturity: production/stable
+        adoption: baseline
+        extends_model: account.analytic.account
+        purpose: budget management (EE parity)
+
+  # =========================================================================
+  # Sales / CRM
+  # =========================================================================
+  oca_sales:
+    repo: OCA/sale-workflow
+    extends: sales_crm
+    modules:
+      - name: sale_order_line_sequence
+        maturity: production/stable
+        adoption: optional
+        extends_model: sale.order.line
+        purpose: manual line ordering
+
+      - name: sale_order_type
+        maturity: production/stable
+        adoption: optional
+        extends_model: sale.order
+        purpose: order type classification
+
+  oca_crm:
+    repo: OCA/crm
+    extends: sales_crm
+    modules:
+      - name: crm_stage_probability
+        maturity: production/stable
+        adoption: optional
+        extends_model: crm.lead
+        purpose: stage-based win probability
+
+  # =========================================================================
+  # Purchase / Stock / Logistics
+  # =========================================================================
+  oca_purchase:
+    repo: OCA/purchase-workflow
+    extends: purchase_inventory
+    modules:
+      - name: purchase_order_approved
+        maturity: production/stable
+        adoption: baseline
+        extends_model: purchase.order
+        purpose: approval workflow for POs
+
+  oca_stock:
+    repo: OCA/stock-logistics-workflow
+    extends: purchase_inventory
+    modules:
+      - name: stock_no_negative
+        maturity: production/stable
+        adoption: baseline
+        extends_model: stock.quant
+        purpose: prevent negative stock
+
+  oca_bank_statement:
+    repo: OCA/bank-statement-import
+    extends: finance
+    modules:
+      - name: account_statement_import
+        maturity: mature
+        adoption: baseline
+        extends_model: account.bank.statement
+        purpose: bank statement file import (CSV, OFX, QIF, CAMT)
+
+  # =========================================================================
+  # Project / Services
+  # =========================================================================
+  oca_project:
+    repo: OCA/project
+    extends: projects
+    modules:
+      - name: project_task_default_stage
+        maturity: production/stable
+        adoption: optional
+        extends_model: project.task.type
+        purpose: default stages per project
+
+      - name: project_timeline
+        maturity: production/stable
+        adoption: optional
+        extends_model: project.task
+        purpose: Gantt-like timeline view
+
+  oca_timesheet:
+    repo: OCA/timesheet
+    extends: projects
+    modules:
+      - name: hr_timesheet_sheet
+        maturity: mature
+        adoption: baseline
+        extends_model: account.analytic.line
+        purpose: timesheet approval workflow (EE parity)
+
+  # =========================================================================
+  # HR / Workforce
+  # =========================================================================
+  oca_hr:
+    repo: OCA/hr
+    extends: hr
+    modules:
+      - name: hr_employee_document
+        maturity: production/stable
+        adoption: optional
+        extends_model: hr.employee
+        purpose: document management per employee
+
+  oca_payroll:
+    repo: OCA/payroll
+    extends: hr
+    modules:
+      - name: hr_payroll_community
+        maturity: production/stable
+        adoption: optional
+        extends_model: hr.contract
+        purpose: payroll computation (EE parity)
+
+  # =========================================================================
+  # Partner / Contact
+  # =========================================================================
+  oca_partner:
+    repo: OCA/partner-contact
+    extends: spine
+    modules:
+      - name: partner_firstname
+        maturity: mature
+        adoption: baseline
+        extends_model: res.partner
+        purpose: split first/last name on contacts
+
+      - name: partner_contact_gender
+        maturity: production/stable
+        adoption: optional
+        extends_model: res.partner
+
+      - name: partner_contact_nationality
+        maturity: production/stable
+        adoption: optional
+        extends_model: res.partner
+
+  # =========================================================================
+  # Website / Marketing
+  # =========================================================================
+  oca_website:
+    repo: OCA/website
+    extends: website_marketing
+    modules:
+      - name: website_legal_page
+        maturity: production/stable
+        adoption: optional
+        extends_model: website
+        purpose: legal/privacy page management
+
+  # =========================================================================
+  # Connector / Queue / Integration
+  # =========================================================================
+  oca_connector:
+    repo: OCA/connector
+    extends: platform
+    modules:
+      - name: connector
+        maturity: mature
+        adoption: reference
+        purpose: generic connector framework (pattern reference only)
+
+  oca_queue:
+    repo: OCA/queue
+    extends: platform
+    modules:
+      - name: queue_job
+        maturity: mature
+        adoption: baseline
+        purpose: async background job execution (critical for agent workloads)
+
+      - name: queue_job_cron_jobrunner
+        maturity: production/stable
+        adoption: baseline
+        purpose: cron-based job runner for containerized deploys
+
+  # =========================================================================
+  # Localization — PH
+  # =========================================================================
+  oca_l10n_ph:
+    repo: OCA/l10n-philippines
+    extends: finance
+    modules:
+      - name: l10n_ph
+        maturity: beta
+        adoption: optional
+        purpose: PH chart of accounts + fiscal localization
+        note: "Verify 18.0 readiness before adopting"
+
+# =============================================================================
+# ipai_* bridge/overlay modules (thin deltas only)
+# =============================================================================
+ipai_extensions:
+  - name: ipai_bir_tax_compliance
+    extends: finance
+    extends_model: account.move + account.tax
+    purpose: PH BIR 2307/2316/1601C/1701Q computation + filing
+    type: bridge
+
+  - name: ipai_expense_liquidation
+    extends: finance
+    extends_model: hr.expense.sheet
+    purpose: PH expense liquidation workflow (cash advance → liquidation)
+    type: bridge
+
+  - name: ipai_ar_collections
+    extends: finance
+    extends_model: account.move (out_invoice)
+    purpose: AR aging + collection agent surface
+    type: overlay
+
+  - name: ipai_finance_ppm
+    extends: projects
+    extends_model: project.project + account.analytic.line
+    purpose: Clarity PPM-like portfolio management overlay
+    type: overlay
+
+  - name: ipai_odoo_copilot
+    extends: platform
+    extends_model: mail.message (chat surface)
+    purpose: Pulser chat widget + skill router + Foundry integration
+    type: overlay
+
+  - name: ipai_web_branding
+    extends: website_marketing
+    extends_model: web.login template
+    purpose: login page branding (Entra + Google OAuth buttons)
+    type: overlay
+
+# =============================================================================
+# Rules
+# =============================================================================
+rules:
+  - "OCA modules listed as 'baseline' should be installed in every environment"
+  - "OCA modules listed as 'optional' are installed only when the use case demands"
+  - "OCA modules listed as 'reference' are pattern references, not installed"
+  - "ipai_* modules must have MODULE_INTROSPECTION.md + TECHNICAL_GUIDE.md per CLAUDE.md doctrine"
+  - "Every module that extends a core model must declare extends_model"
+  - "Maturity level must match OCA's published classification at time of adoption"
+  - "No EE modules — OCA parity modules replace EE functionality"

--- a/ssot/odoo/orm-registry.yaml
+++ b/ssot/odoo/orm-registry.yaml
@@ -1,0 +1,989 @@
+# orm_registry.yaml
+# Canonical ORM model registry for Odoo CE 18 + OCA + ipai_* modules.
+# SSOT for data-model bounded context. Machine-readable. Do not hand-edit generated fields.
+# Last updated: 2026-04-15
+# Maintainer: ipai-platform / data-model worktree
+
+models:
+
+  # ──────────────────────────────────────────────
+  # SPINE (15 models)
+  # ──────────────────────────────────────────────
+
+  - model: res.partner
+    table: res_partner
+    type: Model
+    owning_module: base
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - format.address.mixin
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company (optional company_id); user-own for portal contacts
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: res.users
+    table: res_users
+    type: Model
+    owning_module: base
+    inherits_from:
+      - res.partner
+    delegates_via:
+      res.partner: partner_id
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: user-own; groups-based visibility; portal vs internal split
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: res.company
+    table: res_company
+    type: Model
+    owning_module: base
+    inherits_from:
+      - mail.thread
+    delegates_via:
+      res.partner: partner_id
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; user sees only their own companies
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: res.groups
+    table: res_groups
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global (no per-record rules); access controlled by group membership
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: res.currency
+    table: res_currency
+    type: Model
+    owning_module: base
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: global read; write restricted to base.group_system
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: res.country
+    table: res_country
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global read; write restricted to admin
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: ir.module.module
+    table: ir_module_module
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global; managed by Odoo upgrade framework only
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: ir.model
+    table: ir_model
+    type: Model
+    owning_module: base
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: global read; write restricted to base.group_system
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: ir.model.fields
+    table: ir_model_fields
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global read; write restricted to base.group_system
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: ir.model.access
+    table: ir_model_access
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global; enforced by ORM on every CRUD call
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: ir.rule
+    table: ir_rule
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global; rules evaluated at query-time by ORM
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: ir.attachment
+    table: ir_attachment
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: user-own for private attachments; public for website assets
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: ir.sequence
+    table: ir_sequence
+    type: Model
+    owning_module: base
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: mail.message
+    table: mail_message
+    type: Model
+    owning_module: mail
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: user-own; follower-based visibility; internal messages restricted
+    source_domain: spine
+    extension_policy: core_ce
+
+  - model: mail.activity
+    table: mail_activity
+    type: Model
+    owning_module: mail
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: user-own (assigned user); manager sees all
+    source_domain: spine
+    extension_policy: core_ce
+
+  # ──────────────────────────────────────────────
+  # FINANCE (15 models)
+  # ──────────────────────────────────────────────
+
+  - model: account.account
+    table: account_account
+    type: Model
+    owning_module: account
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.journal
+    table: account_journal
+    type: Model
+    owning_module: account
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.move
+    table: account_move
+    type: Model
+    owning_module: account
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; portal access for own invoices
+    source_domain: finance
+    extension_policy: oca_baseline
+
+  - model: account.move.line
+    table: account_move_line
+    type: Model
+    owning_module: account
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; inherits parent move visibility
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.tax
+    table: account_tax
+    type: Model
+    owning_module: account
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company
+    source_domain: finance
+    extension_policy: oca_baseline
+
+  - model: account.payment
+    table: account_payment
+    type: Model
+    owning_module: account
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via:
+      account.move: move_id
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.bank.statement
+    table: account_bank_statement
+    type: Model
+    owning_module: account
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; journal-level access
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.bank.statement.line
+    table: account_bank_statement_line
+    type: Model
+    owning_module: account
+    inherits_from: []
+    delegates_via:
+      account.move: move_id
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; inherits parent statement visibility
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.analytic.account
+    table: account_analytic_account
+    type: Model
+    owning_module: analytic
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; plan-scoped
+    source_domain: finance
+    extension_policy: oca_baseline
+
+  - model: account.analytic.line
+    table: account_analytic_line
+    type: Model
+    owning_module: analytic
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; user-own for timesheets
+    source_domain: finance
+    extension_policy: oca_baseline
+
+  - model: account.analytic.plan
+    table: account_analytic_plan
+    type: Model
+    owning_module: analytic
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.fiscal.year
+    table: account_fiscal_year
+    type: Model
+    owning_module: account
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: hr.expense
+    table: hr_expense
+    type: Model
+    owning_module: hr_expense
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: user-own; manager sees all; multi-company
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: hr.expense.sheet
+    table: hr_expense_sheet
+    type: Model
+    owning_module: hr_expense
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: user-own; manager sees all; multi-company
+    source_domain: finance
+    extension_policy: core_ce
+
+  - model: account.reconcile.model
+    table: account_reconcile_model
+    type: Model
+    owning_module: account
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; journal-restricted
+    source_domain: finance
+    extension_policy: core_ce
+
+  # ──────────────────────────────────────────────
+  # SALES / CRM (8 models)
+  # ──────────────────────────────────────────────
+
+  - model: crm.lead
+    table: crm_lead
+    type: Model
+    owning_module: crm
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - utm.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: user-own; team-based visibility; multi-company
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  - model: sale.order
+    table: sale_order
+    type: Model
+    owning_module: sale
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - portal.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: user-own; portal access for own orders; multi-company
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  - model: sale.order.line
+    table: sale_order_line
+    type: Model
+    owning_module: sale
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; inherits parent order visibility
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  - model: product.template
+    table: product_template
+    type: Model
+    owning_module: product
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - image.mixin
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: global read; write restricted to product managers
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  - model: product.product
+    table: product_product
+    type: Model
+    owning_module: product
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via:
+      product.template: product_tmpl_id
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: global read; write restricted to product managers
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  - model: product.pricelist
+    table: product_pricelist
+    type: Model
+    owning_module: product
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; currency-scoped
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  - model: product.pricelist.item
+    table: product_pricelist_item
+    type: Model
+    owning_module: product
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; inherits parent pricelist visibility
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  - model: product.category
+    table: product_category
+    type: Model
+    owning_module: product
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global
+    source_domain: sales_crm
+    extension_policy: core_ce
+
+  # ──────────────────────────────────────────────
+  # PURCHASE / INVENTORY (10 models)
+  # ──────────────────────────────────────────────
+
+  - model: purchase.order
+    table: purchase_order
+    type: Model
+    owning_module: purchase
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - portal.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: user-own; portal access for vendors; multi-company
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: purchase.order.line
+    table: purchase_order_line
+    type: Model
+    owning_module: purchase
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; inherits parent order visibility
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: stock.picking
+    table: stock_picking
+    type: Model
+    owning_module: stock
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; warehouse-scoped
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: stock.move
+    table: stock_move
+    type: Model
+    owning_module: stock
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; inherits parent picking visibility
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: stock.move.line
+    table: stock_move_line
+    type: Model
+    owning_module: stock
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; inherits parent move visibility
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: stock.quant
+    table: stock_quant
+    type: Model
+    owning_module: stock
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; location-scoped
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: stock.location
+    table: stock_location
+    type: Model
+    owning_module: stock
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; internal vs external location visibility
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: stock.warehouse
+    table: stock_warehouse
+    type: Model
+    owning_module: stock
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; one warehouse per company minimum
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: uom.uom
+    table: uom_uom
+    type: Model
+    owning_module: uom
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global read; write restricted to inventory managers
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  - model: uom.category
+    table: uom_category
+    type: Model
+    owning_module: uom
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global
+    source_domain: purchase_inventory
+    extension_policy: core_ce
+
+  # ──────────────────────────────────────────────
+  # PROJECTS (5 models)
+  # ──────────────────────────────────────────────
+
+  - model: project.project
+    table: project_project
+    type: Model
+    owning_module: project
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - rating.mixin
+    delegates_via:
+      account.analytic.account: analytic_account_id
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; visibility field (followers/all employees/portal)
+    source_domain: projects
+    extension_policy: core_ce
+
+  - model: project.task
+    table: project_task
+    type: Model
+    owning_module: project
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - rating.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; project visibility cascade; user-own personal tasks
+    source_domain: projects
+    extension_policy: core_ce
+
+  - model: project.task.type
+    table: project_task_type
+    type: Model
+    owning_module: project
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: global; shared across projects unless project-scoped
+    source_domain: projects
+    extension_policy: core_ce
+
+  - model: project.milestone
+    table: project_milestone
+    type: Model
+    owning_module: project
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; project-scoped
+    source_domain: projects
+    extension_policy: core_ce
+
+  - model: project.update
+    table: project_update
+    type: Model
+    owning_module: project
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; project-scoped
+    source_domain: projects
+    extension_policy: core_ce
+
+  # ──────────────────────────────────────────────
+  # HR (8 models)
+  # ──────────────────────────────────────────────
+
+  - model: hr.employee
+    table: hr_employee
+    type: Model
+    owning_module: hr
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - image.mixin
+    delegates_via:
+      hr.employee.public: employee_id
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; user-own (limited fields); HR manager sees all
+    source_domain: hr
+    extension_policy: core_ce
+
+  - model: hr.department
+    table: hr_department
+    type: Model
+    owning_module: hr
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company
+    source_domain: hr
+    extension_policy: core_ce
+
+  - model: hr.job
+    table: hr_job
+    type: Model
+    owning_module: hr
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company
+    source_domain: hr
+    extension_policy: core_ce
+
+  - model: hr.contract
+    table: hr_contract
+    type: Model
+    owning_module: hr_contract
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; HR manager only (sensitive pay data)
+    source_domain: hr
+    extension_policy: core_ce
+
+  - model: hr.attendance
+    table: hr_attendance
+    type: Model
+    owning_module: hr_attendance
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company; user-own; kiosk mode bypass
+    source_domain: hr
+    extension_policy: core_ce
+
+  - model: hr.leave
+    table: hr_leave
+    type: Model
+    owning_module: hr_holidays
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; user-own; manager approval flow
+    source_domain: hr
+    extension_policy: core_ce
+
+  - model: hr.leave.type
+    table: hr_leave_type
+    type: Model
+    owning_module: hr_holidays
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: multi-company
+    source_domain: hr
+    extension_policy: core_ce
+
+  - model: hr.applicant
+    table: hr_applicant
+    type: Model
+    owning_module: hr_recruitment
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+      - utm.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; recruiter-own; hiring manager visibility
+    source_domain: hr
+    extension_policy: core_ce
+
+  # ──────────────────────────────────────────────
+  # PLATFORM / OVERLAY (6 models)
+  # ──────────────────────────────────────────────
+
+  - model: ops.runs
+    table: ops_runs
+    type: Model
+    owning_module: ipai_platform_ops
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: global; append-only enforced at application layer
+    source_domain: platform
+    extension_policy: ipai_bridge
+
+  - model: ops.run_events
+    table: ops_run_events
+    type: Model
+    owning_module: ipai_platform_ops
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: global; append-only enforced at application layer
+    source_domain: platform
+    extension_policy: ipai_bridge
+
+  - model: ops.tool_catalog
+    table: ops_tool_catalog
+    type: Model
+    owning_module: ipai_platform_ops
+    inherits_from:
+      - mail.thread
+    delegates_via: {}
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: global read; write restricted to platform admins
+    source_domain: platform
+    extension_policy: ipai_bridge
+
+  - model: ops.feature_flags
+    table: ops_feature_flags
+    type: Model
+    owning_module: ipai_platform_ops
+    inherits_from: []
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: false
+    activity_enabled: false
+    record_rules: multi-company; write restricted to platform admins
+    source_domain: platform
+    extension_policy: ipai_bridge
+
+  - model: ops.tenants
+    table: ops_tenants
+    type: Model
+    owning_module: ipai_platform_ops
+    inherits_from:
+      - mail.thread
+    delegates_via:
+      res.company: company_id
+    company_scoped: false
+    chatter_enabled: true
+    activity_enabled: false
+    record_rules: global; tenant isolation enforced at application layer
+    source_domain: platform
+    extension_policy: ipai_overlay
+
+  - model: ipai.bir.tax.compliance.register
+    table: ipai_bir_tax_compliance_register
+    type: Model
+    owning_module: ipai_bir_2307
+    inherits_from:
+      - mail.thread
+      - mail.activity.mixin
+    delegates_via: {}
+    company_scoped: true
+    chatter_enabled: true
+    activity_enabled: true
+    record_rules: multi-company; PH BIR-sensitive; accountant and tax manager only
+    source_domain: platform
+    extension_policy: ipai_overlay

--- a/ssot/semantic/cdm-manifest-map.yaml
+++ b/ssot/semantic/cdm-manifest-map.yaml
@@ -1,0 +1,203 @@
+# SSOT — CDM Semantic Projection Map
+# Locked: 2026-04-16
+# Authority: this file maps Odoo ORM models to CDM entity projections.
+# CDM is the EXPORT/INTERCHANGE semantic layer, NOT the OLTP truth.
+# OLTP truth = Odoo ORM (ssot/odoo/orm-registry.yaml).
+#
+# CDM reference: https://learn.microsoft.com/common-data-model/sdk/overview
+# CDM folder format: https://learn.microsoft.com/common-data-model/data-lake
+#
+# Companion: platform/contracts/cdm-entity-map.yaml (machine-readable attribute mapping)
+
+schema_version: 1
+last_updated: "2026-04-16"
+
+output_layout:
+  root: "abfss://gold@stipaidevlake.dfs.core.windows.net/"
+  manifest_file: manifest.cdm.json
+  per_entity:
+    layout: "<EntityName>/<EntityName>.cdm.json + partitions/"
+    format: parquet
+    compression: snappy
+
+doctrine:
+  cdm_is: semantic_export_interchange_layer
+  cdm_is_not: oltp_replacement
+  odoo_orm_is: operational_truth
+  rule: "Odoo model names and column names are NEVER renamed to match CDM in the OLTP layer. CDM naming applies ONLY in the export/gold/ADLS layer."
+
+# =============================================================================
+# Entity projections — Odoo model → CDM entity
+# =============================================================================
+entities:
+
+  # --- Core Business ---
+  - cdm_entity: Account
+    odoo_source: res.partner (is_company=true)
+    export_grain: per-company-record
+    snapshot_or_event: snapshot
+    partition_column: write_date
+    unity_catalog_target: ppm.gold.cdm_account
+    notes: Customers + vendors as accounts
+
+  - cdm_entity: Contact
+    odoo_source: res.partner (is_company=false)
+    export_grain: per-contact-record
+    snapshot_or_event: snapshot
+    partition_column: write_date
+    unity_catalog_target: ppm.gold.cdm_contact
+
+  - cdm_entity: Lead
+    odoo_source: crm.lead (type='lead')
+    export_grain: per-lead-record
+    snapshot_or_event: snapshot
+    partition_column: create_date
+    unity_catalog_target: ppm.gold.cdm_lead
+
+  - cdm_entity: Opportunity
+    odoo_source: crm.lead (type='opportunity')
+    export_grain: per-opportunity-record
+    snapshot_or_event: snapshot
+    partition_column: write_date
+    unity_catalog_target: ppm.gold.cdm_opportunity
+
+  # --- Finance ---
+  - cdm_entity: Invoice
+    odoo_source: account.move (move_type in ['out_invoice','out_refund'])
+    export_grain: per-invoice-header
+    snapshot_or_event: event
+    partition_column: invoice_date
+    unity_catalog_target: ppm.gold.cdm_invoice
+
+  - cdm_entity: VendorInvoice
+    odoo_source: account.move (move_type in ['in_invoice','in_refund'])
+    export_grain: per-invoice-header
+    snapshot_or_event: event
+    partition_column: invoice_date
+    unity_catalog_target: ppm.gold.cdm_vendor_invoice
+
+  - cdm_entity: Payment
+    odoo_source: account.payment
+    export_grain: per-payment-record
+    snapshot_or_event: event
+    partition_column: date
+    unity_catalog_target: ppm.gold.cdm_payment
+
+  - cdm_entity: JournalEntry
+    odoo_source: account.move (move_type='entry')
+    export_grain: per-journal-entry
+    snapshot_or_event: event
+    partition_column: date
+    unity_catalog_target: ppm.gold.cdm_journal_entry
+
+  - cdm_entity: JournalLine
+    odoo_source: account.move.line
+    export_grain: per-line
+    snapshot_or_event: event
+    partition_column: date
+    unity_catalog_target: ppm.gold.cdm_journal_line
+
+  - cdm_entity: BankStatementLine
+    odoo_source: account.bank.statement.line
+    export_grain: per-line
+    snapshot_or_event: event
+    partition_column: date
+    unity_catalog_target: ppm.gold.cdm_bank_statement_line
+
+  - cdm_entity: ChartOfAccounts
+    odoo_source: account.account
+    export_grain: per-account
+    snapshot_or_event: snapshot
+    partition_column: write_date
+    unity_catalog_target: ppm.gold.cdm_chart_of_accounts
+
+  - cdm_entity: Expense
+    odoo_source: hr.expense
+    export_grain: per-expense-line
+    snapshot_or_event: event
+    partition_column: date
+    unity_catalog_target: ppm.gold.cdm_expense
+
+  # --- Sales ---
+  - cdm_entity: SalesOrder
+    odoo_source: sale.order
+    export_grain: per-order-header
+    snapshot_or_event: event
+    partition_column: date_order
+    unity_catalog_target: ppm.gold.cdm_sales_order
+
+  - cdm_entity: SalesOrderLine
+    odoo_source: sale.order.line
+    export_grain: per-line
+    snapshot_or_event: event
+    partition_column: create_date
+    unity_catalog_target: ppm.gold.cdm_sales_order_line
+
+  # --- Purchase ---
+  - cdm_entity: PurchaseOrder
+    odoo_source: purchase.order
+    export_grain: per-order-header
+    snapshot_or_event: event
+    partition_column: date_order
+    unity_catalog_target: ppm.gold.cdm_purchase_order
+
+  # --- Project ---
+  - cdm_entity: Project
+    odoo_source: project.project
+    export_grain: per-project
+    snapshot_or_event: snapshot
+    partition_column: write_date
+    unity_catalog_target: ppm.gold.cdm_project
+
+  - cdm_entity: ProjectTask
+    odoo_source: project.task
+    export_grain: per-task
+    snapshot_or_event: snapshot
+    partition_column: write_date
+    unity_catalog_target: ppm.gold.cdm_project_task
+
+  # --- HR ---
+  - cdm_entity: Employee
+    odoo_source: hr.employee
+    export_grain: per-employee
+    snapshot_or_event: snapshot
+    partition_column: write_date
+    unity_catalog_target: ppm.gold.cdm_employee
+
+  # --- Inventory ---
+  - cdm_entity: Product
+    odoo_source: product.product + product.template
+    export_grain: per-product-variant
+    snapshot_or_event: snapshot
+    partition_column: write_date
+    unity_catalog_target: ppm.gold.cdm_product
+
+  - cdm_entity: StockMove
+    odoo_source: stock.move
+    export_grain: per-move
+    snapshot_or_event: event
+    partition_column: date
+    unity_catalog_target: ppm.gold.cdm_stock_move
+
+  # --- Platform / Agent ---
+  - cdm_entity: AgentRun
+    odoo_source: ops.runs (platform schema, not Odoo ORM)
+    export_grain: per-run
+    snapshot_or_event: event
+    partition_column: started_at
+    unity_catalog_target: ppm.gold.cdm_agent_run
+
+  - cdm_entity: AgentRunEvent
+    odoo_source: ops.run_events (platform schema)
+    export_grain: per-event
+    snapshot_or_event: event
+    partition_column: timestamp
+    unity_catalog_target: ppm.gold.cdm_agent_run_event
+
+rules:
+  - "CDM entity names use PascalCase (Microsoft convention)"
+  - "Odoo model names use dot.notation (Odoo convention)"
+  - "Mapping is one-directional: Odoo → CDM export. CDM never writes back to Odoo."
+  - "CDM attributes are defined in platform/contracts/cdm-entity-map.yaml (machine-readable)"
+  - "Every CDM entity must have a unity_catalog_target"
+  - "Snapshot entities export full-state; event entities export incremental"


### PR DESCRIPTION
## Summary

5-layer canonical data model for Odoo CE 18 + OCA + Pulser. Not one giant ERD — a layered model stack faithful to what Odoo ORM, CDM, and Unity Catalog each actually do.

## The 5 layers

| Layer | File(s) | Models/Entities | Purpose |
|---|---|---|---|
| **1. ORM Registry** | `ssot/odoo/orm-registry.yaml` | 67 models | Operational truth: model type, inheritance, delegation, security, chatter, extension policy |
| **2. Logical DBML** | `ssot/odoo/global-spine.dbml` + `ssot/odoo/domains/*.dbml` | ~120 anchor models | Design truth: 1 spine + 7 bounded-context ERDs (finance, sales, inventory/MRP, services, HR, marketing/web, platform/Pulser) |
| **3. CDM Projection** | `ssot/semantic/cdm-manifest-map.yaml` | 22 CDM entities | Export/interchange truth: Odoo model → CDM entity mapping, grain, snapshot/event semantics |
| **4. UC Governance** | `ssot/lakehouse/unity-catalog-map.yaml` | 3 schemas, 20+ objects | Governance truth: per-object classification, policy, lineage, quality, shareability |
| **5. Physical Schema** | `evidence/schema/README.md` | (blocked) | Generated evidence from live DB — placeholder with generation instructions |

## Additional artifacts

| File | Purpose |
|---|---|
| `ssot/odoo/oca-extension-map.yaml` | OCA module → bounded context mapping, maturity, adoption class |
| `docs/data-model/oca_extension_map.yaml` | Same (backward-compat copy for data-model-index.md refs) |

## Key doctrine

- **Odoo ORM = operational truth.** CDM and UC never replace it.
- **CDM = export semantic layer.** Odoo names are never renamed in OLTP to match CDM.
- **UC = governance layer for curated analytics/AI.** Not raw OLTP tables.
- **Physical schema = generated evidence**, not hand-maintained. Blocked on PG auth.
- **DBML split by bounded context**, not one giant file. Follows Odoo 18 app families.

## Bounded contexts (Layer 2)

| Domain DBML | Key models |
|---|---|
| `finance.dbml` | account_move, account_move_line, account_account, account_journal, account_tax, account_payment, bank_statement*, analytic*, hr_expense* |
| `sales.dbml` | crm_lead, crm_stage, sale_order, sale_order_line, product_pricelist* |
| `inventory_mrp.dbml` | purchase_order*, stock_picking, stock_move*, stock_quant, stock_location, stock_warehouse |
| `services.dbml` | project_project, project_task, project_milestone, project_update |
| `hr.dbml` | hr_employee, hr_department, hr_job, hr_contract, hr_attendance, hr_leave*, hr_applicant |
| `marketing_productivity_websites.dbml` | website, website_page, mailing_*, calendar_event, event_event, survey_survey |
| `platform_identity_pulser.dbml` | ops.runs, ops.run_events, ops.tool_catalog, ops.feature_flags, ops.tenants, platform.audit_log + Cosmos containers (documented as comments) |

## Test plan

- [ ] All DBML files parse with `dbml-cli` or render on dbdiagram.io
- [ ] `orm-registry.yaml` parses as valid YAML; 67 models present
- [ ] `cdm-manifest-map.yaml` — every entity has `unity_catalog_target`
- [ ] `unity-catalog-map.yaml` — every gold object has `business_semantics_binding`
- [ ] `oca-extension-map.yaml` — maturity levels match OCA published status
- [ ] No EE modules referenced anywhere
- [ ] Physical schema placeholder has correct `pg_dump` command

## Issues supported

- Supports #685 — Day-1 data model prerequisite
- Supports #688, #689, #690 — Wave-2 Finance modules reference finance.dbml models
- Supports #721 — UC governance map feeds the Fabric/Databricks mirror decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)