### PR TITLE
ssot(infra): upstream source policy + Databricks workspace IaC contract

### DIFF
--- a/infra/ssot/databricks/workspace-resource.contract.yaml
+++ b/infra/ssot/databricks/workspace-resource.contract.yaml
@@ -1,0 +1,85 @@
+contract_version: 1
+
+resource_type:
+  azure_resource: Microsoft.Databricks/workspaces
+  source_of_truth: bicep_arm_template_reference
+
+api_policy:
+  preferred_api_version: 2025-03-01-preview
+  fallback_api_versions:
+    - 2024-05-01
+    - 2023-02-01
+  rule: preview_only_when_required_property_or_feature_is_needed
+
+workspace_contract:
+  required_fields:
+    - name
+    - location
+    - managedResourceGroupId
+    - sku
+    - tags
+
+  required_properties:
+    - managedResourceGroupId
+    - publicNetworkAccess
+    - requiredNsgRules
+
+  network_posture:
+    publicNetworkAccess:
+      allowed:
+        - Disabled
+        - Enabled
+    requiredNsgRules:
+      allowed:
+        - AllRules
+        - NoAzureDatabricksRules
+    no_public_ip_parameter:
+      path: properties.parameters.enableNoPublicIp.value
+      required: true
+
+  access_connector:
+    path: properties.accessConnector
+    required: true
+    fields:
+      - id
+      - identityType
+      - userAssignedIdentityId
+    rule: use_access_connector_for_workspace_identity_binding
+
+  default_catalog:
+    path: properties.defaultCatalog
+    fields:
+      - initialName
+      - initialType
+    initialType_allowed:
+      - HiveMetastore
+      - UnityCatalog
+    rule: unity_catalog_default_when_governed_lakehouse_mode
+
+  encryption:
+    workspace_encryption_supported: true
+    cmk_supported: true
+    managed_disk_encryption_supported: true
+    managed_services_encryption_supported: true
+
+  workspace_parameters:
+    supported_core:
+      - customVirtualNetworkId
+      - customPublicSubnetName
+      - customPrivateSubnetName
+      - enableNoPublicIp
+      - loadBalancerId
+      - loadBalancerBackendPoolName
+      - natGatewayName
+      - prepareEncryption
+      - requireInfrastructureEncryption
+      - storageAccountName
+      - storageAccountSkuName
+      - vnetAddressPrefix
+
+  security_compliance:
+    enhancedSecurityCompliance_supported: true
+    controls:
+      - automaticClusterUpdate
+      - complianceSecurityProfile
+      - enhancedSecurityMonitoring

--- a/ssot/lakehouse/fabric-consumer-map.yaml
+++ b/ssot/lakehouse/fabric-consumer-map.yaml
@@ -49,3 +49,9 @@ fabric_consumption_binding:
     - databricks_sql_to_power_bi
     - unity_catalog_metadata_to_purview
     - governed_data_to_fabric_copilot_consumers
+
+databricks_workspace_runtime_binding:
+  source: infra/ssot/databricks/workspace-resource.contract.yaml
+  rules:
+    - no_public_ip_expected_for_governed_prod_workspaces
+    - unity_catalog_expected_for_governed_prod_workspaces

--- a/ssot/lakehouse/fabric-consumer-map.yaml
+++ b/ssot/lakehouse/fabric-consumer-map.yaml
@@ -1,0 +1,51 @@
+version: 1
+
+metadata:
+  purpose:
+    - define how Fabric consumes governed Databricks outputs
+    - keep Fabric in the downstream semantic/BI plane
+    - prevent duplication of lakehouse-governance truth
+
+fabric_consumers:
+  power_bi_semantic_models:
+    source_layer:
+      - unity_catalog_governed_gold
+      - databricks_sql
+    purpose:
+      - dashboarding
+      - governed_metrics_consumption
+      - executive_reporting
+
+  fabric_copilot_consumers:
+    source_layer:
+      - power_bi_semantic_models
+      - governed_gold_data
+    purpose:
+      - natural_language_analytics
+      - business_user_insight_access
+
+  purview_metadata_visibility:
+    source_layer:
+      - unity_catalog
+    purpose:
+      - enterprise_metadata_visibility
+      - data_estate_discovery
+
+rules:
+  fabric_not_primary_data_engineering_plane: true
+  fabric_not_primary_governance_plane: true
+  fabric_consumes_only_governed_outputs_by_default: true
+
+fabric_consumption_binding:
+  source_reference: microsoft_architecture_blog_databricks_fabric_2024_09_03
+  posture:
+    databricks_is_primary_data_intelligence_plane: true
+    unity_catalog_is_primary_governance_plane: true
+    fabric_is_downstream_consumption_plane: true
+    power_bi_semantic_models_consume_governed_gold_data: true
+    purview_receives_published_metadata_from_unity_catalog: true
+  allowed_consumption_paths:
+    - databricks_gold_to_power_bi_semantic_model
+    - databricks_sql_to_power_bi
+    - unity_catalog_metadata_to_purview
+    - governed_data_to_fabric_copilot_consumers

--- a/ssot/lakehouse/purview-publication-map.yaml
+++ b/ssot/lakehouse/purview-publication-map.yaml
@@ -1,0 +1,169 @@
+version: 1
+
+metadata:
+  purpose:
+    - define which Unity Catalog assets are published into Microsoft Purview
+    - distinguish engineering/governance authority from metadata publication/discovery
+    - bind technical metadata, lineage, and business context to published assets
+  layering:
+    databricks: primary_data_intelligence_plane
+    unity_catalog: primary_governance_plane
+    purview: metadata_publication_and_discovery_plane
+    semantic_layer: business_metric_dimension_plane
+    odata_entity_map: governed_consumer_interface
+
+global_rules:
+  publish_only_governed_assets: true
+  publish_only_gold_or_explicitly_curated_semantic_assets_by_default: true
+  raw_bronze_assets_not_published_by_default: true
+  lineage_required_for_production_publication: true
+  classification_required_for_production_publication: true
+  business_owner_required_for_production_publication: true
+  glossary_binding_recommended: true
+  purview_not_primary_access_control_authority: true
+
+publication_sources:
+  unity_catalog_scan:
+    enabled: true
+    capabilities_expected:
+      - metastore
+      - catalogs
+      - schemas
+      - tables
+      - views
+      - columns
+      - uc_tags_as_properties
+      - lineage_from_notebook_runs
+  lineage_connections:
+    enabled: true
+    capabilities_expected:
+      - source_to_output_relationships
+      - transformation_activity_metadata
+
+publication_scopes:
+  technical_metadata:
+    publish: true
+    includes:
+      - object_name
+      - fully_qualified_name
+      - schema
+      - columns
+      - tags
+      - object_type
+  lineage:
+    publish: true
+    includes:
+      - upstream_sources
+      - downstream_outputs
+      - transformation_relationships
+  governance_metadata:
+    publish: true
+    includes:
+      - classification
+      - business_owner
+      - governance_domain
+      - glossary_terms
+      - critical_data_elements
+  semantic_metadata:
+    publish: true
+    includes:
+      - metric_name
+      - dimension_name
+      - semantic_version
+      - lineage_version
+
+publishable_objects:
+  finance:
+    - uc_object: main.finance.fact_revenue
+      publish_to_purview: true
+      asset_type: table
+      classification: confidential
+      governance_domain: finance
+      glossary_terms:
+        - Revenue
+        - Invoiced Amount
+      critical_data_elements:
+        - revenue_amount
+    - uc_object: main.finance.semantic_revenue
+      publish_to_purview: true
+      asset_type: view
+      classification: confidential
+      governance_domain: finance
+      glossary_terms:
+        - Revenue
+        - Fiscal Period
+  projects:
+    - uc_object: main.projects.fact_project_burn
+      publish_to_purview: true
+      asset_type: table
+      classification: confidential
+      governance_domain: services_delivery
+      glossary_terms:
+        - Project Burn
+        - Budget Variance
+    - uc_object: main.projects.semantic_project_burn
+      publish_to_purview: true
+      asset_type: view
+      classification: confidential
+      governance_domain: services_delivery
+      glossary_terms:
+        - Project Burn
+        - Billable Utilization
+  tax_compliance:
+    - uc_object: main.tax_compliance.fact_tax_due
+      publish_to_purview: true
+      asset_type: table
+      classification: restricted
+      governance_domain: tax_compliance
+      glossary_terms:
+        - Tax Due
+        - Tax Jurisdiction
+      critical_data_elements:
+        - tax_due_amount
+    - uc_object: main.tax_compliance.semantic_tax_due
+      publish_to_purview: true
+      asset_type: view
+      classification: restricted
+      governance_domain: tax_compliance
+      glossary_terms:
+        - Tax Due
+        - Tax Variance
+  shared_dimensions:
+    - uc_object: main.shared.dim_customer
+      publish_to_purview: true
+      asset_type: table
+      classification: confidential
+      governance_domain: shared_business_dimensions
+      glossary_terms:
+        - Customer
+    - uc_object: main.shared.dim_project
+      publish_to_purview: true
+      asset_type: table
+      classification: confidential
+      governance_domain: shared_business_dimensions
+      glossary_terms:
+        - Project
+    - uc_object: main.shared.dim_tax_jurisdiction
+      publish_to_purview: true
+      asset_type: table
+      classification: internal
+      governance_domain: shared_business_dimensions
+      glossary_terms:
+        - Tax Jurisdiction
+
+non_publish_defaults:
+  bronze:
+    publish_to_purview: false
+  silver_intermediate:
+    publish_to_purview: false
+  internal_platform_telemetry:
+    publish_to_purview: selective_only
+
+purview_bindings:
+  unified_catalog_features:
+    - governance_domains
+    - glossary_terms
+    - critical_data_elements
+    - data_products
+  search_and_browse_expected: true
+  access_request_flow_optional: true

--- a/ssot/lakehouse/unity-catalog-map.yaml
+++ b/ssot/lakehouse/unity-catalog-map.yaml
@@ -218,3 +218,9 @@ rules:
 security_bindings:
   source: ssot/semantic/semantic-security-policy.yaml
   rule: uc_objects_must_bind_to_workspace_privilege_and_abac_or_filter_mask_policy
+
+workspace_binding:
+  resource_contract: infra/ssot/databricks/workspace-resource.contract.yaml
+  default_catalog_policy:
+    require_initialType: UnityCatalog
+    rule: do_not_default_new_governed_workspaces_to_hive_metastore

--- a/ssot/lakehouse/unity-catalog-map.yaml
+++ b/ssot/lakehouse/unity-catalog-map.yaml
@@ -214,3 +214,7 @@ rules:
   - "shareability determines cross-tenant/partner data sharing scope"
   - "No direct Odoo PG connection from UC users — Lakehouse Federation is the read path"
   - "Bronze/Silver are internal-only; Gold + CDM projections can be partner-shared"
+
+security_bindings:
+  source: ssot/semantic/semantic-security-policy.yaml
+  rule: uc_objects_must_bind_to_workspace_privilege_and_abac_or_filter_mask_policy

--- a/ssot/reference/upstream-source-policy.yaml
+++ b/ssot/reference/upstream-source-policy.yaml
@@ -1,0 +1,13 @@
+azure_docs_root:
+  url: https://learn.microsoft.com/en-us/azure/?product=popular
+  classification: upstream_navigation_root
+  allowed_uses:
+    - service_doc_discovery
+    - category_discovery
+    - architecture_center_entrypoint
+    - cloud_adoption_framework_entrypoint
+  disallowed_uses:
+    - direct_runtime_contract_source
+    - direct_bom_source
+    - direct_security_policy_source
+    - direct_service_configuration_source

--- a/ssot/semantic/curated-fact-dimension-map.yaml
+++ b/ssot/semantic/curated-fact-dimension-map.yaml
@@ -604,3 +604,11 @@ odata_exposure:
 
 derived_interfaces:
   odata_entity_map: ssot/semantic/odata-entity-map.yaml
+
+curation_doctrine:
+  upstream_processing_pattern:
+    - bronze_raw
+    - silver_cleansed
+    - gold_business_ready
+  rule:
+    semantic_metrics_bind_only_to_gold_or_other_explicitly_curated_objects

--- a/ssot/semantic/odata-entity-map.yaml
+++ b/ssot/semantic/odata-entity-map.yaml
@@ -344,3 +344,7 @@ examples:
     shape: apply_groupby_aggregate
     example: >
       TaxDue?$apply=groupby((tax_jurisdiction_id,fiscal_period_key),aggregate(tax_due_amount with sum as TaxDue))
+
+security_binding:
+  source: ssot/semantic/semantic-security-policy.yaml
+  rule: entity_set_fields_filters_and_expands_must_comply_with_semantic_security_policy

--- a/ssot/semantic/semantic-layer.yaml
+++ b/ssot/semantic/semantic-layer.yaml
@@ -231,3 +231,17 @@ domains:
 
 derived_model_bindings:
   curated_fact_dimension_map: ssot/semantic/curated-fact-dimension-map.yaml
+
+consumption_doctrine:
+  primary_serving_plane:
+    - databricks_sql_serverless
+    - unity_catalog_governed_gold
+  downstream_consumption_plane:
+    - power_bi_in_microsoft_fabric
+    - fabric_copilot_consumers
+  rule:
+    semantic_definitions_are_authored_in_governed_semantic_contracts_then_exposed_to_downstream_consumers
+
+metadata_publication_doctrine:
+  purview_publication_source: ssot/lakehouse/purview-publication-map.yaml
+  rule: published_semantic_assets_must_have_classification_owner_and_governance_domain

--- a/ssot/semantic/semantic-security-policy.yaml
+++ b/ssot/semantic/semantic-security-policy.yaml
@@ -1,0 +1,240 @@
+version: 1
+
+metadata:
+  purpose:
+    - unify security policy across unity_catalog semantic views and odata exposure
+    - centralize tenant and company boundary enforcement
+    - define masking and filtering behavior for governed consumers
+    - separate identity authentication from business authorization
+  layering:
+    entra_id: identity_control_plane
+    aca_auth: edge_auth_layer
+    unity_catalog: data_governance_layer
+    semantic_views: governed_metric_dimension_layer
+    odata_entity_map: governed_query_interface
+    app_authorization: business_authorization_layer
+
+global_rules:
+  default_deny: true
+  least_privilege_required: true
+  tenant_scope_required_for_business_data: true
+  company_scope_required_when_company_sensitive: true
+  raw_odoo_tables_not_exposed: true
+  semantic_views_only_for_external_consumers: true
+  direct_cross_tenant_access_forbidden: true
+  direct_cross_company_access_forbidden_without_mapping: true
+  write_operations_via_odata_forbidden: true
+  managed_identity_for_service_runtime_only: true
+  entra_directory_not_sufficient_as_customer_tenant_boundary: true
+
+identity_policy:
+  user_interactive:
+    allowed_principal_types:
+      - entra_user_principal
+      - entra_group_mapped_principal
+    conditional_access_expected: true
+    edge_auth_allowed: true
+  service_runtime:
+    allowed_principal_types:
+      - managed_identity
+      - app_principal
+    conditional_access_expected: false
+    managed_identity_preferred: true
+    edge_auth_allowed: false
+  auth_boundary_rules:
+    - aca_auth_establishes_identity_but_not_business_permissions
+    - app_authorization_must_enforce_record_and_workflow_permissions
+    - tenant_context_must_resolve_from_app_mapping_not_directory_id_alone
+
+unity_catalog_policy:
+  access_control_layers:
+    - workspace_bindings
+    - privileges_and_ownership
+    - abac
+    - row_filters_and_column_masks
+  default_policy_model:
+    mechanism: abac_first
+    fallback_mechanisms:
+      - row_filters
+      - column_masks
+      - dynamic_views
+  row_filters:
+    enabled: true
+    rule: use_for_tenant_and_company_row_level_restrictions
+  column_masks:
+    enabled: true
+    rule: use_for_sensitive_columns_like_pii_contact_fields_tax_identifiers
+  privileges:
+    catalogs_and_schemas_governed: true
+    table_and_view_access_governed: true
+  workspace_bindings:
+    enabled: true
+    rule: prod_catalogs_restricted_to_authorized_workspaces_only
+
+semantic_view_policy:
+  approved_security_predicates:
+    - tenant_id
+    - company_id
+    - consumer_class
+    - role_class
+  masking_classes:
+    - public
+    - internal
+    - confidential
+    - restricted
+  required_columns:
+    - tenant_id
+    - company_id
+    - lineage_version
+    - semantic_version
+  domain_defaults:
+    finance:
+      row_filter:
+        - tenant_id
+        - company_id
+      mask_columns:
+        - customer_name
+        - vendor_name
+    sales:
+      row_filter:
+        - tenant_id
+        - company_id
+      mask_columns:
+        - customer_name
+    inventory:
+      row_filter:
+        - tenant_id
+        - company_id
+      mask_columns: []
+    projects:
+      row_filter:
+        - tenant_id
+        - company_id
+      mask_columns:
+        - employee_name
+    hr:
+      row_filter:
+        - tenant_id
+        - company_id
+      mask_columns:
+        - employee_name
+        - personal_email
+        - phone_number
+    tax_compliance:
+      row_filter:
+        - tenant_id
+        - company_id
+      mask_columns:
+        - customer_name
+        - vendor_name
+        - tax_identifier
+    pulser_ops:
+      row_filter:
+        - tenant_id
+      mask_columns:
+        - prompt_text
+        - response_text
+
+odata_policy:
+  metadata_access:
+    allowed: true
+    requires_authenticated_consumer_class: true
+  query_rules:
+    select_or_apply_required: true
+    explicit_field_allowlist_required: true
+    paging_via_nextlink_required_over_10000_rows: true
+    unbounded_extracts_forbidden: true
+    expand_only_for_whitelisted_dimensions: true
+  consumer_scoping:
+    tenant_filter_mandatory_for_business_entity_sets: true
+    company_filter_mandatory_when_company_sensitive: true
+  internal_only_entity_sets:
+    - InteractionSummary
+
+role_mappings:
+  bi_internal:
+    uc_policy_class: internal_analytics_reader
+    semantic_role_class: semantic_reader_internal
+    odata_scope: tenant_and_company_scoped
+  pulser_agent_runtime:
+    uc_policy_class: agent_runtime_reader
+    semantic_role_class: semantic_reader_agent
+    odata_scope: tenant_and_company_scoped
+  customer_embedded_api:
+    uc_policy_class: customer_embedded_reader
+    semantic_role_class: semantic_reader_customer
+    odata_scope: strict_customer_scope
+  customer_bi_readonly:
+    uc_policy_class: customer_bi_reader
+    semantic_role_class: semantic_reader_customer
+    odata_scope: strict_customer_scope
+  internal_ops:
+    uc_policy_class: internal_ops_reader
+    semantic_role_class: semantic_reader_ops
+    odata_scope: explicit_scope_only
+  finance_close_ops:
+    uc_policy_class: finance_close_reader
+    semantic_role_class: semantic_reader_finance
+    odata_scope: strict_finance_scope
+  compliance_ops:
+    uc_policy_class: compliance_reader
+    semantic_role_class: semantic_reader_compliance
+    odata_scope: strict_compliance_scope
+
+entity_set_security:
+  Revenue:
+    classification: confidential
+    required_row_filters:
+      - tenant_id
+      - company_id
+    allowed_roles:
+      - bi_internal
+      - pulser_agent_runtime
+      - customer_embedded_api
+      - customer_bi_readonly
+      - internal_ops
+      - finance_close_ops
+  ProjectBurn:
+    classification: confidential
+    required_row_filters:
+      - tenant_id
+      - company_id
+    allowed_roles:
+      - bi_internal
+      - pulser_agent_runtime
+      - customer_embedded_api
+      - customer_bi_readonly
+      - internal_ops
+  TaxDue:
+    classification: restricted
+    required_row_filters:
+      - tenant_id
+      - company_id
+    allowed_roles:
+      - bi_internal
+      - pulser_agent_runtime
+      - customer_embedded_api
+      - customer_bi_readonly
+      - internal_ops
+      - finance_close_ops
+      - compliance_ops
+  InteractionSummary:
+    classification: internal
+    required_row_filters:
+      - tenant_id
+    allowed_roles:
+      - bi_internal
+      - pulser_agent_runtime
+      - internal_ops
+
+enforcement_checks:
+  - name: uc_object_must_have_policy_binding
+    rule: every_governed_uc_object_must_bind_to_a_policy_class
+  - name: semantic_view_must_have_required_security_columns
+    rule: tenant_and_company_and_lineage_columns_must_exist_when_applicable
+  - name: customer_consumers_cannot_access_internal_only_sets
+    rule: deny_customer_classes_for_internal_only_entity_sets
+  - name: service_runtime_must_use_managed_identity_or_app_principal
+    rule: deny_user_principal_for_service_runtime_paths
+  - name: masked_columns_must_not_escape_via_odata_allowlists
+    rule: odata_allowed_fields_must_respect_masking_policy


### PR DESCRIPTION
## Summary

2 new SSOT files + 2 patches. Adds upstream-doc-resolution policy + Databricks workspace resource contract from Bicep/ARM reference.

| File | Purpose |
|---|---|
| `ssot/reference/upstream-source-policy.yaml` | Azure docs root = navigation only; contracts must resolve to service-specific docs |
| `infra/ssot/databricks/workspace-resource.contract.yaml` | `Microsoft.Databricks/workspaces` resource contract: API versions, network, identity, catalog, encryption, compliance |
| `unity-catalog-map.yaml` (patch) | `workspace_binding` — UC-first enforced for governed workspaces |
| `fabric-consumer-map.yaml` (patch) | `databricks_workspace_runtime_binding` — no-public-IP + UC for prod |

Stacks on top of PR #772 (security + Fabric + Purview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)