### PR TITLE
ssot(infra): Databricks workspace policy validator

### DIFF
--- a/infra/ssot/databricks/workspace-policy-validator.yaml
+++ b/infra/ssot/databricks/workspace-policy-validator.yaml
@@ -1,0 +1,187 @@
+version: 1
+
+metadata:
+  purpose:
+    - fail_prs_when_databricks_workspace_contracts_are_incomplete
+    - enforce_uc_first_identity_first_and_network_explicit_policy
+    - prevent implicit_or_drifted_workspace_posture
+  applies_to:
+    - infra/ssot/databricks/workspace-resource.contract.yaml
+
+global_rules:
+  default_deny_on_missing_required_policy: true
+  preview_api_requires_explicit_justification: true
+  catalog_mode_must_not_be_implicit: true
+  network_posture_must_not_be_implicit: true
+  identity_binding_must_not_be_implicit: true
+  prod_workspace_must_be_governed: true
+
+required_contract_sections:
+  - resource_type
+  - api_policy
+  - workspace_contract
+
+required_workspace_fields:
+  - name
+  - location
+  - managedResourceGroupId
+  - sku
+  - tags
+
+required_workspace_properties:
+  - managedResourceGroupId
+  - publicNetworkAccess
+  - requiredNsgRules
+
+required_nested_properties:
+  accessConnector:
+    path: workspace_contract.access_connector
+    required_fields:
+      - path
+      - required
+      - fields
+      - rule
+  defaultCatalog:
+    path: workspace_contract.default_catalog
+    required_fields:
+      - path
+      - fields
+      - initialType_allowed
+      - rule
+  network:
+    path: workspace_contract.network_posture
+    required_fields:
+      - publicNetworkAccess
+      - requiredNsgRules
+      - no_public_ip_parameter
+  encryption:
+    path: workspace_contract.encryption
+    required_fields:
+      - workspace_encryption_supported
+      - cmk_supported
+      - managed_disk_encryption_supported
+      - managed_services_encryption_supported
+  security_compliance:
+    path: workspace_contract.security_compliance
+    required_fields:
+      - enhancedSecurityCompliance_supported
+      - controls
+
+policy_assertions:
+  - id: api_version_declared
+    description: preferred API version must be declared explicitly
+    check:
+      path_exists: api_policy.preferred_api_version
+  - id: preview_api_has_policy
+    description: preview API usage must be intentional
+    check:
+      when_path_matches:
+        path: api_policy.preferred_api_version
+        pattern: "preview"
+      require_path_equals:
+        path: api_policy.rule
+        value: preview_only_when_required_property_or_feature_is_needed
+  - id: access_connector_required
+    description: workspace access connector must be explicitly required
+    check:
+      require_path_equals:
+        path: workspace_contract.access_connector.required
+        value: true
+  - id: access_connector_identity_rule_present
+    description: access connector must be treated as workspace identity-binding surface
+    check:
+      require_path_contains:
+        path: workspace_contract.access_connector.rule
+        value: access_connector
+  - id: catalog_initial_type_explicit
+    description: default catalog initial type must be explicitly modeled
+    check:
+      require_path_contains:
+        path: workspace_contract.default_catalog.initialType_allowed
+        value: UnityCatalog
+  - id: uc_first_rule_present
+    description: governed workspaces must not default silently to Hive Metastore
+    check:
+      require_path_contains:
+        path: workspace_contract.default_catalog.rule
+        value: unity_catalog_default_when_governed_lakehouse_mode
+  - id: public_network_access_explicit
+    description: public network access posture must be explicitly declared
+    check:
+      require_path_contains:
+        path: workspace_contract.network_posture.publicNetworkAccess.allowed
+        value: Disabled
+  - id: required_nsg_rules_explicit
+    description: required NSG rules posture must be explicitly declared
+    check:
+      require_path_contains:
+        path: workspace_contract.network_posture.requiredNsgRules.allowed
+        value: NoAzureDatabricksRules
+  - id: no_public_ip_parameter_required
+    description: no-public-IP parameter must be explicitly required
+    check:
+      require_path_equals:
+        path: workspace_contract.network_posture.no_public_ip_parameter.required
+        value: true
+  - id: custom_vnet_surface_present
+    description: workspace parameter surface must expose custom VNet fields
+    check:
+      require_all_values_present:
+        path: workspace_contract.workspace_parameters.supported_core
+        values:
+          - customVirtualNetworkId
+          - customPrivateSubnetName
+          - customPublicSubnetName
+          - enableNoPublicIp
+  - id: encryption_surface_present
+    description: encryption controls must be declared
+    check:
+      require_path_equals:
+        path: workspace_contract.encryption.cmk_supported
+        value: true
+  - id: enhanced_security_surface_present
+    description: enhanced security/compliance controls must be declared
+    check:
+      require_path_equals:
+        path: workspace_contract.security_compliance.enhancedSecurityCompliance_supported
+        value: true
+
+environment_rules:
+  prod:
+    required_assertions:
+      - access_connector_required
+      - catalog_initial_type_explicit
+      - uc_first_rule_present
+      - public_network_access_explicit
+      - required_nsg_rules_explicit
+      - no_public_ip_parameter_required
+      - encryption_surface_present
+      - enhanced_security_surface_present
+    deny_values:
+      - path: workspace_contract.network_posture.publicNetworkAccess.allowed
+        value: Enabled
+        unless: approved_exception_present
+  nonprod:
+    required_assertions:
+      - access_connector_required
+      - catalog_initial_type_explicit
+      - public_network_access_explicit
+
+exception_policy:
+  approved_exception_present:
+    required_fields:
+      - exception_id
+      - approver
+      - rationale
+      - expiry_date
+    allowed_categories:
+      - temporary_public_network_access
+      - legacy_catalog_mode_transition
+      - preview_feature_dependency
+
+validator_outcomes:
+  on_missing_required_section: fail
+  on_missing_required_property: fail
+  on_policy_assertion_failure: fail
+  on_exception_missing_fields: fail
+  on_unknown_exception_category: fail

--- a/infra/ssot/databricks/workspace-resource.contract.yaml
+++ b/infra/ssot/databricks/workspace-resource.contract.yaml
@@ -1,0 +1,85 @@
+contract_version: 1
+
+resource_type:
+  azure_resource: Microsoft.Databricks/workspaces
+  source_of_truth: bicep_arm_template_reference
+
+api_policy:
+  preferred_api_version: 2025-03-01-preview
+  fallback_api_versions:
+    - 2024-05-01
+    - 2023-02-01
+  rule: preview_only_when_required_property_or_feature_is_needed
+
+workspace_contract:
+  required_fields:
+    - name
+    - location
+    - managedResourceGroupId
+    - sku
+    - tags
+
+  required_properties:
+    - managedResourceGroupId
+    - publicNetworkAccess
+    - requiredNsgRules
+
+  network_posture:
+    publicNetworkAccess:
+      allowed:
+        - Disabled
+        - Enabled
+    requiredNsgRules:
+      allowed:
+        - AllRules
+        - NoAzureDatabricksRules
+    no_public_ip_parameter:
+      path: properties.parameters.enableNoPublicIp.value
+      required: true
+
+  access_connector:
+    path: properties.accessConnector
+    required: true
+    fields:
+      - id
+      - identityType
+      - userAssignedIdentityId
+    rule: use_access_connector_for_workspace_identity_binding
+
+  default_catalog:
+    path: properties.defaultCatalog
+    fields:
+      - initialName
+      - initialType
+    initialType_allowed:
+      - HiveMetastore
+      - UnityCatalog
+    rule: unity_catalog_default_when_governed_lakehouse_mode
+
+  encryption:
+    workspace_encryption_supported: true
+    cmk_supported: true
+    managed_disk_encryption_supported: true
+    managed_services_encryption_supported: true
+
+  workspace_parameters:
+    supported_core:
+      - customVirtualNetworkId
+      - customPublicSubnetName
+      - customPrivateSubnetName
+      - enableNoPublicIp
+      - loadBalancerId
+      - loadBalancerBackendPoolName
+      - natGatewayName
+      - prepareEncryption
+      - requireInfrastructureEncryption
+      - storageAccountName
+      - storageAccountSkuName
+      - vnetAddressPrefix
+
+  security_compliance:
+    enhancedSecurityCompliance_supported: true
+    controls:
+      - automaticClusterUpdate
+      - complianceSecurityProfile
+      - enhancedSecurityMonitoring

--- a/infra/ssot/databricks/workspace-resource.contract.yaml
+++ b/infra/ssot/databricks/workspace-resource.contract.yaml
@@ -83,3 +83,7 @@ workspace_contract:
       - automaticClusterUpdate
       - complianceSecurityProfile
       - enhancedSecurityMonitoring
+
+validator_binding:
+  source: infra/ssot/databricks/workspace-policy-validator.yaml
+  rule: workspace_contract_changes_must_pass_policy_validator_before_merge

--- a/ssot/lakehouse/fabric-consumer-map.yaml
+++ b/ssot/lakehouse/fabric-consumer-map.yaml
@@ -49,3 +49,9 @@ fabric_consumption_binding:
     - databricks_sql_to_power_bi
     - unity_catalog_metadata_to_purview
     - governed_data_to_fabric_copilot_consumers
+
+databricks_workspace_runtime_binding:
+  source: infra/ssot/databricks/workspace-resource.contract.yaml
+  rules:
+    - no_public_ip_expected_for_governed_prod_workspaces
+    - unity_catalog_expected_for_governed_prod_workspaces

--- a/ssot/lakehouse/fabric-consumer-map.yaml
+++ b/ssot/lakehouse/fabric-consumer-map.yaml
@@ -1,0 +1,51 @@
+version: 1
+
+metadata:
+  purpose:
+    - define how Fabric consumes governed Databricks outputs
+    - keep Fabric in the downstream semantic/BI plane
+    - prevent duplication of lakehouse-governance truth
+
+fabric_consumers:
+  power_bi_semantic_models:
+    source_layer:
+      - unity_catalog_governed_gold
+      - databricks_sql
+    purpose:
+      - dashboarding
+      - governed_metrics_consumption
+      - executive_reporting
+
+  fabric_copilot_consumers:
+    source_layer:
+      - power_bi_semantic_models
+      - governed_gold_data
+    purpose:
+      - natural_language_analytics
+      - business_user_insight_access
+
+  purview_metadata_visibility:
+    source_layer:
+      - unity_catalog
+    purpose:
+      - enterprise_metadata_visibility
+      - data_estate_discovery
+
+rules:
+  fabric_not_primary_data_engineering_plane: true
+  fabric_not_primary_governance_plane: true
+  fabric_consumes_only_governed_outputs_by_default: true
+
+fabric_consumption_binding:
+  source_reference: microsoft_architecture_blog_databricks_fabric_2024_09_03
+  posture:
+    databricks_is_primary_data_intelligence_plane: true
+    unity_catalog_is_primary_governance_plane: true
+    fabric_is_downstream_consumption_plane: true
+    power_bi_semantic_models_consume_governed_gold_data: true
+    purview_receives_published_metadata_from_unity_catalog: true
+  allowed_consumption_paths:
+    - databricks_gold_to_power_bi_semantic_model
+    - databricks_sql_to_power_bi
+    - unity_catalog_metadata_to_purview
+    - governed_data_to_fabric_copilot_consumers

--- a/ssot/lakehouse/purview-publication-map.yaml
+++ b/ssot/lakehouse/purview-publication-map.yaml
@@ -1,0 +1,169 @@
+version: 1
+
+metadata:
+  purpose:
+    - define which Unity Catalog assets are published into Microsoft Purview
+    - distinguish engineering/governance authority from metadata publication/discovery
+    - bind technical metadata, lineage, and business context to published assets
+  layering:
+    databricks: primary_data_intelligence_plane
+    unity_catalog: primary_governance_plane
+    purview: metadata_publication_and_discovery_plane
+    semantic_layer: business_metric_dimension_plane
+    odata_entity_map: governed_consumer_interface
+
+global_rules:
+  publish_only_governed_assets: true
+  publish_only_gold_or_explicitly_curated_semantic_assets_by_default: true
+  raw_bronze_assets_not_published_by_default: true
+  lineage_required_for_production_publication: true
+  classification_required_for_production_publication: true
+  business_owner_required_for_production_publication: true
+  glossary_binding_recommended: true
+  purview_not_primary_access_control_authority: true
+
+publication_sources:
+  unity_catalog_scan:
+    enabled: true
+    capabilities_expected:
+      - metastore
+      - catalogs
+      - schemas
+      - tables
+      - views
+      - columns
+      - uc_tags_as_properties
+      - lineage_from_notebook_runs
+  lineage_connections:
+    enabled: true
+    capabilities_expected:
+      - source_to_output_relationships
+      - transformation_activity_metadata
+
+publication_scopes:
+  technical_metadata:
+    publish: true
+    includes:
+      - object_name
+      - fully_qualified_name
+      - schema
+      - columns
+      - tags
+      - object_type
+  lineage:
+    publish: true
+    includes:
+      - upstream_sources
+      - downstream_outputs
+      - transformation_relationships
+  governance_metadata:
+    publish: true
+    includes:
+      - classification
+      - business_owner
+      - governance_domain
+      - glossary_terms
+      - critical_data_elements
+  semantic_metadata:
+    publish: true
+    includes:
+      - metric_name
+      - dimension_name
+      - semantic_version
+      - lineage_version
+
+publishable_objects:
+  finance:
+    - uc_object: main.finance.fact_revenue
+      publish_to_purview: true
+      asset_type: table
+      classification: confidential
+      governance_domain: finance
+      glossary_terms:
+        - Revenue
+        - Invoiced Amount
+      critical_data_elements:
+        - revenue_amount
+    - uc_object: main.finance.semantic_revenue
+      publish_to_purview: true
+      asset_type: view
+      classification: confidential
+      governance_domain: finance
+      glossary_terms:
+        - Revenue
+        - Fiscal Period
+  projects:
+    - uc_object: main.projects.fact_project_burn
+      publish_to_purview: true
+      asset_type: table
+      classification: confidential
+      governance_domain: services_delivery
+      glossary_terms:
+        - Project Burn
+        - Budget Variance
+    - uc_object: main.projects.semantic_project_burn
+      publish_to_purview: true
+      asset_type: view
+      classification: confidential
+      governance_domain: services_delivery
+      glossary_terms:
+        - Project Burn
+        - Billable Utilization
+  tax_compliance:
+    - uc_object: main.tax_compliance.fact_tax_due
+      publish_to_purview: true
+      asset_type: table
+      classification: restricted
+      governance_domain: tax_compliance
+      glossary_terms:
+        - Tax Due
+        - Tax Jurisdiction
+      critical_data_elements:
+        - tax_due_amount
+    - uc_object: main.tax_compliance.semantic_tax_due
+      publish_to_purview: true
+      asset_type: view
+      classification: restricted
+      governance_domain: tax_compliance
+      glossary_terms:
+        - Tax Due
+        - Tax Variance
+  shared_dimensions:
+    - uc_object: main.shared.dim_customer
+      publish_to_purview: true
+      asset_type: table
+      classification: confidential
+      governance_domain: shared_business_dimensions
+      glossary_terms:
+        - Customer
+    - uc_object: main.shared.dim_project
+      publish_to_purview: true
+      asset_type: table
+      classification: confidential
+      governance_domain: shared_business_dimensions
+      glossary_terms:
+        - Project
+    - uc_object: main.shared.dim_tax_jurisdiction
+      publish_to_purview: true
+      asset_type: table
+      classification: internal
+      governance_domain: shared_business_dimensions
+      glossary_terms:
+        - Tax Jurisdiction
+
+non_publish_defaults:
+  bronze:
+    publish_to_purview: false
+  silver_intermediate:
+    publish_to_purview: false
+  internal_platform_telemetry:
+    publish_to_purview: selective_only
+
+purview_bindings:
+  unified_catalog_features:
+    - governance_domains
+    - glossary_terms
+    - critical_data_elements
+    - data_products
+  search_and_browse_expected: true
+  access_request_flow_optional: true

--- a/ssot/lakehouse/unity-catalog-map.yaml
+++ b/ssot/lakehouse/unity-catalog-map.yaml
@@ -218,3 +218,9 @@ rules:
 security_bindings:
   source: ssot/semantic/semantic-security-policy.yaml
   rule: uc_objects_must_bind_to_workspace_privilege_and_abac_or_filter_mask_policy
+
+workspace_binding:
+  resource_contract: infra/ssot/databricks/workspace-resource.contract.yaml
+  default_catalog_policy:
+    require_initialType: UnityCatalog
+    rule: do_not_default_new_governed_workspaces_to_hive_metastore

--- a/ssot/lakehouse/unity-catalog-map.yaml
+++ b/ssot/lakehouse/unity-catalog-map.yaml
@@ -214,3 +214,7 @@ rules:
   - "shareability determines cross-tenant/partner data sharing scope"
   - "No direct Odoo PG connection from UC users — Lakehouse Federation is the read path"
   - "Bronze/Silver are internal-only; Gold + CDM projections can be partner-shared"
+
+security_bindings:
+  source: ssot/semantic/semantic-security-policy.yaml
+  rule: uc_objects_must_bind_to_workspace_privilege_and_abac_or_filter_mask_policy

--- a/ssot/lakehouse/unity-catalog-map.yaml
+++ b/ssot/lakehouse/unity-catalog-map.yaml
@@ -224,3 +224,7 @@ workspace_binding:
   default_catalog_policy:
     require_initialType: UnityCatalog
     rule: do_not_default_new_governed_workspaces_to_hive_metastore
+
+workspace_validation_binding:
+  source: infra/ssot/databricks/workspace-policy-validator.yaml
+  rule: uc_first_workspace_policy_must_pass_before_governed_workspace_is_approved

--- a/ssot/reference/upstream-source-policy.yaml
+++ b/ssot/reference/upstream-source-policy.yaml
@@ -1,0 +1,13 @@
+azure_docs_root:
+  url: https://learn.microsoft.com/en-us/azure/?product=popular
+  classification: upstream_navigation_root
+  allowed_uses:
+    - service_doc_discovery
+    - category_discovery
+    - architecture_center_entrypoint
+    - cloud_adoption_framework_entrypoint
+  disallowed_uses:
+    - direct_runtime_contract_source
+    - direct_bom_source
+    - direct_security_policy_source
+    - direct_service_configuration_source

--- a/ssot/semantic/curated-fact-dimension-map.yaml
+++ b/ssot/semantic/curated-fact-dimension-map.yaml
@@ -604,3 +604,11 @@ odata_exposure:
 
 derived_interfaces:
   odata_entity_map: ssot/semantic/odata-entity-map.yaml
+
+curation_doctrine:
+  upstream_processing_pattern:
+    - bronze_raw
+    - silver_cleansed
+    - gold_business_ready
+  rule:
+    semantic_metrics_bind_only_to_gold_or_other_explicitly_curated_objects

--- a/ssot/semantic/odata-entity-map.yaml
+++ b/ssot/semantic/odata-entity-map.yaml
@@ -344,3 +344,7 @@ examples:
     shape: apply_groupby_aggregate
     example: >
       TaxDue?$apply=groupby((tax_jurisdiction_id,fiscal_period_key),aggregate(tax_due_amount with sum as TaxDue))
+
+security_binding:
+  source: ssot/semantic/semantic-security-policy.yaml
+  rule: entity_set_fields_filters_and_expands_must_comply_with_semantic_security_policy

--- a/ssot/semantic/semantic-layer.yaml
+++ b/ssot/semantic/semantic-layer.yaml
@@ -231,3 +231,17 @@ domains:
 
 derived_model_bindings:
   curated_fact_dimension_map: ssot/semantic/curated-fact-dimension-map.yaml
+
+consumption_doctrine:
+  primary_serving_plane:
+    - databricks_sql_serverless
+    - unity_catalog_governed_gold
+  downstream_consumption_plane:
+    - power_bi_in_microsoft_fabric
+    - fabric_copilot_consumers
+  rule:
+    semantic_definitions_are_authored_in_governed_semantic_contracts_then_exposed_to_downstream_consumers
+
+metadata_publication_doctrine:
+  purview_publication_source: ssot/lakehouse/purview-publication-map.yaml
+  rule: published_semantic_assets_must_have_classification_owner_and_governance_domain

--- a/ssot/semantic/semantic-security-policy.yaml
+++ b/ssot/semantic/semantic-security-policy.yaml
@@ -1,0 +1,240 @@
+version: 1
+
+metadata:
+  purpose:
+    - unify security policy across unity_catalog semantic views and odata exposure
+    - centralize tenant and company boundary enforcement
+    - define masking and filtering behavior for governed consumers
+    - separate identity authentication from business authorization
+  layering:
+    entra_id: identity_control_plane
+    aca_auth: edge_auth_layer
+    unity_catalog: data_governance_layer
+    semantic_views: governed_metric_dimension_layer
+    odata_entity_map: governed_query_interface
+    app_authorization: business_authorization_layer
+
+global_rules:
+  default_deny: true
+  least_privilege_required: true
+  tenant_scope_required_for_business_data: true
+  company_scope_required_when_company_sensitive: true
+  raw_odoo_tables_not_exposed: true
+  semantic_views_only_for_external_consumers: true
+  direct_cross_tenant_access_forbidden: true
+  direct_cross_company_access_forbidden_without_mapping: true
+  write_operations_via_odata_forbidden: true
+  managed_identity_for_service_runtime_only: true
+  entra_directory_not_sufficient_as_customer_tenant_boundary: true
+
+identity_policy:
+  user_interactive:
+    allowed_principal_types:
+      - entra_user_principal
+      - entra_group_mapped_principal
+    conditional_access_expected: true
+    edge_auth_allowed: true
+  service_runtime:
+    allowed_principal_types:
+      - managed_identity
+      - app_principal
+    conditional_access_expected: false
+    managed_identity_preferred: true
+    edge_auth_allowed: false
+  auth_boundary_rules:
+    - aca_auth_establishes_identity_but_not_business_permissions
+    - app_authorization_must_enforce_record_and_workflow_permissions
+    - tenant_context_must_resolve_from_app_mapping_not_directory_id_alone
+
+unity_catalog_policy:
+  access_control_layers:
+    - workspace_bindings
+    - privileges_and_ownership
+    - abac
+    - row_filters_and_column_masks
+  default_policy_model:
+    mechanism: abac_first
+    fallback_mechanisms:
+      - row_filters
+      - column_masks
+      - dynamic_views
+  row_filters:
+    enabled: true
+    rule: use_for_tenant_and_company_row_level_restrictions
+  column_masks:
+    enabled: true
+    rule: use_for_sensitive_columns_like_pii_contact_fields_tax_identifiers
+  privileges:
+    catalogs_and_schemas_governed: true
+    table_and_view_access_governed: true
+  workspace_bindings:
+    enabled: true
+    rule: prod_catalogs_restricted_to_authorized_workspaces_only
+
+semantic_view_policy:
+  approved_security_predicates:
+    - tenant_id
+    - company_id
+    - consumer_class
+    - role_class
+  masking_classes:
+    - public
+    - internal
+    - confidential
+    - restricted
+  required_columns:
+    - tenant_id
+    - company_id
+    - lineage_version
+    - semantic_version
+  domain_defaults:
+    finance:
+      row_filter:
+        - tenant_id
+        - company_id
+      mask_columns:
+        - customer_name
+        - vendor_name
+    sales:
+      row_filter:
+        - tenant_id
+        - company_id
+      mask_columns:
+        - customer_name
+    inventory:
+      row_filter:
+        - tenant_id
+        - company_id
+      mask_columns: []
+    projects:
+      row_filter:
+        - tenant_id
+        - company_id
+      mask_columns:
+        - employee_name
+    hr:
+      row_filter:
+        - tenant_id
+        - company_id
+      mask_columns:
+        - employee_name
+        - personal_email
+        - phone_number
+    tax_compliance:
+      row_filter:
+        - tenant_id
+        - company_id
+      mask_columns:
+        - customer_name
+        - vendor_name
+        - tax_identifier
+    pulser_ops:
+      row_filter:
+        - tenant_id
+      mask_columns:
+        - prompt_text
+        - response_text
+
+odata_policy:
+  metadata_access:
+    allowed: true
+    requires_authenticated_consumer_class: true
+  query_rules:
+    select_or_apply_required: true
+    explicit_field_allowlist_required: true
+    paging_via_nextlink_required_over_10000_rows: true
+    unbounded_extracts_forbidden: true
+    expand_only_for_whitelisted_dimensions: true
+  consumer_scoping:
+    tenant_filter_mandatory_for_business_entity_sets: true
+    company_filter_mandatory_when_company_sensitive: true
+  internal_only_entity_sets:
+    - InteractionSummary
+
+role_mappings:
+  bi_internal:
+    uc_policy_class: internal_analytics_reader
+    semantic_role_class: semantic_reader_internal
+    odata_scope: tenant_and_company_scoped
+  pulser_agent_runtime:
+    uc_policy_class: agent_runtime_reader
+    semantic_role_class: semantic_reader_agent
+    odata_scope: tenant_and_company_scoped
+  customer_embedded_api:
+    uc_policy_class: customer_embedded_reader
+    semantic_role_class: semantic_reader_customer
+    odata_scope: strict_customer_scope
+  customer_bi_readonly:
+    uc_policy_class: customer_bi_reader
+    semantic_role_class: semantic_reader_customer
+    odata_scope: strict_customer_scope
+  internal_ops:
+    uc_policy_class: internal_ops_reader
+    semantic_role_class: semantic_reader_ops
+    odata_scope: explicit_scope_only
+  finance_close_ops:
+    uc_policy_class: finance_close_reader
+    semantic_role_class: semantic_reader_finance
+    odata_scope: strict_finance_scope
+  compliance_ops:
+    uc_policy_class: compliance_reader
+    semantic_role_class: semantic_reader_compliance
+    odata_scope: strict_compliance_scope
+
+entity_set_security:
+  Revenue:
+    classification: confidential
+    required_row_filters:
+      - tenant_id
+      - company_id
+    allowed_roles:
+      - bi_internal
+      - pulser_agent_runtime
+      - customer_embedded_api
+      - customer_bi_readonly
+      - internal_ops
+      - finance_close_ops
+  ProjectBurn:
+    classification: confidential
+    required_row_filters:
+      - tenant_id
+      - company_id
+    allowed_roles:
+      - bi_internal
+      - pulser_agent_runtime
+      - customer_embedded_api
+      - customer_bi_readonly
+      - internal_ops
+  TaxDue:
+    classification: restricted
+    required_row_filters:
+      - tenant_id
+      - company_id
+    allowed_roles:
+      - bi_internal
+      - pulser_agent_runtime
+      - customer_embedded_api
+      - customer_bi_readonly
+      - internal_ops
+      - finance_close_ops
+      - compliance_ops
+  InteractionSummary:
+    classification: internal
+    required_row_filters:
+      - tenant_id
+    allowed_roles:
+      - bi_internal
+      - pulser_agent_runtime
+      - internal_ops
+
+enforcement_checks:
+  - name: uc_object_must_have_policy_binding
+    rule: every_governed_uc_object_must_bind_to_a_policy_class
+  - name: semantic_view_must_have_required_security_columns
+    rule: tenant_and_company_and_lineage_columns_must_exist_when_applicable
+  - name: customer_consumers_cannot_access_internal_only_sets
+    rule: deny_customer_classes_for_internal_only_entity_sets
+  - name: service_runtime_must_use_managed_identity_or_app_principal
+    rule: deny_user_principal_for_service_runtime_paths
+  - name: masked_columns_must_not_escape_via_odata_allowlists
+    rule: odata_allowed_fields_must_respect_masking_policy


### PR DESCRIPTION
## Summary
- Adds `infra/ssot/databricks/workspace-policy-validator.yaml` as the fail-closed gate for `Microsoft.Databricks/workspaces` contract changes
- Validates: API version declaration, accessConnector (UC identity-binding), defaultCatalog UC-first, network posture (public network access + NSG rules), encryption surface, enhanced security compliance
- Prod environment denies `publicNetworkAccess: Enabled` without an approved exception record; nonprod requires minimum 3 assertions

## Stacks on
#773

## Test plan
- [ ] Verify `workspace-policy-validator.yaml` parses as valid YAML
- [ ] Confirm `workspace-resource.contract.yaml` contains `validator_binding` section pointing to correct source path
- [ ] Confirm `unity-catalog-map.yaml` contains `workspace_validation_binding` section with correct rule name
- [ ] Validate all 13 `policy_assertions` IDs are unique and well-formed
- [ ] Validate `environment_rules.prod.deny_values` block references correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)