### PR TITLE
ssot(infra): Databricks workspace contracts — resource + validator + runtime + admin + upstream policy

### DIFF
--- a/infra/ssot/databricks/workspace-admin-posture.yaml
+++ b/infra/ssot/databricks/workspace-admin-posture.yaml
@@ -1,0 +1,35 @@
+contract_version: 1
+
+workspace_admin_posture:
+  dbw-ipai-dev:
+    environment: dev
+    observed_settings:
+      repos:
+        git_url_allow_list_permission:
+          observed: disabled_no_restrictions
+        git_url_allow_list:
+          observed: []
+        allow_repos_to_export_ipynb_output:
+          observed: unknown
+          note: screenshot_does_not_show_selected_value
+      apps:
+        only_allow_app_deployments_from_git:
+          observed: false
+    target_policy:
+      repos:
+        git_url_allow_list_permission:
+          dev: optional_explicit
+          prod: required_enabled
+        git_url_allow_list:
+          dev: optional
+          prod: required_non_empty
+        allow_repos_to_export_ipynb_output:
+          dev: explicit_required
+          prod: restricted_or_disabled
+      apps:
+        only_allow_app_deployments_from_git:
+          dev: recommended_true
+          prod: required_true
+    policy_notes:
+      - workspace_admin_settings_are_distinct_from_arm_bicep_resource_contract
+      - unknown_critical_settings_must_not_be_treated_as_compliant

--- a/infra/ssot/databricks/workspace-policy-validator.yaml
+++ b/infra/ssot/databricks/workspace-policy-validator.yaml
@@ -1,0 +1,175 @@
+version: 1
+
+metadata:
+  purpose: Fail-closed policy gate for Azure Databricks workspace provisioning and governance
+  authority: infra/ssot/databricks/
+  contract_source: infra/ssot/databricks/workspace-resource.contract.yaml
+  last_updated: "2026-04-16"
+
+global_rules:
+  fail_closed: true
+  unknown_is_noncompliant: true
+  rationale: >
+    Any setting that cannot be verified is treated as noncompliant.
+    Passing the gate requires explicit evidence, not absence of failure.
+
+required_contract_sections:
+  - resource_type
+  - api_policy
+  - workspace_contract
+
+required_workspace_fields:
+  - name
+  - location
+  - resource_group
+  - sku.name
+  - properties
+
+required_workspace_properties:
+  - managedResourceGroupId
+  - parameters
+
+required_nested_properties:
+  network_posture:
+    prod:
+      - properties.parameters.enableNoPublicIp.value == true
+  access_connector:
+    governed:
+      - properties.accessConnector.id is not null
+  default_catalog:
+    governed:
+      - properties.defaultCatalog.initialType == "UnityCatalog"
+
+policy_assertions:
+  - id: PA-001
+    name: api_version_minimum
+    description: Deployment must use API version >= 2024-05-01
+    rule: api_version >= "2024-05-01"
+    severity: FAIL
+    environment: all
+
+  - id: PA-002
+    name: api_version_preferred
+    description: Governed workspaces should use preferred API version 2025-03-01-preview
+    rule: api_version == "2025-03-01-preview"
+    severity: WARN
+    environment: governed
+
+  - id: PA-003
+    name: sku_tier_premium_for_governed
+    description: Governed workspaces require Premium SKU for Unity Catalog
+    rule: sku.name == "premium"
+    severity: FAIL
+    environment: governed
+
+  - id: PA-004
+    name: managed_resource_group_set
+    description: managedResourceGroupId must be explicitly set
+    rule: properties.managedResourceGroupId is not null and not empty
+    severity: FAIL
+    environment: all
+
+  - id: PA-005
+    name: no_public_ip_prod
+    description: Production workspaces must disable public IP
+    rule: properties.parameters.enableNoPublicIp.value == true
+    severity: FAIL
+    environment: prod
+
+  - id: PA-006
+    name: access_connector_governed
+    description: Governed workspaces require an Access Connector for Unity Catalog
+    rule: properties.accessConnector.id is not null
+    severity: FAIL
+    environment: governed
+
+  - id: PA-007
+    name: unity_catalog_default_governed
+    description: Governed workspaces must default to UnityCatalog, not HiveMetastore
+    rule: properties.defaultCatalog.initialType == "UnityCatalog"
+    severity: FAIL
+    environment: governed
+
+  - id: PA-008
+    name: cmk_managed_disk_prod
+    description: Production workspaces must use Customer Managed Key for managed disk encryption
+    rule: properties.encryption.entities.managedDisk.keySource == "Microsoft.Keyvault"
+    severity: FAIL
+    environment: prod
+
+  - id: PA-009
+    name: cmk_managed_services_prod
+    description: Production workspaces must use Customer Managed Key for managed services encryption
+    rule: properties.encryption.entities.managedServices.keySource == "Microsoft.Keyvault"
+    severity: FAIL
+    environment: prod
+
+  - id: PA-010
+    name: vnet_injection_prod
+    description: Production workspaces should use VNet injection
+    rule: properties.parameters.customVirtualNetworkId is not null
+    severity: WARN
+    environment: prod
+
+  - id: PA-011
+    name: enhanced_security_monitoring_prod
+    description: Production workspaces should enable enhanced security monitoring
+    rule: properties.enhancedSecurityMonitoring.value.status == "enabled"
+    severity: WARN
+    environment: prod
+
+  - id: PA-012
+    name: automatic_cluster_update_prod
+    description: Production workspaces should enable automatic cluster updates
+    rule: properties.automaticClusterUpdate.value.enabled == "enabled"
+    severity: WARN
+    environment: prod
+
+  - id: PA-013
+    name: unknown_settings_noncompliant
+    description: Any required setting with unknown/unverified state is treated as noncompliant
+    rule: all_required_settings_have_verified_observed_values
+    severity: FAIL
+    environment: all
+
+environment_rules:
+  prod:
+    required_passing_assertions:
+      - PA-001
+      - PA-003
+      - PA-004
+      - PA-005
+      - PA-006
+      - PA-007
+      - PA-008
+      - PA-009
+      - PA-013
+    recommended_passing_assertions:
+      - PA-002
+      - PA-010
+      - PA-011
+      - PA-012
+
+  nonprod:
+    required_passing_assertions:
+      - PA-001
+      - PA-004
+      - PA-013
+    recommended_passing_assertions:
+      - PA-002
+      - PA-003
+      - PA-006
+      - PA-007
+
+exception_policy:
+  allowed: false
+  rationale: >
+    No exceptions to FAIL-severity assertions in prod.
+    WARN-severity assertions may be deferred with documented justification
+    in infra/ssot/databricks/workspace-runtime-state.yaml.
+
+validator_outcomes:
+  PASS: all required assertions for environment pass
+  WARN: all required assertions pass; one or more recommended assertions fail
+  FAIL: one or more required assertions fail; provisioning blocked
+  UNKNOWN: validator cannot determine compliance; treated as FAIL per fail-closed rule

--- a/infra/ssot/databricks/workspace-resource.contract.yaml
+++ b/infra/ssot/databricks/workspace-resource.contract.yaml
@@ -1,0 +1,100 @@
+contract_version: 1
+
+metadata:
+  purpose: ARM resource contract for Azure Databricks workspaces
+  authority: infra/ssot/databricks/
+  scope: all governed Databricks workspaces in the IPAI platform
+  last_updated: "2026-04-16"
+
+resource_type: Microsoft.Databricks/workspaces
+
+api_policy:
+  preferred_api_version: "2025-03-01-preview"
+  minimum_api_version: "2024-05-01"
+  rationale: >
+    2025-03-01-preview exposes defaultCatalog initialType (UnityCatalog),
+    enhancedSecurityMonitoring, automaticClusterUpdate, and complianceSecurityProfile
+    not available in stable GA versions.
+
+workspace_contract:
+  required_fields:
+    - name
+    - location
+    - resource_group
+    - sku.name
+    - properties
+
+  required_properties:
+    - managedResourceGroupId
+    - parameters
+
+  network_posture:
+    rule: no_public_ip_preferred_for_prod
+    fields:
+      enableNoPublicIp:
+        dev: optional
+        prod: required_true
+      natGatewayName:
+        dev: optional
+        prod: recommended
+      publicIpName:
+        dev: optional
+        prod: recommended_if_no_public_ip_disabled
+
+  access_connector:
+    rule: required_for_unity_catalog_and_fabric_mirroring
+    fields:
+      accessConnector.id:
+        governance: required_when_unity_catalog_enabled
+        purpose: Managed Identity for Unity Catalog + Fabric mirroring
+
+  default_catalog:
+    rule: unity_catalog_first_for_governed_workspaces
+    fields:
+      defaultCatalog.initialType:
+        allowed_values:
+          - UnityCatalog
+          - HiveMetastore
+        governed_workspaces: UnityCatalog
+        note: do_not_default_governed_workspaces_to_hive_metastore
+
+  encryption:
+    rule: customer_managed_key_required_for_prod
+    fields:
+      encryption.entities.managedDisk.keySource:
+        prod: Microsoft.Keyvault
+        dev: optional
+      encryption.entities.managedServices.keySource:
+        prod: Microsoft.Keyvault
+        dev: optional
+
+  workspace_parameters:
+    customVirtualNetworkId:
+      dev: optional
+      prod: recommended_for_vnet_injection
+    customPrivateSubnetName:
+      dev: optional
+      prod: required_if_vnet_injected
+    customPublicSubnetName:
+      dev: optional
+      prod: required_if_vnet_injected
+    requireInfrastructureEncryption:
+      dev: optional
+      prod: recommended_true
+
+  security_compliance:
+    enhancedSecurityMonitoring:
+      status:
+        dev: optional
+        prod: recommended_enabled
+    automaticClusterUpdate:
+      enabledValue:
+        dev: optional
+        prod: recommended_enabled
+    complianceSecurityProfile:
+      complianceStandards:
+        dev: []
+        prod:
+          - recommended: HIPAA
+          - recommended: PCI_DSS
+          - note: enable_per_data_classification_requirements

--- a/infra/ssot/databricks/workspace-runtime-state.yaml
+++ b/infra/ssot/databricks/workspace-runtime-state.yaml
@@ -1,0 +1,19 @@
+contract_version: 1
+
+observed_workspaces:
+  dbw-ipai-dev:
+    classification: runtime_evidence
+    environment: dev
+    resource_type: Azure Databricks Service
+    status: Active
+    workspace_type: Hybrid
+    pricing_tier: Premium
+    resource_group: rg-ipai-dev-ai-sea
+    managed_resource_group: rg-ipai-dev-dbw-managed
+    location: southeastasia
+    subscription_name: Microsoft Azure Sponsorship
+    subscription_id: eba824fb-332d-4623-9dfb-2c9f7ee83f4e
+    workspace_url: https://adb-7405608559466577.17.azuredatabricks.net
+    evidence_source:
+      type: portal_screenshot
+      captured_on: 2026-04-16

--- a/ssot/lakehouse/fabric-consumer-map.yaml
+++ b/ssot/lakehouse/fabric-consumer-map.yaml
@@ -49,3 +49,9 @@ fabric_consumption_binding:
     - databricks_sql_to_power_bi
     - unity_catalog_metadata_to_purview
     - governed_data_to_fabric_copilot_consumers
+
+databricks_workspace_runtime_binding:
+  source: infra/ssot/databricks/workspace-resource.contract.yaml
+  rules:
+    - no_public_ip_expected_for_governed_prod_workspaces
+    - unity_catalog_expected_for_governed_prod_workspaces

--- a/ssot/lakehouse/unity-catalog-map.yaml
+++ b/ssot/lakehouse/unity-catalog-map.yaml
@@ -218,3 +218,13 @@ rules:
 security_bindings:
   source: ssot/semantic/semantic-security-policy.yaml
   rule: uc_objects_must_bind_to_workspace_privilege_and_abac_or_filter_mask_policy
+
+workspace_binding:
+  resource_contract: infra/ssot/databricks/workspace-resource.contract.yaml
+  default_catalog_policy:
+    require_initialType: UnityCatalog
+    rule: do_not_default_new_governed_workspaces_to_hive_metastore
+
+workspace_validation_binding:
+  source: infra/ssot/databricks/workspace-policy-validator.yaml
+  rule: uc_first_workspace_policy_must_pass_before_governed_workspace_is_approved

--- a/ssot/reference/upstream-source-policy.yaml
+++ b/ssot/reference/upstream-source-policy.yaml
@@ -1,0 +1,13 @@
+azure_docs_root:
+  url: https://learn.microsoft.com/en-us/azure/?product=popular
+  classification: upstream_navigation_root
+  allowed_uses:
+    - service_doc_discovery
+    - category_discovery
+    - architecture_center_entrypoint
+    - cloud_adoption_framework_entrypoint
+  disallowed_uses:
+    - direct_runtime_contract_source
+    - direct_bom_source
+    - direct_security_policy_source
+    - direct_service_configuration_source


### PR DESCRIPTION
Combined from closed #773 + #774 + workspace runtime/admin evidence. 5 new files + 2 patches.

## Summary
- `ssot/reference/upstream-source-policy.yaml` — Azure docs root classified as navigation only, not runtime/BOM/security contract source
- `infra/ssot/databricks/workspace-resource.contract.yaml` — ARM resource contract (API version, SKU, network, access connector, Unity Catalog default, CMK, security compliance)
- `infra/ssot/databricks/workspace-policy-validator.yaml` — Fail-closed gate with 13 policy assertions (PA-001..PA-013), PASS/WARN/FAIL/UNKNOWN outcomes
- `infra/ssot/databricks/workspace-runtime-state.yaml` — Observed live evidence for `dbw-ipai-dev` (portal screenshot 2026-04-16)
- `infra/ssot/databricks/workspace-admin-posture.yaml` — Workspace admin console settings: repos git URL allowlist, ipynb export, apps deploy-from-git; observed vs. target policy per env
- Patch `ssot/lakehouse/unity-catalog-map.yaml` — binds workspace resource contract + validator to UC governance map
- Patch `ssot/lakehouse/fabric-consumer-map.yaml` — binds workspace runtime contract to Fabric consumption posture

## Test plan
- [ ] YAML lints clean (no tabs, valid structure)
- [ ] Contract references resolve within repo (infra/ssot/databricks/ paths exist)
- [ ] Validator PA-007 (UnityCatalog default) cross-checked against workspace-runtime-state.yaml
- [ ] Patch bindings in unity-catalog-map.yaml and fabric-consumer-map.yaml point to valid file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)