### PR TITLE
feat(analytics): Azure Boards dashboard — Databricks notebook + PBIP

### DIFF
--- a/analytics/databricks/azure_boards_dashboard.py
+++ b/analytics/databricks/azure_boards_dashboard.py
@@ -1,0 +1,238 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Azure Boards Dashboard — IPAI Platform
+# MAGIC
+# MAGIC Live dashboard from Azure DevOps Analytics OData.
+# MAGIC Org: `insightpulseai` | Project: `ipai-platform`
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## 1. Load data from ADO Analytics OData
+
+# COMMAND ----------
+
+import requests
+import pandas as pd
+from datetime import datetime
+
+ADO_ORG = "insightpulseai"
+ADO_PROJECT = "ipai-platform"
+ODATA_BASE = f"https://analytics.dev.azure.com/{ADO_ORG}/{ADO_PROJECT}/_odata/v4.0-preview"
+
+# Auth: use PAT from dbutils secrets or env var
+# For dev: set AZURE_DEVOPS_PAT in cluster env vars or Databricks secrets
+try:
+    pat = dbutils.secrets.get(scope="ipai-secrets", key="azure-devops-pat")
+except Exception:
+    import os
+    pat = os.environ.get("AZURE_DEVOPS_PAT", "")
+
+if not pat:
+    raise ValueError("Set AZURE_DEVOPS_PAT in cluster env vars or Databricks secrets scope 'ipai-secrets'")
+
+headers = {"Authorization": f"Basic {__import__('base64').b64encode(f':{pat}'.encode()).decode()}"}
+
+# COMMAND ----------
+
+# Fetch work items
+wi_url = (
+    f"{ODATA_BASE}/WorkItems?"
+    "$select=WorkItemId,Title,WorkItemType,State,IterationPath,AreaPath,Priority,Tags,CreatedDate,ChangedDate"
+    "&$filter=State ne 'Removed'"
+    "&$top=500"
+)
+wi_resp = requests.get(wi_url, headers=headers)
+wi_resp.raise_for_status()
+wi_data = wi_resp.json().get("value", [])
+df_wi = pd.DataFrame(wi_data)
+
+# Parse iteration name from path
+df_wi["Iteration"] = df_wi["IterationPath"].apply(
+    lambda p: p.split("\\")[-1] if "\\" in str(p) else "Unassigned"
+)
+df_wi["CreatedDate"] = pd.to_datetime(df_wi["CreatedDate"])
+df_wi["ChangedDate"] = pd.to_datetime(df_wi["ChangedDate"])
+
+print(f"Loaded {len(df_wi)} work items")
+df_wi.head()
+
+# COMMAND ----------
+
+# Fetch iterations
+iter_url = (
+    f"{ODATA_BASE}/Iterations?"
+    "$select=IterationId,IterationName,IterationPath,StartDate,EndDate,IsCurrentIteration"
+)
+iter_resp = requests.get(iter_url, headers=headers)
+iter_resp.raise_for_status()
+iter_data = iter_resp.json().get("value", [])
+df_iter = pd.DataFrame(iter_data)
+
+if not df_iter.empty:
+    df_iter["StartDate"] = pd.to_datetime(df_iter["StartDate"])
+    df_iter["EndDate"] = pd.to_datetime(df_iter["EndDate"])
+
+print(f"Loaded {len(df_iter)} iterations")
+df_iter
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## 2. Save to Unity Catalog (governed table)
+
+# COMMAND ----------
+
+# Convert to Spark DataFrames and save as UC tables
+spark_wi = spark.createDataFrame(df_wi)
+spark_wi.write.mode("overwrite").saveAsTable("ipai_dev.bronze.ado_work_items")
+
+if not df_iter.empty:
+    spark_iter = spark.createDataFrame(df_iter)
+    spark_iter.write.mode("overwrite").saveAsTable("ipai_dev.bronze.ado_iterations")
+
+print("Saved to ipai_dev.bronze.ado_work_items + ado_iterations")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## 3. Summary KPIs
+
+# COMMAND ----------
+
+total = len(df_wi)
+by_state = df_wi["State"].value_counts().to_dict()
+by_type = df_wi["WorkItemType"].value_counts().to_dict()
+by_iter = df_wi["Iteration"].value_counts().to_dict()
+
+print(f"""
+╔══════════════════════════════════════════╗
+║   IPAI Platform — Azure Boards Summary   ║
+╠══════════════════════════════════════════╣
+║  Total Work Items:  {total:<20} ║
+║  To Do:             {by_state.get('To Do', 0):<20} ║
+║  Doing:             {by_state.get('Doing', 0):<20} ║
+║  Done:              {by_state.get('Done', 0):<20} ║
+╠══════════════════════════════════════════╣
+║  Epics:             {by_type.get('Epic', 0):<20} ║
+║  Issues:            {by_type.get('Issue', 0):<20} ║
+║  Tasks:             {by_type.get('Task', 0):<20} ║
+║  Bugs:              {by_type.get('Bug', 0):<20} ║
+╠══════════════════════════════════════════╣
+║  By Iteration:                           ║""")
+for it, count in sorted(by_iter.items()):
+    print(f"║    {it:<28} {count:<5}  ║")
+print("╚══════════════════════════════════════════╝")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## 4. Visualizations
+
+# COMMAND ----------
+
+import plotly.express as px
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+# -- Work items by State --
+fig_state = px.pie(
+    df_wi, names="State",
+    title="Work Items by State",
+    color_discrete_sequence=px.colors.qualitative.Set2,
+    hole=0.4
+)
+fig_state.show()
+
+# COMMAND ----------
+
+# -- Work items by Iteration × State --
+iter_order = ["R1-Foundation-30d", "R2-Core-Execution-60d", "R3-PH-Ops-Hardening-90d", "R4-GA", "Sprint 1", "Unassigned", "ipai-platform"]
+cross = df_wi.groupby(["Iteration", "State"]).size().reset_index(name="Count")
+
+fig_iter = px.bar(
+    cross, x="Iteration", y="Count", color="State",
+    title="Work Items by Iteration × State",
+    category_orders={"Iteration": iter_order},
+    color_discrete_sequence=px.colors.qualitative.Set2,
+    barmode="stack"
+)
+fig_iter.update_layout(xaxis_tickangle=-30)
+fig_iter.show()
+
+# COMMAND ----------
+
+# -- Work items by Type --
+fig_type = px.bar(
+    df_wi, x="WorkItemType",
+    title="Work Items by Type",
+    color="WorkItemType",
+    color_discrete_sequence=px.colors.qualitative.Pastel
+)
+fig_type.update_layout(showlegend=False)
+fig_type.show()
+
+# COMMAND ----------
+
+# -- Priority distribution --
+df_wi["PriorityLabel"] = df_wi["Priority"].map({1: "P1 Critical", 2: "P2 High", 3: "P3 Medium", 4: "P4 Low"}).fillna("Unset")
+fig_pri = px.histogram(
+    df_wi, x="PriorityLabel",
+    title="Work Items by Priority",
+    color="PriorityLabel",
+    category_orders={"PriorityLabel": ["P1 Critical", "P2 High", "P3 Medium", "P4 Low", "Unset"]}
+)
+fig_pri.update_layout(showlegend=False)
+fig_pri.show()
+
+# COMMAND ----------
+
+# -- Timeline: Iterations gantt --
+if not df_iter.empty:
+    gantt_data = df_iter[df_iter["StartDate"].notna()].copy()
+    if not gantt_data.empty:
+        today_line = datetime.now()
+        fig_gantt = px.timeline(
+            gantt_data,
+            x_start="StartDate", x_end="EndDate",
+            y="IterationName",
+            title="Release Timeline (R1 → R4)",
+            color="IterationName",
+            color_discrete_sequence=px.colors.qualitative.Set2
+        )
+        fig_gantt.add_vline(x=today_line, line_dash="dash", line_color="red", annotation_text="Today")
+        fig_gantt.update_yaxes(autorange="reversed")
+        fig_gantt.show()
+
+# COMMAND ----------
+
+# -- Tag cloud (top 20 tags) --
+all_tags = df_wi["Tags"].dropna().str.split("; ").explode()
+tag_counts = all_tags.value_counts().head(20).reset_index()
+tag_counts.columns = ["Tag", "Count"]
+
+fig_tags = px.bar(
+    tag_counts, x="Count", y="Tag", orientation="h",
+    title="Top 20 Tags",
+    color="Count",
+    color_continuous_scale="Tealgrn"
+)
+fig_tags.update_layout(yaxis=dict(autorange="reversed"))
+fig_tags.show()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## 5. Publish as Dashboard
+# MAGIC
+# MAGIC To convert this notebook into a Databricks Dashboard:
+# MAGIC 1. Click the **kebab menu (⋮)** at the top right of this notebook
+# MAGIC 2. Select **Create Dashboard from Notebook**
+# MAGIC 3. Databricks auto-converts the plotly charts into dashboard tiles
+# MAGIC 4. Share the dashboard URL with stakeholders
+# MAGIC
+# MAGIC Or create a SQL Dashboard manually using the UC tables:
+# MAGIC ```sql
+# MAGIC SELECT * FROM ipai_dev.bronze.ado_work_items
+# MAGIC SELECT * FROM ipai_dev.bronze.ado_iterations
+# MAGIC ```

--- a/analytics/powerbi/README.md
+++ b/analytics/powerbi/README.md
@@ -1,0 +1,62 @@
+# Azure Boards Power BI Dashboard
+
+PBIP (Power BI Project) format — version-controlled, diffable, CI-ready.
+
+## Data source
+
+**Azure DevOps Analytics OData v4.0-preview**
+
+```
+https://analytics.dev.azure.com/insightpulseai/ipai-platform/_odata/v4.0-preview/
+```
+
+Entity sets:
+- `WorkItems` — all work items with fields, state, iteration, tags
+- `Iterations` — iteration paths with start/end dates
+
+Auth: Entra ID (same as `az login` session). Power BI prompts for organizational account on first connect.
+
+## Semantic model (TMDL)
+
+| Table | Source | Key measures |
+|---|---|---|
+| `WorkItems` | OData `WorkItems` entity | Total Work Items, To Do / In Progress / Done counts, Completion Rate, Issue/Task/Epic counts |
+| `Iterations` | OData `Iterations` entity | Days Remaining in Current Iteration |
+
+Relationship: `WorkItems.Iteration` → `Iterations.IterationName` (bidirectional)
+
+## How to open
+
+1. Install [Power BI Desktop](https://powerbi.microsoft.com/desktop/) (free)
+2. Open `azure-boards-dashboard.pbip`
+3. Sign in with `admin@insightpulseai.com` when prompted for OData credentials
+4. Data loads from ADO Analytics
+5. Build visuals on the canvas
+
+## Suggested visuals
+
+| Visual | Measure / Field | Purpose |
+|---|---|---|
+| **Card** | Total Work Items | KPI header |
+| **Card** | Completion Rate | Progress % |
+| **Stacked bar** | Count by State × Iteration | Iteration burndown |
+| **Donut** | Count by WorkItemType | Epic / Issue / Task split |
+| **Matrix** | Iteration × State (count) | Pivot table of progress |
+| **Slicer** | Tags | Filter by wave, domain, etc. |
+| **Timeline** | Iteration StartDate → EndDate | Release timeline R1→R4 |
+
+## Iterations (from live ADO data)
+
+| Iteration | Start | End | Duration |
+|---|---|---|---|
+| R1-Foundation-30d | 2026-04-14 | 2026-05-14 | 30 days |
+| R2-Core-Execution-60d | 2026-05-15 | 2026-07-14 | 60 days |
+| R3-PH-Ops-Hardening-90d | 2026-07-15 | 2026-10-14 | 90 days |
+| R4-GA | 2026-10-15 | 2026-12-15 | 60 days |
+
+## Doctrine
+
+- Power BI is the primary mandatory business-facing reporting surface (CLAUDE.md cross-repo invariant #12)
+- ADO Analytics OData is the canonical query path for Boards data (not REST API scraping)
+- PBIP format enables git version control + PR review of report changes
+- Auth: Entra organizational account, not PAT

--- a/analytics/powerbi/azure-boards-dashboard.Report/definition.pbir
+++ b/analytics/powerbi/azure-boards-dashboard.Report/definition.pbir
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "datasetReference": {
+    "byPath": {
+      "path": "../azure-boards-dashboard.SemanticModel"
+    }
+  }
+}

--- a/analytics/powerbi/azure-boards-dashboard.Report/report.json
+++ b/analytics/powerbi/azure-boards-dashboard.Report/report.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/report/1.0.0/schema.json",
+  "themeCollection": {
+    "baseTheme": {
+      "name": "CY24SU06",
+      "reportVersionAtImport": "5.53",
+      "type": "SharedResources"
+    }
+  },
+  "datasetBinding": {
+    "byConnection": {
+      "connectionString": null,
+      "pbiServiceModelId": null,
+      "pbiModelVirtualServerName": "sobe_wowvirtualserver",
+      "pbiModelDatabaseName": "",
+      "name": "EntityDataSource"
+    },
+    "datasetId": ""
+  }
+}

--- a/analytics/powerbi/azure-boards-dashboard.SemanticModel/definition/model.tmdl
+++ b/analytics/powerbi/azure-boards-dashboard.SemanticModel/definition/model.tmdl
@@ -1,0 +1,6 @@
+model Model
+	culture: en-US
+	defaultPowerBIDataSourceVersion: powerBI_V3
+	sourceQueryCulture: en-US
+
+	annotation PBI_QueryOrder = ["WorkItems","Iterations"]

--- a/analytics/powerbi/azure-boards-dashboard.SemanticModel/definition/relationships.tmdl
+++ b/analytics/powerbi/azure-boards-dashboard.SemanticModel/definition/relationships.tmdl
@@ -1,0 +1,4 @@
+relationship WorkItems_Iterations
+	fromColumn: WorkItems.Iteration
+	toColumn: Iterations.IterationName
+	crossFilteringBehavior: bothDirections

--- a/analytics/powerbi/azure-boards-dashboard.SemanticModel/definition/tables/Iterations.tmdl
+++ b/analytics/powerbi/azure-boards-dashboard.SemanticModel/definition/tables/Iterations.tmdl
@@ -1,0 +1,61 @@
+table Iterations
+	lineageTag: b1b2c3d4-e5f6-7890-abcd-ef1234567890
+
+	column IterationId
+		dataType: int64
+		formatString: 0
+		lineageTag: 30000001-0000-0000-0000-000000000001
+		summarizeBy: none
+		sourceColumn: IterationId
+
+	column IterationName
+		dataType: string
+		lineageTag: 30000001-0000-0000-0000-000000000002
+		summarizeBy: none
+		sourceColumn: IterationName
+
+	column IterationPath
+		dataType: string
+		lineageTag: 30000001-0000-0000-0000-000000000003
+		summarizeBy: none
+		sourceColumn: IterationPath
+
+	column StartDate
+		dataType: dateTime
+		formatString: Short Date
+		lineageTag: 30000001-0000-0000-0000-000000000004
+		summarizeBy: none
+		sourceColumn: StartDate
+
+	column EndDate
+		dataType: dateTime
+		formatString: Short Date
+		lineageTag: 30000001-0000-0000-0000-000000000005
+		summarizeBy: none
+		sourceColumn: EndDate
+
+	column IsCurrentIteration
+		dataType: boolean
+		formatString: """TRUE"";""TRUE"";""FALSE"""
+		lineageTag: 30000001-0000-0000-0000-000000000006
+		summarizeBy: none
+		sourceColumn: IsCurrentIteration
+
+	partition Iterations = m
+		mode: import
+		source =
+			let
+				Source = OData.Feed(
+					"https://analytics.dev.azure.com/insightpulseai/ipai-platform/_odata/v4.0-preview/Iterations?"
+					& "$select=IterationId,IterationName,IterationPath,StartDate,EndDate,IsCurrentIteration",
+					null,
+					[Implementation="2.0"]
+				)
+			in
+				Source
+
+	measure 'Days Remaining in Current Iteration' =
+		VAR CurrentIter = CALCULATE(MAX(Iterations[EndDate]), Iterations[IsCurrentIteration] = TRUE)
+		RETURN IF(NOT ISBLANK(CurrentIter), CurrentIter - TODAY(), BLANK())
+		formatString: #,0
+		lineageTag: 40000001-0000-0000-0000-000000000001

--- a/analytics/powerbi/azure-boards-dashboard.SemanticModel/definition/tables/WorkItems.tmdl
+++ b/analytics/powerbi/azure-boards-dashboard.SemanticModel/definition/tables/WorkItems.tmdl
@@ -1,0 +1,122 @@
+table WorkItems
+	lineageTag: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+
+	column WorkItemId
+		dataType: int64
+		formatString: 0
+		lineageTag: 10000001-0000-0000-0000-000000000001
+		summarizeBy: none
+		sourceColumn: WorkItemId
+
+	column Title
+		dataType: string
+		lineageTag: 10000001-0000-0000-0000-000000000002
+		summarizeBy: none
+		sourceColumn: Title
+
+	column WorkItemType
+		dataType: string
+		lineageTag: 10000001-0000-0000-0000-000000000003
+		summarizeBy: none
+		sourceColumn: WorkItemType
+
+	column State
+		dataType: string
+		lineageTag: 10000001-0000-0000-0000-000000000004
+		summarizeBy: none
+		sourceColumn: State
+
+	column IterationPath
+		dataType: string
+		lineageTag: 10000001-0000-0000-0000-000000000005
+		summarizeBy: none
+		sourceColumn: IterationPath
+
+	column AreaPath
+		dataType: string
+		lineageTag: 10000001-0000-0000-0000-000000000006
+		summarizeBy: none
+		sourceColumn: AreaPath
+
+	column Priority
+		dataType: int64
+		formatString: 0
+		lineageTag: 10000001-0000-0000-0000-000000000007
+		summarizeBy: none
+		sourceColumn: Priority
+
+	column Tags
+		dataType: string
+		lineageTag: 10000001-0000-0000-0000-000000000008
+		summarizeBy: none
+		sourceColumn: Tags
+
+	column CreatedDate
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 10000001-0000-0000-0000-000000000009
+		summarizeBy: none
+		sourceColumn: CreatedDate
+
+	column ChangedDate
+		dataType: dateTime
+		formatString: General Date
+		lineageTag: 10000001-0000-0000-0000-000000000010
+		summarizeBy: none
+		sourceColumn: ChangedDate
+
+	column Iteration
+		dataType: string
+		lineageTag: 10000001-0000-0000-0000-000000000011
+		summarizeBy: none
+		sourceColumn: Iteration
+
+	partition WorkItems = m
+		mode: import
+		source =
+			let
+				Source = OData.Feed(
+					"https://analytics.dev.azure.com/insightpulseai/ipai-platform/_odata/v4.0-preview/WorkItems?"
+					& "$select=WorkItemId,Title,WorkItemType,State,IterationPath,AreaPath,Priority,Tags,CreatedDate,ChangedDate"
+					& "&$filter=State ne 'Removed'",
+					null,
+					[Implementation="2.0"]
+				),
+				AddIteration = Table.AddColumn(Source, "Iteration", each
+					let parts = Text.Split([IterationPath], "\")
+					in if List.Count(parts) > 1 then parts{1} else "Unassigned"
+				)
+			in
+				AddIteration
+
+	measure 'Total Work Items' = COUNTROWS(WorkItems)
+		formatString: #,0
+		lineageTag: 20000001-0000-0000-0000-000000000001
+
+	measure 'To Do Count' = CALCULATE(COUNTROWS(WorkItems), WorkItems[State] = "To Do")
+		formatString: #,0
+		lineageTag: 20000001-0000-0000-0000-000000000002
+
+	measure 'In Progress Count' = CALCULATE(COUNTROWS(WorkItems), WorkItems[State] = "Doing")
+		formatString: #,0
+		lineageTag: 20000001-0000-0000-0000-000000000003
+
+	measure 'Done Count' = CALCULATE(COUNTROWS(WorkItems), WorkItems[State] = "Done")
+		formatString: #,0
+		lineageTag: 20000001-0000-0000-0000-000000000004
+
+	measure 'Completion Rate' = DIVIDE([Done Count], [Total Work Items], 0)
+		formatString: 0.0%;-0.0%;0.0%
+		lineageTag: 20000001-0000-0000-0000-000000000005
+
+	measure 'Issue Count' = CALCULATE(COUNTROWS(WorkItems), WorkItems[WorkItemType] = "Issue")
+		formatString: #,0
+		lineageTag: 20000001-0000-0000-0000-000000000006
+
+	measure 'Task Count' = CALCULATE(COUNTROWS(WorkItems), WorkItems[WorkItemType] = "Task")
+		formatString: #,0
+		lineageTag: 20000001-0000-0000-0000-000000000007
+
+	measure 'Epic Count' = CALCULATE(COUNTROWS(WorkItems), WorkItems[WorkItemType] = "Epic")
+		formatString: #,0
+		lineageTag: 20000001-0000-0000-0000-000000000008

--- a/analytics/powerbi/azure-boards-dashboard.pbip
+++ b/analytics/powerbi/azure-boards-dashboard.pbip
@@ -1,0 +1,18 @@
+{
+  "version": "1.0",
+  "artifacts": [
+    {
+      "report": {
+        "path": "azure-boards-dashboard.Report"
+      }
+    },
+    {
+      "semanticModel": {
+        "path": "azure-boards-dashboard.SemanticModel"
+      }
+    }
+  ],
+  "settings": {
+    "enableAutoRecovery": true
+  }
+}


### PR DESCRIPTION
## Summary

Azure Boards dashboard for `ipai-platform` project. Two formats:

**Primary (Databricks — no Desktop needed):**
- Notebook at `/Shared/ipai/dashboards/azure_boards_dashboard` on `dbw-ipai-dev`
- Queries ADO Analytics OData, saves to UC `ipai_dev.bronze.ado_*`, renders 6 plotly charts
- Converts to shareable Databricks Dashboard via notebook menu

**Secondary (Power BI — when Desktop available):**
- PBIP scaffold at `analytics/powerbi/` with TMDL semantic model + 8 DAX measures

## To run the Databricks notebook

1. Open `dbw-ipai-dev` → Shared → ipai → dashboards → azure_boards_dashboard
2. Set `AZURE_DEVOPS_PAT` in cluster env vars (or add to Databricks secrets scope `ipai-secrets`)
3. Run All

## Visualizations

- State distribution (donut)
- Iteration × State (stacked bar)
- Work item type distribution
- Priority histogram
- Release timeline R1→R4 (gantt with today marker)
- Top 20 tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)