### PR TITLE
docs(ssot): formalize data-intelligence as vertical operating intelligence layer

### DIFF
--- a/data-intelligence/contracts/ado/work_items.contract.yaml
+++ b/data-intelligence/contracts/ado/work_items.contract.yaml
@@ -1,0 +1,16 @@
+contract: ado_work_items
+status: active
+grain: one_row_per_work_item_state_snapshot_or_event
+minimum_fields:
+  - work_item_id
+  - title
+  - state
+  - type
+  - assigned_to
+  - iteration_path
+  - created_date
+  - changed_date
+quality_rules:
+  - work_item_id_not_null
+  - state_not_null
+  - type_not_null

--- a/data-intelligence/contracts/finance/bir_deadlines.contract.yaml
+++ b/data-intelligence/contracts/finance/bir_deadlines.contract.yaml
@@ -1,0 +1,13 @@
+contract: bir_deadlines
+status: planned
+grain: one_row_per_form_period_deadline
+minimum_fields:
+  - bir_form
+  - period_covered
+  - filing_deadline
+  - prep_due_date
+  - report_approval_due_date
+  - payment_approval_due_date
+quality_rules:
+  - bir_form_not_null
+  - filing_deadline_not_null

--- a/data-intelligence/contracts/finance/month_end_close_tasks.contract.yaml
+++ b/data-intelligence/contracts/finance/month_end_close_tasks.contract.yaml
@@ -1,0 +1,15 @@
+contract: month_end_close_tasks
+status: planned
+grain: one_row_per_role_task_period
+minimum_fields:
+  - employee_or_owner_code
+  - task_category
+  - task_name
+  - reviewed_by
+  - approved_by
+  - preparation_days
+  - review_days
+  - approval_days
+quality_rules:
+  - task_category_not_null
+  - task_name_not_null

--- a/data-intelligence/contracts/serving/genie/finance_ops_space.contract.yaml
+++ b/data-intelligence/contracts/serving/genie/finance_ops_space.contract.yaml
@@ -1,0 +1,10 @@
+contract: genie_finance_ops_space
+status: planned
+domain: finance_close
+required_assets:
+  - gold_finance_close_workload
+  - gold_finance_approval_latency
+required_examples:
+  - who_has_the_highest_month_end_workload
+  - which_tasks_take_the_most_review_time
+  - what_close_steps_are_best_candidates_for_automation

--- a/data-intelligence/contracts/serving/genie/platform_tracker_space.contract.yaml
+++ b/data-intelligence/contracts/serving/genie/platform_tracker_space.contract.yaml
@@ -1,0 +1,10 @@
+contract: genie_platform_tracker_space
+status: pilot
+domain: ado
+required_assets:
+  - gold_ado_work_item_flow
+  - gold_ado_iteration_health
+required_examples:
+  - how_many_work_items_are_in_r2
+  - what_is_blocked_right_now
+  - which_owner_has_the_most_open_items

--- a/data-intelligence/docs/architecture/DATABRICKS_ONE_STRATEGY.md
+++ b/data-intelligence/docs/architecture/DATABRICKS_ONE_STRATEGY.md
@@ -1,0 +1,57 @@
+# DATABRICKS_ONE_STRATEGY
+
+## Role
+
+Databricks One is the **primary business user consumption surface** for operating intelligence. It replaces ad-hoc notebook sharing, raw SQL access, and standalone BI tool sprawl.
+
+Databricks One hosts:
+- Vertical domain dashboards (Delivery, Finance, Tax, ERP)
+- Genie Spaces (natural language Q&A over gold marts)
+- Vertical analytics apps (if needed — Databricks Apps layer)
+
+## Target Users
+
+| User type | Primary surface | Access pattern |
+|---|---|---|
+| Executives | Dashboards | Read-only, scheduled refresh |
+| Finance managers | Genie Spaces + dashboards | Question-first, natural language |
+| Analysts | Genie Spaces + SQL editor | Curated + exploratory |
+| Consumer access stakeholders | Dashboards | Embedded or link-based read-only |
+
+## Non-Goals
+
+Databricks One is **not**:
+- A transactional workspace (Odoo owns transactions)
+- A replacement ERP UI
+- A data engineering workspace (that is notebooks/jobs)
+- A platform control surface (that is `platform` repo)
+
+## Rollout — 3 Phases
+
+### Phase 1: ADO Delivery Intelligence (now)
+- Bronze ingest from Azure DevOps REST API
+- Silver transformation (state normalization, iteration mapping)
+- Gold mart: `gold_ado_work_item_flow`, `gold_ado_iteration_health`
+- Genie Space: IPAI Platform Tracker (pilot)
+- Dashboard: Delivery Intelligence v1
+
+### Phase 2: Finance Operations Intelligence
+- Bronze ingest from month-end close task schedules (CSV/SharePoint)
+- Silver: task normalization, owner mapping, workload scoring
+- Gold marts: `gold_finance_close_workload`, `gold_finance_approval_latency`, `gold_finance_recurring_task_load`
+- Genie Space: Finance Operations
+- Dashboard: Finance Operations v1
+
+### Phase 3: Tax and Compliance Intelligence
+- Bronze ingest from BIR deadline calendars, internal approval calendars
+- Silver: deadline normalization, risk scoring, form-period mapping
+- Gold marts: `gold_tax_deadline_control`, `gold_tax_filing_readiness`, `gold_tax_approval_latency`
+- Genie Space: Compliance & Tax
+- Dashboard: Compliance & Tax v1
+
+## Data Source Doctrine
+
+- **Bronze-backed pilots** are acceptable temporarily during initial domain build-out.
+- **Canonical production serving** uses gold marts or curated serving views only.
+- Bronze tables must never be exposed directly in Genie Spaces or dashboards in steady state.
+- All gold mart schemas are governed by contracts in `data-intelligence/contracts/`.

--- a/data-intelligence/docs/architecture/GENIE_SPACE_STRATEGY.md
+++ b/data-intelligence/docs/architecture/GENIE_SPACE_STRATEGY.md
@@ -1,0 +1,41 @@
+# GENIE_SPACE_STRATEGY
+
+## Purpose
+
+Genie Spaces are the **natural language question-answering surface** for operating intelligence. They allow business users to ask questions in plain language and receive answers grounded in gold mart data — without writing SQL.
+
+## Principles
+
+1. **Prefer curated gold marts** — Genie Spaces must be backed by gold or curated serving views. Raw bronze/silver exposure is prohibited in steady state.
+2. **Bronze-backed pilots are time-limited** — A space may launch on bronze backing during initial domain development, but must be promoted to gold backing within one sprint.
+3. **Curated example questions are mandatory** — Every Genie Space must have a defined set of seed example questions (see contracts in `data-intelligence/contracts/serving/genie/`).
+4. **Live data only** — No synthetic data, no static snapshots in production or pilot spaces.
+5. **One space per domain** — Avoid space sprawl. Each vertical domain has one canonical Genie Space.
+
+## Initial Spaces (3)
+
+### Space 1: IPAI Platform Tracker
+- **Domain**: Delivery Intelligence (ADO)
+- **Status**: Pilot
+- **Backing assets**: `gold_ado_work_item_flow`, `gold_ado_iteration_health`
+- **Seed questions**: How many work items are in R2? What is blocked right now? Which owner has the most open items?
+
+### Space 2: Finance Operations
+- **Domain**: Finance Operations Intelligence
+- **Status**: Planned
+- **Backing assets**: `gold_finance_close_workload`, `gold_finance_approval_latency`
+- **Seed questions**: Who has the highest month-end workload? Which tasks take the most review time? What close steps are best candidates for automation?
+
+### Space 3: Compliance & Tax
+- **Domain**: Tax and Compliance Intelligence
+- **Status**: Planned
+- **Backing assets**: `gold_tax_deadline_control`, `gold_tax_filing_readiness`
+- **Seed questions**: Which BIR filings are at risk this month? Which approvals are bottlenecked? What deadlines need escalation?
+
+## Promotion Rule
+
+A Genie Space is **not production-ready** until:
+1. It is backed by a gold mart (not bronze/silver directly)
+2. Its contract file exists in `data-intelligence/contracts/serving/genie/`
+3. At least 3 seed example questions are defined and verified against live data
+4. Access is controlled via Unity Catalog row/column security (where applicable)

--- a/data-intelligence/docs/architecture/REPO_ROLE_DATA_INTELLIGENCE.md
+++ b/data-intelligence/docs/architecture/REPO_ROLE_DATA_INTELLIGENCE.md
@@ -1,0 +1,64 @@
+# REPO_ROLE_DATA_INTELLIGENCE
+
+## Purpose
+
+`data-intelligence` is the analytics and operating intelligence layer for the IPAI platform. It owns all medallion pipeline code (bronze → silver → gold), Unity Catalog schema definitions, Databricks One dashboards, Genie Space configurations, and vertical control tower definitions.
+
+## Owns / Does Not Own
+
+### Owns
+- Medallion pipeline code (bronze → silver → gold) in Databricks
+- Unity Catalog schema and table definitions
+- Databricks One dashboard definitions
+- Genie Space configurations and curated example questions
+- Vertical domain SSOT files (`ssot/domains/`)
+- Data contracts (`contracts/`)
+- Serving surface contracts (`ssot/serving/`)
+- Vertical metrics and control tower definitions (`ssot/metrics/`)
+
+### Does Not Own
+- Odoo ERP source data — that is owned by the `odoo` repo
+- Agent personas and tool definitions — owned by the `agents` repo
+- Platform control metadata — owned by the `platform` repo
+- User-facing product surfaces — owned by the `web` repo
+- Infrastructure provisioning — owned by `infra/`
+
+## Source System Relationship
+
+`data-intelligence` consumes from source systems. It does not write back to them.
+
+| Source system | Ingest pattern | Bronze landing |
+|---|---|---|
+| Azure DevOps (ADO) | REST API → Delta | `bronze_ado_*` |
+| Finance workload sheets | CSV / SharePoint export → Delta | `bronze_finance_*` |
+| BIR deadline calendars | Structured seed data → Delta | `bronze_bir_*` |
+| Odoo ERP (PostgreSQL) | Foreign Catalog (Unity Catalog) or JDBC | `bronze_odoo_*` |
+
+## Strategic Role
+
+`data-intelligence` answers: **what is happening in the business?**
+
+- `odoo` (ERP): **do the work** — transactions, approvals, records
+- `data-intelligence`: **understand the work** — flow, bottlenecks, risk, patterns
+- `agents`: **act on the understanding** — Pulser surfaces intelligence as copilot behavior
+- `platform`: **control the metadata** — governance, RBAC, release gates
+
+## Initial Telemetry Domains (4)
+
+### 1. Delivery Intelligence (ADO)
+Work item flow, iteration health, bottleneck detection across Azure DevOps epics, issues, and tasks. Primary question: **what is blocked and why?**
+
+### 2. Finance Operations Intelligence
+Month-end close workload analysis, task recurrence patterns, approval latency across the finance team. Primary question: **who is overloaded and where is the close delayed?**
+
+### 3. Tax and Compliance Intelligence
+BIR deadline control tower, filing readiness by form and period, approval bottleneck analysis for PH tax obligations. Primary question: **which filings are at risk?**
+
+### 4. ERP Operations Intelligence (Odoo)
+Odoo transaction health, vendor/customer flow, invoice aging, payment reconciliation status. Consumed via Unity Catalog Foreign Catalog from `pg-ipai-odoo`. Primary question: **what is the current state of the books?**
+
+## Serving Doctrine
+
+All data intelligence output is served through **Databricks One** (dashboards and Genie Spaces). No direct database access by end users. No standalone BI tool outside Databricks One and Power BI (Power BI consumes gold marts via Databricks SQL Warehouse connector).
+
+Databricks is the **understand the business** layer.

--- a/data-intelligence/docs/architecture/VERTICAL_OPERATING_INTELLIGENCE.md
+++ b/data-intelligence/docs/architecture/VERTICAL_OPERATING_INTELLIGENCE.md
@@ -1,0 +1,53 @@
+# VERTICAL_OPERATING_INTELLIGENCE
+
+## Thesis
+
+IPAI's data platform strategy is **Databricks + Unity Catalog as the vertical operating intelligence layer**. This is not a general-purpose data warehouse. It is a purpose-built intelligence substrate for the vertical domains IPAI serves: delivery operations, finance operations, tax compliance, and ERP health.
+
+## Core Split
+
+| System | Role | Question it answers |
+|---|---|---|
+| **Odoo ERP** | Do the work | Is the invoice posted? Is the close task complete? Is the tax payment approved? |
+| **Databricks (data-intelligence)** | Understand the work | Where is the bottleneck? Who is overloaded? Which filing is at risk? What pattern repeats? |
+| **Pulser agents** | Act on the understanding | Surface intelligence as Genie answers, copilot suggestions, proactive alerts |
+| **Power BI** | Report to stakeholders | Board-level KPIs, external-facing financial summaries |
+
+Odoo is never the analytics surface. Databricks is never the transaction surface.
+
+## Four Vertical Domains
+
+### Domain 1: Delivery Intelligence
+- **Source**: Azure DevOps (work items, iterations, sprints)
+- **Gold marts**: `gold_ado_work_item_flow`, `gold_ado_iteration_health`
+- **Control tower questions**: What is blocked? Where are bottlenecks? Which iterations are at risk?
+- **Genie Space**: IPAI Platform Tracker
+
+### Domain 2: Finance Operations Intelligence
+- **Source**: Month-end close task schedules, finance workload sheets
+- **Gold marts**: `gold_finance_close_workload`, `gold_finance_approval_latency`, `gold_finance_recurring_task_load`
+- **Control tower questions**: Who is overloaded? What tasks repeat most? Where are close delays?
+- **Genie Space**: Finance Operations
+
+### Domain 3: Tax and Compliance Intelligence
+- **Source**: BIR deadline calendars, internal approval calendars
+- **Gold marts**: `gold_tax_deadline_control`, `gold_tax_filing_readiness`, `gold_tax_approval_latency`
+- **Control tower questions**: What filings are at risk? Which approvals are bottlenecked? What deadlines need escalation?
+- **Genie Space**: Compliance & Tax
+
+### Domain 4: ERP Operations Intelligence
+- **Source**: Odoo PostgreSQL via Unity Catalog Foreign Catalog (`odoo_erp`)
+- **Gold marts**: `gold_odoo_invoice_aging`, `gold_odoo_payment_recon`, `gold_odoo_vendor_flow`
+- **Control tower questions**: What is the current AR/AP position? Which invoices are overdue? Where is reconciliation pending?
+- **Genie Space**: ERP Health (planned)
+
+## Product Implications
+
+1. **Genie Spaces are the primary analyst surface** — curated, question-first, not raw SQL.
+2. **Dashboards are the executive surface** — Databricks One dashboards backed by gold marts.
+3. **Power BI is the external/board reporting surface** — consumes gold via SQL Warehouse.
+4. **Agents consume gold marts directly** — Pulser finance and tax agents are grounded on gold data, not raw Odoo queries.
+
+## Live Data First Doctrine
+
+Genie Spaces and dashboards **must use live data from Unity Catalog gold tables**. Synthetic data or static sample data is not acceptable for production or pilot spaces. Synthetic data may be used for isolated UI prototyping only.

--- a/data-intelligence/ssot/domains/ado.yaml
+++ b/data-intelligence/ssot/domains/ado.yaml
@@ -1,0 +1,18 @@
+domain: ado
+title: Delivery Intelligence
+status: active
+source_systems:
+  - azure_devops
+owned_by_repo: data-intelligence
+purpose:
+  - work_item_flow_analysis
+  - iteration_health
+  - delivery_bottleneck_detection
+gold_marts:
+  - gold_ado_work_item_flow
+  - gold_ado_iteration_health
+serving_surfaces:
+  - databricks_one_dashboard
+  - genie_space
+target_space_names:
+  - IPAI Platform Tracker

--- a/data-intelligence/ssot/domains/finance-close.yaml
+++ b/data-intelligence/ssot/domains/finance-close.yaml
@@ -1,0 +1,21 @@
+domain: finance_close
+title: Finance Operations Intelligence
+status: planned
+source_systems:
+  - finance_workload_sheets
+  - close_task_schedules
+owned_by_repo: data-intelligence
+purpose:
+  - close_workload_analysis
+  - approval_latency_analysis
+  - recurring_task_analysis
+  - automation_candidate_scoring
+gold_marts:
+  - gold_finance_close_workload
+  - gold_finance_approval_latency
+  - gold_finance_recurring_task_load
+serving_surfaces:
+  - databricks_one_dashboard
+  - genie_space
+target_space_names:
+  - Finance Operations

--- a/data-intelligence/ssot/domains/tax-compliance.yaml
+++ b/data-intelligence/ssot/domains/tax-compliance.yaml
@@ -1,0 +1,21 @@
+domain: tax_compliance
+title: Tax and Compliance Intelligence
+status: planned
+source_systems:
+  - bir_deadline_calendars
+  - internal_approval_calendars
+owned_by_repo: data-intelligence
+purpose:
+  - filing_readiness
+  - deadline_risk_analysis
+  - approval_bottleneck_analysis
+  - compliance_control_tower
+gold_marts:
+  - gold_tax_deadline_control
+  - gold_tax_filing_readiness
+  - gold_tax_approval_latency
+serving_surfaces:
+  - databricks_one_dashboard
+  - genie_space
+target_space_names:
+  - Compliance & Tax

--- a/data-intelligence/ssot/metrics/vertical-control-towers.yaml
+++ b/data-intelligence/ssot/metrics/vertical-control-towers.yaml
@@ -1,0 +1,25 @@
+control_towers:
+  - name: delivery_intelligence
+    marts:
+      - gold_ado_work_item_flow
+      - gold_ado_iteration_health
+    questions:
+      - what_is_blocked
+      - where_are_bottlenecks
+      - which_iterations_are_at_risk
+  - name: finance_operations
+    marts:
+      - gold_finance_close_workload
+      - gold_finance_approval_latency
+    questions:
+      - who_is_overloaded
+      - what_tasks_repeat_most
+      - where_are_close_delays
+  - name: tax_compliance
+    marts:
+      - gold_tax_deadline_control
+      - gold_tax_filing_readiness
+    questions:
+      - what_filings_are_at_risk
+      - which_approvals_are_bottlenecked
+      - what_deadlines_need_escalation

--- a/data-intelligence/ssot/serving/databricks-one.yaml
+++ b/data-intelligence/ssot/serving/databricks-one.yaml
@@ -1,0 +1,19 @@
+surface: databricks_one
+role: business_user_consumption_surface
+owned_by_repo: data-intelligence
+supported_assets:
+  - dashboards
+  - genie_spaces
+  - vertical_analytics_apps
+primary_users:
+  - executives
+  - managers
+  - analysts
+  - consumer_access_stakeholders
+non_goals:
+  - transactional_execution_workspace
+  - erp_replacement_ui
+promotion_rules:
+  - use_live_data_first
+  - prefer_gold_or_curated_serving_views
+  - allow_bronze_backed_pilots_only_temporarily

--- a/data-intelligence/ssot/serving/genie-spaces.yaml
+++ b/data-intelligence/ssot/serving/genie-spaces.yaml
@@ -1,0 +1,19 @@
+spaces:
+  - name: IPAI Platform Tracker
+    status: pilot
+    domain: ado
+    backing_assets:
+      - gold_ado_work_item_flow
+      - gold_ado_iteration_health
+  - name: Finance Operations
+    status: planned
+    domain: finance_close
+    backing_assets:
+      - gold_finance_close_workload
+      - gold_finance_approval_latency
+  - name: Compliance & Tax
+    status: planned
+    domain: tax_compliance
+    backing_assets:
+      - gold_tax_deadline_control
+      - gold_tax_filing_readiness


### PR DESCRIPTION
## Summary
- 15 new files across 4 artifact families: 4 architecture docs, 6 SSOT files, 5 contracts
- Establishes `data-intelligence` as the vertical operating intelligence layer with clear ownership, domain boundaries, and serving surface contracts
- Encodes the core split: `data-intelligence` = understand the business, `odoo` = do the work, `platform` = control metadata, `web` = user-facing product surfaces, `agents` = persona behavior

## Test plan
- [ ] Verify 4 arch docs present: REPO_ROLE, VERTICAL_OPERATING_INTELLIGENCE, DATABRICKS_ONE_STRATEGY, GENIE_SPACE_STRATEGY
- [ ] Verify 3 domain SSOT files: ado.yaml, finance-close.yaml, tax-compliance.yaml
- [ ] Verify 2 serving SSOT files: databricks-one.yaml, genie-spaces.yaml
- [ ] Verify 1 metrics SSOT file: vertical-control-towers.yaml
- [ ] Verify 5 contracts: ado/work_items, finance/bir_deadlines, finance/month_end_close_tasks, serving/genie/platform_tracker_space, serving/genie/finance_ops_space
- [ ] Confirm no secrets or hardcoded credentials in any file

🤖 Generated with [Claude Code](https://claude.com/claude-code)