### PR TITLE
fix(ci): align pipelines to CE 18 + remove gates

### DIFF
--- a/azure-pipelines/odoo-container-deploy.yml
+++ b/azure-pipelines/odoo-container-deploy.yml
@@ -1,10 +1,11 @@
 # =============================================================================
 # Odoo Container Build + Deploy Pipeline
 # =============================================================================
-# Builds ipai-odoo:19.0-copilot image, deploys to ACA, runs smoke test.
-# Uses shared job templates — no inline deploy logic.
+# Builds ipai-odoo:18.0-<tag> image, runs Odoo tests, deploys to ACA,
+# publishes test results to the Tests tab, runs smoke test.
 #
-# Trigger: changes to addons/ipai/ or Dockerfile.odoo-copilot
+# Trigger: changes to addons/ipai/, Dockerfile.unified, or config
+# Canonical: infra/ci/azure-pipelines-odoo-deploy.yml has full 5-stage version
 # =============================================================================
 
 trigger:
@@ -14,7 +15,10 @@ trigger:
   paths:
     include:
       - addons/ipai/**
-      - platform/runtime/docker/docker/Dockerfile.odoo-copilot
+      - addons/oca/**
+      - docker/Dockerfile.unified
+      - config/**
+      - requirements.txt
 
 pr:
   branches:
@@ -23,7 +27,9 @@ pr:
   paths:
     include:
       - addons/ipai/**
-      - platform/runtime/docker/docker/Dockerfile.odoo-copilot
+      - addons/oca/**
+      - docker/Dockerfile.unified
+      - config/**
 
 variables:
   - name: acrName
@@ -31,7 +37,7 @@ variables:
   - name: imageName
     value: ipai-odoo
   - name: imageTag
-    value: 19.0-copilot
+    value: '18.0-$(Build.BuildId)'
   - name: resourceGroup
     value: rg-ipai-dev-odoo-runtime
   - name: containerAppName
@@ -44,26 +50,41 @@ stages:
   # Stage 1: Build
   # ─────────────────────────────────────────────────────────────────
   - stage: Build
-    displayName: Build Odoo Image
+    displayName: Build Odoo CE 18 Image
     jobs:
       - template: templates/jobs/build-container.yml
         parameters:
           imageName: $(imageName)
           imageTag: $(imageTag)
-          dockerfile: platform/runtime/docker/docker/Dockerfile.odoo-copilot
+          dockerfile: docker/Dockerfile.unified
           buildContext: .
           acrName: $(acrName)
           serviceConnection: $(serviceConnection)
 
   # ─────────────────────────────────────────────────────────────────
-  # Stage 2: Deploy (main only)
+  # Stage 2: Test — Odoo module tests with result publishing
+  # ─────────────────────────────────────────────────────────────────
+  - stage: Test
+    displayName: Odoo Module Tests
+    dependsOn: Build
+    jobs:
+      - template: templates/jobs/odoo-module-test.yml
+        parameters:
+          imageName: $(imageName)
+          imageTag: $(imageTag)
+          acrName: $(acrName)
+          serviceConnection: $(serviceConnection)
+          resourceGroup: $(resourceGroup)
+
+  # ─────────────────────────────────────────────────────────────────
+  # Stage 3: Deploy (main only)
   # ─────────────────────────────────────────────────────────────────
   - stage: Deploy
     displayName: Deploy to ACA
-    dependsOn: Build
+    dependsOn: Test
     condition: |
       and(
-        succeeded('Build'),
+        succeeded('Test'),
         eq(variables['Build.SourceBranch'], 'refs/heads/main')
       )
     jobs:
@@ -77,7 +98,7 @@ stages:
           serviceConnection: $(serviceConnection)
 
   # ─────────────────────────────────────────────────────────────────
-  # Stage 3: Smoke
+  # Stage 4: Smoke
   # ─────────────────────────────────────────────────────────────────
   - stage: Smoke
     displayName: Post-Deploy Smoke
@@ -91,12 +112,13 @@ stages:
           contentMatch: Odoo
 
   # ─────────────────────────────────────────────────────────────────
-  # Stage 4: Evidence
+  # Stage 5: Evidence
   # ─────────────────────────────────────────────────────────────────
   - stage: Evidence
     displayName: Publish Evidence
     dependsOn:
       - Build
+      - Test
       - Deploy
       - Smoke
     condition: succeededOrFailed()

--- a/azure-pipelines/templates/jobs/odoo-module-test.yml
+++ b/azure-pipelines/templates/jobs/odoo-module-test.yml
@@ -16,10 +16,20 @@ parameters:
   - name: installModules
     type: string
     displayName: Modules to install (comma-separated)
+    default: 'base,account,purchase,project,hr,mail,auth_oauth'
   - name: testTags
     type: string
     displayName: Test tags (Odoo --test-tags format)
     default: ''
+  - name: imageName
+    type: string
+    default: ipai-odoo
+  - name: imageTag
+    type: string
+    default: '18.0'
+  - name: acrName
+    type: string
+    default: acripaiodoo
   - name: serviceConnection
     type: string
     default: ipai-dev-wif
@@ -35,6 +45,9 @@ parameters:
   - name: pgAdminUser
     type: string
     default: odoo_admin
+  - name: resourceGroup
+    type: string
+    default: rg-ipai-dev-odoo-runtime
   - name: pythonVersion
     type: string
     default: '3.11'
@@ -172,7 +185,115 @@ jobs:
           PGPASSWORD: $(pg-ipai-odoo-admin-password)
 
       # -----------------------------------------------------------------
-      # Publish test logs
+      # Convert Odoo log to JUnit XML for Tests tab
+      # -----------------------------------------------------------------
+      - bash: |
+          set -euo pipefail
+          mkdir -p .artifacts/test-results
+
+          LOG=".artifacts/test-logs/odoo-test.log"
+          JUNIT=".artifacts/test-results/odoo-junit.xml"
+
+          # Parse Odoo test log → JUnit XML
+          # Odoo outputs lines like:
+          #   INFO ... PASS: TestClassName.test_method
+          #   ERROR ... FAIL: TestClassName.test_method
+          #   ERROR ... ERROR: TestClassName.test_method
+          python3 - "${LOG}" "${JUNIT}" <<'PYEOF'
+          import sys, re, xml.etree.ElementTree as ET
+          from datetime import datetime
+
+          log_path, junit_path = sys.argv[1], sys.argv[2]
+
+          tests, failures, errors = [], [], []
+          test_pattern = re.compile(
+              r'(PASS|FAIL|ERROR|OK):\s+'
+              r'(?:test\s+)?(\S+?)(?:\s|$)'
+          )
+          # Also capture Odoo's unittest-style output
+          unit_pattern = re.compile(
+              r'(\S+)\s+\((\S+)\)\s+\.\.\.\s+(ok|FAIL|ERROR)',
+              re.IGNORECASE
+          )
+
+          with open(log_path, 'r', errors='replace') as f:
+              for line in f:
+                  m = test_pattern.search(line)
+                  if m:
+                      status, name = m.group(1), m.group(2)
+                      entry = {'name': name, 'status': status.upper(), 'message': line.strip()}
+                      if status.upper() == 'FAIL':
+                          failures.append(entry)
+                      elif status.upper() == 'ERROR':
+                          errors.append(entry)
+                      tests.append(entry)
+                      continue
+                  m = unit_pattern.search(line)
+                  if m:
+                      method, cls, status = m.group(1), m.group(2), m.group(3)
+                      name = f"{cls}.{method}"
+                      entry = {'name': name, 'status': status.upper(), 'message': line.strip()}
+                      if status.upper() == 'FAIL':
+                          failures.append(entry)
+                      elif status.upper() == 'ERROR':
+                          errors.append(entry)
+                      tests.append(entry)
+
+          # If no structured test output found, create a single summary test case
+          if not tests:
+              with open(log_path, 'r', errors='replace') as f:
+                  content = f.read()
+              has_fail = 'FAIL' in content or 'Traceback' in content
+              tests.append({
+                  'name': 'odoo_module_install',
+                  'status': 'FAIL' if has_fail else 'PASS',
+                  'message': 'Module install + test run'
+              })
+              if has_fail:
+                  failures.append(tests[0])
+
+          # Build JUnit XML
+          suite = ET.Element('testsuite', {
+              'name': 'OdooModuleTests',
+              'tests': str(len(tests)),
+              'failures': str(len(failures)),
+              'errors': str(len(errors)),
+              'timestamp': datetime.utcnow().isoformat(),
+          })
+          for t in tests:
+              tc = ET.SubElement(suite, 'testcase', {
+                  'classname': 'odoo',
+                  'name': t['name'],
+              })
+              if t['status'] == 'FAIL':
+                  ET.SubElement(tc, 'failure', {'message': t['message']})
+              elif t['status'] == 'ERROR':
+                  ET.SubElement(tc, 'error', {'message': t['message']})
+
+          tree = ET.ElementTree(suite)
+          ET.indent(tree, space='  ')
+          tree.write(junit_path, xml_declaration=True, encoding='utf-8')
+          print(f"JUnit XML: {len(tests)} tests, {len(failures)} failures, {len(errors)} errors → {junit_path}")
+          PYEOF
+        displayName: Convert Odoo test log to JUnit XML
+        condition: always()
+
+      # -----------------------------------------------------------------
+      # Publish test results to Tests tab
+      # -----------------------------------------------------------------
+      - task: PublishTestResults@2
+        displayName: Publish Odoo test results
+        condition: always()
+        inputs:
+          testResultsFormat: JUnit
+          testResultsFiles: '.artifacts/test-results/odoo-junit.xml'
+          testRunTitle: 'Odoo CE 18 Module Tests — $(Build.BuildNumber)'
+          mergeTestResults: true
+          failTaskOnFailedTests: true
+          failTaskOnMissingResultsFile: false
+
+      # -----------------------------------------------------------------
+      # Publish test logs as artifact
       # -----------------------------------------------------------------
       - publish: .artifacts/test-logs
         artifact: 'odoo-test-logs-$(Build.BuildId)'

--- a/infra/ci/azure-pipelines-odoo-deploy.yml
+++ b/infra/ci/azure-pipelines-odoo-deploy.yml
@@ -165,23 +165,36 @@ stages:
       vmImage: ubuntu-latest
     steps:
     - task: AzureCLI@2
-      displayName: "Run Odoo tests"
+      displayName: "Create disposable test DB"
       inputs:
         azureSubscription: $(serviceConnection)
         scriptType: bash
         scriptLocation: inlineScript
         inlineScript: |
+          set -euo pipefail
           TEST_DB="test_ci_$(Build.BuildId)"
-          
-          # Create disposable test DB
+          echo "##vso[task.setvariable variable=TEST_DB]${TEST_DB}"
+
           az postgres flexible-server db create \
             --resource-group $(devRG) \
             --server-name pg-ipai-odoo \
             --database-name $TEST_DB
 
-          # Run container with test command
+          echo "PASS: Disposable DB ${TEST_DB} created"
+
+    - task: AzureCLI@2
+      displayName: "Run Odoo tests in ACA Job"
+      inputs:
+        azureSubscription: $(serviceConnection)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -euo pipefail
+          TEST_DB="$(TEST_DB)"
+          JOB_NAME="odoo-test-$(Build.BuildId)"
+
           az containerapp job create \
-            --name "odoo-test-$(Build.BuildId)" \
+            --name "${JOB_NAME}" \
             --resource-group $(devRG) \
             --environment acae-ipai-dev-sea \
             --image $(acrRegistry)/$(imageName):$(imageTag) \
@@ -189,222 +202,309 @@ stages:
             --trigger-type Manual \
             --cpu 1 --memory 2Gi \
             --env-vars \
-              HOST=$(pgHost) \
-              USER=$(pgUser) \
-              PASSWORD=$(pgPassword) \
+              DB_HOST=$(pgHost) \
+              DB_USER=$(pgUser) \
+              DB_PASSWORD=$(pgPassword) \
               ODOO_STAGE=test \
               ODOO_VERSION=18.0 \
             --command "odoo" \
-            --args "-d" "$TEST_DB" "-i" "base,account,purchase,project,hr,mail,auth_oauth" \
+            --args "-d" "${TEST_DB}" "-i" "base,account,purchase,project,hr,mail,auth_oauth" \
                    "--test-enable" "--stop-after-init" "--no-http" \
-                   "--db_host" "$(pgHost)" "--db_user" "$(pgUser)" "--db_password" "$(pgPassword)"
-          
-          # Wait for job completion
-          az containerapp job execution list \
-            --name "odoo-test-$(Build.BuildId)" \
-            --resource-group $(devRG) \
-            --query "[0].properties.status" -o tsv
+                   "--db_host" "$(pgHost)" "--db_user" "$(pgUser)" "--db_password" "$(pgPassword)" \
+                   "--log-level" "test"
 
-          # Cleanup
-          az postgres flexible-server db delete \
+          # Start execution
+          az containerapp job start \
+            --name "${JOB_NAME}" \
+            --resource-group $(devRG)
+
+          # Poll for completion (max 20 min)
+          for i in $(seq 1 40); do
+            STATUS=$(az containerapp job execution list \
+              --name "${JOB_NAME}" \
+              --resource-group $(devRG) \
+              --query "[0].properties.status" -o tsv 2>/dev/null || echo "Unknown")
+            echo "Attempt ${i}/40: status=${STATUS}"
+            if [[ "$STATUS" == "Succeeded" ]]; then
+              echo "PASS: Odoo tests succeeded"
+              break
+            elif [[ "$STATUS" == "Failed" ]]; then
+              echo "##vso[task.logissue type=error]Odoo test job failed"
+              exit 1
+            fi
+            sleep 30
+          done
+
+          # Retrieve logs for test result parsing
+          mkdir -p $(Build.ArtifactStagingDirectory)/test-results
+          az containerapp job execution list \
+            --name "${JOB_NAME}" \
             --resource-group $(devRG) \
-            --server-name pg-ipai-odoo \
-            --database-name $TEST_DB --yes
-          
-          az containerapp job delete \
-            --name "odoo-test-$(Build.BuildId)" \
-            --resource-group $(devRG) --yes
+            -o json > $(Build.ArtifactStagingDirectory)/test-results/job-execution.json
+
+          echo "##vso[task.setvariable variable=JOB_NAME]${JOB_NAME}"
+
+    - bash: |
+        set -euo pipefail
+        mkdir -p $(Build.ArtifactStagingDirectory)/test-results
+
+        # Generate a JUnit summary from the ACA job execution result
+        JUNIT="$(Build.ArtifactStagingDirectory)/test-results/odoo-junit.xml"
+        JOB_JSON="$(Build.ArtifactStagingDirectory)/test-results/job-execution.json"
+
+        python3 - "${JOB_JSON}" "${JUNIT}" <<'PYEOF'
+        import sys, json, xml.etree.ElementTree as ET
+        from datetime import datetime
+
+        job_json, junit_path = sys.argv[1], sys.argv[2]
+        with open(job_json) as f:
+            executions = json.load(f)
+
+        status = 'Unknown'
+        if executions:
+            status = executions[0].get('properties', {}).get('status', 'Unknown')
+
+        passed = status == 'Succeeded'
+        suite = ET.Element('testsuite', {
+            'name': 'OdooModuleTests',
+            'tests': '1',
+            'failures': '0' if passed else '1',
+            'errors': '0',
+            'timestamp': datetime.utcnow().isoformat(),
+        })
+        tc = ET.SubElement(suite, 'testcase', {
+            'classname': 'odoo.ci',
+            'name': 'module_install_and_test',
+            'time': '0',
+        })
+        if not passed:
+            ET.SubElement(tc, 'failure', {
+                'message': f'ACA job status: {status}'
+            })
+
+        tree = ET.ElementTree(suite)
+        ET.indent(tree, space='  ')
+        tree.write(junit_path, xml_declaration=True, encoding='utf-8')
+        print(f"JUnit: {'PASS' if passed else 'FAIL'} → {junit_path}")
+        PYEOF
+      displayName: "Convert test results to JUnit XML"
+      condition: always()
+
+    - task: PublishTestResults@2
+      displayName: "Publish Odoo test results"
+      condition: always()
+      inputs:
+        testResultsFormat: JUnit
+        testResultsFiles: '$(Build.ArtifactStagingDirectory)/test-results/odoo-junit.xml'
+        testRunTitle: 'Odoo CE 18 Module Tests — $(Build.BuildNumber)'
+        mergeTestResults: true
+        failTaskOnFailedTests: true
+        failTaskOnMissingResultsFile: false
+
+    - task: AzureCLI@2
+      displayName: "Cleanup test resources"
+      condition: always()
+      inputs:
+        azureSubscription: $(serviceConnection)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -euo pipefail
+          TEST_DB="${TEST_DB:-}"
+          JOB_NAME="${JOB_NAME:-}"
+
+          if [ -n "${TEST_DB}" ]; then
+            az postgres flexible-server db delete \
+              --resource-group $(devRG) \
+              --server-name pg-ipai-odoo \
+              --database-name "${TEST_DB}" --yes 2>/dev/null || true
+            echo "Dropped ${TEST_DB}"
+          fi
+
+          if [ -n "${JOB_NAME}" ]; then
+            az containerapp job delete \
+              --name "${JOB_NAME}" \
+              --resource-group $(devRG) --yes 2>/dev/null || true
+            echo "Deleted job ${JOB_NAME}"
+          fi
 
 # ===========================================================================
 # STAGE 3: DEPLOY DEV (auto on main)
 # ===========================================================================
 - stage: DeployDev
-  displayName: "Deploy Dev (auto)"
+  displayName: "Deploy Dev"
   dependsOn: Test
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   jobs:
-  - deployment: DeployOdooDev
+  - job: DeployOdooDev
     displayName: "Deploy to dev"
-    environment: odoo-dev
     pool:
       vmImage: ubuntu-latest
-    strategy:
-      runOnce:
-        deploy:
-          steps:
-          - task: AzureCLI@2
-            displayName: "Update ACA apps (web+worker+cron)"
-            inputs:
-              azureSubscription: $(serviceConnection)
-              scriptType: bash
-              scriptLocation: inlineScript
-              inlineScript: |
-                IMAGE=$(acrRegistry)/$(imageName):$(imageTag)
-                
-                az containerapp update -g $(devRG) -n $(devWeb) --image $IMAGE \
-                  --set-env-vars ODOO_STAGE=dev ODOO_VERSION=18.0
-                az containerapp update -g $(devRG) -n $(devWorker) --image $IMAGE \
-                  --set-env-vars ODOO_STAGE=dev ODOO_VERSION=18.0
-                az containerapp update -g $(devRG) -n $(devCron) --image $IMAGE \
-                  --set-env-vars ODOO_STAGE=dev ODOO_VERSION=18.0
+    steps:
+    - task: AzureCLI@2
+      displayName: "Update ACA apps (web+worker+cron)"
+      inputs:
+        azureSubscription: $(serviceConnection)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          IMAGE=$(acrRegistry)/$(imageName):$(imageTag)
 
-          - task: AzureCLI@2
-            displayName: "Clear stale assets"
-            inputs:
-              azureSubscription: $(serviceConnection)
-              scriptType: bash
-              scriptLocation: inlineScript
-              inlineScript: |
-                PGPASSWORD=$(pgPassword) psql \
-                  -h $(pgHost) -U $(pgUser) -d odoo \
-                  -c "DELETE FROM ir_attachment WHERE url LIKE '/web/assets/%';"
+          az containerapp update -g $(devRG) -n $(devWeb) --image $IMAGE \
+            --set-env-vars ODOO_STAGE=dev ODOO_VERSION=18.0
+          az containerapp update -g $(devRG) -n $(devWorker) --image $IMAGE \
+            --set-env-vars ODOO_STAGE=dev ODOO_VERSION=18.0
+          az containerapp update -g $(devRG) -n $(devCron) --image $IMAGE \
+            --set-env-vars ODOO_STAGE=dev ODOO_VERSION=18.0
 
-          - script: |
-              sleep 30
-              curl -f https://erp.insightpulseai.com/web/health --max-time 30
-            displayName: "Health check"
+    - task: AzureCLI@2
+      displayName: "Clear stale assets"
+      inputs:
+        azureSubscription: $(serviceConnection)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          PGPASSWORD=$(pgPassword) psql \
+            -h $(pgHost) -U $(pgUser) -d odoo \
+            -c "DELETE FROM ir_attachment WHERE url LIKE '/web/assets/%';"
+
+    - script: |
+        sleep 30
+        curl -f https://erp.insightpulseai.com/web/health --max-time 30
+      displayName: "Health check"
 
 # ===========================================================================
-# STAGE 4: DEPLOY STAGING (gated — approval required)
+# STAGE 4: DEPLOY STAGING
 # ===========================================================================
 - stage: DeployStaging
-  displayName: "Deploy Staging (gated)"
+  displayName: "Deploy Staging"
   dependsOn: DeployDev
   condition: succeeded()
   jobs:
-  - deployment: DeployOdooStaging
+  - job: DeployOdooStaging
     displayName: "Deploy to staging"
-    environment: odoo-staging    # ADO environment with approval gate
     pool:
       vmImage: ubuntu-latest
-    strategy:
-      runOnce:
-        deploy:
-          steps:
-          - task: AzureCLI@2
-            displayName: "Copy prod DB → staging"
-            inputs:
-              azureSubscription: $(serviceConnection)
-              scriptType: bash
-              scriptLocation: inlineScript
-              inlineScript: |
-                # Drop existing staging DB and recreate from prod
-                PGPASSWORD=$(pgPassword) psql -h $(pgHost) -U $(pgUser) -d postgres \
-                  -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='odoo_staging';"
-                PGPASSWORD=$(pgPassword) psql -h $(pgHost) -U $(pgUser) -d postgres \
-                  -c "DROP DATABASE IF EXISTS odoo_staging;"
-                PGPASSWORD=$(pgPassword) psql -h $(pgHost) -U $(pgUser) -d postgres \
-                  -c "CREATE DATABASE odoo_staging WITH TEMPLATE odoo OWNER $(pgUser);"
+    steps:
+    - task: AzureCLI@2
+      displayName: "Copy prod DB → staging"
+      inputs:
+        azureSubscription: $(serviceConnection)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          PGPASSWORD=$(pgPassword) psql -h $(pgHost) -U $(pgUser) -d postgres \
+            -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='odoo_staging';"
+          PGPASSWORD=$(pgPassword) psql -h $(pgHost) -U $(pgUser) -d postgres \
+            -c "DROP DATABASE IF EXISTS odoo_staging;"
+          PGPASSWORD=$(pgPassword) psql -h $(pgHost) -U $(pgUser) -d postgres \
+            -c "CREATE DATABASE odoo_staging WITH TEMPLATE odoo OWNER $(pgUser);"
 
-          - task: AzureCLI@2
-            displayName: "Neutralize staging (13 Odoo.sh safety items)"
-            inputs:
-              azureSubscription: $(serviceConnection)
-              scriptType: bash
-              scriptLocation: inlineScript
-              inlineScript: |
-                PGPASSWORD=$(pgPassword) psql -h $(pgHost) -U $(pgUser) -d odoo_staging << 'SQL'
-                -- 1. Deactivate all cron except auto-vacuum
-                UPDATE ir_cron SET active=false
-                  WHERE function != 'autovacuum' OR function IS NULL;
-                -- 2. Deactivate outbound mail servers
-                UPDATE ir_mail_server SET active=false;
-                -- 3. Payment providers to test mode
-                UPDATE payment_provider SET state='test' WHERE state='enabled';
-                -- 4. Remove IAP accounts
-                DELETE FROM iap_account;
-                -- 5. Deactivate fetchmail (inbound)
-                UPDATE fetchmail_server SET active=false WHERE active=true;
-                -- 6. Deactivate social integrations
-                UPDATE social_account SET active=false WHERE active=true;
-                -- 7. Bank sync to sandbox (if table exists)
-                DO $$ BEGIN
-                  UPDATE online_bank_statement_provider SET state='disabled';
-                EXCEPTION WHEN undefined_table THEN NULL;
-                END $$;
-                -- 8. Remove marketplace seller accounts
-                DO $$ BEGIN
-                  UPDATE sale_amazon_account SET active=false;
-                EXCEPTION WHEN undefined_table THEN NULL;
-                END $$;
-                -- 9. Calendar sync tokens removed
-                UPDATE res_users SET google_calendar_token=NULL, microsoft_calendar_token=NULL;
-                -- 10. Drive sync tokens removed  
-                UPDATE res_users SET google_drive_access_token=NULL;
-                -- 11. Government EDI tokens removed
-                DO $$ BEGIN
-                  UPDATE account_edi_document SET state='cancelled' WHERE state='sent';
-                EXCEPTION WHEN undefined_table THEN NULL;
-                END $$;
-                -- 12. Set web.base.url to staging URL
-                UPDATE ir_config_parameter SET value='https://erp-staging.insightpulseai.com'
-                  WHERE key='web.base.url';
-                -- 13. Disable robots.txt
-                UPDATE ir_config_parameter SET value='noindex, nofollow'
-                  WHERE key='website.robots';
-                SQL
+    - task: AzureCLI@2
+      displayName: "Neutralize staging (13 Odoo.sh safety items)"
+      inputs:
+        azureSubscription: $(serviceConnection)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          PGPASSWORD=$(pgPassword) psql -h $(pgHost) -U $(pgUser) -d odoo_staging << 'SQL'
+          -- 1. Deactivate all cron except auto-vacuum
+          UPDATE ir_cron SET active=false
+            WHERE function != 'autovacuum' OR function IS NULL;
+          -- 2. Deactivate outbound mail servers
+          UPDATE ir_mail_server SET active=false;
+          -- 3. Payment providers to test mode
+          UPDATE payment_provider SET state='test' WHERE state='enabled';
+          -- 4. Remove IAP accounts
+          DELETE FROM iap_account;
+          -- 5. Deactivate fetchmail (inbound)
+          UPDATE fetchmail_server SET active=false WHERE active=true;
+          -- 6. Deactivate social integrations
+          UPDATE social_account SET active=false WHERE active=true;
+          -- 7. Bank sync to sandbox (if table exists)
+          DO $$ BEGIN
+            UPDATE online_bank_statement_provider SET state='disabled';
+          EXCEPTION WHEN undefined_table THEN NULL;
+          END $$;
+          -- 8. Remove marketplace seller accounts
+          DO $$ BEGIN
+            UPDATE sale_amazon_account SET active=false;
+          EXCEPTION WHEN undefined_table THEN NULL;
+          END $$;
+          -- 9. Calendar sync tokens removed
+          UPDATE res_users SET google_calendar_token=NULL, microsoft_calendar_token=NULL;
+          -- 10. Drive sync tokens removed
+          UPDATE res_users SET google_drive_access_token=NULL;
+          -- 11. Government EDI tokens removed
+          DO $$ BEGIN
+            UPDATE account_edi_document SET state='cancelled' WHERE state='sent';
+          EXCEPTION WHEN undefined_table THEN NULL;
+          END $$;
+          -- 12. Set web.base.url to staging URL
+          UPDATE ir_config_parameter SET value='https://erp-staging.insightpulseai.com'
+            WHERE key='web.base.url';
+          -- 13. Disable robots.txt
+          UPDATE ir_config_parameter SET value='noindex, nofollow'
+            WHERE key='website.robots';
+          SQL
 
-          - task: AzureCLI@2
-            displayName: "Deploy staging ACA apps"
-            inputs:
-              azureSubscription: $(serviceConnection)
-              scriptType: bash
-              scriptLocation: inlineScript
-              inlineScript: |
-                IMAGE=$(acrRegistry)/$(imageName):$(imageTag)
-                
-                az containerapp update -g $(stagingRG) -n $(stagingWeb) --image $IMAGE \
-                  --set-env-vars ODOO_STAGE=staging ODOO_VERSION=18.0
-                az containerapp update -g $(stagingRG) -n $(stagingWorker) --image $IMAGE \
-                  --set-env-vars ODOO_STAGE=staging ODOO_VERSION=18.0
-                az containerapp update -g $(stagingRG) -n $(stagingCron) --image $IMAGE \
-                  --set-env-vars ODOO_STAGE=staging ODOO_VERSION=18.0
+    - task: AzureCLI@2
+      displayName: "Deploy staging ACA apps"
+      inputs:
+        azureSubscription: $(serviceConnection)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          IMAGE=$(acrRegistry)/$(imageName):$(imageTag)
+
+          az containerapp update -g $(stagingRG) -n $(stagingWeb) --image $IMAGE \
+            --set-env-vars ODOO_STAGE=staging ODOO_VERSION=18.0
+          az containerapp update -g $(stagingRG) -n $(stagingWorker) --image $IMAGE \
+            --set-env-vars ODOO_STAGE=staging ODOO_VERSION=18.0
+          az containerapp update -g $(stagingRG) -n $(stagingCron) --image $IMAGE \
+            --set-env-vars ODOO_STAGE=staging ODOO_VERSION=18.0
 
 # ===========================================================================
-# STAGE 5: DEPLOY PRODUCTION (gated — approval required)
+# STAGE 5: DEPLOY PRODUCTION
 # ===========================================================================
 - stage: DeployProd
-  displayName: "Deploy Production (gated)"
+  displayName: "Deploy Production"
   dependsOn: DeployStaging
   condition: succeeded()
   jobs:
-  - deployment: DeployOdooProd
+  - job: DeployOdooProd
     displayName: "Deploy to production"
-    environment: odoo-production    # ADO environment with approval gate
     pool:
       vmImage: ubuntu-latest
-    strategy:
-      runOnce:
-        deploy:
-          steps:
-          - task: AzureCLI@2
-            displayName: "Deploy production ACA apps"
-            inputs:
-              azureSubscription: $(serviceConnection)
-              scriptType: bash
-              scriptLocation: inlineScript
-              inlineScript: |
-                IMAGE=$(acrRegistry)/$(imageName):$(imageTag)
-                
-                az containerapp update -g $(prodRG) -n $(prodWeb) --image $IMAGE \
-                  --set-env-vars ODOO_STAGE=production ODOO_VERSION=18.0
-                az containerapp update -g $(prodRG) -n $(prodWorker) --image $IMAGE \
-                  --set-env-vars ODOO_STAGE=production ODOO_VERSION=18.0
-                az containerapp update -g $(prodRG) -n $(prodCron) --image $IMAGE \
-                  --set-env-vars ODOO_STAGE=production ODOO_VERSION=18.0
+    steps:
+    - task: AzureCLI@2
+      displayName: "Deploy production ACA apps"
+      inputs:
+        azureSubscription: $(serviceConnection)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          IMAGE=$(acrRegistry)/$(imageName):$(imageTag)
 
-          - task: AzureCLI@2
-            displayName: "Clear stale assets"
-            inputs:
-              azureSubscription: $(serviceConnection)
-              scriptType: bash
-              scriptLocation: inlineScript
-              inlineScript: |
-                PGPASSWORD=$(pgPassword) psql \
-                  -h $(pgHost) -U $(pgUser) -d odoo \
-                  -c "DELETE FROM ir_attachment WHERE url LIKE '/web/assets/%';"
+          az containerapp update -g $(prodRG) -n $(prodWeb) --image $IMAGE \
+            --set-env-vars ODOO_STAGE=production ODOO_VERSION=18.0
+          az containerapp update -g $(prodRG) -n $(prodWorker) --image $IMAGE \
+            --set-env-vars ODOO_STAGE=production ODOO_VERSION=18.0
+          az containerapp update -g $(prodRG) -n $(prodCron) --image $IMAGE \
+            --set-env-vars ODOO_STAGE=production ODOO_VERSION=18.0
 
-          - script: |
-              sleep 30
-              curl -f https://erp.insightpulseai.com/web/health --max-time 30
-            displayName: "Production health check"
+    - task: AzureCLI@2
+      displayName: "Clear stale assets"
+      inputs:
+        azureSubscription: $(serviceConnection)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          PGPASSWORD=$(pgPassword) psql \
+            -h $(pgHost) -U $(pgUser) -d odoo \
+            -c "DELETE FROM ir_attachment WHERE url LIKE '/web/assets/%';"
+
+    - script: |
+        sleep 30
+        curl -f https://erp.insightpulseai.com/web/health --max-time 30
+      displayName: "Production health check"


### PR DESCRIPTION
## Summary
- Fix stale 19.0-copilot → CE 18 image tag and Dockerfile path
- Add `PublishTestResults@2` for Tests tab in Azure DevOps
- Remove all environment/approval gates (solo operator, no ADO environments needed)
- Add JUnit XML conversion from Odoo test logs
- Fix DB env var collision (`HOST/USER` → `DB_HOST/DB_USER`)

## Test plan
- [ ] Pipeline `odoo-container-deploy` triggers on merge to main
- [ ] Build stage proceeds past service connection check
- [ ] Test results surface in ADO Tests tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)