### PR TITLE
infra(odoo): Odoo-only Bicep stack + tag contract

### DIFF
--- a/infra/azure/odoo/README.md
+++ b/infra/azure/odoo/README.md
@@ -1,0 +1,59 @@
+# Odoo-only Azure footprint
+
+## Purpose
+
+This stack codifies only the Azure footprint required to run Odoo CE 18.
+
+It does not own:
+- Databricks / Unity Catalog
+- Non-Odoo container apps
+- Broader platform/shared services outside the Odoo runtime contract
+- AI Foundry / Cognitive Services
+- Networking / VNet / Private Endpoints
+
+## Design rules
+
+1. Adopt existing canonical resource names where they already exist.
+2. Do not rename or replace existing shared/data/platform resources.
+3. Apply one tag contract to every managed resource.
+4. Keep the stack small and environment-scoped.
+5. Cross-subscription resources (PG, ACR on sponsored sub) are referenced by FQDN, not managed.
+
+## Current scope
+
+| Module | Type | Purpose |
+|---|---|---|
+| `aca-env.bicep` | Reference | Existing ACA managed environment |
+| `aca-odoo-apps.bicep` | **Managed** | Odoo web + worker + cron container apps |
+| `postgres-ref.bicep` | Reference | Existing PostgreSQL flexible server |
+| `keyvault-ref.bicep` | Reference | Existing Key Vault |
+| `monitoring-ref.bicep` | Reference | Existing Log Analytics workspace |
+| `managed-identity-ref.bicep` | Reference | Existing user-assigned managed identity |
+
+## Canonical resource names
+
+| Resource | Name | RG | Sub |
+|---|---|---|---|
+| ACA Environment | `ipai-odoo-dev-env-v2` | `rg-ipai-dev-odoo-runtime` | Sub 1 |
+| Odoo Web | `ipai-odoo-dev-web` | `rg-ipai-dev-odoo-runtime` | Sub 1 |
+| Odoo Worker | `ipai-odoo-dev-worker` | `rg-ipai-dev-odoo-runtime` | Sub 1 |
+| Odoo Cron | `ipai-odoo-dev-cron` | `rg-ipai-dev-odoo-runtime` | Sub 1 |
+| PostgreSQL | `pg-ipai-odoo` | `rg-ipai-data-sea` | Sponsored |
+| ACR | `acripaiodoo` | `rg-ipai-shared` | Sponsored |
+| Key Vault | `kv-ipai-dev` | `rg-ipai-dev-platform` | Sub 1 |
+| Managed Identity | `id-ipai-dev` | `rg-ipai-dev-odoo-runtime` | Sub 1 |
+| Log Analytics | `la-ipai-odoo-dev` | `rg-ipai-dev-odoo-runtime` | Sub 1 |
+
+## Tag contract
+
+All managed resources inherit the same tag object from the parameters file.
+SSOT: `ssot/azure/odoo-footprint.yaml`.
+
+## Deployment
+
+```bash
+az deployment group create \
+  --resource-group rg-ipai-dev-odoo-runtime \
+  --template-file infra/azure/odoo/main.bicep \
+  --parameters infra/azure/odoo/main.dev.bicepparam
+```

--- a/infra/azure/odoo/main.bicep
+++ b/infra/azure/odoo/main.bicep
@@ -1,0 +1,133 @@
+// ==========================================================================
+// Odoo-only Azure footprint — main stack
+// ==========================================================================
+//
+// Scope: Odoo runtime on ACA only.
+// Does NOT own: Databricks, non-Odoo apps, shared platform resources.
+//
+// Design rules:
+//   1. Existing canonical resource names are reused, never renamed.
+//   2. One tag contract applied to every managed resource.
+//   3. Cross-sub resources (PG, ACR) are referenced by FQDN, not managed.
+//
+// SSOT: ssot/azure/odoo-footprint.yaml
+// ==========================================================================
+
+targetScope = 'resourceGroup'
+
+// ---------------------------------------------------------------------------
+// Parameters
+// ---------------------------------------------------------------------------
+
+@description('Location — inherits from the target resource group')
+param location string = resourceGroup().location
+
+@description('Canonical tag contract applied to all resources')
+param tags object
+
+@description('Existing ACA environment name (in this RG)')
+param acaEnvironmentName string
+
+@description('PostgreSQL FQDN (cross-sub, referenced not managed)')
+param postgresFqdn string
+
+@description('Database name')
+param dbName string = 'odoo'
+
+@description('Database user')
+param dbUser string = 'odoo_admin'
+
+@description('Key Vault URI (pre-resolved, avoids cross-RG scope)')
+param keyVaultUri string
+
+@description('Existing Log Analytics workspace name (in this RG)')
+param logAnalyticsWorkspaceName string
+
+@description('Existing user-assigned managed identity name (in this RG)')
+param managedIdentityName string
+
+@description('Odoo app names')
+param webAppName string
+param workerAppName string
+param cronAppName string
+
+@description('Container image for Odoo runtime')
+param odooImage string
+
+@description('ACA target port')
+param targetPort int = 8069
+
+@description('CPU/memory sizing')
+param webCpu string = '2.0'
+param webMemory string = '4Gi'
+param workerCpu string = '1.0'
+param workerMemory string = '2Gi'
+param cronCpu string = '0.5'
+param cronMemory string = '1Gi'
+
+// ---------------------------------------------------------------------------
+// Reference modules — existing resources, read-only
+// ---------------------------------------------------------------------------
+
+module acaEnv './modules/aca-env.bicep' = {
+  name: 'ref-aca-env'
+  params: {
+    environmentName: acaEnvironmentName
+  }
+}
+
+module monitoring './modules/monitoring-ref.bicep' = {
+  name: 'ref-monitoring'
+  params: {
+    logAnalyticsWorkspaceName: logAnalyticsWorkspaceName
+  }
+}
+
+module mi './modules/managed-identity-ref.bicep' = {
+  name: 'ref-managed-identity'
+  params: {
+    managedIdentityName: managedIdentityName
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Odoo ACA apps — the only resources this stack manages
+// ---------------------------------------------------------------------------
+
+module apps './modules/aca-odoo-apps.bicep' = {
+  name: 'odoo-apps'
+  params: {
+    location: location
+    tags: tags
+    acaEnvironmentId: acaEnv.outputs.id
+    odooImage: odooImage
+    webAppName: webAppName
+    workerAppName: workerAppName
+    cronAppName: cronAppName
+    enableExternalIngress: true
+    targetPort: targetPort
+    webCpu: webCpu
+    webMemory: webMemory
+    workerCpu: workerCpu
+    workerMemory: workerMemory
+    cronCpu: cronCpu
+    cronMemory: cronMemory
+    userAssignedIdentityId: mi.outputs.identityId
+    keyVaultUri: keyVaultUri
+    postgresFqdn: postgresFqdn
+    dbName: dbName
+    dbUser: dbUser
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Outputs
+// ---------------------------------------------------------------------------
+
+output webFqdn string = apps.outputs.webFqdn
+output webAppName string = webAppName
+output workerAppName string = workerAppName
+output cronAppName string = cronAppName
+output postgresHost string = postgresFqdn
+output keyVaultUri string = keyVaultUri
+output managedIdentityClientId string = mi.outputs.clientId

--- a/infra/azure/odoo/main.dev.bicepparam
+++ b/infra/azure/odoo/main.dev.bicepparam
@@ -1,0 +1,36 @@
+using './main.bicep'
+
+param acaEnvironmentName = 'ipai-odoo-dev-env-v2'
+param postgresFqdn = 'pg-ipai-odoo.postgres.database.azure.com'
+param dbName = 'odoo'
+param dbUser = 'odoo_admin'
+param keyVaultUri = 'https://kv-ipai-dev.vault.azure.net/'
+param logAnalyticsWorkspaceName = 'la-ipai-odoo-dev'
+param managedIdentityName = 'id-ipai-dev'
+
+param webAppName = 'ipai-odoo-dev-web'
+param workerAppName = 'ipai-odoo-dev-worker'
+param cronAppName = 'ipai-odoo-dev-cron'
+
+param odooImage = 'acripaiodoo.azurecr.io/ipai-odoo:18.0-copilot'
+
+param webCpu = '2.0'
+param webMemory = '4Gi'
+param workerCpu = '1.0'
+param workerMemory = '2Gi'
+param cronCpu = '0.5'
+param cronMemory = '1Gi'
+
+param tags = {
+  app: 'odoo'
+  workload: 'odoo'
+  platform: 'azure'
+  'managed-by': 'bicep'
+  owner: 'insightpulseai'
+  repo: 'odoo'
+  service: 'erp'
+  environment: 'dev'
+  'cost-center': 'ipai'
+  'data-classification': 'internal'
+  lifecycle: 'active'
+}

--- a/infra/azure/odoo/modules/aca-env.bicep
+++ b/infra/azure/odoo/modules/aca-env.bicep
@@ -1,0 +1,7 @@
+param environmentName string
+
+resource env 'Microsoft.App/managedEnvironments@2024-03-01' existing = {
+  name: environmentName
+}
+
+output id string = env.id

--- a/infra/azure/odoo/modules/aca-odoo-apps.bicep
+++ b/infra/azure/odoo/modules/aca-odoo-apps.bicep
@@ -1,0 +1,151 @@
+param location string
+param tags object
+
+param acaEnvironmentId string
+param odooImage string
+
+param webAppName string
+param workerAppName string
+param cronAppName string
+
+param enableExternalIngress bool
+param targetPort int
+
+param webCpu string
+param webMemory string
+param workerCpu string
+param workerMemory string
+param cronCpu string
+param cronMemory string
+
+param userAssignedIdentityId string
+param keyVaultUri string
+param postgresFqdn string
+param dbName string
+param dbUser string
+
+// ---------------------------------------------------------------------------
+// Shared env var block
+// ---------------------------------------------------------------------------
+var baseEnvVars = [
+  { name: 'DB_HOST', value: postgresFqdn }
+  { name: 'DB_PORT', value: '5432' }
+  { name: 'DB_USER', value: dbUser }
+  { name: 'DB_NAME', value: dbName }
+  { name: 'KEY_VAULT_URI', value: keyVaultUri }
+]
+
+// ---------------------------------------------------------------------------
+// Odoo web (external ingress)
+// ---------------------------------------------------------------------------
+resource web 'Microsoft.App/containerApps@2024-03-01' = {
+  name: webAppName
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned, UserAssigned'
+    userAssignedIdentities: {
+      '${userAssignedIdentityId}': {}
+    }
+  }
+  properties: {
+    managedEnvironmentId: acaEnvironmentId
+    configuration: {
+      ingress: enableExternalIngress ? {
+        external: true
+        targetPort: targetPort
+        transport: 'auto'
+      } : null
+      activeRevisionsMode: 'Single'
+    }
+    template: {
+      containers: [
+        {
+          name: 'web'
+          image: odooImage
+          resources: {
+            cpu: json(webCpu)
+            memory: webMemory
+          }
+          env: concat(baseEnvVars, [
+            { name: 'PROXY_MODE', value: 'True' }
+            { name: 'LIST_DB', value: 'False' }
+            { name: 'WITHOUT_DEMO', value: 'all' }
+            { name: 'ODOO_ROLE', value: 'web' }
+          ])
+        }
+      ]
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Odoo worker (internal only)
+// ---------------------------------------------------------------------------
+resource worker 'Microsoft.App/containerApps@2024-03-01' = {
+  name: workerAppName
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    managedEnvironmentId: acaEnvironmentId
+    configuration: {
+      activeRevisionsMode: 'Single'
+    }
+    template: {
+      containers: [
+        {
+          name: 'worker'
+          image: odooImage
+          resources: {
+            cpu: json(workerCpu)
+            memory: workerMemory
+          }
+          env: concat(baseEnvVars, [
+            { name: 'ODOO_ROLE', value: 'worker' }
+          ])
+        }
+      ]
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Odoo cron (internal only)
+// ---------------------------------------------------------------------------
+resource cron 'Microsoft.App/containerApps@2024-03-01' = {
+  name: cronAppName
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    managedEnvironmentId: acaEnvironmentId
+    configuration: {
+      activeRevisionsMode: 'Single'
+    }
+    template: {
+      containers: [
+        {
+          name: 'cron'
+          image: odooImage
+          resources: {
+            cpu: json(cronCpu)
+            memory: cronMemory
+          }
+          env: concat(baseEnvVars, [
+            { name: 'ODOO_ROLE', value: 'cron' }
+          ])
+        }
+      ]
+    }
+  }
+}
+
+output webFqdn string = web.properties.configuration.ingress.fqdn
+output webId string = web.id
+output workerId string = worker.id
+output cronId string = cron.id

--- a/infra/azure/odoo/modules/keyvault-ref.bicep
+++ b/infra/azure/odoo/modules/keyvault-ref.bicep
@@ -1,0 +1,8 @@
+param keyVaultName string
+
+resource kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+output id string = kv.id
+output vaultUri string = kv.properties.vaultUri

--- a/infra/azure/odoo/modules/managed-identity-ref.bicep
+++ b/infra/azure/odoo/modules/managed-identity-ref.bicep
@@ -1,0 +1,9 @@
+param managedIdentityName string
+
+resource mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: managedIdentityName
+}
+
+output identityId string = mi.id
+output principalId string = mi.properties.principalId
+output clientId string = mi.properties.clientId

--- a/infra/azure/odoo/modules/monitoring-ref.bicep
+++ b/infra/azure/odoo/modules/monitoring-ref.bicep
@@ -1,0 +1,7 @@
+param logAnalyticsWorkspaceName string
+
+resource law 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
+  name: logAnalyticsWorkspaceName
+}
+
+output id string = law.id

--- a/infra/azure/odoo/modules/postgres-ref.bicep
+++ b/infra/azure/odoo/modules/postgres-ref.bicep
@@ -1,0 +1,8 @@
+param postgresServerName string
+
+resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview' existing = {
+  name: postgresServerName
+}
+
+output fqdn string = postgres.properties.fullyQualifiedDomainName
+output id string = postgres.id

--- a/ssot/azure/odoo-footprint.yaml
+++ b/ssot/azure/odoo-footprint.yaml
@@ -1,0 +1,87 @@
+stack: odoo-only-azure-footprint
+scope:
+  workload: odoo
+  environment: dev
+
+tag_contract:
+  app: odoo
+  workload: odoo
+  platform: azure
+  managed-by: bicep
+  owner: insightpulseai
+  repo: odoo
+  service: erp
+  environment: dev
+  cost-center: ipai
+  data-classification: internal
+  lifecycle: active
+
+resource_groups:
+  runtime: rg-ipai-dev-odoo-runtime
+  data: rg-ipai-data-sea
+  platform: rg-ipai-dev-platform
+
+existing_resources:
+  postgres_server:
+    name: pg-ipai-odoo
+    resource_group: rg-ipai-data-sea
+    subscription: eba824fb-332d-4623-9dfb-2c9f7ee83f4e  # sponsored
+  aca_environment:
+    name: ipai-odoo-dev-env-v2
+    resource_group: rg-ipai-dev-odoo-runtime
+    subscription: 536d8cf6-89e1-4815-aef3-d5f2c5f4d070  # sub 1
+  key_vault:
+    name: kv-ipai-dev
+    resource_group: rg-ipai-dev-platform
+    subscription: 536d8cf6-89e1-4815-aef3-d5f2c5f4d070
+  managed_identity:
+    name: id-ipai-dev
+    resource_group: rg-ipai-dev-odoo-runtime
+    subscription: 536d8cf6-89e1-4815-aef3-d5f2c5f4d070
+  log_analytics:
+    name: la-ipai-odoo-dev
+    resource_group: rg-ipai-dev-odoo-runtime
+    subscription: 536d8cf6-89e1-4815-aef3-d5f2c5f4d070
+  container_registry:
+    name: acripaiodoo
+    resource_group: rg-ipai-shared
+    subscription: eba824fb-332d-4623-9dfb-2c9f7ee83f4e  # sponsored
+
+apps:
+  web:
+    name: ipai-odoo-dev-web
+    cpu: '2.0'
+    memory: 4Gi
+    ingress: external
+    port: 8069
+  worker:
+    name: ipai-odoo-dev-worker
+    cpu: '1.0'
+    memory: 2Gi
+    ingress: none
+  cron:
+    name: ipai-odoo-dev-cron
+    cpu: '0.5'
+    memory: 1Gi
+    ingress: none
+  staging_web:
+    name: ipai-odoo-staging-web
+    cpu: '1.0'
+    memory: 2Gi
+    ingress: external
+    port: 8069
+  staging_worker:
+    name: ipai-odoo-staging-worker
+    cpu: '0.5'
+    memory: 1Gi
+    ingress: none
+  staging_cron:
+    name: ipai-odoo-staging-cron
+    cpu: '0.25'
+    memory: 0.5Gi
+    ingress: none
+
+image:
+  registry: acripaiodoo.azurecr.io
+  repository: ipai-odoo
+  tag: 18.0-copilot


### PR DESCRIPTION
## Summary
- Small Bicep stack under `infra/azure/odoo/` covering only the Odoo runtime footprint
- Adopts existing canonical resource names (`ipai-odoo-dev-env-v2`, `pg-ipai-odoo`, `kv-ipai-dev`, etc.)
- One shared tag contract across all managed resources (`ssot/azure/odoo-footprint.yaml`)
- 6 reference modules (ACA env, PG, KV, Log Analytics, MI) + 1 managed module (Odoo apps)
- Does NOT absorb Databricks, AI, or shared platform resources

## Test plan
- [x] `az bicep build` compiles clean
- [ ] `az deployment group what-if` validates against live resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)