### PR TITLE
ssot(domain): domain site map + repo rationalization

### DIFF
--- a/docs/architecture/REPO_BOUNDARY_MODEL.md
+++ b/docs/architecture/REPO_BOUNDARY_MODEL.md
@@ -1,0 +1,32 @@
+# Repo Boundary Model
+
+> SSOT: `platform/ssot/domain/domain-site-map.yaml`
+> Rationalization plan: `platform/ssot/org/repo-rationalization-plan.yaml`
+
+---
+
+## Domain site map baseline
+
+Public domains are mapped as follows:
+
+| Domain | Repo | Role |
+|---|---|---|
+| `insightpulseai.com` | `web` | Company/product shell |
+| `prismalab.insightpulseai.com` | `web` | Demo/lab surface |
+| `w9studio.net` | `web` | W9 public brand site |
+| `erp.insightpulseai.com` | `odoo` | ERP runtime only |
+
+## Retired
+
+- `landing.io` — redirect-shell repo, replaced by `web` repo owning all public surfaces
+
+## Deleted
+
+- `demo-repository` — no domain or surface boundary ownership
+
+## Rules
+
+1. One public domain maps to one canonical surface
+2. `erp.insightpulseai.com` is reserved for Odoo ERP only — no marketing, no lab, no mixed shell
+3. All public sites (`insightpulseai.com`, `prismalab.*`, `w9studio.net`) are owned by `web`
+4. No new redirect-only repos

--- a/platform/ssot/domain/domain-site-map.yaml
+++ b/platform/ssot/domain/domain-site-map.yaml
@@ -1,0 +1,161 @@
+contract_version: 1
+
+domain_site_map:
+  rules:
+    - one_public_domain_maps_to_one_canonical_surface
+    - erp_domain_is_reserved_for_odoo_only
+    - lab_domain_is_reserved_for_demo_or_experiment_surfaces
+    - brand_domain_is_reserved_for_brand_specific_public_site
+    - public_site_code_lives_in_web_repo
+    - erp_runtime_code_lives_in_odoo_repo
+    - redirect_only_repos_should_be_absorbed_or_retired
+
+  domains:
+    insightpulseai.com:
+      role: company_and_product_root
+      repo: web
+      app_type: marketing_product_site
+      status: target_active
+      canonical: true
+      pages:
+        - /
+        - /pulser-for-odoo
+        - /solutions
+        - /solutions/finance-operations
+        - /solutions/marketing-operations
+        - /solutions/media-operations
+        - /solutions/research-knowledge-workflows
+        - /analytics-dashboards
+        - /managed-services
+        - /architecture
+        - /pricing
+        - /demo
+        - /about
+        - /contact
+        - /privacy
+        - /terms
+      links_out:
+        - prismalab.insightpulseai.com
+        - erp.insightpulseai.com
+        - w9studio.net
+
+    www.insightpulseai.com:
+      role: alias
+      repo: web
+      app_type: redirect_or_alias
+      status: target_active
+      canonical_to: insightpulseai.com
+
+    prismalab.insightpulseai.com:
+      role: lab_demo_surface
+      repo: web
+      app_type: demo_lab_app
+      status: target_active
+      canonical: true
+      pages:
+        - /
+        - /pulser
+        - /scenarios
+        - /scenarios/finance-close
+        - /scenarios/expenses-approvals
+        - /scenarios/operations-qna
+        - /analytics
+        - /erp-walkthrough
+        - /request-access
+        - /about-prismalab
+      links_out:
+        - insightpulseai.com/pulser-for-odoo
+        - erp.insightpulseai.com
+
+    erp.insightpulseai.com:
+      role: erp_runtime
+      repo: odoo
+      app_type: odoo_ui
+      status: target_active
+      canonical: true
+      pages:
+        - /web/login
+        - /web
+        - /odoo
+      restrictions:
+        - no_marketing_pages
+        - no_lab_navigation
+        - no_non_erp_product_shell
+
+    w9studio.net:
+      role: brand_site
+      repo: web
+      app_type: brand_public_site
+      status: target_active
+      canonical: true
+      pages:
+        - /
+        - /services
+        - /portfolio
+        - /workflow-operations
+        - /case-studies
+        - /about
+        - /contact
+        - /privacy
+        - /terms
+      links_out:
+        - insightpulseai.com
+
+    www.w9studio.net:
+      role: alias
+      repo: web
+      app_type: redirect_or_alias
+      status: target_active
+      canonical_to: w9studio.net
+
+repo_actions:
+  web:
+    action: keep
+    reason: owns_all_public_sites_and_browser_facing_surfaces
+
+  odoo:
+    action: keep
+    reason: owns_erp_runtime_only
+
+  landing.io:
+    action: retire
+    preferred_handling:
+      - keep_archived_or_delete
+      - do_not_reuse_as_canonical_public_surface
+    reason: redirect_shell_is_redundant_now_that_web_repo_owns_public_site_surfaces
+
+  demo-repository:
+    action: delete
+    reason: no_domain_or_surface_ownership_value
+
+  templates:
+    action: keep
+    reason: starter_scaffolds_not_public_surface
+
+  docs:
+    action: keep
+    reason: public_docs_and_governance_not_primary_public_marketing_surface
+
+implementation_priority:
+  phase_1:
+    - insightpulseai.com
+    - erp.insightpulseai.com
+  phase_2:
+    - prismalab.insightpulseai.com
+  phase_3:
+    - w9studio.net
+
+domain_to_repo_contract:
+  public_company_product_sites:
+    repo: web
+  public_brand_sites:
+    repo: web
+  demo_lab_sites:
+    repo: web
+  erp_runtime:
+    repo: odoo
+
+non_goals:
+  - move_erp_into_web
+  - split_odoo_by_business_module
+  - create_new_redirect_only_repo

--- a/platform/ssot/org/repo-rationalization-plan.yaml
+++ b/platform/ssot/org/repo-rationalization-plan.yaml
@@ -1,0 +1,45 @@
+contract_version: 1
+
+repo_rationalization:
+  purpose: align_repo_boundaries_to_domain_site_map
+
+  keep:
+    web:
+      reason: owns_all_public_sites_and_browser_facing_surfaces
+      domains:
+        - insightpulseai.com
+        - prismalab.insightpulseai.com
+        - w9studio.net
+    odoo:
+      reason: owns_erp_runtime_only
+      domains:
+        - erp.insightpulseai.com
+    platform:
+      reason: platform_control_plane
+    infra:
+      reason: infrastructure_as_code
+    docs:
+      reason: public_docs_and_governance
+    design:
+      reason: shared_design_tokens
+    data-intelligence:
+      reason: lakehouse_and_databricks
+    agent-platform:
+      reason: agent_runtime_orchestration
+    agents:
+      reason: agent_definitions_runtime_free
+    templates:
+      reason: starter_scaffolds
+
+  merge_then_delete:
+    landing.io:
+      action: retire
+      merge_target: web
+      reason: redirect_shell_replaced_by_domain_site_map_and_web_repo_ownership
+
+  delete:
+    demo-repository:
+      action: delete
+      reason: pure_demo_noise_no_domain_or_surface_boundary
+
+  authority: platform/ssot/domain/domain-site-map.yaml


### PR DESCRIPTION
## Summary
- `platform/ssot/domain/domain-site-map.yaml` — 6 domains with page inventories, cross-site linking, repo ownership
- `platform/ssot/org/repo-rationalization-plan.yaml` — keep/retire/delete actions for repos
- `docs/architecture/REPO_BOUNDARY_MODEL.md` — domain → repo mapping baseline

## Verification
- [x] YAML validates
- [x] Every domain maps to exactly one canonical repo
- [x] `insightpulseai.com`, `prismalab.*`, `w9studio.net` → `web`
- [x] `erp.insightpulseai.com` → `odoo` only
- [x] `landing.io` → retire
- [x] `demo-repository` → delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)