### PR TITLE
chore(ci): align web-landing-deploy pipeline with live ACA values (Step B)

### DIFF
--- a/azure-pipelines/web-landing-deploy.yml
+++ b/azure-pipelines/web-landing-deploy.yml
@@ -29,8 +29,8 @@ variables:
   acrName: acripaiodoo
   imageName: ipai-website
   imageTag: latest
-  containerAppName: ipai-website-dev
-  resourceGroup: rg-ipai-dev-odoo-runtime
+  containerAppName: ipai-website
+  resourceGroup: rg-ipai-dev-odoo-sea
   serviceConnection: ipai-dev-wif
   smokeUrl: https://www.insightpulseai.com
 


### PR DESCRIPTION
## Summary

Step B from the website update sequence: fix the pipeline drift that's been blocking deploy of Scope A (PR #807, merged).

## Drift surfaced by earlier evidence

| Variable | Before | After | Source of truth |
|---|---|---|---|
| `containerAppName` | `ipai-website-dev` | `ipai-website` | live ACA in `rg-ipai-dev-odoo-sea` (verified via earlier domain-routing investigation) |
| `resourceGroup` | `rg-ipai-dev-odoo-runtime` | `rg-ipai-dev-odoo-sea` | live RG hosting all 5 ACA apps including `ipai-website` |

## Why this is needed

Without this fix, the `Deploy` stage of `azure-pipelines/web-landing-deploy.yml` fails on the first `az containerapp update` call because:
- `ipai-website-dev` ACA does not exist
- `rg-ipai-dev-odoo-runtime` resource group does not exist

The live ACA is `ipai-website` in `rg-ipai-dev-odoo-sea` (single ACA serving https://www.insightpulseai.com/ directly per the earlier domain-routing evidence).

## Scope guarantee

- 🚫 No deployment triggered by this PR.
- 🚫 No Azure mutation (we are not creating, deleting, or updating any ACA / RG / image).
- 🚫 No DNS / Front Door changes.
- 🚫 No secrets.
- 🚫 No runtime code changes.
- ✅ Only a 2-line variable rename in the pipeline YAML.

## What this enables (NOT in this PR)

After merge, the next pipeline run will:
1. Build a new image containing Scope A's `/security`, `/subprocessors`, `/llms.txt`, `/sitemap.xml`, `/robots.txt`, `/features` redirect.
2. Push to ACR (`acripaiodoo.azurecr.io/ipai-website:latest`).
3. Update the `ipai-website` ACA in `rg-ipai-dev-odoo-sea` to point at the new image.

That deploy is **separately gated** — needs explicit go-ahead per the staging-first workflow (deploy as a new revision with traffic 0%, smoke, then shift to 100%).

## Test plan

- [ ] Reviewer confirms variable values match live ACA.
- [ ] After merge, queue the pipeline manually (do NOT auto-trigger from this PR).
- [ ] First pipeline run validates the `Build` stage succeeds end-to-end.
- [ ] First pipeline run validates the `Deploy` stage now reaches the correct ACA / RG (this surfaces any remaining auth / role / WIF issues separately).

## Rollback

Single-commit revert.