### PR TITLE
chore(deploy): add ACA revision-safe website deployment flow (B-prime)

### DIFF
--- a/azure-pipelines/web-landing-deploy.yml
+++ b/azure-pipelines/web-landing-deploy.yml
@@ -1,9 +1,18 @@
 # =============================================================================
-# Web Landing Deploy Pipeline
+# Web Landing Deploy Pipeline — revision-safe (B-prime)
 # =============================================================================
-# Build -> Deploy -> Smoke -> Evidence for the public landing page.
-# Surface: ipai-website-dev ACA, https://www.insightpulseai.com
+# Build -> Deploy new revision @ 0% traffic -> Smoke revision FQDN ->
+#   ManualValidation gate -> ShiftTraffic 100% -> Smoke production -> Evidence
+#
+# Surface: ipai-website ACA in rg-ipai-dev-odoo-sea, served at
+# https://www.insightpulseai.com (single-ACA, no separate prod env).
 # ACR image: acripaiodoo.azurecr.io/ipai-website:latest
+#
+# Why revision-safe: a flat `containerapp update` flips 100% traffic to
+# the new revision immediately. With multi-revision mode + 0% initial
+# traffic + manual approval, we get a staging-style flow on a single ACA
+# without a separate staging environment. See:
+#   docs/deployment/ACA_REVISION_SAFE_DEPLOY.md
 # =============================================================================
 
 trigger:
@@ -33,6 +42,7 @@ variables:
   resourceGroup: rg-ipai-dev-odoo-sea
   serviceConnection: ipai-dev-wif
   smokeUrl: https://www.insightpulseai.com
+  revisionSuffix: build-$(Build.BuildId)
 
 stages:
   # ── Stage 1: Build ──
@@ -48,25 +58,247 @@ stages:
           acrName: $(acrName)
           serviceConnection: $(serviceConnection)
 
-  # ── Stage 2: Deploy ──
+  # ── Stage 2: Deploy new revision at 0% traffic ──
   - stage: Deploy
-    displayName: Deploy to ACA
+    displayName: Deploy New Revision (0% traffic)
     dependsOn: Build
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
     jobs:
-      - template: templates/jobs/deploy-containerapp.yml
-        parameters:
-          containerAppName: $(containerAppName)
-          resourceGroup: $(resourceGroup)
-          imageName: $(imageName)
-          imageTag: $(imageTag)
-          acrName: $(acrName)
-          serviceConnection: $(serviceConnection)
+      - job: DeployRevision
+        displayName: 'Deploy revision $(revisionSuffix) at 0% traffic'
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: AzureCLI@2
+            displayName: 'Ensure multi-revision mode + create revision at 0% traffic'
+            name: deployRev
+            inputs:
+              azureSubscription: $(serviceConnection)
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                set -euo pipefail
 
-  # ── Stage 3: Smoke ──
-  - stage: Smoke
-    displayName: Smoke Test
+                APP="$(containerAppName)"
+                RG="$(resourceGroup)"
+                IMAGE="$(acrName).azurecr.io/$(imageName):$(imageTag)"
+                SUFFIX="$(revisionSuffix)"
+                NEW_REV="${APP}--${SUFFIX}"
+
+                echo "=== Revision-safe deploy ==="
+                echo "App:           ${APP}"
+                echo "RG:            ${RG}"
+                echo "Image:         ${IMAGE}"
+                echo "New revision:  ${NEW_REV}"
+
+                # Step 1: ensure multi-revision mode (idempotent).
+                # In single-revision mode, an update flips 100% traffic to the
+                # new revision immediately. Multi-revision mode preserves
+                # existing traffic on the active revision and creates the new
+                # revision with 0% traffic by default.
+                echo "Setting revisions-mode=multiple (idempotent)..."
+                az containerapp revision set-mode \
+                  --name "${APP}" \
+                  --resource-group "${RG}" \
+                  --mode multiple \
+                  --output none
+
+                # Step 2: capture currently-active revision name (for rollback).
+                CURRENT_REV=$(az containerapp revision list \
+                  --name "${APP}" \
+                  --resource-group "${RG}" \
+                  --query "[?properties.active && properties.trafficWeight>\`0\`] | [0].name" \
+                  -o tsv)
+                echo "Current active revision: ${CURRENT_REV:-<none>}"
+
+                # Step 3: update with new image and named revision suffix.
+                # In multi-revision mode this creates a new revision with 0%
+                # traffic; existing traffic continues to flow to CURRENT_REV.
+                echo "Creating new revision ${NEW_REV} ..."
+                az containerapp update \
+                  --name "${APP}" \
+                  --resource-group "${RG}" \
+                  --image "${IMAGE}" \
+                  --revision-suffix "${SUFFIX}" \
+                  --output none
+
+                # Step 4: wait briefly for revision to provision.
+                sleep 30
+
+                # Step 5: verify new revision exists and capture its FQDN.
+                NEW_FQDN=$(az containerapp revision show \
+                  --name "${APP}" \
+                  --resource-group "${RG}" \
+                  --revision "${NEW_REV}" \
+                  --query "properties.fqdn" \
+                  -o tsv)
+
+                if [[ -z "${NEW_FQDN}" ]]; then
+                  echo "FAIL: new revision ${NEW_REV} has no FQDN"
+                  exit 1
+                fi
+
+                # Step 6: enforce 0% traffic on the new revision (defensive).
+                # In multi-revision mode the new revision *should* default to
+                # 0%, but we set it explicitly so first-deploy edge cases
+                # (e.g. transitioning from single to multi mode) are covered.
+                if [[ -n "${CURRENT_REV}" && "${CURRENT_REV}" != "${NEW_REV}" ]]; then
+                  echo "Pinning traffic: 100% -> ${CURRENT_REV}, 0% -> ${NEW_REV}"
+                  az containerapp ingress traffic set \
+                    --name "${APP}" \
+                    --resource-group "${RG}" \
+                    --revision-weight "${CURRENT_REV}=100" "${NEW_REV}=0" \
+                    --output none
+                else
+                  echo "No previous revision (or new == current); skipping defensive traffic pin."
+                fi
+
+                # Step 7: emit revision name + FQDN as pipeline outputs for
+                # downstream stages.
+                echo "##vso[task.setvariable variable=newRevisionName;isOutput=true]${NEW_REV}"
+                echo "##vso[task.setvariable variable=newRevisionFqdn;isOutput=true]${NEW_FQDN}"
+                echo "##vso[task.setvariable variable=previousRevisionName;isOutput=true]${CURRENT_REV}"
+                echo ""
+                echo "PASS"
+                echo "  New revision:        ${NEW_REV}"
+                echo "  New revision FQDN:   https://${NEW_FQDN}"
+                echo "  Previous revision:   ${CURRENT_REV:-<none>}"
+                echo "  Production traffic:  still on ${CURRENT_REV:-<previous>}"
+
+  # ── Stage 3: Smoke the new revision via its direct FQDN ──
+  - stage: SmokeNewRevision
+    displayName: Smoke new revision (direct FQDN, no production traffic)
     dependsOn: Deploy
+    condition: succeeded()
+    variables:
+      newRevisionFqdn: $[ stageDependencies.Deploy.DeployRevision.outputs['deployRev.newRevisionFqdn'] ]
+    jobs:
+      - job: SmokeRevision
+        displayName: 'Smoke https://$(newRevisionFqdn)/'
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - bash: |
+              set -euo pipefail
+              FQDN="$(newRevisionFqdn)"
+              if [[ -z "${FQDN}" ]]; then
+                echo "FAIL: newRevisionFqdn not set from Deploy stage"
+                exit 1
+              fi
+              echo "Smoking new revision FQDN: https://${FQDN}/"
+
+              FAIL=0
+
+              # Test the canonical Scope-A routes that should be live in the
+              # new revision but are not yet on production.
+              for ROUTE in "/" "/security" "/subprocessors" "/llms.txt" "/sitemap.xml" "/robots.txt"; do
+                # /security and /subprocessors are 301 redirects to /#... ;
+                # /llms.txt /sitemap.xml /robots.txt are static 200s; / is 200.
+                URL="https://${FQDN}${ROUTE}"
+                CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 -L "${URL}" || echo "000")
+                if [[ "${CODE}" == "200" ]]; then
+                  echo "  PASS  ${ROUTE}  (HTTP ${CODE})"
+                else
+                  echo "  FAIL  ${ROUTE}  (HTTP ${CODE})"
+                  FAIL=1
+                fi
+              done
+
+              # /features should now 301 to /
+              FEAT_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "https://${FQDN}/features" || echo "000")
+              if [[ "${FEAT_CODE}" == "301" || "${FEAT_CODE}" == "302" ]]; then
+                echo "  PASS  /features  (HTTP ${FEAT_CODE} redirect)"
+              else
+                echo "  WARN  /features  (HTTP ${FEAT_CODE} — expected 301/302)"
+                # Not failing the pipeline on /features alone; flag for review.
+              fi
+
+              if [[ ${FAIL} -ne 0 ]]; then
+                echo "RESULT: FAIL"
+                exit 1
+              fi
+              echo "RESULT: PASS — new revision serves Scope-A content correctly"
+            displayName: 'Smoke new revision routes'
+
+  # ── Stage 4: Manual approval before traffic shift ──
+  - stage: PromoteApproval
+    displayName: Manual approval to promote
+    dependsOn:
+      - Deploy
+      - SmokeNewRevision
+    condition: succeeded()
+    variables:
+      newRevisionName: $[ stageDependencies.Deploy.DeployRevision.outputs['deployRev.newRevisionName'] ]
+      newRevisionFqdn: $[ stageDependencies.Deploy.DeployRevision.outputs['deployRev.newRevisionFqdn'] ]
+      previousRevisionName: $[ stageDependencies.Deploy.DeployRevision.outputs['deployRev.previousRevisionName'] ]
+    jobs:
+      - job: WaitForApproval
+        displayName: 'Awaiting manual approval'
+        pool: server
+        timeoutInMinutes: 4320  # 72h max wait
+        steps:
+          - task: ManualValidation@0
+            timeoutInMinutes: 4320
+            inputs:
+              instructions: |
+                Smoke test on the new revision FQDN passed.
+
+                New revision:        $(newRevisionName)
+                New revision FQDN:   https://$(newRevisionFqdn)
+                Previous revision:   $(previousRevisionName)
+
+                APPROVE  -> shift 100% production traffic from the previous
+                            revision to the new revision. https://www.insightpulseai.com/
+                            will then serve the new revision.
+
+                REJECT   -> leave the new revision at 0% traffic. To roll
+                            back the deploy, see
+                            docs/deployment/ACA_REVISION_SAFE_DEPLOY.md
+                            (Rollback section).
+              onTimeout: 'reject'
+
+  # ── Stage 5: Shift production traffic to the new revision ──
+  - stage: PromoteShiftTraffic
+    displayName: Shift production traffic to new revision
+    dependsOn:
+      - Deploy
+      - PromoteApproval
+    condition: succeeded()
+    variables:
+      newRevisionName: $[ stageDependencies.Deploy.DeployRevision.outputs['deployRev.newRevisionName'] ]
+    jobs:
+      - job: ShiftTraffic
+        displayName: 'Shift 100% traffic to $(newRevisionName)'
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: AzureCLI@2
+            displayName: 'az containerapp ingress traffic set'
+            inputs:
+              azureSubscription: $(serviceConnection)
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                set -euo pipefail
+                NEW_REV="$(newRevisionName)"
+                APP="$(containerAppName)"
+                RG="$(resourceGroup)"
+                if [[ -z "${NEW_REV}" ]]; then
+                  echo "FAIL: newRevisionName not set"
+                  exit 1
+                fi
+                echo "Shifting 100% traffic to ${NEW_REV} on ${APP}/${RG} ..."
+                az containerapp ingress traffic set \
+                  --name "${APP}" \
+                  --resource-group "${RG}" \
+                  --revision-weight "${NEW_REV}=100" \
+                  --output none
+                echo "PASS — production traffic now on ${NEW_REV}"
+
+  # ── Stage 6: Smoke production URL post-promote ──
+  - stage: SmokeProduction
+    displayName: Smoke production URL post-promote
+    dependsOn: PromoteShiftTraffic
     condition: succeeded()
     jobs:
       - template: templates/jobs/smoke-http.yml
@@ -74,13 +306,17 @@ stages:
           url: $(smokeUrl)
           expectedStatus: '200'
           contentMatch: InsightPulse
-          retries: 3
-          retryDelaySeconds: 15
+          retries: 5
+          retryDelaySeconds: 20
 
-  # ── Stage 4: Evidence ──
+  # ── Stage 7: Evidence ──
   - stage: Evidence
     displayName: Publish Evidence
-    dependsOn: Smoke
+    dependsOn:
+      - Deploy
+      - SmokeNewRevision
+      - PromoteShiftTraffic
+      - SmokeProduction
     condition: succeededOrFailed()
     jobs:
       - template: templates/jobs/publish-evidence.yml

--- a/docs/deployment/ACA_REVISION_SAFE_DEPLOY.md
+++ b/docs/deployment/ACA_REVISION_SAFE_DEPLOY.md
@@ -1,0 +1,170 @@
+# ACA revision-safe deployment — Pulser web landing
+
+## Why this exists
+
+The InsightPulseAI public website (`https://www.insightpulseai.com/`) is
+served by a **single Azure Container App**:
+
+| Resource | Value |
+|---|---|
+| ACA name | `ipai-website` |
+| Resource group | `rg-ipai-dev-odoo-sea` |
+| Region | Southeast Asia |
+| Image | `acripaiodoo.azurecr.io/ipai-website:latest` |
+
+There is **no separate staging ACA**. A flat `az containerapp update`
+call flips 100% production traffic to the new revision immediately —
+there is no time window to smoke-test the new revision before it goes
+live to real visitors.
+
+This document explains how the pipeline avoids that flat-cutover risk.
+
+## The flow
+
+```
+Build  ->  Deploy (new revision @ 0% traffic)
+       ->  Smoke (new revision FQDN, no prod traffic involved)
+       ->  ManualValidation (approval gate)
+       ->  ShiftTraffic (100% to new revision)
+       ->  Smoke (production URL post-promote)
+       ->  Evidence
+```
+
+The Container App is configured for **multi-revision mode** so that an
+update creates a new revision while the previous revision keeps serving
+100% of traffic. The pipeline's `Deploy` stage explicitly sets
+`revisions-mode=multiple` (idempotent) before each deploy.
+
+## Why the new revision starts at 0% traffic
+
+In multi-revision mode, `az containerapp update --revision-suffix <s>`
+creates a new revision but does **not** automatically shift traffic to
+it — existing traffic remains on whatever revisions currently have
+weight > 0. As a defensive measure, the pipeline also explicitly pins
+the previous revision at 100% and the new revision at 0% before moving
+on, so even on the first transition from single → multi mode the new
+revision cannot accidentally take production traffic.
+
+## Smoke testing the new revision
+
+Each new revision in ACA gets its own per-revision FQDN, distinct from
+the production app FQDN. The pipeline captures the new revision's FQDN
+from `az containerapp revision show ... --query properties.fqdn` and
+smokes it directly:
+
+| Route | Expected | Source |
+|---|---|---|
+| `/` | 200 + body contains `InsightPulse` | SPA homepage |
+| `/security` | 301 → `/#security` | Server redirect (Scope A) |
+| `/subprocessors` | 301 → `/#subprocessors` | Server redirect (Scope A) |
+| `/llms.txt` | 200 (text/plain) | Static file (Scope A) |
+| `/sitemap.xml` | 200 (text/xml) | Static file (Scope A) |
+| `/robots.txt` | 200 (text/plain) | Static file (Scope A) |
+| `/features` | 301 → `/` | Server redirect (Scope A) |
+
+Smoke against the per-revision FQDN does NOT route through production
+ingress and does NOT affect real visitors.
+
+## Manual approval gate
+
+After smoke passes, the pipeline pauses at a `ManualValidation@0` step.
+The reviewer sees:
+- New revision name and FQDN
+- Previous revision name (rollback target)
+- Approve / Reject options
+
+**Approve** triggers the `PromoteShiftTraffic` stage, which runs:
+
+```bash
+az containerapp ingress traffic set \
+  --name ipai-website \
+  --resource-group rg-ipai-dev-odoo-sea \
+  --revision-weight <new-revision>=100
+```
+
+After the shift, the pipeline smokes the production URL one more time
+to confirm the cutover served the new content correctly, then publishes
+evidence.
+
+**Reject** (or timeout — default 72h) leaves the new revision at 0%
+traffic. The new revision is preserved in ACA history; production
+continues serving the previous revision unchanged. To clean up an
+abandoned revision, deactivate it (see Rollback section below).
+
+## Rollback
+
+### Scenario A — production has already been promoted to the new revision and we want to revert
+
+```bash
+# 1. Identify the previous good revision.
+az containerapp revision list \
+  --name ipai-website \
+  --resource-group rg-ipai-dev-odoo-sea \
+  --query "[?properties.active].{name: name, created: properties.createdTime, weight: properties.trafficWeight}" \
+  --output table
+
+# 2. Shift 100% traffic back to the previous good revision.
+az containerapp ingress traffic set \
+  --name ipai-website \
+  --resource-group rg-ipai-dev-odoo-sea \
+  --revision-weight <previous-revision>=100
+
+# 3. Smoke the production URL.
+curl -sI https://www.insightpulseai.com/
+```
+
+### Scenario B — manual approval was rejected; we want to clean up the unused new revision
+
+```bash
+# Deactivate the unused new revision (does not delete history).
+az containerapp revision deactivate \
+  --name ipai-website \
+  --resource-group rg-ipai-dev-odoo-sea \
+  --revision <new-revision>
+```
+
+### Scenario C — partial / canary traffic split (advanced)
+
+The pipeline currently shifts 100% on approval. For a slower canary,
+manually run:
+
+```bash
+# 10% canary on new revision, 90% on previous good revision.
+az containerapp ingress traffic set \
+  --name ipai-website \
+  --resource-group rg-ipai-dev-odoo-sea \
+  --revision-weight <new-revision>=10 <previous-revision>=90
+```
+
+A future PR can wire a canary stage into the pipeline if needed.
+
+## Trigger and authority
+
+- **CI/CD authority split per ADR-0010**: GitHub Actions through staging;
+  Azure Pipelines for production apply. This pipeline runs in Azure
+  Pipelines.
+- **Trigger**: pushes to `main` that touch `web/ipai-landing/**`. Changes
+  to `azure-pipelines/**` (including this file) do NOT auto-trigger the
+  deploy pipeline — they are repo-only.
+- **Manual trigger** for revision-safe deploy after a doc-only PR or
+  emergency hotfix: `az pipelines run --name web-landing-deploy --branch main`
+  (requires Azure DevOps PAT or the dev team's queue access).
+
+## What this does NOT do
+
+- It does NOT change DNS or Azure Front Door routing.
+- It does NOT deploy to a separate staging ACA (one does not exist).
+- It does NOT modify the shared `templates/jobs/deploy-containerapp.yml`
+  template; that template is still used by other pipelines that want
+  flat-deploy semantics. Web landing now uses inline `az` calls instead.
+- It does NOT auto-promote without manual approval.
+- It does NOT autoroll back; rollback is manual per the procedures above.
+- It does NOT send notifications; the ManualValidation step is the
+  notification surface.
+
+## References
+
+- Azure Container Apps revisions: https://learn.microsoft.com/en-us/azure/container-apps/revisions
+- `az containerapp ingress traffic set`: https://learn.microsoft.com/en-us/cli/azure/containerapp/ingress/traffic
+- ManualValidation task: https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/manual-validation-v0
+- ADR-0010 (CI deploy authority split): see `docs/architecture/adrs/`

--- a/docs/evidence/20260426-website-aca-revision-safe-deploy/EVIDENCE.md
+++ b/docs/evidence/20260426-website-aca-revision-safe-deploy/EVIDENCE.md
@@ -1,0 +1,140 @@
+# Evidence — ACA revision-safe website deployment (B-prime)
+
+- **Timestamp**: 2026-04-26 (UTC+8)
+- **Branch**: `chore/pipeline-aca-revision-safe-deploy`
+- **PR title**: `chore(deploy): add ACA revision-safe website deployment flow`
+- **Repo**: `Insightpulseai/odoo`
+- **Base**: `main` (post-#807 + post-#808 merges)
+
+## Goal
+
+Add staging-style revision support to the public-website deploy
+pipeline so a flat-cutover deploy directly to the only live ACA
+becomes avoidable risk.
+
+## Prior state
+
+| PR | Title | Status | Effect |
+|---|---|---|---|
+| #807 | Scope A — trust pages + SEO/LLM artifacts | merged | New /security, /subprocessors, /llms.txt, /sitemap.xml, /robots.txt, /features redirect on `main`. **Not yet deployed.** |
+| #808 | Pipeline drift fix (`containerAppName`, `resourceGroup`) | merged | Pipeline targets the live ACA. **No deploy run yet.** |
+
+The next deploy after #808 would have been a flat 100% cutover of
+Scope A onto production. This PR replaces that with revision-safe
+deploy.
+
+## What this PR changes
+
+| File | Change |
+|---|---|
+| `azure-pipelines/web-landing-deploy.yml` | REPLACED with revision-safe pipeline (Build → Deploy @ 0% → Smoke revision FQDN → ManualValidation gate → ShiftTraffic → Smoke prod → Evidence). 7 stages instead of 4. |
+| `docs/deployment/ACA_REVISION_SAFE_DEPLOY.md` | NEW — explains flow, rollback procedures (Scenarios A/B/C), authority split per ADR-0010. |
+| `docs/evidence/20260426-website-aca-revision-safe-deploy/EVIDENCE.md` | NEW (this file). |
+
+The shared `templates/jobs/deploy-containerapp.yml` template is **NOT**
+modified — it remains available for other pipelines that want
+flat-deploy semantics. Web-landing now uses inline `az containerapp`
+calls within `web-landing-deploy.yml`.
+
+## Pipeline stage map
+
+```
+Build (template)
+  ↓
+Deploy
+  ├─ az containerapp revision set-mode --mode multiple   (idempotent)
+  ├─ az containerapp update --revision-suffix build-<id>  (creates revision)
+  └─ az containerapp ingress traffic set                  (defensive: prev=100, new=0)
+       outputs: newRevisionName, newRevisionFqdn, previousRevisionName
+  ↓
+SmokeNewRevision
+  └─ curl https://<newRevisionFqdn>/ , /security, /subprocessors,
+       /llms.txt, /sitemap.xml, /robots.txt, /features
+  ↓
+PromoteApproval
+  └─ ManualValidation@0  (timeout 72h, default reject on timeout)
+  ↓
+PromoteShiftTraffic
+  └─ az containerapp ingress traffic set --revision-weight <new>=100
+  ↓
+SmokeProduction
+  └─ curl https://www.insightpulseai.com/  (HTTP 200 + content match)
+  ↓
+Evidence (template, dependsOn all)
+```
+
+## Scope guarantee
+
+- 🚫 **No deployment triggered by this PR.** The pipeline trigger is
+  `paths.include: web/ipai-landing/**`. This PR changes
+  `azure-pipelines/**` and `docs/**`; neither is under that path. So
+  merging this PR does not auto-run the deploy pipeline.
+- 🚫 No Azure mutation in this PR (no ACA / RG / image / DNS changes).
+- 🚫 No website content changes.
+- 🚫 No secrets added.
+- 🚫 No DNS / Front Door changes.
+- 🚫 No environment created or deleted in Azure DevOps (the
+  `ManualValidation@0` task does NOT require a deployment environment;
+  it runs inline on `pool: server`).
+- 🚫 No touching `Odoo`, `agent-platform`, `infra`,
+  `marketplace-publishing`, or `docs` repos in the canonical
+  `Insightpulse-ai` org. Changes are confined to the legacy
+  `Insightpulseai/odoo` monorepo at `azure-pipelines/**` and `docs/**`.
+
+## What is required to actually update the live site
+
+After this PR merges:
+
+1. Manually queue the pipeline (Azure DevOps UI or
+   `az pipelines run --name web-landing-deploy --branch main`). The
+   pipeline does not auto-trigger on this PR's merge because of the
+   path filter.
+2. The pipeline will:
+   - Build a new image containing Scope A.
+   - Deploy a new revision at 0% traffic.
+   - Smoke the new revision FQDN.
+   - Pause at ManualValidation.
+3. A reviewer with Azure DevOps approval permission clicks Approve.
+4. The pipeline shifts 100% traffic to the new revision, smokes
+   production, and publishes evidence.
+
+That deploy is **separately gated** — it requires explicit go-ahead and
+manual approval at the ManualValidation step. This PR alone does not
+trigger any of it.
+
+## Verification of pipeline correctness (without running)
+
+YAML parses cleanly:
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('azure-pipelines/web-landing-deploy.yml'))"
+```
+
+Stage dependencies are well-formed (each `dependsOn` references an
+earlier-defined stage).
+
+`stageDependencies` references for cross-stage variables use the
+correct path: `Deploy.DeployRevision.outputs['deployRev.<varName>']`
+where `Deploy` is the stage, `DeployRevision` is the job, `deployRev`
+is the step name (`name: deployRev`), and `<varName>` is the variable
+emitted by `##vso[task.setvariable variable=<varName>;isOutput=true]`.
+
+## Confirmations
+
+- [x] No deployment triggered.
+- [x] No Azure mutation.
+- [x] No GitHub environment / Azure DevOps environment created or deleted.
+- [x] No DNS / Azure Front Door change.
+- [x] No secrets added or moved.
+- [x] No website content changed (Scope A content remains exactly as
+      merged in PR #807).
+- [x] Existing shared template `templates/jobs/deploy-containerapp.yml`
+      not modified; other pipelines that depend on it are unaffected.
+- [x] Pipeline trigger paths preserved (`web/ipai-landing/**`); this
+      PR's diff does not auto-run the pipeline.
+
+## Rollback (this PR itself)
+
+Single-commit revert. Reverting restores the previous flat-deploy
+behavior. No Azure mutation occurred between this PR's merge and the
+revert, so there is no Azure-side cleanup needed.


### PR DESCRIPTION
## Summary

B-prime from the website update sequence. Replaces the flat-cutover deploy on the single \`ipai-website\` ACA with a staging-style revision-safe flow.

Builds on the already-merged:
- **#807** Scope A — trust pages + SEO/LLM artifacts on \`main\`.
- **#808** Pipeline drift fix — \`containerAppName\` + \`resourceGroup\` aligned with live ACA.

## Why

The next deploy after #808 would have been a flat 100% cutover of Scope A onto production (single ACA, no separate staging ACA). This PR makes that deploy revision-safe instead.

## New flow

```
Build  →  Deploy (new revision @ 0% traffic)
       →  Smoke (per-revision FQDN — does NOT touch prod traffic)
       →  ManualValidation gate (72h timeout, default reject)
       →  ShiftTraffic 100% to new revision
       →  Smoke production URL post-promote
       →  Evidence
```

## Key behaviours

- \`az containerapp revision set-mode --mode multiple\` (idempotent) so update creates a new revision instead of flat-cutting.
- \`az containerapp update --revision-suffix build-<BuildId>\` for deterministic revision naming.
- Defensive \`ingress traffic set --revision-weight prev=100 new=0\` to handle the first single→multi mode transition edge case.
- Capture \`newRevisionFqdn\` and smoke it directly — production traffic remains on the previous revision throughout smoke.
- \`ManualValidation@0\` task on \`pool: server\` (no Azure DevOps environment required for the approval gate).
- Smoke production URL post-promote with content match (\`InsightPulse\`).
- Rollback procedures documented (Scenarios A/B/C in the deploy doc).

## Files

| File | Change |
|---|---|
| \`azure-pipelines/web-landing-deploy.yml\` | REPLACED — 7 stages instead of 4. |
| \`docs/deployment/ACA_REVISION_SAFE_DEPLOY.md\` | NEW — flow, rollback, authority split per ADR-0010. |
| \`docs/evidence/20260426-website-aca-revision-safe-deploy/EVIDENCE.md\` | NEW — scope guarantee + verification. |

## Scope guarantee

- 🚫 No deployment triggered by this PR. Pipeline trigger paths are unchanged (\`web/ipai-landing/**\`); this PR's diff (\`azure-pipelines/**\` + \`docs/**\`) is outside the trigger path.
- 🚫 No Azure mutation.
- 🚫 No DNS / Azure Front Door changes.
- 🚫 No secrets added.
- 🚫 No environment created or deleted (in Azure DevOps or Azure).
- 🚫 No website content changed (Scope A content from #807 stays exactly as merged).
- 🚫 No modification to the shared \`templates/jobs/deploy-containerapp.yml\` template (other pipelines that use flat-deploy semantics are unaffected).

## What is required to actually update the live site

After this PR merges:

1. Manually queue the pipeline (\`az pipelines run --name web-landing-deploy --branch main\`).
2. The pipeline builds + deploys a new revision at 0% traffic + smokes the per-revision FQDN.
3. The pipeline pauses at ManualValidation. A reviewer approves.
4. Pipeline shifts 100% traffic to the new revision + smokes production + publishes evidence.

This PR alone does not trigger any of that.

## Test plan

- [ ] Reviewer confirms YAML parses cleanly (verified locally with \`yaml.safe_load\`).
- [ ] Reviewer confirms stage dependencies + \`stageDependencies\` variable references are well-formed.
- [ ] Reviewer confirms the trigger path filter is unchanged.
- [ ] Reviewer confirms no shared template file is modified.
- [ ] After merge: queue the pipeline manually and observe the staged flow end-to-end.

## Rollback

Single-commit revert. Reverting restores flat-deploy behaviour. No Azure mutation occurred between this PR's merge and a revert, so there is no Azure-side cleanup needed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>