### PR TITLE
fix(web): use existing Azure service connection for landing deploy

### DIFF
--- a/azure-pipelines/web-landing-deploy.yml
+++ b/azure-pipelines/web-landing-deploy.yml
@@ -40,7 +40,7 @@ variables:
   imageTag: latest
   containerAppName: ipai-website
   resourceGroup: rg-ipai-dev-odoo-sea
-  serviceConnection: ipai-dev-wif
+  serviceConnection: azure-ipai
   smokeUrl: https://www.insightpulseai.com
   revisionSuffix: build-$(Build.BuildId)
 


### PR DESCRIPTION
## Summary

One-line tactical change to unblock the stale-site deploy. Aligns the B-prime web-landing pipeline with the Azure service connection that actually exists in the `ipai-platform` Azure DevOps project.

## What this PR changes

`azure-pipelines/web-landing-deploy.yml`, line 43:

```diff
-  serviceConnection: ipai-dev-wif
+  serviceConnection: azure-ipai
```

**1 file changed, 1 insertion(+), 1 deletion(-).**

## Why this is needed

- Pipeline #7 (`ipai-landing-deploy`) was repointed earlier today from the legacy `web/ipai-landing/azure-pipelines.yml` to the B-prime `azure-pipelines/web-landing-deploy.yml`.
- The first B-prime run (build `#20260426.1`, run id `1080`) failed **before the Build stage** because:

```
Service connection 'ipai-dev-wif' could not be found.
The service connection does not exist, has been disabled or has not been authorized.
```

- Repo hardcodes `serviceConnection: ipai-dev-wif` (introduced by PR #684 — `fix(ci): migrate all pipelines to WIF service connection`), but the matching service connection was never created/authorized in this ADO project.
- The `ipai-platform` ADO project has **only one** ready Azure service connection: `azure-ipai`.

## azure-ipai service endpoint metadata (no secrets)

| Field | Value |
|---|---|
| name | `azure-ipai` |
| type | `azurerm` |
| isReady | ✅ True |
| isShared | False |
| url | https://management.azure.com/ |
| authorization.scheme | ServicePrincipal |
| data.scopeLevel | Subscription |
| data.subscriptionId | `536d8cf6-89e1-4815-aef3-d5f2c5f4d070` |
| data.subscriptionName | Azure subscription 1 |
| data.environment | AzureCloud |
| data.identityType | AppRegistrationManual |
| data.creationMode | Manual |
| parameters.tenantid | `402de71a-87ec-4302-a609-fb76098d1da7` |

**Caveat:** this is a manual Service Principal connection, not WIF. It is the only ready Azure service connection currently present in the `ipai-platform` ADO project, so this PR aligns the pipeline with the SC that actually exists.

RBAC scope (AcrPush on `acripaiodoo` + Container Apps Contributor on `rg-ipai-dev-odoo-sea`) is presumed adequate (subscription-level scope) but will be verified empirically by the next pipeline run. If a 403 surfaces at `az containerapp update`, ACA stays on the current revision; no production damage.

## Scope guarantee — what this PR does NOT do

- ❌ No new service connection created
- ❌ No Entra app registration created
- ❌ No federated credential created
- ❌ No RBAC role assignment
- ❌ No org-wide YAML rename (other pipelines untouched)
- ❌ No ACA / ACR / Front Door / DNS / Odoo runtime change
- ❌ No production traffic shift authorized
- ❌ No secrets, no env vars
- ❌ No deployment triggered by this PR (path-trigger on `web/ipai-landing/**` does not match `azure-pipelines/web-landing-deploy.yml`)

## What happens after merge

The B-prime pipeline (revision-safe by construction) will:

1. Build a fresh image from `main` HEAD (where Scope A copy is committed under `be51c15eb chore(web): add trust pages and search/LLM discovery artifacts (#807)`)
2. Push to `acripaiodoo.azurecr.io/ipai-website:latest`
3. Create a new ACA revision in `rg-ipai-dev-odoo-sea` at **0% traffic**
4. Smoke the new revision via its direct FQDN
5. **STOP at the ManualValidation gate**

No production traffic shift will occur without explicit human approval on the ManualValidation gate.

The pipeline must be **manually queued** after this PR merges (path-trigger on `web/ipai-landing/**` will not auto-fire on this YAML change):

```bash
az pipelines run --id 7 \
  --org https://dev.azure.com/insightpulseai \
  --project ipai-platform \
  --branch main
```

## Long-term follow-up (separate governance PR — NOT this one)

```
chore(ci): reconcile Azure service connection naming and WIF migration
```

Scope:
- Audit all pipelines using `ipai-dev-wif`
- Decide canonical SC: recreate `ipai-dev-wif` as proper WIF, or standardize on `azure-ipai`
- Per-pipeline RBAC + target-environment verification before any broad rename

## Refs

- PR #807 (Scope A copy, merged 2026-04-26 13:32 PHT)
- PR #808 (drift fix to ACA/RG values in B-prime YAML, merged 2026-04-26 13:37 PHT)
- PR #809 (B-prime revision-safe pipeline, merged 2026-04-26 13:42 PHT)
- PR #684 (introduced WIF SC naming convention)
- ADO pipeline #7 repointed to B-prime YAML 2026-04-26 ~10:34 UTC
- Failed run 1080: https://dev.azure.com/insightpulseai/ipai-platform/_build/results?buildId=1080

## Test plan

- [ ] Reviewer confirms diff is exactly one line in one pipeline file
- [ ] Reviewer confirms `azure-ipai` is the only ready Azure SC in `ipai-platform` (via `az devops service-endpoint list`)
- [ ] After merge, manually queue pipeline #7 on `main`
- [ ] Confirm Build stage succeeds (passes the previous validation failure)
- [ ] Confirm new ACA revision created at 0% traffic with new image digest
- [ ] Smoke the new revision FQDN for `/`, `/security`, `/subprocessors`, `/llms.txt`, `/sitemap.xml`, `/robots.txt`, `/features`, `/privacy`, `/terms`
- [ ] Pipeline halts at ManualValidation gate; no production traffic shift without explicit approval